### PR TITLE
Add Brush suppport for tints

### DIFF
--- a/haze-materials/api/api.txt
+++ b/haze-materials/api/api.txt
@@ -1,6 +1,14 @@
 // Signature format: 4.0
 package dev.chrisbanes.haze.materials {
 
+  public final class CupertinoMaterials {
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.HazeStyle regular(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.HazeStyle thick(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.HazeStyle thin(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.HazeStyle ultraThin(optional long containerColor);
+    field public static final dev.chrisbanes.haze.materials.CupertinoMaterials INSTANCE;
+  }
+
   @kotlin.RequiresOptIn(message="Experimental Haze Materials API", level=kotlin.RequiresOptIn.Level.WARNING) public @interface ExperimentalHazeMaterialsApi {
   }
 

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/materials/CupertinoMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/materials/CupertinoMaterials.kt
@@ -1,0 +1,117 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.materials
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
+
+/**
+ * A class which contains functions to build [HazeStyle]s which implement 'material' styles similar
+ * to those available on Apple platforms. The values used are taken from the
+ * [iOS 18 Figma](https://www.figma.com/community/file/1385659531316001292) file published by
+ * Apple.
+ *
+ * The primary use case for using these is for when aiming for consistency with native UI
+ * (i.e. for when mixing Compose Multiplatform content alongside SwiftUI content).
+ */
+object CupertinoMaterials {
+
+  /**
+   * A [HazeStyle] which implements a mostly translucent material.
+   */
+  @ExperimentalHazeMaterialsApi
+  @Composable
+  @ReadOnlyComposable
+  fun ultraThin(
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+  ): HazeStyle = hazeMaterial(
+    containerColor = containerColor,
+    lightBackgroundColor = Color(0xFF0D0D0D),
+    lightForegroundColor = Color(color = 0xBFBFBF, alpha = 0.44f),
+    darkBackgroundColor = Color(0xFF9C9C9C),
+    darkForegroundColor = Color(color = 0x252525, alpha = 0.55f),
+  )
+
+  /**
+   * A [HazeStyle] which implements a translucent material. More opaque than [ultraThin],
+   * more translucent than [regular].
+   */
+  @ExperimentalHazeMaterialsApi
+  @Composable
+  @ReadOnlyComposable
+  fun thin(
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+  ): HazeStyle = hazeMaterial(
+    containerColor = containerColor,
+    lightBackgroundColor = Color(0xFF333333),
+    lightForegroundColor = Color(color = 0xA6A6A6, alpha = 0.7f),
+    darkBackgroundColor = Color(0xFF9C9C9C),
+    darkForegroundColor = Color(color = 0x252525, alpha = 0.7f),
+  )
+
+  /**
+   * A [HazeStyle] which implements a somewhat opaque material. More opaque than [thin],
+   * more translucent than [thick].
+   */
+  @ExperimentalHazeMaterialsApi
+  @Composable
+  @ReadOnlyComposable
+  fun regular(
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+  ): HazeStyle = hazeMaterial(
+    containerColor = containerColor,
+    lightBackgroundColor = Color(0xFF383838),
+    lightForegroundColor = Color(color = 0xB3B3B3, alpha = 0.82f),
+    darkBackgroundColor = Color(0xFF8C8C8C),
+    darkForegroundColor = Color(color = 0x252525, alpha = 0.82f),
+  )
+
+  /**
+   * A [HazeStyle] which implements a mostly opaque material. More opaque than [regular].
+   */
+  @ExperimentalHazeMaterialsApi
+  @Composable
+  @ReadOnlyComposable
+  fun thick(
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+  ): HazeStyle = hazeMaterial(
+    containerColor = containerColor,
+    lightBackgroundColor = Color(0xFF5C5C5C),
+    lightForegroundColor = Color(color = 0x999999, alpha = 0.97f),
+    darkBackgroundColor = Color(0xFF7C7C7C),
+    darkForegroundColor = Color(color = 0x252525, alpha = 0.9f),
+  )
+
+  @ReadOnlyComposable
+  @Composable
+  private fun hazeMaterial(
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+    isDark: Boolean = containerColor.luminance() < 0.5f,
+    lightBackgroundColor: Color,
+    lightForegroundColor: Color,
+    darkBackgroundColor: Color,
+    darkForegroundColor: Color,
+  ): HazeStyle = HazeStyle(
+    blurRadius = 24.dp,
+    backgroundColor = MaterialTheme.colorScheme.surface,
+    tints = listOf(
+      HazeTint.Color(
+        color = if (isDark) darkBackgroundColor else lightBackgroundColor,
+        blendMode = if (isDark) BlendMode.Overlay else BlendMode.ColorDodge,
+      ),
+      HazeTint.Color(color = if (isDark) darkForegroundColor else lightForegroundColor),
+    ),
+  )
+}
+
+private fun Color(color: Int, alpha: Float): Color {
+  return Color(color).copy(alpha = alpha)
+}

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/materials/HazeMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/materials/HazeMaterials.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
 
 @RequiresOptIn(
   message = "Experimental Haze Materials API",
@@ -106,8 +107,8 @@ object HazeMaterials {
   ): HazeStyle = HazeStyle(
     blurRadius = 24.dp,
     backgroundColor = containerColor,
-    tint = containerColor.copy(
-      alpha = if (containerColor.luminance() >= 0.5) lightAlpha else darkAlpha,
+    tint = HazeTint.Color(
+      containerColor.copy(alpha = if (containerColor.luminance() >= 0.5) lightAlpha else darkAlpha),
     ),
   )
 }

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -26,7 +26,8 @@ package dev.chrisbanes.haze {
 
   public final class HazeDefaults {
     method public float getBlurRadius();
-    method public dev.chrisbanes.haze.HazeStyle style(optional long backgroundColor, optional long tint, optional float blurRadius, optional float noiseFactor);
+    method public dev.chrisbanes.haze.HazeStyle style(optional long backgroundColor, optional dev.chrisbanes.haze.HazeTint tint, optional float blurRadius, optional float noiseFactor);
+    method @Deprecated public dev.chrisbanes.haze.HazeStyle style(optional long backgroundColor, long tint, optional float blurRadius, optional float noiseFactor);
     method public long tint(long color);
     property public final float blurRadius;
     field public static final dev.chrisbanes.haze.HazeDefaults INSTANCE;
@@ -47,26 +48,55 @@ package dev.chrisbanes.haze {
   }
 
   @androidx.compose.runtime.Immutable public final class HazeStyle {
-    ctor public HazeStyle(optional long backgroundColor, optional long tint, optional float blurRadius, optional float noiseFactor);
+    ctor public HazeStyle(optional long backgroundColor, optional dev.chrisbanes.haze.HazeTint? tint, optional float blurRadius, optional float noiseFactor, optional dev.chrisbanes.haze.HazeTint? fallbackTint);
+    ctor public HazeStyle(optional long backgroundColor, optional java.util.List<? extends dev.chrisbanes.haze.HazeTint> tints, optional float blurRadius, optional float noiseFactor, optional dev.chrisbanes.haze.HazeTint? fallbackTint);
     method public long component1-0d7_KjU();
-    method public long component2-0d7_KjU();
+    method public java.util.List<dev.chrisbanes.haze.HazeTint> component2();
     method public float component3-D9Ej5fM();
     method public float component4();
-    method public dev.chrisbanes.haze.HazeStyle copy-gs-jSAA(long backgroundColor, long tint, float blurRadius, float noiseFactor);
+    method public dev.chrisbanes.haze.HazeTint? component5();
+    method public dev.chrisbanes.haze.HazeStyle copy-cq6XJ1M(long backgroundColor, java.util.List<? extends dev.chrisbanes.haze.HazeTint> tints, float blurRadius, float noiseFactor, dev.chrisbanes.haze.HazeTint? fallbackTint);
     method public long getBackgroundColor();
     method public float getBlurRadius();
+    method public dev.chrisbanes.haze.HazeTint? getFallbackTint();
     method public float getNoiseFactor();
-    method public long getTint();
+    method public java.util.List<dev.chrisbanes.haze.HazeTint> getTints();
     property public final long backgroundColor;
     property public final float blurRadius;
+    property public final dev.chrisbanes.haze.HazeTint? fallbackTint;
     property public final float noiseFactor;
-    property public final long tint;
+    property public final java.util.List<dev.chrisbanes.haze.HazeTint> tints;
     field public static final dev.chrisbanes.haze.HazeStyle.Companion Companion;
   }
 
   public static final class HazeStyle.Companion {
     method public dev.chrisbanes.haze.HazeStyle getUnspecified();
     property public final dev.chrisbanes.haze.HazeStyle Unspecified;
+  }
+
+  @androidx.compose.runtime.Stable public interface HazeTint {
+  }
+
+  public static final class HazeTint.Brush implements dev.chrisbanes.haze.HazeTint {
+    ctor public HazeTint.Brush(androidx.compose.ui.graphics.Brush brush, optional int blendMode);
+    method public androidx.compose.ui.graphics.Brush component1();
+    method public int component2-0nO6VwU();
+    method public dev.chrisbanes.haze.HazeTint.Brush copy-GB0RdKg(androidx.compose.ui.graphics.Brush brush, int blendMode);
+    method public int getBlendMode();
+    method public androidx.compose.ui.graphics.Brush getBrush();
+    property public final int blendMode;
+    property public final androidx.compose.ui.graphics.Brush brush;
+  }
+
+  public static final class HazeTint.Color implements dev.chrisbanes.haze.HazeTint {
+    ctor public HazeTint.Color(long color, optional int blendMode);
+    method public long component1-0d7_KjU();
+    method public int component2-0nO6VwU();
+    method public dev.chrisbanes.haze.HazeTint.Color copy-xETnrds(long color, int blendMode);
+    method public int getBlendMode();
+    method public long getColor();
+    property public final int blendMode;
+    property public final long color;
   }
 
 }

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -15,9 +15,11 @@ plugins {
 
 android {
   namespace = "dev.chrisbanes.haze"
+
   defaultConfig {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
+
   testOptions {
     unitTests {
       isIncludeAndroidResources = true

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/BlendMode.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/BlendMode.kt
@@ -1,0 +1,40 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import android.graphics.BlendMode as PlatformBlendMode
+import androidx.annotation.RequiresApi
+import androidx.compose.ui.graphics.BlendMode
+
+@RequiresApi(29)
+internal fun BlendMode.toAndroidBlendMode(): PlatformBlendMode = when {
+  this == BlendMode.Clear -> PlatformBlendMode.CLEAR
+  this == BlendMode.Color -> PlatformBlendMode.COLOR
+  this == BlendMode.ColorBurn -> PlatformBlendMode.COLOR_BURN
+  this == BlendMode.ColorDodge -> PlatformBlendMode.COLOR_DODGE
+  this == BlendMode.Darken -> PlatformBlendMode.DARKEN
+  this == BlendMode.Difference -> PlatformBlendMode.DIFFERENCE
+  this == BlendMode.Dst -> PlatformBlendMode.DST
+  this == BlendMode.DstAtop -> PlatformBlendMode.DST_ATOP
+  this == BlendMode.DstIn -> PlatformBlendMode.DST_IN
+  this == BlendMode.DstOut -> PlatformBlendMode.DST_OUT
+  this == BlendMode.DstOver -> PlatformBlendMode.DST_OVER
+  this == BlendMode.Exclusion -> PlatformBlendMode.EXCLUSION
+  this == BlendMode.Hardlight -> PlatformBlendMode.HARD_LIGHT
+  this == BlendMode.Hue -> PlatformBlendMode.HUE
+  this == BlendMode.Lighten -> PlatformBlendMode.LIGHTEN
+  this == BlendMode.Luminosity -> PlatformBlendMode.LUMINOSITY
+  this == BlendMode.Modulate -> PlatformBlendMode.MODULATE
+  this == BlendMode.Multiply -> PlatformBlendMode.MULTIPLY
+  this == BlendMode.Overlay -> PlatformBlendMode.OVERLAY
+  this == BlendMode.Saturation -> PlatformBlendMode.SATURATION
+  this == BlendMode.Screen -> PlatformBlendMode.SCREEN
+  this == BlendMode.Softlight -> PlatformBlendMode.SOFT_LIGHT
+  this == BlendMode.Src -> PlatformBlendMode.SRC
+  this == BlendMode.SrcAtop -> PlatformBlendMode.SRC_ATOP
+  this == BlendMode.SrcIn -> PlatformBlendMode.SRC_IN
+  this == BlendMode.SrcOut -> PlatformBlendMode.SRC_OUT
+  this == BlendMode.SrcOver -> PlatformBlendMode.SRC_OVER
+  else -> PlatformBlendMode.SRC_IN
+}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.isSpecified
@@ -22,6 +23,7 @@ import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.takeOrElse
 
 @Stable
@@ -113,6 +115,17 @@ object HazeDefaults {
     else -> color
   }
 
+  @Deprecated(
+    "Migrate to HazeTint for tint",
+    ReplaceWith("HazeStyle(backgroundColor, HazeTint.Color(tint), blurRadius, noiseFactor)"),
+  )
+  fun style(
+    backgroundColor: Color = Color.Unspecified,
+    tint: Color,
+    blurRadius: Dp = this.blurRadius,
+    noiseFactor: Float = this.noiseFactor,
+  ): HazeStyle = HazeStyle(backgroundColor, HazeTint.Color(tint), blurRadius, noiseFactor)
+
   /**
    * Default [HazeStyle] for usage with [Modifier.haze].
    *
@@ -127,15 +140,10 @@ object HazeDefaults {
    */
   fun style(
     backgroundColor: Color = Color.Unspecified,
-    tint: Color = tint(backgroundColor),
+    tint: HazeTint = HazeTint.Color(tint(backgroundColor)),
     blurRadius: Dp = this.blurRadius,
     noiseFactor: Float = this.noiseFactor,
-  ): HazeStyle = HazeStyle(
-    backgroundColor = backgroundColor,
-    tint = tint,
-    blurRadius = blurRadius,
-    noiseFactor = noiseFactor,
-  )
+  ): HazeStyle = HazeStyle(backgroundColor, tint, blurRadius, noiseFactor)
 }
 
 internal data class HazeNodeElement(
@@ -167,38 +175,82 @@ internal data class HazeNodeElement(
  * @property backgroundColor Color to draw behind the blurred content. Ideally should be opaque
  * so that the original content is not visible behind. Typically this would be
  * `MaterialTheme.colorScheme.surface` or similar.
- * @property tint Color to tint the blurred content. Should be translucent, otherwise you will not see
- * the blurred content.
+ * @property tints The [HazeTint]s to apply to the blurred content.
  * @property blurRadius Radius of the blur.
  * @property noiseFactor Amount of noise applied to the content, in the range `0f` to `1f`.
  * Anything outside of that range will be clamped.
+ * @property fallbackTint The [HazeTint] to use when Haze uses the fallback scrim functionality.
+ * In this scenario, the tints provided in [tints] are ignored.
  */
 @Immutable
 data class HazeStyle(
   val backgroundColor: Color = Color.Unspecified,
-  val tint: Color = Color.Unspecified,
+  val tints: List<HazeTint> = emptyList(),
   val blurRadius: Dp = Dp.Unspecified,
   val noiseFactor: Float = -1f,
+  val fallbackTint: HazeTint? = boostTintForFallback(tints.firstOrNull(), blurRadius),
 ) {
+  constructor(
+    backgroundColor: Color = Color.Unspecified,
+    tint: HazeTint? = null,
+    blurRadius: Dp = Dp.Unspecified,
+    noiseFactor: Float = -1f,
+    fallbackTint: HazeTint? = boostTintForFallback(tint, blurRadius),
+  ) : this(backgroundColor, listOfNotNull(tint), blurRadius, noiseFactor, fallbackTint)
+
   companion object {
-    val Unspecified: HazeStyle = HazeStyle()
+    val Unspecified: HazeStyle = HazeStyle(tints = emptyList())
   }
+}
+
+private fun boostTintForFallback(tint: HazeTint?, blurRadius: Dp): HazeTint? = when (tint) {
+  is HazeTint.Color -> {
+    // For color, we can boost the alpha
+    val boosted = tint.color.boostAlphaForBlurRadius(blurRadius.takeOrElse { HazeDefaults.blurRadius })
+    tint.copy(color = boosted)
+  }
+  // For anything else we just use as-is
+  else -> tint
+}
+
+/**
+ * In this implementation, the only tool we have is translucency.
+ */
+private fun Color.boostAlphaForBlurRadius(blurRadius: Dp): Color {
+  // We treat a blur radius of 72.dp as near 'opaque', and linearly boost using that
+  val factor = 1 + (blurRadius.value / 72)
+  return copy(alpha = (alpha * factor).coerceAtMost(1f))
+}
+
+@Stable
+interface HazeTint {
+  data class Color(
+    val color: androidx.compose.ui.graphics.Color,
+    val blendMode: BlendMode = BlendMode.SrcOver,
+  ) : HazeTint
+
+  data class Brush(
+    val brush: androidx.compose.ui.graphics.Brush,
+    val blendMode: BlendMode = BlendMode.SrcOver,
+  ) : HazeTint
 }
 
 /**
  * Resolves the style which should be used by renderers. The style returned from here
  * is guaranteed to contains specified values.
  */
-internal fun resolveStyle(default: HazeStyle, child: HazeStyle): HazeStyle {
-  return HazeStyle(
-    tint = child.tint.takeOrElse { default.tint }.takeOrElse { Color.Unspecified },
-    blurRadius = child.blurRadius.takeOrElse { default.blurRadius }.takeOrElse { 0.dp },
-    noiseFactor = child.noiseFactor.takeOrElse { default.noiseFactor }.takeOrElse { 0f },
-    backgroundColor = child.backgroundColor
-      .takeOrElse { default.backgroundColor }
-      .takeOrElse { Color.Unspecified },
-  )
-}
+internal fun resolveStyle(
+  default: HazeStyle,
+  child: HazeStyle,
+): HazeStyle = HazeStyle(
+  tints = child.tints.takeIf { it.isNotEmpty() } ?: default.tints,
+  blurRadius = child.blurRadius.takeOrElse { default.blurRadius }.takeOrElse { 0.dp },
+  noiseFactor = child.noiseFactor.takeOrElse { default.noiseFactor }.takeOrElse { 0f },
+  backgroundColor = child.backgroundColor
+    .takeOrElse { default.backgroundColor }
+    .takeOrElse { Color.Unspecified },
+  fallbackTint = child.fallbackTint ?: default.fallbackTint,
+)
 
 private inline fun Float.takeOrElse(block: () -> Float): Float =
   if (this in 0f..1f) this else block()

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -106,7 +106,8 @@ internal abstract class HazeEffectNode :
         effect.positionOnScreen = effect.area.positionOnScreen
         effect.blurRadius = resolvedStyle.blurRadius
         effect.noiseFactor = resolvedStyle.noiseFactor
-        effect.tint = resolvedStyle.tint
+        effect.tints = resolvedStyle.tints
+        effect.fallbackTint = resolvedStyle.fallbackTint
         effect.backgroundColor = resolvedStyle.backgroundColor
         effect.mask = effect.area.mask
       }
@@ -270,7 +271,15 @@ internal class HazeEffect(val area: HazeArea) {
 
   var backgroundColor: Color = Color.Unspecified
 
-  var tint: Color = Color.Unspecified
+  var tints: List<HazeTint> = emptyList()
+    set(value) {
+      if (value != field) {
+        renderEffectDirty = true
+        field = value
+      }
+    }
+
+  var fallbackTint: HazeTint? = null
     set(value) {
       if (value != field) {
         renderEffectDirty = true

--- a/haze/src/screenshotTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
+++ b/haze/src/screenshotTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
@@ -54,7 +54,9 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_childTint() = runScreenshotTest {
-    var tint by mutableStateOf(Color.Magenta.copy(alpha = 0.5f))
+    var tint by mutableStateOf(
+      HazeTint.Color(Color.Magenta.copy(alpha = 0.5f)),
+    )
 
     setContent {
       ScreenshotTheme {
@@ -65,26 +67,34 @@ class HazeScreenshotTest : ScreenshotTest() {
     waitForIdle()
     captureRoot("magenta")
 
-    tint = Color.Yellow.copy(alpha = 0.5f)
+    tint = HazeTint.Color(Color.Yellow.copy(alpha = 0.5f))
     waitForIdle()
     captureRoot("yellow")
 
-    tint = Color.Red.copy(alpha = 0.5f)
+    tint = HazeTint.Color(Color.Red.copy(alpha = 0.5f))
     waitForIdle()
     captureRoot("red")
   }
 
   @Test
-  fun creditCard_roundedCorner_topStart() = roundedCornerTest(RoundedCornerShape(topStart = 32.dp))
+  fun creditCard_roundedCorner_topStart() {
+    roundedCornerTest(RoundedCornerShape(topStart = 32.dp))
+  }
 
   @Test
-  fun creditCard_roundedCorner_topEnd() = roundedCornerTest(RoundedCornerShape(topEnd = 32.dp))
+  fun creditCard_roundedCorner_topEnd() {
+    roundedCornerTest(RoundedCornerShape(topEnd = 32.dp))
+  }
 
   @Test
-  fun creditCard_roundedCorner_bottomEnd() = roundedCornerTest(RoundedCornerShape(bottomEnd = 32.dp))
+  fun creditCard_roundedCorner_bottomEnd() {
+    roundedCornerTest(RoundedCornerShape(bottomEnd = 32.dp))
+  }
 
   @Test
-  fun creditCard_roundedCorner_bottomStart() = roundedCornerTest(RoundedCornerShape(bottomStart = 32.dp))
+  fun creditCard_roundedCorner_bottomStart() {
+    roundedCornerTest(RoundedCornerShape(bottomStart = 32.dp))
+  }
 
   @Test
   fun creditCard_conditional() = runScreenshotTest {

--- a/haze/src/screenshotTest/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
+++ b/haze/src/screenshotTest/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -26,7 +27,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 internal fun CreditCardSample(
   defaultTint: Color = Color.White.copy(alpha = 0.1f),
-  childTint: Color = Color.Unspecified,
+  childTint: HazeTint? = null,
   shape: RoundedCornerShape = RoundedCornerShape(16.dp),
   enabled: Boolean = true,
   mask: Brush? = null,
@@ -40,10 +41,11 @@ internal fun CreditCardSample(
         .fillMaxSize()
         .haze(
           state = hazeState,
-          style = HazeDefaults.style(
+          style = HazeStyle(
             backgroundColor = MaterialTheme.colorScheme.background,
-            tint = defaultTint,
+            tint = HazeTint.Color(defaultTint),
             blurRadius = 8.dp,
+            noiseFactor = HazeDefaults.noiseFactor,
           ),
         ),
     ) {
@@ -66,17 +68,17 @@ internal fun CreditCardSample(
         .fillMaxWidth(0.7f)
         .aspectRatio(16 / 9f)
         .align(Alignment.Center)
+        .clip(shape)
         .then(
-          if (enabled) {
-            @Suppress("DEPRECATION")
-            Modifier.hazeChild(
-              state = hazeState,
-              shape = shape,
-              style = HazeStyle(tint = childTint),
-              mask = mask,
-            )
-          } else {
-            Modifier
+          when {
+            enabled -> {
+              Modifier.hazeChild(
+                state = hazeState,
+                style = HazeStyle(tints = listOfNotNull(childTint), blurRadius = 8.dp),
+                mask = mask,
+              )
+            }
+            else -> Modifier
           },
         ),
     ) {

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/BlendMode.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/BlendMode.kt
@@ -1,0 +1,40 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.ui.graphics.BlendMode
+
+internal fun BlendMode.toSkiaBlendMode() = when (this) {
+  BlendMode.Clear -> org.jetbrains.skia.BlendMode.CLEAR
+  BlendMode.Src -> org.jetbrains.skia.BlendMode.SRC
+  BlendMode.Dst -> org.jetbrains.skia.BlendMode.DST
+  BlendMode.SrcOver -> org.jetbrains.skia.BlendMode.SRC_OVER
+  BlendMode.DstOver -> org.jetbrains.skia.BlendMode.DST_OVER
+  BlendMode.SrcIn -> org.jetbrains.skia.BlendMode.SRC_IN
+  BlendMode.DstIn -> org.jetbrains.skia.BlendMode.DST_IN
+  BlendMode.SrcOut -> org.jetbrains.skia.BlendMode.SRC_OUT
+  BlendMode.DstOut -> org.jetbrains.skia.BlendMode.DST_OUT
+  BlendMode.SrcAtop -> org.jetbrains.skia.BlendMode.SRC_ATOP
+  BlendMode.DstAtop -> org.jetbrains.skia.BlendMode.DST_ATOP
+  BlendMode.Xor -> org.jetbrains.skia.BlendMode.XOR
+  BlendMode.Plus -> org.jetbrains.skia.BlendMode.PLUS
+  BlendMode.Modulate -> org.jetbrains.skia.BlendMode.MODULATE
+  BlendMode.Screen -> org.jetbrains.skia.BlendMode.SCREEN
+  BlendMode.Overlay -> org.jetbrains.skia.BlendMode.OVERLAY
+  BlendMode.Darken -> org.jetbrains.skia.BlendMode.DARKEN
+  BlendMode.Lighten -> org.jetbrains.skia.BlendMode.LIGHTEN
+  BlendMode.ColorDodge -> org.jetbrains.skia.BlendMode.COLOR_DODGE
+  BlendMode.ColorBurn -> org.jetbrains.skia.BlendMode.COLOR_BURN
+  BlendMode.Hardlight -> org.jetbrains.skia.BlendMode.HARD_LIGHT
+  BlendMode.Softlight -> org.jetbrains.skia.BlendMode.SOFT_LIGHT
+  BlendMode.Difference -> org.jetbrains.skia.BlendMode.DIFFERENCE
+  BlendMode.Exclusion -> org.jetbrains.skia.BlendMode.EXCLUSION
+  BlendMode.Multiply -> org.jetbrains.skia.BlendMode.MULTIPLY
+  BlendMode.Hue -> org.jetbrains.skia.BlendMode.HUE
+  BlendMode.Saturation -> org.jetbrains.skia.BlendMode.SATURATION
+  BlendMode.Color -> org.jetbrains.skia.BlendMode.COLOR
+  BlendMode.Luminosity -> org.jetbrains.skia.BlendMode.LUMINOSITY
+  // Always fallback to default blendmode of src over
+  else -> org.jetbrains.skia.BlendMode.SRC_OVER
+}

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeDefaults
 import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.HazeStyle
+import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.haze
 import dev.chrisbanes.haze.hazeChild
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
@@ -57,10 +59,11 @@ fun CreditCardSample(navigator: Navigator) {
         .fillMaxSize()
         .haze(
           state = hazeState,
-          style = HazeDefaults.style(
+          style = HazeStyle(
             backgroundColor = Color.Blue,
-            tint = Color.White.copy(alpha = 0.1f),
+            tint = HazeTint.Color(Color.White.copy(alpha = 0.1f)),
             blurRadius = 8.dp,
+            noiseFactor = HazeDefaults.noiseFactor,
           ),
         ),
     ) {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -32,6 +32,7 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.haze
 import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.materials.CupertinoMaterials
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -50,6 +51,7 @@ fun MaterialsSample(@Suppress("UNUSED_PARAMETER") navigator: Navigator) {
     )
 
     Column(
+      verticalArrangement = Arrangement.spacedBy(24.dp),
       modifier = Modifier
         .fillMaxSize()
         .verticalScroll(rememberScrollState())
@@ -57,31 +59,61 @@ fun MaterialsSample(@Suppress("UNUSED_PARAMETER") navigator: Navigator) {
     ) {
       Spacer(Modifier.height(400.dp))
 
-      Card(modifier = Modifier.padding(bottom = 24.dp)) {
+      Card {
         Text(
-          text = "Materials - Light",
+          text = "HazeMaterials - Light",
           style = MaterialTheme.typography.titleLarge,
           modifier = Modifier.padding(16.dp),
         )
       }
 
       SamplesTheme(useDarkColors = false) {
-        MaterialsRow(
+        HazeMaterialsRow(
           hazeState = hazeState,
           modifier = Modifier.fillMaxWidth(),
         )
       }
 
-      Card(modifier = Modifier.padding(top = 48.dp, bottom = 24.dp)) {
+      Card(modifier = Modifier.padding(top = 24.dp)) {
         Text(
-          text = "Materials - Dark",
+          text = "HazeMaterials - Dark",
           style = MaterialTheme.typography.titleLarge,
           modifier = Modifier.padding(16.dp),
         )
       }
 
       SamplesTheme(useDarkColors = true) {
-        MaterialsRow(
+        HazeMaterialsRow(
+          hazeState = hazeState,
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+
+      Card(modifier = Modifier.padding(top = 24.dp)) {
+        Text(
+          text = "CupertinoMaterials - Light",
+          style = MaterialTheme.typography.titleLarge,
+          modifier = Modifier.padding(16.dp),
+        )
+      }
+
+      SamplesTheme(useDarkColors = false) {
+        CupertinoMaterialsRow(
+          hazeState = hazeState,
+          modifier = Modifier.fillMaxWidth(),
+        )
+      }
+
+      Card {
+        Text(
+          text = "CupertinoMaterials - Dark",
+          style = MaterialTheme.typography.titleLarge,
+          modifier = Modifier.padding(16.dp),
+        )
+      }
+
+      SamplesTheme(useDarkColors = true) {
+        CupertinoMaterialsRow(
           hazeState = hazeState,
           modifier = Modifier.fillMaxWidth(),
         )
@@ -94,7 +126,7 @@ fun MaterialsSample(@Suppress("UNUSED_PARAMETER") navigator: Navigator) {
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalHazeMaterialsApi::class)
 @Composable
-private fun MaterialsRow(hazeState: HazeState, modifier: Modifier = Modifier) {
+private fun HazeMaterialsRow(hazeState: HazeState, modifier: Modifier = Modifier) {
   FlowRow(
     modifier = modifier,
     horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -133,6 +165,44 @@ private fun MaterialsRow(hazeState: HazeState, modifier: Modifier = Modifier) {
       shape = MaterialTheme.shapes.large,
       state = hazeState,
       style = HazeMaterials.ultraThick(),
+    )
+  }
+}
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalHazeMaterialsApi::class)
+@Composable
+private fun CupertinoMaterialsRow(hazeState: HazeState, modifier: Modifier = Modifier) {
+  FlowRow(
+    modifier = modifier,
+    horizontalArrangement = Arrangement.spacedBy(16.dp),
+    verticalArrangement = Arrangement.spacedBy(16.dp),
+  ) {
+    MaterialsCard(
+      name = "Ultra Thin",
+      shape = MaterialTheme.shapes.large,
+      state = hazeState,
+      style = CupertinoMaterials.ultraThin(),
+    )
+
+    MaterialsCard(
+      name = "Thin",
+      shape = MaterialTheme.shapes.large,
+      state = hazeState,
+      style = CupertinoMaterials.thin(),
+    )
+
+    MaterialsCard(
+      name = "Regular",
+      shape = MaterialTheme.shapes.large,
+      state = hazeState,
+      style = CupertinoMaterials.regular(),
+    )
+
+    MaterialsCard(
+      name = "Thick",
+      shape = MaterialTheme.shapes.large,
+      state = hazeState,
+      style = CupertinoMaterials.thick(),
     )
   }
 }


### PR DESCRIPTION

- Allows multiple tint effects to be applied
- Adds `CupertinoMaterials` which are close approximations of the effects provided on Apple platforms.
- Adds `fallbackTint` parameter to `HazeStyle`. Fixes #117 