### PR TITLE
Calculate areas in screen coordinates

### DIFF
--- a/haze-jetpack-compose/api/api.txt
+++ b/haze-jetpack-compose/api/api.txt
@@ -2,14 +2,14 @@
 package dev.chrisbanes.haze {
 
   @androidx.compose.runtime.Stable public final class HazeArea {
-    ctor public HazeArea(optional long size, optional long positionInRoot, optional androidx.compose.ui.graphics.Shape shape, optional long tint);
-    method public long getPositionInRoot();
+    ctor public HazeArea(optional long size, optional long positionOnScreen, optional androidx.compose.ui.graphics.Shape shape, optional long tint);
+    method public long getPositionOnScreen();
     method public androidx.compose.ui.graphics.Shape getShape();
     method public long getSize();
     method public long getTint();
     method public boolean isValid();
     property public final boolean isValid;
-    property public final long positionInRoot;
+    property public final long positionOnScreen;
     property public final androidx.compose.ui.graphics.Shape shape;
     property public final long size;
     property public final long tint;

--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -46,24 +46,6 @@ class HazeState {
   }
 }
 
-internal fun HazeState.addAreasToPath(
-  path: Path,
-  positionInRoot: Offset,
-  layoutDirection: LayoutDirection,
-  density: Density,
-) {
-  if (positionInRoot.isUnspecified) return
-
-  areas.asSequence()
-    .filter { it.isValid }
-    .forEach { area ->
-      path.addOutline(
-        outline = area.shape.createOutline(area.size, layoutDirection, density),
-        offset = area.positionInRoot - positionInRoot,
-      )
-    }
-}
-
 internal fun Path.addOutline(outline: Outline, offset: Offset) = when (outline) {
   is Outline.Rectangle -> addRect(outline.rect.translate(offset))
   is Outline.Rounded -> addRoundRect(outline.roundRect.translate(offset))
@@ -73,14 +55,14 @@ internal fun Path.addOutline(outline: Outline, offset: Offset) = when (outline) 
 @Stable
 class HazeArea(
   size: Size = Size.Unspecified,
-  positionInRoot: Offset = Offset.Unspecified,
+  positionOnScreen: Offset = Offset.Unspecified,
   shape: Shape = RectangleShape,
   tint: Color = Color.Unspecified,
 ) {
   var size: Size by mutableStateOf(size)
     internal set
 
-  var positionInRoot: Offset by mutableStateOf(positionInRoot)
+  var positionOnScreen: Offset by mutableStateOf(positionOnScreen)
     internal set
 
   var shape: Shape by mutableStateOf(shape)
@@ -90,14 +72,14 @@ class HazeArea(
     internal set
 
   val isValid: Boolean
-    get() = size.isSpecified && positionInRoot.isSpecified && !size.isEmpty()
+    get() = size.isSpecified && positionOnScreen.isSpecified && !size.isEmpty()
 }
 
-internal fun HazeArea.boundsInLocal(hazePositionInRoot: Offset): Rect? {
+internal fun HazeArea.boundsInLocal(position: Offset): Rect? {
   if (!isValid) return null
-  if (hazePositionInRoot.isUnspecified) return null
+  if (position.isUnspecified) return null
 
-  return size.toRect().translate(positionInRoot - hazePositionInRoot)
+  return size.toRect().translate(positionOnScreen - position)
 }
 
 internal fun HazeArea.updatePath(

--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeChild.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeChild.kt
@@ -8,7 +8,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
@@ -57,7 +58,9 @@ private data class HazeChildNode(
   var state: HazeState,
   var shape: Shape,
   var tint: Color,
-) : Modifier.Node(), LayoutAwareModifierNode {
+) : Modifier.Node(),
+  LayoutAwareModifierNode,
+  CompositionLocalConsumerModifierNode {
 
   private val area: HazeArea by lazy {
     HazeArea(shape = shape, tint = tint)
@@ -83,8 +86,8 @@ private data class HazeChildNode(
   }
 
   override fun onPlaced(coordinates: LayoutCoordinates) {
-    // After we've been placed, update the state with our new bounds (in root coordinates)
-    area.positionInRoot = coordinates.positionInRoot()
+    // After we've been placed, update the state with our new bounds (in 'screen' coordinates)
+    area.positionOnScreen = coordinates.positionInWindow() + calculateWindowOffset()
     area.size = coordinates.size.toSize()
   }
 

--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNodeBase.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNodeBase.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
@@ -44,7 +44,7 @@ internal class HazeNodeBase(
   private var pathsDirty = true
   private var paths: List<PathHolder> = emptyList()
 
-  private var positionInRoot by observable(Offset.Unspecified) { _, oldValue, newValue ->
+  private var position by observable(Offset.Unspecified) { _, oldValue, newValue ->
     if (oldValue != newValue) {
       invalidatePaths()
     }
@@ -69,7 +69,7 @@ internal class HazeNodeBase(
   }
 
   override fun onPlaced(coordinates: LayoutCoordinates) {
-    positionInRoot = coordinates.positionInRoot()
+    position = coordinates.positionInWindow() + calculateWindowOffset()
     size = coordinates.size.toSize()
   }
 
@@ -101,7 +101,7 @@ internal class HazeNodeBase(
   ): List<PathHolder> = state.areas.asSequence()
     .filter { it.isValid }
     .mapNotNull { area ->
-      val bounds = area.boundsInLocal(positionInRoot) ?: return@mapNotNull null
+      val bounds = area.boundsInLocal(position) ?: return@mapNotNull null
 
       // TODO: Should try and re-use this
       val path = Path()

--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNodeRenderEffect.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/HazeNodeRenderEffect.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
@@ -70,7 +70,7 @@ internal class HazeNodeRenderEffect(
   private var effectsDirty = true
   private var effects: List<EffectHolder> = emptyList()
 
-  private var positionInRoot by observable(Offset.Unspecified) { _, oldValue, newValue ->
+  private var position by observable(Offset.Unspecified) { _, oldValue, newValue ->
     if (oldValue != newValue) {
       invalidateEffects()
     }
@@ -98,7 +98,7 @@ internal class HazeNodeRenderEffect(
   }
 
   override fun onPlaced(coordinates: LayoutCoordinates) {
-    positionInRoot = coordinates.positionInRoot()
+    position = coordinates.positionInWindow() + calculateWindowOffset()
     size = coordinates.size.toSize()
   }
 
@@ -197,7 +197,7 @@ internal class HazeNodeRenderEffect(
 
     // We create a RenderNode for each of the areas we need to apply our effect to
     return state.areas.asSequence().mapNotNull { area ->
-      val bounds = area.boundsInLocal(positionInRoot) ?: return@mapNotNull null
+      val bounds = area.boundsInLocal(position) ?: return@mapNotNull null
 
       // We expand the area where our effect is applied to. This is necessary so that the blur
       // effect is applied evenly to all edges. If we don't do this, the blur effect is much less
@@ -275,5 +275,6 @@ private fun RenderEffect.applyTint(tint: Color): RenderEffect = when {
       this,
     )
   }
+
   else -> this
 }

--- a/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/Platform.kt
+++ b/haze-jetpack-compose/src/main/kotlin/dev/chrisbanes/haze/Platform.kt
@@ -4,8 +4,13 @@
 package dev.chrisbanes.haze
 
 import android.os.Build
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
+import kotlin.concurrent.getOrSet
 
 internal fun createHazeNode(
   state: HazeState,
@@ -36,3 +41,12 @@ internal fun createHazeNode(
     )
   }
 }
+
+internal fun CompositionLocalConsumerModifierNode.calculateWindowOffset(): Offset {
+  val view = currentValueOf(LocalView)
+  val loc = tmpArray.getOrSet { IntArray(2) }
+  view.getLocationOnScreen(loc)
+  return Offset(loc[0].toFloat(), loc[1].toFloat())
+}
+
+private val tmpArray = ThreadLocal<IntArray>()

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -2,14 +2,14 @@
 package dev.chrisbanes.haze {
 
   @androidx.compose.runtime.Stable public final class HazeArea {
-    ctor public HazeArea(optional long size, optional long positionInRoot, optional androidx.compose.ui.graphics.Shape shape, optional long tint);
-    method public long getPositionInRoot();
+    ctor public HazeArea(optional long size, optional long positionOnScreen, optional androidx.compose.ui.graphics.Shape shape, optional long tint);
+    method public long getPositionOnScreen();
     method public androidx.compose.ui.graphics.Shape getShape();
     method public long getSize();
     method public long getTint();
     method public boolean isValid();
     property public final boolean isValid;
-    property public final long positionInRoot;
+    property public final long positionOnScreen;
     property public final androidx.compose.ui.graphics.Shape shape;
     property public final long size;
     property public final long tint;

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeNodeBase.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeNodeBase.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
@@ -44,7 +44,7 @@ internal class HazeNodeBase(
   private var pathsDirty = true
   private var paths: List<PathHolder> = emptyList()
 
-  private var positionInRoot by observable(Offset.Unspecified) { _, oldValue, newValue ->
+  private var position by observable(Offset.Unspecified) { _, oldValue, newValue ->
     if (oldValue != newValue) {
       invalidatePaths()
     }
@@ -69,7 +69,7 @@ internal class HazeNodeBase(
   }
 
   override fun onPlaced(coordinates: LayoutCoordinates) {
-    positionInRoot = coordinates.positionInRoot()
+    position = coordinates.positionInWindow() + calculateWindowOffset()
     size = coordinates.size.toSize()
   }
 
@@ -101,7 +101,7 @@ internal class HazeNodeBase(
   ): List<PathHolder> = state.areas.asSequence()
     .filter { it.isValid }
     .mapNotNull { area ->
-      val bounds = area.boundsInLocal(positionInRoot) ?: return@mapNotNull null
+      val bounds = area.boundsInLocal(position) ?: return@mapNotNull null
 
       // TODO: Should try and re-use this
       val path = Path()

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Platform.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Platform.kt
@@ -3,8 +3,13 @@
 
 package dev.chrisbanes.haze
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.Dp
+import kotlin.concurrent.getOrSet
 
 internal actual fun createHazeNode(
   state: HazeState,
@@ -13,3 +18,12 @@ internal actual fun createHazeNode(
   blurRadius: Dp,
   noiseFactor: Float,
 ): HazeNode = HazeNodeBase(state, backgroundColor, tint, blurRadius, noiseFactor)
+
+internal actual fun CompositionLocalConsumerModifierNode.calculateWindowOffset(): Offset {
+  val view = currentValueOf(LocalView)
+  val loc = tmpArray.getOrSet { IntArray(2) }
+  view.getLocationOnScreen(loc)
+  return Offset(loc[0].toFloat(), loc[1].toFloat())
+}
+
+private val tmpArray = ThreadLocal<IntArray>()

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -46,24 +46,6 @@ class HazeState {
   }
 }
 
-internal fun HazeState.addAreasToPath(
-  path: Path,
-  positionInRoot: Offset,
-  layoutDirection: LayoutDirection,
-  density: Density,
-) {
-  if (positionInRoot.isUnspecified) return
-
-  areas.asSequence()
-    .filter { it.isValid }
-    .forEach { area ->
-      path.addOutline(
-        outline = area.shape.createOutline(area.size, layoutDirection, density),
-        offset = area.positionInRoot - positionInRoot,
-      )
-    }
-}
-
 internal fun Path.addOutline(outline: Outline, offset: Offset) = when (outline) {
   is Outline.Rectangle -> addRect(outline.rect.translate(offset))
   is Outline.Rounded -> addRoundRect(outline.roundRect.translate(offset))
@@ -73,14 +55,14 @@ internal fun Path.addOutline(outline: Outline, offset: Offset) = when (outline) 
 @Stable
 class HazeArea(
   size: Size = Size.Unspecified,
-  positionInRoot: Offset = Offset.Unspecified,
+  positionOnScreen: Offset = Offset.Unspecified,
   shape: Shape = RectangleShape,
   tint: Color = Color.Unspecified,
 ) {
   var size: Size by mutableStateOf(size)
     internal set
 
-  var positionInRoot: Offset by mutableStateOf(positionInRoot)
+  var positionOnScreen: Offset by mutableStateOf(positionOnScreen)
     internal set
 
   var shape: Shape by mutableStateOf(shape)
@@ -90,14 +72,14 @@ class HazeArea(
     internal set
 
   val isValid: Boolean
-    get() = size.isSpecified && positionInRoot.isSpecified && !size.isEmpty()
+    get() = size.isSpecified && positionOnScreen.isSpecified && !size.isEmpty()
 }
 
-internal fun HazeArea.boundsInLocal(hazePositionInRoot: Offset): Rect? {
+internal fun HazeArea.boundsInLocal(position: Offset): Rect? {
   if (!isValid) return null
-  if (hazePositionInRoot.isUnspecified) return null
+  if (position.isUnspecified) return null
 
-  return size.toRect().translate(positionInRoot - hazePositionInRoot)
+  return size.toRect().translate(positionOnScreen - position)
 }
 
 internal fun HazeArea.updatePath(

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
@@ -8,7 +8,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
@@ -57,7 +58,9 @@ private data class HazeChildNode(
   var state: HazeState,
   var shape: Shape,
   var tint: Color,
-) : Modifier.Node(), LayoutAwareModifierNode {
+) : Modifier.Node(),
+  LayoutAwareModifierNode,
+  CompositionLocalConsumerModifierNode {
 
   private val area: HazeArea by lazy {
     HazeArea(shape = shape, tint = tint)
@@ -83,8 +86,8 @@ private data class HazeChildNode(
   }
 
   override fun onPlaced(coordinates: LayoutCoordinates) {
-    // After we've been placed, update the state with our new bounds (in root coordinates)
-    area.positionInRoot = coordinates.positionInRoot()
+    // After we've been placed, update the state with our new bounds (in 'screen' coordinates)
+    area.positionOnScreen = coordinates.positionInWindow() + calculateWindowOffset()
     area.size = coordinates.size.toSize()
   }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Platform.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Platform.kt
@@ -3,7 +3,9 @@
 
 package dev.chrisbanes.haze
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.unit.Dp
 
 internal expect fun createHazeNode(
@@ -13,3 +15,5 @@ internal expect fun createHazeNode(
   blurRadius: Dp,
   noiseFactor: Float,
 ): HazeNode
+
+internal expect fun CompositionLocalConsumerModifierNode.calculateWindowOffset(): Offset

--- a/sample/android-jetpack/src/main/kotlin/dev/chrisbanes/haze/sample/android/DialogSample.kt
+++ b/sample/android-jetpack/src/main/kotlin/dev/chrisbanes/haze/sample/android/DialogSample.kt
@@ -1,0 +1,104 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample.android
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.haze
+import dev.chrisbanes.haze.hazeChild
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DialogSample(navigator: Navigator) {
+  Scaffold(
+    modifier = Modifier.fillMaxSize(),
+    topBar = {
+      TopAppBar(
+        title = { Text(text = "Haze Dialog sample") },
+        navigationIcon = {
+          IconButton(onClick = navigator::navigateUp) {
+            Icon(Icons.Default.ArrowBack, null)
+          }
+        },
+        modifier = Modifier.fillMaxWidth(),
+      )
+    },
+  ) { innerPadding ->
+    val hazeState = remember { HazeState() }
+    var showDialog by remember { mutableStateOf(false) }
+
+    if (showDialog) {
+      Dialog(onDismissRequest = { showDialog = false }) {
+        Surface(
+          modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(fraction = .5f)
+            .hazeChild(state = hazeState, shape = MaterialTheme.shapes.extraLarge),
+          shape = MaterialTheme.shapes.extraLarge,
+          // We can't use Haze tint with dialogs, as the tint will display a scrim over the
+          // background content. Instead we need to set a translucent background on the
+          // dialog content.
+          color = MaterialTheme.colorScheme.surface.copy(alpha = 0.2f),
+          contentColor = MaterialTheme.colorScheme.onSurface,
+        ) {
+          // empty
+        }
+      }
+    }
+
+    LazyVerticalGrid(
+      modifier = Modifier.haze(
+        state = hazeState,
+        backgroundColor = MaterialTheme.colorScheme.background,
+        tint = Color.Transparent,
+      ),
+      columns = GridCells.Fixed(4),
+      contentPadding = innerPadding,
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+      horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      items(40) {
+        Card(
+          modifier = Modifier.height(100.dp),
+          onClick = { showDialog = true },
+        ) {
+          Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize(),
+          ) {
+            Text(text = "Card $it")
+          }
+        }
+      }
+    }
+  }
+}

--- a/sample/android-jetpack/src/main/kotlin/dev/chrisbanes/haze/sample/android/Samples.kt
+++ b/sample/android-jetpack/src/main/kotlin/dev/chrisbanes/haze/sample/android/Samples.kt
@@ -30,6 +30,7 @@ val Samples = listOf(
   Sample("Scaffold") { ScaffoldSample(it) },
   Sample("Credit Card") { CreditCardSample(it) },
   Sample("Images List") { ImagesList(it) },
+  Sample("Dialog") { DialogSample(it) },
 )
 
 data class Sample(

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
@@ -1,0 +1,104 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.haze
+import dev.chrisbanes.haze.hazeChild
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DialogSample(navigator: Navigator) {
+  Scaffold(
+    modifier = Modifier.fillMaxSize(),
+    topBar = {
+      TopAppBar(
+        title = { Text(text = "Haze Dialog sample") },
+        navigationIcon = {
+          IconButton(onClick = navigator::navigateUp) {
+            Icon(Icons.Default.ArrowBack, null)
+          }
+        },
+        modifier = Modifier.fillMaxWidth(),
+      )
+    },
+  ) { innerPadding ->
+    val hazeState = remember { HazeState() }
+    var showDialog by remember { mutableStateOf(false) }
+
+    if (showDialog) {
+      Dialog(onDismissRequest = { showDialog = false }) {
+        Surface(
+          modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(fraction = .5f)
+            .hazeChild(state = hazeState, shape = MaterialTheme.shapes.extraLarge),
+          shape = MaterialTheme.shapes.extraLarge,
+          // We can't use Haze tint with dialogs, as the tint will display a scrim over the
+          // background content. Instead we need to set a translucent background on the
+          // dialog content.
+          color = MaterialTheme.colorScheme.surface.copy(alpha = 0.2f),
+          contentColor = MaterialTheme.colorScheme.onSurface,
+        ) {
+          // empty
+        }
+      }
+    }
+
+    LazyVerticalGrid(
+      modifier = Modifier.haze(
+        state = hazeState,
+        backgroundColor = MaterialTheme.colorScheme.background,
+        tint = Color.Transparent,
+      ),
+      columns = GridCells.Fixed(4),
+      contentPadding = innerPadding,
+      verticalArrangement = Arrangement.spacedBy(16.dp),
+      horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+      items(40) {
+        Card(
+          modifier = Modifier.height(100.dp),
+          onClick = { showDialog = true },
+        ) {
+          Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize(),
+          ) {
+            Text(text = "Card $it")
+          }
+        }
+      }
+    }
+  }
+}

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
@@ -30,6 +30,7 @@ val Samples = listOf(
   Sample("Scaffold") { ScaffoldSample(it) },
   Sample("Credit Card") { CreditCardSample(it) },
   Sample("Images List") { ImagesList(it) },
+  Sample("Dialog") { DialogSample(it) },
 )
 
 data class Sample(


### PR DESCRIPTION
This allows us to support things like Dialogs, which use a separate native window on Android. Currently we calculate everything in root composable coordinates, which does not work across window boundaries.

![Screenshot_1704819619](https://github.com/chrisbanes/haze/assets/227486/294290a2-01f5-49bd-9dcd-b09d111bfa26)

Fixes #86 