### PR TITLE
Add workaround for invalidations not happening on Skia backed platforms

### DIFF
--- a/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/Kotlin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/Kotlin.kt
@@ -9,13 +9,16 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
-fun Project.configureKotlin() {
+fun Project.configureKotlin(enableAllWarningsAsErrors: Boolean = false) {
   // Configure Java to use our chosen language level. Kotlin will automatically pick this up
   configureJava()
 
   tasks.withType<KotlinCompilationTask<*>>().configureEach {
     compilerOptions {
-      allWarningsAsErrors.set(true)
+      // Blocked by https://youtrack.jetbrains.com/issue/KT-69701/
+      if (enableAllWarningsAsErrors) {
+        allWarningsAsErrors.set(true)
+      }
 
       if (this is KotlinJvmCompilerOptions) {
         // Target JVM 11 bytecode

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeEffect.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeEffect.android.kt
@@ -1,0 +1,8 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual fun HazeEffectNode.observeInvalidationTick() {
+  // No need to do anything on Android
+}

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Log.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Log.android.kt
@@ -1,0 +1,12 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import android.util.Log
+
+internal actual fun log(tag: String, message: () -> String) {
+  if (LOG_ENABLED && Log.isLoggable(tag, Log.DEBUG)) {
+    Log.d(tag, message())
+  }
+}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -6,6 +6,7 @@ package dev.chrisbanes.haze
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -36,6 +37,8 @@ class HazeState {
    */
   var contentLayer: GraphicsLayer? = null
     internal set
+
+  internal var invalidateTick by mutableIntStateOf(Int.MIN_VALUE)
 }
 
 @Stable

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -55,6 +55,8 @@ internal abstract class HazeEffectNode :
 
   override val shouldAutoInvalidate: Boolean = false
 
+  internal var lastInvalidationTick = Int.MIN_VALUE
+
   open fun update() {
     onObservedReadsChanged()
   }
@@ -64,12 +66,9 @@ internal abstract class HazeEffectNode :
   }
 
   override fun onObservedReadsChanged() {
-    observeReads(::readState)
-  }
-
-  internal open fun readState() {
-    if (updateEffects()) {
-      invalidateDraw()
+    observeReads {
+      updateEffects()
+      observeInvalidationTick()
     }
   }
 
@@ -79,7 +78,7 @@ internal abstract class HazeEffectNode :
 
   override fun onGloballyPositioned(coordinates: LayoutCoordinates) = onPlaced(coordinates)
 
-  protected open fun updateEffects(): Boolean {
+  protected open fun updateEffects() {
     val currentEffectsIsEmpty = effects.isEmpty()
     val currentEffects = effects.associateByTo(mutableMapOf(), HazeEffect::area)
 
@@ -120,7 +119,9 @@ internal abstract class HazeEffectNode :
 
     // Invalidate if any of the effects triggered an invalidation, or we now have zero
     // effects but were previously showing some
-    return needInvalidate || (effects.isEmpty() != currentEffectsIsEmpty)
+    if (needInvalidate || (effects.isEmpty() != currentEffectsIsEmpty)) {
+      invalidateDraw()
+    }
   }
 
   protected fun DrawScope.drawEffectsWithGraphicsLayer(contentLayer: GraphicsLayer) {
@@ -206,6 +207,8 @@ internal expect fun HazeEffectNode.createRenderEffect(
   effect: HazeEffect,
   density: Density,
 ): RenderEffect?
+
+internal expect fun HazeEffectNode.observeInvalidationTick()
 
 internal class HazeEffect(val area: HazeArea) {
   var renderEffect: RenderEffect? = null

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -64,10 +64,12 @@ internal abstract class HazeEffectNode :
   }
 
   override fun onObservedReadsChanged() {
-    observeReads {
-      if (updateEffects()) {
-        invalidateDraw()
-      }
+    observeReads(::readState)
+  }
+
+  internal open fun readState() {
+    if (updateEffects()) {
+      invalidateDraw()
     }
   }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Log.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Log.kt
@@ -1,0 +1,8 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal const val LOG_ENABLED = false
+
+internal expect fun log(tag: String, message: () -> String)

--- a/haze/src/iosMain/kotlin/dev/chrisbanes/haze/Log.ios.kt
+++ b/haze/src/iosMain/kotlin/dev/chrisbanes/haze/Log.ios.kt
@@ -1,0 +1,12 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import platform.Foundation.NSLog
+
+internal actual fun log(tag: String, message: () -> String) {
+  if (LOG_ENABLED) {
+    NSLog("[%s] %s", tag, message())
+  }
+}

--- a/haze/src/jsMain/kotlin/dev/chrisbanes/haze/Log.js.kt
+++ b/haze/src/jsMain/kotlin/dev/chrisbanes/haze/Log.js.kt
@@ -1,0 +1,10 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual fun log(tag: String, message: () -> String) {
+  if (LOG_ENABLED) {
+    println("[$tag] ${message()}")
+  }
+}

--- a/haze/src/jvmMain/kotlin/dev/chrisbanes/haze/Log.jvm.kt
+++ b/haze/src/jvmMain/kotlin/dev/chrisbanes/haze/Log.jvm.kt
@@ -1,0 +1,10 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual fun log(tag: String, message: () -> String) {
+  if (LOG_ENABLED) {
+    println("[$tag] ${message()}")
+  }
+}

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeEffect.skiko.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeEffect.skiko.kt
@@ -1,0 +1,23 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.ui.node.invalidateDraw
+
+internal actual fun HazeEffectNode.observeInvalidationTick() {
+  // Yes, this is very very gross. The HazeNode will update the contentLayer in it's draw
+  // function. HazeNode and also updates `state.invalidateTick` as a way for HazeChild[ren] to
+  // know when the contentLayer has been updated. All fine so far, but for us to draw with the
+  // updated `contentLayer` we need to invalidate. Invalidating ourselves will trigger us to
+  // draw, but it will also trigger `contentLayer` to invalidate, and here's an infinite
+  // draw loop we trigger.
+  //
+  // This is a huge giant hack, but by skipping every other invalidation caused by a
+  // `invalidationTick` change, we break the loop.
+  val tick = state.invalidateTick
+  if (tick != lastInvalidationTick && tick % 2 == 0) {
+    invalidateDraw()
+  }
+  lastInvalidationTick = tick
+}

--- a/haze/src/wasmJsMain/kotlin/dev/chrisbanes/haze/Log.wasmJs.kt
+++ b/haze/src/wasmJsMain/kotlin/dev/chrisbanes/haze/Log.wasmJs.kt
@@ -1,0 +1,10 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual fun log(tag: String, message: () -> String) {
+  if (LOG_ENABLED) {
+    println("[$tag] ${message()}")
+  }
+}


### PR DESCRIPTION
We need to re-draw children (`Modifier.hazeChild`) when the background content `Modifier.haze`) has updated the `contentLayer`. 

That works automatically on Android, as it uses `RenderNodes` which automatically repaint when an upstream `RenderNode` is updated. The Skia backed platforms do not do this though, so we can't rely on this behavior.

This PR adds in a state backed `invalidationTick`, allowing the `hazeChild` on Skia-backed platforms to know when the content layer has been updated. Why don't we just the `contentLayer` in a state I hear you ask? GraphicsLayers aren't state. They don't implmenent equality, so every draw will trigger readers that the value has changed. This means that we can easily get into invalidation loops:

1. Parent draws, creates a new GraphicsLayer and updates state.
2. Children are notified that the GL has changed. They trigger a draw invalidation.
3. Parent is drawn, creates a new GraphicsLayer and updates state.
4. Repeat.

The invalidationTick added here would act exactly the same, but because it's an `Int` we can use it to know when NOT to invalidate in step 2. This is the very giant hack in this MR: we only invalidate every other invalidation tick change.