### PR TITLE
Invalidate the render effect on size changes

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -226,6 +226,8 @@ internal class HazeEffect(val area: HazeArea) {
   var size: Size = Size.Unspecified
     set(value) {
       if (value != field) {
+        // We use the size for crop rects/brush sizing
+        renderEffectDirty = true
         pathDirty = true
         field = value
       }


### PR DESCRIPTION
We need to, as the RenderEffects use the size for the crop rect and brush sizing.

Fixes #277 