### PR TITLE
Reduce variance in benchmarks

### DIFF
--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImageItem.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImageItem.kt
@@ -28,12 +28,13 @@ import coil3.compose.AsyncImage
 @Composable
 internal fun ImageItem(
   text: String,
+  index: Int = -1,
   modifier: Modifier = Modifier,
 ) {
   Surface(modifier) {
     Box {
       AsyncImage(
-        model = rememberRandomSampleImageUrl(width = 400),
+        model = rememberRandomSampleImageUrl(index),
         contentScale = ContentScale.Crop,
         contentDescription = null,
         modifier = Modifier.fillMaxSize(),
@@ -54,20 +55,19 @@ internal fun ImageItem(
   }
 }
 
-private val rangeForRandom = (0..100000)
+val precannedImageUrls: List<String> by lazy {
+  (0 until 50).map { randomSampleImageUrl() }
+}
+
+private val rangeForRandom = (0..100_000)
 
 fun randomSampleImageUrl(
   seed: Int = rangeForRandom.random(),
-  width: Int = 300,
+  width: Int = 800,
   height: Int = width,
 ): String = "https://picsum.photos/seed/$seed/$width/$height"
 
-/**
- * Remember a URL generate by [randomSampleImageUrl].
- */
 @Composable
-fun rememberRandomSampleImageUrl(
-  seed: Int = rangeForRandom.random(),
-  width: Int = 300,
-  height: Int = width,
-): String = rememberSaveable { randomSampleImageUrl(seed, width, height) }
+fun rememberRandomSampleImageUrl(index: Int = -1): String = rememberSaveable {
+  precannedImageUrls.getOrNull(index) ?: randomSampleImageUrl()
+}

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
@@ -71,7 +71,7 @@ fun ImagesList(navigator: Navigator) {
               .height(160.dp),
           ) {
             AsyncImage(
-              model = rememberRandomSampleImageUrl(width = 800),
+              model = rememberRandomSampleImageUrl(index),
               contentScale = ContentScale.Crop,
               contentDescription = null,
               modifier = Modifier

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
@@ -57,7 +57,7 @@ fun ListOverImage(navigator: Navigator) {
 
       Box {
         AsyncImage(
-          model = rememberRandomSampleImageUrl(width = 800),
+          model = rememberRandomSampleImageUrl(0),
           contentScale = ContentScale.Crop,
           contentDescription = null,
           modifier = Modifier

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -43,7 +43,7 @@ fun MaterialsSample(@Suppress("UNUSED_PARAMETER") navigator: Navigator) {
 
   Box {
     AsyncImage(
-      model = rememberRandomSampleImageUrl(width = 720, height = 1280),
+      model = rememberRandomSampleImageUrl(),
       contentScale = ContentScale.Crop,
       contentDescription = null,
       modifier = Modifier

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
@@ -23,12 +23,16 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import coil3.SingletonImageLoader
+import coil3.compose.LocalPlatformContext
+import coil3.request.ImageRequest
 
 val Samples = listOf(
   Sample("Scaffold") { ScaffoldSample(it) },
@@ -72,6 +76,16 @@ fun Samples(
 
     val navigator = remember {
       Navigator { currentSample = null }
+    }
+
+    val coilPlatformContext = LocalPlatformContext.current
+    LaunchedEffect(coilPlatformContext) {
+      // Preload the first 20 precanned image urls
+      val imageLoader = SingletonImageLoader.get(coilPlatformContext)
+      precannedImageUrls
+        .asSequence()
+        .map { ImageRequest.Builder(coilPlatformContext).data(it).build() }
+        .forEach { imageLoader.enqueue(it) }
     }
 
     Crossfade(

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -83,9 +83,7 @@ fun ScaffoldSample(
           scrolledContainerColor = Color.Transparent,
         ),
         modifier = Modifier
-          .hazeChild(hazeState) {
-            this.style = style
-
+          .hazeChild(state = hazeState, style = style) {
             when (mode) {
               ScaffoldSampleMode.Default -> Unit
               ScaffoldSampleMode.Progressive -> {
@@ -134,6 +132,7 @@ fun ScaffoldSample(
       items(50) { index ->
         ImageItem(
           text = "${index + 1}",
+          index = index,
           modifier = Modifier
             .fillMaxWidth()
             .aspectRatio(3 / 4f),


### PR DESCRIPTION
We use the same image urls across runs, as well
as preloading images when the sample is opened.