### PR TITLE
Correct default value for Noise in Usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,7 +41,7 @@ A tint effect is applied, primarily to maintain contrast and legibility. By defa
 
 ### Noise
 
-Some visual noise is applied, to provide some tactility. This is completely optional, and defaults to a value of `0.1f` (10% strength). You can disable this by providing `0f`.
+Some visual noise is applied, to provide some tactility. This is completely optional, and defaults to a value of `0.15f` (15% strength). You can disable this by providing `0f`.
 
 ## Shapes
 


### PR DESCRIPTION
Minor correction: The current documentation in the "Usage.md" file states that the default value for "noise" is 0.1f (10%). However, the exact default value for noise is 0.15f (15%)