### PR TITLE
Fix hazeChild tint not updating on Android base

### DIFF
--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNodeBase.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNodeBase.kt
@@ -56,7 +56,7 @@ internal class HazeNodeBase(
   }
 
   override fun onUpdate() {
-    invalidateDraw()
+    invalidatePaths()
   }
 
   override fun onObservedReadsChanged() {


### PR DESCRIPTION
Caused by not invalidating the paths. Fixes #82