### PR TITLE
Apply Jetpack Compose Shape to HazeChild.kt on init

### DIFF
--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeChild.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeChild.kt
@@ -47,7 +47,7 @@ private data class HazeChildNode(
   var shape: Shape,
 ) : Modifier.Node(), LayoutAwareModifierNode {
 
-  private val area: HazeArea by lazy { HazeArea() }
+  private val area: HazeArea by lazy { HazeArea().apply { shape = this@HazeChildNode.shape } }
 
   private var attachedState: HazeState? = null
 


### PR DESCRIPTION
Shape must be applied to HazeChild area upon creation, as there is no guarantee there would be at least one call to onUpdate before attach to state happens.