### PR TITLE
Skip RenderNode impl on API 31

### DIFF
--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNodeRenderEffect.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNodeRenderEffect.kt
@@ -49,7 +49,7 @@ import kotlin.math.roundToInt
 import kotlin.properties.Delegates.observable
 
 @RequiresApi(31)
-internal class HazeNode31(
+internal class HazeNodeRenderEffect(
   state: HazeState,
   backgroundColor: Color,
   tint: Color,

--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/Platform.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/Platform.kt
@@ -14,8 +14,10 @@ internal fun createHazeNode(
   blurRadius: Dp,
   noiseFactor: Float,
 ): HazeNode = when {
-  Build.VERSION.SDK_INT >= 31 -> {
-    HazeNode31(
+  Build.VERSION.SDK_INT >= 32 -> {
+    // We can't currently use this impl on API 31 due to
+    // https://github.com/chrisbanes/haze/issues/77
+    HazeNodeRenderEffect(
       state = state,
       backgroundColor = backgroundColor,
       tint = tint,


### PR DESCRIPTION
Seems to be a Compose/platform bug. See #77 