### PR TITLE
Rename modifiers

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,9 +17,9 @@ In older versions of Haze (older than v1.0), the Android implementation was alwa
 
 The migration to [GraphicsLayer][graphicslayer] has resulted in Haze now having a single implementation across all platforms, based on the previous Android implementation. This will help minimize platform differences, and bugs.
 
-It goes further though. In v0.7.x and older, Haze is all 'smoke and mirrors'. It draws all of the blurred areas in the `haze` layout node. The `hazeChild` nodes just updates the size, shape, etc, which the `haze` modifier reads, to know where to draw blurred.
+It goes further though. In v0.7.x and older, Haze is all 'smoke and mirrors'. It draws all of the blurred areas in the `hazeBackground` layout node. The `hazeContent` nodes just updates the size, shape, etc, which the `hazeBackground` modifier reads, to know where to draw blurred.
 
-With the adoption of [GraphicsLayer][graphicslayer]s, we now have a way to pass 'drawn' content around, meaning that we are no longer bound by the previous restrictions. v1.0 contains a re-written drawing pipeline, where the blurred content is drawn by the `hazeChild`, not the parent. The parent `haze` is now only responsible for drawing the background content into a graphics layer, and putting it somewhere for the children to access.
+With the adoption of [GraphicsLayer][graphicslayer]s, we now have a way to pass 'drawn' content around, meaning that we are no longer bound by the previous restrictions. v1.0 contains a re-written drawing pipeline, where the blurred content is drawn by the `hazeContent`, not the parent. The parent `hazeBackground` is now only responsible for drawing the background content into a graphics layer, and putting it somewhere for the children to access.
 
 This fixes a number of long-known issues on Haze, where all were caused by the fact that the blurred area wasn't drawn by the child.
 
@@ -31,10 +31,10 @@ Haze works on all versions of Android, but the effect it uses differs based on t
 
 Haze utilizes RenderEffects for blurring, which technically only 'work' when running on Android 12 (SDK Level 31) or above. However, Haze by default does not enable blurring on SDK Level 31 due to [some issues](https://github.com/chrisbanes/haze/issues/77) found in testing, therefore only enables blurring on SDK Level 32 and above.
 
-You can override this by setting the `blurEnabled` property in the `hazeChild` block, like so:
+You can override this by setting the `blurEnabled` property in the `hazeContent` block, like so:
 
 ```kotlin
-Modifier.hazeChild(...) {
+Modifier.hazeContent(...) {
     // Enable blur everywhere where it is technically possible...
     blurEnabled = true
 }

--- a/docs/materials.md
+++ b/docs/materials.md
@@ -34,7 +34,7 @@ Class reference: [CupertinoMaterials](../api/haze-materials/dev.chrisbanes.haze.
 
 ### FluentMaterials
 
-These implement 'material' styles similar to those available on Windows platforms. The values used are taken from the WinUI 3 Figma file published by Microsoft. 
+These implement 'material' styles similar to those available on Windows platforms. The values used are taken from the WinUI 3 Figma file published by Microsoft.
 
 The primary use case for using these is for when aiming for consistency with native UI (i.e. for when mixing Compose Multiplatform content alongside WinUI content).
 
@@ -52,7 +52,7 @@ Box {
 
   LargeTopAppBar(
     modifier = Modifier
-      .hazeChild(
+      .hazeContent(
         ...
         style = HazeMaterials.thin(),
       ),

--- a/docs/migrating-1.0.md
+++ b/docs/migrating-1.0.md
@@ -25,7 +25,7 @@ As we're now using a common implementation on all platforms, the Skia-backed pla
 
 #### 🆕 HazeChildScope
 
-- **What:** We now have a parameter on `Modifier.hazeChild` which allow you to provide a lambda block for controlling all of Haze's styling parameters. It is similar to concept to `Modifier.graphicsLayer { ... }`. See [here](usage.md#hazechildscope) for more information.
+- **What:** We now have a parameter on `Modifier.hazeContent` which allow you to provide a lambda block for controlling all of Haze's styling parameters. It is similar to concept to `Modifier.graphicsLayer { ... }`. See [here](usage.md#hazechildscope) for more information.
 - **Why:** This has been primarily added to aid animating Haze's styling parameters, in a performant way.
 
 #### Default style functionality on Modifier.haze has been moved
@@ -52,8 +52,8 @@ This has resulted in Haze now having a single implementation across all platform
 
 ### New pipeline
 
-In v0.7 and older, Haze is all 'smoke and mirrors'. It draws all of the blurred areas in the `haze` layout node. The `hazeChild` nodes just update the size, shape, etc, which the `haze` modifier reads, to know where to draw.
+In v0.7 and older, Haze is all 'smoke and mirrors'. It draws all of the blurred areas in the `hazeBackground` layout node. The `hazeContent` nodes just update the size, shape, etc, which the `hazeBackground` modifier reads, to know where to draw.
 
-With the adoption of GraphicsLayers, we now have a way to pass 'drawn' content around, meaning that we are no longer bound by the restraints of before. v1.0 contains a re-written drawing pipeline, where the blurred content is drawn by the `hazeChild`, not the parent. The parent `haze` is now only responsible for drawing the background content into a graphics layer, and putting it somewhere for the children to access.
+With the adoption of GraphicsLayers, we now have a way to pass 'drawn' content around, meaning that we are no longer bound by the restraints of before. v1.0 contains a re-written drawing pipeline, where the blurred content is drawn by the `hazeContent`, not the parent. The parent `hazeBackground` is now only responsible for drawing the background content into a graphics layer, and putting it somewhere for the children to access.
 
 This fixes a number of long-known issues on Haze, where all were caused by the fact that the blurred area wasn't drawn by the child.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,7 +8,7 @@ You can provide an input scale value which determines how much the content is sc
 
 In terms of the performance benefit which scaling provides, it's fairly small. In our Android benchmark tests, using an `inputScale` set to `0.5` reduced the _cost of Haze_ by **5-20%**. You can read more about this below.
 
-!!! abstract "Cost of Haze" 
+!!! abstract "Cost of Haze"
     Just to call out: the percentage that I mentioned is a reduction in the cost of Haze, not the total frame duration. Haze itself introduces a cost, which you can read more about below. The reduction in total frame duration duration will be in the region of 3-5%.
 
 ## Benchmarks
@@ -21,8 +21,8 @@ We currently have 4 benchmark scenarios, each of them is one of the samples in t
 
 - **Scaffold**. The simple example, where the app bar and bottom navigation bar are blurred, with a scrollable list. This example uses rectangular haze areas.
 - **Scaffold, with progressive**. Same as Scaffold, but using a progressive blur.
-- **Images List**. Each item in the list has it's own `haze` and `hazeChild`. As each item has it's own `haze`, the internal haze state does not change all that much (the list item content moves, but the `hazeChild` doesn't in terms of local coordinates). This is more about multiple testing `RenderNode`s. This example uses rounded rectangle haze areas (i.e. we use `clipPath`).
-- **Credit Card**. A simple example, where the user can drag the `hazeChild`. This tests how fast Haze's internal state invalidates and propogates to the `RenderNode`s. This example uses rounded rectangle haze areas like 'Images List'.
+- **Images List**. Each item in the list has it's own `hazeBackground` and `hazeContent`. As each item has it's own `hazeBackground`, the internal haze state does not change all that much (the list item content moves, but the `hazeContent` doesn't in terms of local coordinates). This is more about multiple testing `RenderNode`s. This example uses rounded rectangle haze areas (i.e. we use `clipPath`).
+- **Credit Card**. A simple example, where the user can drag the `hazeContent`. This tests how fast Haze's internal state invalidates and propogates to the `RenderNode`s. This example uses rounded rectangle haze areas like 'Images List'.
 
 !!! abstract "Test setup"
     All of the tests were ran with 16 iterations on a Pixel 6, running the latest version of Android available.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -3,8 +3,8 @@
 
 Blurring the content behind app bars is a common use case, so how can we use Haze with `Scaffold`? It's pretty much the same as above:
 
-!!! tip "Multiple hazeChilds"
-    Note: We are using multiple `hazeChild`s in this example. You can actually use an abitrary number of `hazeChild`s.
+!!! tip "Multiple hazeContents"
+    Note: We are using multiple `hazeContent`s in this example. You can actually use an abitrary number of `hazeContent`s.
 
 ``` kotlin
 val hazeState = remember { HazeState() }
@@ -15,7 +15,7 @@ Scaffold(
       // Need to make app bar transparent to see the content behind
       colors = TopAppBarDefaults.largeTopAppBarColors(Color.Transparent),
       modifier = Modifier
-        .hazeChild(state = hazeState)
+        .hazeContent(state = hazeState)
         .fillMaxWidth(),
     ) {
       /* todo */
@@ -25,7 +25,7 @@ Scaffold(
     NavigationBar(
       containerColor = Color.Transparent,
       modifier = Modifier
-        .hazeChild(state = hazeState)
+        .hazeContent(state = hazeState)
         .fillMaxWidth(),
     ) {
       /* todo */
@@ -34,7 +34,7 @@ Scaffold(
 ) {
   LazyVerticalGrid(
     modifier = Modifier
-      .haze(
+      .hazeBackground(
         state = hazeState,
         style = HazeDefaults.style(backgroundColor = MaterialTheme.colorScheme.surface),
       ),

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-Haze is implemented through two Compose Modifiers: [Modifier.haze](../api/haze/dev.chrisbanes.haze/haze.html) and [Modifier.hazeChild](../api/haze/dev.chrisbanes.haze/haze-child.html).
+Haze is implemented through two Compose Modifiers: [Modifier.hazeBackground](../api/haze/dev.chrisbanes.haze/haze-background.html) and [Modifier.hazeContent](../api/haze/dev.chrisbanes.haze/haze-content.html).
 
 The most basic usage would be something like:
 
@@ -10,7 +10,7 @@ Box {
     modifier = Modifier
       .fillMaxSize()
       // Pass it the HazeState we stored above
-      .haze(state = hazeState)
+      .hazeBackground(state = hazeState)
   ) {
     // todo
   }
@@ -19,9 +19,9 @@ Box {
     // Need to make app bar transparent to see the content behind
     colors = TopAppBarDefaults.largeTopAppBarColors(Color.Transparent),
     modifier = Modifier
-      // We use hazeChild on anything where we want the background
+      // We use hazeContent on anything where we want the background
       // blurred.
-      .hazeChild(state = hazeState)
+      .hazeContent(state = hazeState)
       .fillMaxWidth(),
   )
 }
@@ -29,17 +29,17 @@ Box {
 
 ## Styling
 
-Haze has support for customizing the resulting effect, which is performed via the [HazeStyle](../api/haze/dev.chrisbanes.haze/-haze-style/) class, or the lambda block provided to `hazeChild`.
+Haze has support for customizing the resulting effect, which is performed via the [HazeStyle](../api/haze/dev.chrisbanes.haze/-haze-style/) class, or the lambda block provided to `hazeContent`.
 
 Styles can be provided in a number of different ways:
 
 - [LocalHazeStyle](../api/haze/dev.chrisbanes.haze/-local-haze-style.html) composition local.
-- The style parameter on [Modifier.hazeChild](../api/haze/dev.chrisbanes.haze/haze-child.html).
-- By setting the relevant property in the optional [HazeChildScope](../api/haze/dev.chrisbanes.haze/-haze-child-scope/index.html) lambda `block`, passed into [Modifier.hazeChild](../api/haze/dev.chrisbanes.haze/haze-child.html).
+- The style parameter on [Modifier.hazeContent](../api/haze/dev.chrisbanes.haze/haze-content.html).
+- By setting the relevant property in the optional [HazeChildScope](../api/haze/dev.chrisbanes.haze/-haze-child-scope/index.html) lambda `block`, passed into [Modifier.hazeContent](../api/haze/dev.chrisbanes.haze/haze-content.html).
 
 ### HazeChildScope
 
-We now have a parameter on `Modifier.hazeChild` which allow you to provide a lambda block, for controlling all of Haze's styling parameters. It is similar to concept to `Modifier.graphicsLayer { ... }`.
+We now have a parameter on `Modifier.hazeContent` which allow you to provide a lambda block, for controlling all of Haze's styling parameters. It is similar to concept to `Modifier.graphicsLayer { ... }`.
 
 It's useful for when you need to update styling parameters, using values derived from other state. Here's an example which fades the effect as the user scrolls:
 
@@ -47,7 +47,7 @@ It's useful for when you need to update styling parameters, using values derived
 FooAppBar(
   ...
   modifier = Modifier
-    .hazeChild(state = hazeState) {
+    .hazeContent(state = hazeState) {
       alpha = if (listState.firstVisibleItemIndex == 0) {
         listState.layoutInfo.visibleItemsInfo.first().let {
           (it.offset / it.size.height.toFloat()).absoluteValue
@@ -66,7 +66,7 @@ As we a few different ways to set styling properties, it's important to know how
 Each styling property (such as `blurRadius`) is resolved seperately, and the order of precedence for each property is as follows, in order:
 
 - Value set in [HazeChildScope](../api/haze/dev.chrisbanes.haze/-haze-child-scope/index.html), if specified.
-- Value set in style provided to hazeChild (or HazeChildScope.style), if specified.
+- Value set in style provided to hazeContent (or HazeChildScope.style), if specified.
 - Value set in the [LocalHazeStyle](../api/haze/dev.chrisbanes.haze/-local-haze-style.html) composition local.
 
 ### Styling properties
@@ -94,7 +94,7 @@ Progressive blurs can be enabled by setting the `progressive` property on [HazeC
 ```kotlin
 LargeTopAppBar(
   // ...
-  modifier = Modifier.hazeChild(hazeState) {
+  modifier = Modifier.hazeContent(hazeState) {
     progressive = HazeProgressive.verticalGradient(startIntensity = 1f, endIntensity = 0f)
   }
 )
@@ -113,7 +113,7 @@ You can provide any `Brush`, which will be used as a mask when the final effect 
 ```kotlin
 LargeTopAppBar(
   // ...
-  modifier = Modifier.hazeChild(hazeState) {
+  modifier = Modifier.hazeContent(hazeState) {
     mask = Brush.verticalGradient(...)
   }
 )
@@ -132,7 +132,7 @@ You can provide an input scale value which determines how much the content is sc
 ```kotlin
 LargeTopAppBar(
   // ...
-  modifier = Modifier.hazeChild(hazeState) {
+  modifier = Modifier.hazeContent(hazeState) {
     inputScale = HazeInputScale.Auto
   }
 )

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -4,13 +4,61 @@ package dev.chrisbanes.haze {
   @kotlin.RequiresOptIn(message="Experimental Haze API", level=kotlin.RequiresOptIn.Level.WARNING) public @interface ExperimentalHazeApi {
   }
 
-  public final class HazeChildKt {
-    method @Deprecated public static androidx.compose.ui.Modifier hazeChild(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, androidx.compose.ui.graphics.Shape shape, dev.chrisbanes.haze.HazeStyle style);
-    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeChild(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>? block);
+  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeBackgroundNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode {
+    ctor public HazeBackgroundNode(dev.chrisbanes.haze.HazeState state);
+    method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
+    method public dev.chrisbanes.haze.HazeState getState();
+    method public void onGloballyPositioned(androidx.compose.ui.layout.LayoutCoordinates coordinates);
+    method public void setState(dev.chrisbanes.haze.HazeState);
+    property public boolean shouldAutoInvalidate;
+    property public final dev.chrisbanes.haze.HazeState state;
+    field public static final String TAG = "HazeBackgroundNode";
   }
 
-  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeChildNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode dev.chrisbanes.haze.HazeChildScope androidx.compose.ui.node.ObserverModifierNode {
-    ctor public HazeChildNode(dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>? block);
+  public final class HazeChildKt {
+    method @Deprecated public static androidx.compose.ui.Modifier hazeChild(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, androidx.compose.ui.graphics.Shape shape, dev.chrisbanes.haze.HazeStyle style);
+    method @Deprecated public static androidx.compose.ui.Modifier hazeChild(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>? block);
+    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeContent(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>? block);
+  }
+
+  public interface HazeChildScope {
+    method public float getAlpha();
+    method public long getBackgroundColor();
+    method public boolean getBlurEnabled();
+    method public float getBlurRadius();
+    method public dev.chrisbanes.haze.HazeTint getFallbackTint();
+    method public dev.chrisbanes.haze.HazeInputScale getInputScale();
+    method public androidx.compose.ui.graphics.Brush? getMask();
+    method public float getNoiseFactor();
+    method public dev.chrisbanes.haze.HazeProgressive? getProgressive();
+    method public dev.chrisbanes.haze.HazeStyle getStyle();
+    method public java.util.List<dev.chrisbanes.haze.HazeTint> getTints();
+    method public void setAlpha(float);
+    method public void setBackgroundColor(long);
+    method public void setBlurEnabled(boolean);
+    method public void setBlurRadius(float);
+    method public void setFallbackTint(dev.chrisbanes.haze.HazeTint);
+    method public void setInputScale(dev.chrisbanes.haze.HazeInputScale);
+    method public void setMask(androidx.compose.ui.graphics.Brush?);
+    method public void setNoiseFactor(float);
+    method public void setProgressive(dev.chrisbanes.haze.HazeProgressive?);
+    method public void setStyle(dev.chrisbanes.haze.HazeStyle);
+    method public void setTints(java.util.List<dev.chrisbanes.haze.HazeTint>);
+    property public abstract float alpha;
+    property public abstract long backgroundColor;
+    property public abstract boolean blurEnabled;
+    property public abstract float blurRadius;
+    property public abstract dev.chrisbanes.haze.HazeTint fallbackTint;
+    property public abstract dev.chrisbanes.haze.HazeInputScale inputScale;
+    property public abstract androidx.compose.ui.graphics.Brush? mask;
+    property public abstract float noiseFactor;
+    property public abstract dev.chrisbanes.haze.HazeProgressive? progressive;
+    property public abstract dev.chrisbanes.haze.HazeStyle style;
+    property public abstract java.util.List<dev.chrisbanes.haze.HazeTint> tints;
+  }
+
+  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeContentNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode dev.chrisbanes.haze.HazeChildScope androidx.compose.ui.node.ObserverModifierNode {
+    ctor public HazeContentNode(dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>? block);
     method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
     method public float getAlpha();
     method public long getBackgroundColor();
@@ -54,50 +102,13 @@ package dev.chrisbanes.haze {
     property public final dev.chrisbanes.haze.HazeState state;
     property public dev.chrisbanes.haze.HazeStyle style;
     property public java.util.List<dev.chrisbanes.haze.HazeTint> tints;
-    field public static final String TAG = "HazeChild";
-  }
-
-  public interface HazeChildScope {
-    method public float getAlpha();
-    method public long getBackgroundColor();
-    method public boolean getBlurEnabled();
-    method public float getBlurRadius();
-    method public dev.chrisbanes.haze.HazeTint getFallbackTint();
-    method public dev.chrisbanes.haze.HazeInputScale getInputScale();
-    method public androidx.compose.ui.graphics.Brush? getMask();
-    method public float getNoiseFactor();
-    method public dev.chrisbanes.haze.HazeProgressive? getProgressive();
-    method public dev.chrisbanes.haze.HazeStyle getStyle();
-    method public java.util.List<dev.chrisbanes.haze.HazeTint> getTints();
-    method public void setAlpha(float);
-    method public void setBackgroundColor(long);
-    method public void setBlurEnabled(boolean);
-    method public void setBlurRadius(float);
-    method public void setFallbackTint(dev.chrisbanes.haze.HazeTint);
-    method public void setInputScale(dev.chrisbanes.haze.HazeInputScale);
-    method public void setMask(androidx.compose.ui.graphics.Brush?);
-    method public void setNoiseFactor(float);
-    method public void setProgressive(dev.chrisbanes.haze.HazeProgressive?);
-    method public void setStyle(dev.chrisbanes.haze.HazeStyle);
-    method public void setTints(java.util.List<dev.chrisbanes.haze.HazeTint>);
-    property public abstract float alpha;
-    property public abstract long backgroundColor;
-    property public abstract boolean blurEnabled;
-    property public abstract float blurRadius;
-    property public abstract dev.chrisbanes.haze.HazeTint fallbackTint;
-    property public abstract dev.chrisbanes.haze.HazeInputScale inputScale;
-    property public abstract androidx.compose.ui.graphics.Brush? mask;
-    property public abstract float noiseFactor;
-    property public abstract dev.chrisbanes.haze.HazeProgressive? progressive;
-    property public abstract dev.chrisbanes.haze.HazeStyle style;
-    property public abstract java.util.List<dev.chrisbanes.haze.HazeTint> tints;
+    field public static final String TAG = "HazeContent";
   }
 
   public final class HazeDefaults {
     method public boolean blurEnabled();
     method public float getBlurRadius();
     method public dev.chrisbanes.haze.HazeStyle style(long backgroundColor, optional dev.chrisbanes.haze.HazeTint tint, optional float blurRadius, optional float noiseFactor);
-    method @Deprecated public dev.chrisbanes.haze.HazeStyle style(optional long backgroundColor, long tint, optional float blurRadius, optional float noiseFactor);
     method public dev.chrisbanes.haze.HazeTint tint(long color);
     property public final float blurRadius;
     field public static final dev.chrisbanes.haze.HazeDefaults INSTANCE;
@@ -129,18 +140,8 @@ package dev.chrisbanes.haze {
   }
 
   public final class HazeKt {
-    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier haze(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state);
-  }
-
-  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode {
-    ctor public HazeNode(dev.chrisbanes.haze.HazeState state);
-    method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
-    method public dev.chrisbanes.haze.HazeState getState();
-    method public void onGloballyPositioned(androidx.compose.ui.layout.LayoutCoordinates coordinates);
-    method public void setState(dev.chrisbanes.haze.HazeState);
-    property public boolean shouldAutoInvalidate;
-    property public final dev.chrisbanes.haze.HazeState state;
-    field public static final String TAG = "HazeNode";
+    method @Deprecated public static androidx.compose.ui.Modifier haze(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state);
+    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeBackground(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state);
   }
 
   public sealed interface HazeProgressive {

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeContentNode.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeContentNode.android.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.LocalGraphicsContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.takeOrElse
-import dev.chrisbanes.haze.HazeChildNode.Companion.TAG
+import dev.chrisbanes.haze.HazeContentNode.Companion.TAG
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
@@ -22,7 +22,7 @@ import kotlin.math.min
 private const val USE_RUNTIME_SHADER = true
 
 @RequiresApi(31)
-internal actual fun HazeChildNode.drawLinearGradientProgressiveEffect(
+internal actual fun HazeContentNode.drawLinearGradientProgressiveEffect(
   drawScope: DrawScope,
   progressive: HazeProgressive.LinearGradient,
   contentLayer: GraphicsLayer,
@@ -53,7 +53,7 @@ internal actual fun HazeChildNode.drawLinearGradientProgressiveEffect(
   }
 }
 
-private fun HazeChildNode.drawLinearGradientProgressiveEffectUsingLayers(
+private fun HazeContentNode.drawLinearGradientProgressiveEffectUsingLayers(
   drawScope: DrawScope,
   progressive: HazeProgressive.LinearGradient,
   contentLayer: GraphicsLayer,

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -35,6 +35,12 @@ class HazeState {
   internal var contentDrawing = false
 }
 
+@Deprecated(
+  message = "Modifier.haze() has been renamed to Modifier.hazeBackground()",
+  replaceWith = ReplaceWith("Modifier.hazeBackground(state)", "dev.chrisbanes.haze.hazeBackground"),
+)
+fun Modifier.haze(state: HazeState): Modifier = hazeBackground(state)
+
 /**
  * Draw background content for [hazeChild] child nodes, which will be drawn with a blur
  * in a 'glassmorphism' style.
@@ -44,7 +50,7 @@ class HazeState {
  * instead.
  */
 @Stable
-fun Modifier.haze(state: HazeState): Modifier = this then HazeNodeElement(state)
+fun Modifier.hazeBackground(state: HazeState): Modifier = this then HazeBackgroundNodeElement(state)
 
 /**
  * Default values for the [haze] modifiers.
@@ -73,17 +79,6 @@ object HazeDefaults {
     color.isSpecified -> color.copy(alpha = color.alpha * tintAlpha)
     else -> color
   }.let(::HazeTint)
-
-  @Deprecated(
-    "Migrate to HazeTint for tint",
-    ReplaceWith("HazeStyle(backgroundColor, HazeTint(tint), blurRadius, noiseFactor)"),
-  )
-  fun style(
-    backgroundColor: Color = Color.Unspecified,
-    tint: Color,
-    blurRadius: Dp = this.blurRadius,
-    noiseFactor: Float = this.noiseFactor,
-  ): HazeStyle = HazeStyle(backgroundColor, tint(backgroundColor), blurRadius, noiseFactor)
 
   /**
    * Default [HazeStyle] for usage with [Modifier.haze].
@@ -117,17 +112,17 @@ object HazeDefaults {
   fun blurEnabled(): Boolean = isBlurEnabledByDefault()
 }
 
-internal data class HazeNodeElement(
+internal data class HazeBackgroundNodeElement(
   val state: HazeState,
-) : ModifierNodeElement<HazeNode>() {
+) : ModifierNodeElement<HazeBackgroundNode>() {
 
-  override fun create(): HazeNode = HazeNode(state)
+  override fun create(): HazeBackgroundNode = HazeBackgroundNode(state)
 
-  override fun update(node: HazeNode) {
+  override fun update(node: HazeBackgroundNode) {
     node.state = state
   }
 
   override fun InspectorInfo.inspectableProperties() {
-    name = "haze"
+    name = "hazeBackground"
   }
 }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
@@ -32,7 +32,7 @@ interface HazeChildScope {
   var alpha: Float
 
   /**
-   * Style set on this specific [HazeChildNode].
+   * Style set on this specific [HazeContentNode].
    *
    * There are precedence rules to how each styling property is applied. The order of precedence
    * for each property are as follows:
@@ -188,18 +188,6 @@ sealed interface HazeInputScale {
   }
 }
 
-/**
- * Mark this composable as being a Haze child composable.
- *
- * This will update the given [HazeState] whenever the layout is placed, enabling any layouts using
- * [Modifier.haze] to blur any content behind the host composable.
- *
- * @param shape The shape of the content. This will affect the the bounds and outline of
- * the content. Please be aware that using non-rectangular shapes has an effect on performance,
- * since we need to use path clipping.
- * @param style The [HazeStyle] to use on this content. Any specified values in the given
- * style will override that value from the default style, provided to [haze].
- */
 @Deprecated(
   message = "Shape clipping is no longer necessary with Haze. You can use `Modifier.clip` or similar.",
   replaceWith = ReplaceWith("clip(shape).hazeChild(state, style)"),
@@ -208,7 +196,17 @@ fun Modifier.hazeChild(
   state: HazeState,
   shape: Shape,
   style: HazeStyle,
-): Modifier = clip(shape).hazeChild(state, style)
+): Modifier = clip(shape).hazeContent(state, style)
+
+@Deprecated(
+  "Modifier.hazeChild() has been renamed to Modifier.hazeContent()",
+  ReplaceWith("hazeContent(state, style, block)", "dev.chrisbanes.haze.hazeContent"),
+)
+fun Modifier.hazeChild(
+  state: HazeState,
+  style: HazeStyle = HazeStyle.Unspecified,
+  block: (HazeChildScope.() -> Unit)? = null,
+): Modifier = hazeContent(state, style, block)
 
 /**
  * Mark this composable as being a Haze child composable.
@@ -218,24 +216,24 @@ fun Modifier.hazeChild(
  *
  * @param style The [HazeStyle] to use on this content. Any specified values in the given
  * style will override that value from the default style, provided to [haze].
- * @param block block on HazeChildScope where you define the styling and visual properties.
+ * @param block [HazeChildScope] where you define the styling, visual and configuration properties.
  */
 @Stable
-fun Modifier.hazeChild(
+fun Modifier.hazeContent(
   state: HazeState,
   style: HazeStyle = HazeStyle.Unspecified,
   block: (HazeChildScope.() -> Unit)? = null,
-): Modifier = this then HazeChildNodeElement(state, style, block)
+): Modifier = this then HazeContentNodeElement(state, style, block)
 
-private data class HazeChildNodeElement(
+private data class HazeContentNodeElement(
   val state: HazeState,
   val style: HazeStyle = HazeStyle.Unspecified,
   val block: (HazeChildScope.() -> Unit)? = null,
-) : ModifierNodeElement<HazeChildNode>() {
+) : ModifierNodeElement<HazeContentNode>() {
 
-  override fun create(): HazeChildNode = HazeChildNode(state, style, block)
+  override fun create(): HazeContentNode = HazeContentNode(state, style, block)
 
-  override fun update(node: HazeChildNode) {
+  override fun update(node: HazeContentNode) {
     node.state = state
     node.style = style
     node.block = block
@@ -243,6 +241,9 @@ private data class HazeChildNodeElement(
   }
 
   override fun InspectorInfo.inspectableProperties() {
-    name = "HazeChild"
+    name = "HazeContent"
+    properties["state"] = state
+    properties["style"] = style
+    properties["block"] = block
   }
 }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeContentNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeContentNode.kt
@@ -51,7 +51,7 @@ import io.github.reactivecircus.cache4k.Cache
  * to be able to change the API in the future, hence why it is marked as experimental forever.
  */
 @ExperimentalHazeApi
-class HazeChildNode(
+class HazeContentNode(
   var state: HazeState,
   style: HazeStyle = HazeStyle.Unspecified,
   var block: (HazeChildScope.() -> Unit)? = null,
@@ -405,7 +405,7 @@ class HazeChildNode(
   }
 
   internal companion object {
-    const val TAG = "HazeChild"
+    const val TAG = "HazeContent"
   }
 }
 
@@ -531,7 +531,7 @@ internal class RenderEffectParams(
 )
 
 @ExperimentalHazeApi
-internal fun HazeChildNode.calculateInputScaleFactor(
+internal fun HazeContentNode.calculateInputScaleFactor(
   blurRadius: Dp = resolveBlurRadius(),
 ): Float = when (val s = inputScale) {
   HazeInputScale.None -> 1f
@@ -548,7 +548,7 @@ internal fun HazeChildNode.calculateInputScaleFactor(
 }
 
 @OptIn(ExperimentalHazeApi::class)
-internal fun HazeChildNode.getOrCreateRenderEffect(
+internal fun HazeContentNode.getOrCreateRenderEffect(
   inputScale: Float = calculateInputScaleFactor(),
   blurRadius: Dp = resolveBlurRadius().takeOrElse { 0.dp } * inputScale,
   noiseFactor: Float = resolveNoiseFactor(),
@@ -572,52 +572,52 @@ internal fun HazeChildNode.getOrCreateRenderEffect(
 )
 
 internal fun CompositionLocalConsumerModifierNode.getOrCreateRenderEffect(params: RenderEffectParams): RenderEffect? {
-  log(HazeChildNode.TAG) { "getOrCreateRenderEffect: $params" }
+  log(HazeContentNode.TAG) { "getOrCreateRenderEffect: $params" }
   val cached = renderEffectCache.get(params)
   if (cached != null) {
-    log(HazeChildNode.TAG) { "getOrCreateRenderEffect. Returning cached: $params" }
+    log(HazeContentNode.TAG) { "getOrCreateRenderEffect. Returning cached: $params" }
     return cached
   }
 
-  log(HazeChildNode.TAG) { "getOrCreateRenderEffect. Creating: $params" }
+  log(HazeContentNode.TAG) { "getOrCreateRenderEffect. Creating: $params" }
   return createRenderEffect(params)
     ?.also { renderEffectCache.put(params, it) }
 }
 
 internal expect fun CompositionLocalConsumerModifierNode.createRenderEffect(params: RenderEffectParams): RenderEffect?
 
-internal expect fun HazeChildNode.drawLinearGradientProgressiveEffect(
+internal expect fun HazeContentNode.drawLinearGradientProgressiveEffect(
   drawScope: DrawScope,
   progressive: HazeProgressive.LinearGradient,
   contentLayer: GraphicsLayer,
 )
 
-internal fun HazeChildNode.resolveBackgroundColor(): Color {
+internal fun HazeContentNode.resolveBackgroundColor(): Color {
   return backgroundColor
     .takeOrElse { style.backgroundColor }
     .takeOrElse { compositionLocalStyle.backgroundColor }
 }
 
-internal fun HazeChildNode.resolveBlurRadius(): Dp {
+internal fun HazeContentNode.resolveBlurRadius(): Dp {
   return blurRadius
     .takeOrElse { style.blurRadius }
     .takeOrElse { compositionLocalStyle.blurRadius }
 }
 
-internal fun HazeChildNode.resolveTints(): List<HazeTint> {
+internal fun HazeContentNode.resolveTints(): List<HazeTint> {
   return tints.takeIf { it.isNotEmpty() }
     ?: style.tints.takeIf { it.isNotEmpty() }
     ?: compositionLocalStyle.tints.takeIf { it.isNotEmpty() }
     ?: emptyList()
 }
 
-internal fun HazeChildNode.resolveFallbackTint(): HazeTint {
+internal fun HazeContentNode.resolveFallbackTint(): HazeTint {
   return fallbackTint.takeIf { it.isSpecified }
     ?: style.fallbackTint.takeIf { it.isSpecified }
     ?: compositionLocalStyle.fallbackTint
 }
 
-internal fun HazeChildNode.resolveNoiseFactor(): Float {
+internal fun HazeContentNode.resolveNoiseFactor(): Float {
   return noiseFactor
     .takeOrElse { style.noiseFactor }
     .takeOrElse { compositionLocalStyle.noiseFactor }

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeTest.kt
@@ -36,8 +36,8 @@ class HazeTest {
       runComposeUiTest {
         setContent {
           val hazeState = remember { HazeState() }
-          Box(Modifier.haze(hazeState)) {
-            Spacer(Modifier.hazeChild(hazeState, HazeDefaults.style(Color.Blue)))
+          Box(Modifier.hazeBackground(hazeState)) {
+            Spacer(Modifier.hazeContent(hazeState, HazeDefaults.style(Color.Blue)))
           }
         }
       }

--- a/haze/src/screenshotTest/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
+++ b/haze/src/screenshotTest/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
@@ -41,15 +41,18 @@ internal fun CreditCardSample(
 
   Box {
     // Background content
-    Box(
-      Modifier
-        .fillMaxSize()
-        .haze(state = hazeState),
-    ) {
+    Box(modifier = Modifier.hazeBackground(state = hazeState)) {
       Spacer(
         Modifier
           .fillMaxSize()
-          .background(brush = Brush.linearGradient(colors = listOf(Color.Blue, Color.Cyan))),
+          .background(
+            brush = Brush.linearGradient(
+              colors = listOf(
+                Color.Blue,
+                Color.Cyan,
+              ),
+            ),
+          ),
       )
 
       Text(
@@ -71,7 +74,7 @@ internal fun CreditCardSample(
         .then(
           when {
             enabled -> {
-              Modifier.hazeChild(state = hazeState) {
+              Modifier.hazeContent(state = hazeState) {
                 this.blurEnabled = blurEnabled
                 this.style = style
                 backgroundColor = surfaceColor

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeContentNode.skiko.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeContentNode.skiko.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 
-internal actual fun HazeChildNode.drawLinearGradientProgressiveEffect(
+internal actual fun HazeContentNode.drawLinearGradientProgressiveEffect(
   drawScope: DrawScope,
   progressive: HazeProgressive.LinearGradient,
   contentLayer: GraphicsLayer,

--- a/sample/android/src/main/kotlin/dev/chrisbanes/haze/sample/android/ExoPlayerSample.kt
+++ b/sample/android/src/main/kotlin/dev/chrisbanes/haze/sample/android/ExoPlayerSample.kt
@@ -22,8 +22,8 @@ import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeBackground
+import dev.chrisbanes.haze.hazeContent
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 import dev.chrisbanes.haze.sample.Navigator
@@ -64,15 +64,15 @@ fun ExoPlayerSample(navigator: Navigator) {
       },
       modifier = Modifier
         .fillMaxSize()
-        .haze(hazeState),
+        .hazeBackground(hazeState),
     )
 
     Spacer(
-      Modifier
+      modifier = Modifier
         .fillMaxSize(0.5f)
         .align(Alignment.Center)
         .clip(MaterialTheme.shapes.large)
-        .hazeChild(hazeState, HazeMaterials.ultraThin()),
+        .hazeContent(state = hazeState, style = HazeMaterials.ultraThin()),
     )
   }
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
@@ -42,8 +42,8 @@ import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.HazeDefaults
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeTint
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeBackground
+import dev.chrisbanes.haze.hazeContent
 
 @Composable
 fun CreditCardSample(navigator: Navigator) {
@@ -52,9 +52,9 @@ fun CreditCardSample(navigator: Navigator) {
   Box {
     // Background content
     Box(
-      Modifier
+      modifier = Modifier
         .fillMaxSize()
-        .haze(state = hazeState),
+        .hazeBackground(hazeState),
     ) {
       Spacer(
         Modifier
@@ -95,7 +95,7 @@ fun CreditCardSample(navigator: Navigator) {
           },
         )
         .clip(RoundedCornerShape(16.dp))
-        .hazeChild(state = hazeState) {
+        .hazeContent(state = hazeState) {
           backgroundColor = Color.Blue
           tints = listOf(HazeTint(Color.White.copy(alpha = 0.1f)))
           blurRadius = 8.dp

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeBackground
+import dev.chrisbanes.haze.hazeContent
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -72,7 +72,7 @@ fun DialogSample(navigator: Navigator) {
           contentColor = MaterialTheme.colorScheme.onSurface,
         ) {
           Box(
-            Modifier.hazeChild(state = hazeState, style = HazeMaterials.regular()),
+            Modifier.hazeContent(state = hazeState, style = HazeMaterials.regular()),
           ) {
             // empty
           }
@@ -81,7 +81,7 @@ fun DialogSample(navigator: Navigator) {
     }
 
     LazyVerticalGrid(
-      modifier = Modifier.haze(state = hazeState),
+      modifier = Modifier.hazeBackground(hazeState),
       columns = GridCells.Fixed(4),
       contentPadding = innerPadding,
       verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeBackground
+import dev.chrisbanes.haze.hazeContent
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -75,7 +75,7 @@ fun ImagesList(navigator: Navigator) {
               contentScale = ContentScale.Crop,
               contentDescription = null,
               modifier = Modifier
-                .haze(state = hazeState)
+                .hazeBackground(hazeState)
                 .fillMaxSize(),
             )
 
@@ -84,7 +84,7 @@ fun ImagesList(navigator: Navigator) {
                 .fillMaxSize(0.8f)
                 .align(Alignment.Center)
                 .clip(RoundedCornerShape(4.dp))
-                .hazeChild(state = hazeState, style = HazeMaterials.thin()),
+                .hazeContent(state = hazeState, style = HazeMaterials.thin()),
             ) {
               Text(
                 "Image $index",

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeBackground
+import dev.chrisbanes.haze.hazeContent
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -61,7 +61,7 @@ fun ListOverImage(navigator: Navigator) {
           contentScale = ContentScale.Crop,
           contentDescription = null,
           modifier = Modifier
-            .haze(state = hazeState)
+            .hazeBackground(hazeState)
             .fillMaxSize(),
         )
 
@@ -87,7 +87,7 @@ fun ListOverImage(navigator: Navigator) {
                   .fillMaxSize(0.8f)
                   .align(Alignment.Center)
                   .clip(RoundedCornerShape(4.dp))
-                  .hazeChild(state = hazeState, style = HazeMaterials.thin()),
+                  .hazeContent(state = hazeState, style = HazeMaterials.thin()),
               ) {
                 Text(
                   "Item $index",

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeBackground
+import dev.chrisbanes.haze.hazeContent
 import dev.chrisbanes.haze.materials.CupertinoMaterials
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.FluentMaterials
@@ -47,7 +47,7 @@ fun MaterialsSample(@Suppress("UNUSED_PARAMETER") navigator: Navigator) {
       contentScale = ContentScale.Crop,
       contentDescription = null,
       modifier = Modifier
-        .haze(state = hazeState)
+        .hazeBackground(hazeState)
         .fillMaxSize(),
     )
 
@@ -316,7 +316,7 @@ private fun MaterialsCard(
     Box(
       Modifier
         .fillMaxSize()
-        .hazeChild(state = state, style = style)
+        .hazeContent(state = state, style = style)
         .padding(16.dp),
     ) {
       Text(name)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -43,8 +43,8 @@ import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeBackground
+import dev.chrisbanes.haze.hazeContent
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -90,7 +90,7 @@ fun ScaffoldSample(
           scrolledContainerColor = Color.Transparent,
         ),
         modifier = Modifier
-          .hazeChild(state = hazeState, style = style) {
+          .hazeContent(state = hazeState, style = style) {
             this.inputScale = inputScale
 
             when (mode) {
@@ -101,6 +101,7 @@ fun ScaffoldSample(
                   endIntensity = 0f,
                 )
               }
+
               ScaffoldSampleMode.Mask -> {
                 mask = Brush.easedVerticalGradient(EaseIn)
               }
@@ -120,7 +121,7 @@ fun ScaffoldSample(
           selectedIndex = selectedIndex,
           onItemClicked = { selectedIndex = it },
           modifier = Modifier
-            .hazeChild(state = hazeState, style = style) {
+            .hazeContent(state = hazeState, style = style) {
               this.inputScale = inputScale
             }
             .fillMaxWidth(),
@@ -138,7 +139,7 @@ fun ScaffoldSample(
       modifier = Modifier
         .fillMaxSize()
         .testTag("lazy_grid")
-        .haze(state = hazeState),
+        .hazeBackground(hazeState),
     ) {
       items(50) { index ->
         ImageItem(


### PR DESCRIPTION
`haze` and `hazeChild` do not make sense in the new world, and can confuse developers. This MR renames the modifiers to be clearer from the name:

- `Modifier.haze` -> `Modifier.hazeBackground`
- `Modifier.hazeChild` -> `Modifier.hazeContent` (ideally this would be `Modifier.haze` but that is a compatibility nightmare)
