### PR TITLE
Fix clipping size

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Canvas.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Canvas.kt
@@ -4,6 +4,7 @@
 package dev.chrisbanes.haze
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.isFinite
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.translate
@@ -21,4 +22,10 @@ internal inline fun GraphicsContext.useGraphicsLayer(block: (GraphicsLayer) -> U
 inline fun DrawScope.translate(
   offset: Offset,
   block: DrawScope.() -> Unit,
-) = translate(offset.x, offset.y, block)
+) {
+  if (offset.isFinite && offset != Offset.Zero) {
+    translate(offset.x, offset.y, block)
+  } else {
+    block()
+  }
+}

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -155,9 +155,9 @@ private fun MaterialsCard(
   ) {
     Box(
       Modifier
-        .padding(16.dp)
         .fillMaxSize()
-        .hazeChild(state = state, style = style),
+        .hazeChild(state = state, style = style)
+        .padding(16.dp),
     ) {
       Text(name)
     }


### PR DESCRIPTION
It was broken after the recent shape clipping removal. We still need to clip to a rectangle though due to the expanded area we use for better blurring.