### PR TITLE
[Android] Fix dialog being offset for non edge-to-edge windows

### DIFF
--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Platform.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Platform.kt
@@ -15,9 +15,8 @@ internal actual fun createHazeNode(
 ): HazeNode = AndroidHazeNode(state, style)
 
 internal actual fun CompositionLocalConsumerModifierNode.calculateWindowOffset(): Offset {
-  val view = currentValueOf(LocalView)
   val loc = tmpArray.getOrSet { IntArray(2) }
-  view.getLocationOnScreen(loc)
+  currentValueOf(LocalView).rootView.getLocationOnScreen(loc)
   return Offset(loc[0].toFloat(), loc[1].toFloat())
 }
 


### PR DESCRIPTION
Currently our window offset logic assumes that the host content is drawn at [0,0], which usually happens when content is drawn edge-to-edge. There are still apps which don't use that, or tools which don't (i.e. deploy previews), so we need to handle those cases too. The issue why we don't is that we currently use the host ComposeView's screen location, but that isn't quite correct in these situations, we need to use the window's decor view.

Fixes #200