### PR TITLE
Fix glitch with clipping content out

### DIFF
--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/AndroidHazeNode.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/AndroidHazeNode.kt
@@ -282,13 +282,13 @@ private class RenderNodeImpl(private val context: Context) : AndroidHazeNode.Imp
     // Now we draw `contentNode` into the window canvas, clipping any effect areas which
     // will be drawn below
     with(drawContext.canvas) {
-      withSave {
-        for (effect in effects) {
+      for (effect in effects) {
+        withSave {
           clipShape(effect.shape, effect.contentClipBounds, ClipOp.Difference) {
             effect.getUpdatedContentClipPath(layoutDirection, drawContext.density)
           }
+          nativeCanvas.drawRenderNode(contentNode)
         }
-        nativeCanvas.drawRenderNode(contentNode)
       }
     }
 


### PR DESCRIPTION
Caused by incorrect saving/restoring of canvas operations when clipping out content. Our save was effectively useless as none of the effects are sandboxed from each other.

Fixes #201