### PR TITLE
Apply noise texture using HARD_LIGHT

### DIFF
--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNode31.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNode31.kt
@@ -135,7 +135,7 @@ internal class HazeNode31(
       RenderEffect.createBlendModeEffect(
         RenderEffect.createShaderEffect(BitmapShader(noiseTexture, REPEAT, REPEAT)),
         it,
-        BlendMode.OVERLAY,
+        BlendMode.HARD_LIGHT,
       )
     }.let {
       RenderEffect.createColorFilterEffect(


### PR DESCRIPTION
We currently use `OVERLAY`, which has the unfortunate effect of changing the luminosity of the content.

After some experimentation and research, it seems that `HARD_LIGHT` is a more aggresive relation to `OVERLAY`, which keeps black pixels black, and similar for white. The results are much better to my eye.

Fixes #20 

| OVERLAY  | HARD_LIGHT |
| ------------- | ------------- |
| ![overlay_light_2](https://github.com/chrisbanes/haze/assets/227486/55ec56c0-9abd-4527-b43a-561a2a393907)! | ![hard_light_light_1](https://github.com/chrisbanes/haze/assets/227486/c9bc2d55-f4f2-40ed-b070-cec24fd34c03) |
| ![overlay_light_1](https://github.com/chrisbanes/haze/assets/227486/ff811d0b-6c6e-446c-a5e3-014d084b59e7)  | ![hard_light_light_2](https://github.com/chrisbanes/haze/assets/227486/c6454a71-c24f-4823-b57d-af3db9fdb683) |
| ![overlay_dark_1](https://github.com/chrisbanes/haze/assets/227486/01fbf8bb-6e6c-48fd-aa5a-253b7d3acf85) | ![hard_light_dark_1](https://github.com/chrisbanes/haze/assets/227486/e605823c-508e-477c-8400-3f3579e5ea7d)  |
| ![overlay_dark_2](https://github.com/chrisbanes/haze/assets/227486/938e11e6-b7d1-4afd-9772-08e66ba38a01) | ![hard_light_dark_2](https://github.com/chrisbanes/haze/assets/227486/3a9ab6b1-6760-44c4-a280-40053baac410) |




