### PR TITLE
Reset state when LazyLayout reuses node

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -66,6 +66,11 @@ class HazeArea(
 
   val isValid: Boolean
     get() = size.isSpecified && positionOnScreen.isSpecified && !size.isEmpty()
+
+  internal fun reset() {
+    positionOnScreen = Offset.Unspecified
+    size = Size.Unspecified
+  }
 }
 
 internal fun HazeArea.boundsInLocal(position: Offset): Rect? {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
@@ -105,6 +105,10 @@ private data class HazeChildNode(
     area.size = coordinates.size.toSize()
   }
 
+  override fun onReset() {
+    area.reset()
+  }
+
   override fun onDetach() {
     detachFromHazeState()
   }


### PR DESCRIPTION
We were not resetting our internal state when an node is 'reset', which is commonly what happens when a layout node is detached from a LazyLayout.

Fixes #202 