### PR TITLE
Rename modifiers for clarity

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -17,9 +17,9 @@ In older versions of Haze (older than v1.0), the Android implementation was alwa
 
 The migration to [GraphicsLayer][graphicslayer] has resulted in Haze now having a single implementation across all platforms, based on the previous Android implementation. This will help minimize platform differences, and bugs.
 
-It goes further though. In v0.7.x and older, Haze is all 'smoke and mirrors'. It draws all of the blurred areas in the `haze` layout node. The `hazeChild` nodes just updates the size, shape, etc, which the `haze` modifier reads, to know where to draw blurred.
+It goes further though. In v0.7.x and older, Haze is all 'smoke and mirrors'. It draws all of the blurred areas in the `hazeSource` layout node. The `hazeEffect` nodes just updates the size, shape, etc, which the `hazeSource` modifier reads, to know where to draw blurred.
 
-With the adoption of [GraphicsLayer][graphicslayer]s, we now have a way to pass 'drawn' content around, meaning that we are no longer bound by the previous restrictions. v1.0 contains a re-written drawing pipeline, where the blurred content is drawn by the `hazeChild`, not the parent. The parent `haze` is now only responsible for drawing the background content into a graphics layer, and putting it somewhere for the children to access.
+With the adoption of [GraphicsLayer][graphicslayer]s, we now have a way to pass 'drawn' content around, meaning that we are no longer bound by the previous restrictions. v1.0 contains a re-written drawing pipeline, where the blurred content is drawn by the `hazeEffect`, not the parent. The parent `hazeSource` is now only responsible for drawing the background content into a graphics layer, and putting it somewhere for the children to access.
 
 This fixes a number of long-known issues on Haze, where all were caused by the fact that the blurred area wasn't drawn by the child.
 
@@ -31,10 +31,10 @@ Haze works on all versions of Android, but the effect it uses differs based on t
 
 Haze utilizes RenderEffects for blurring, which technically only 'work' when running on Android 12 (SDK Level 31) or above. However, Haze by default does not enable blurring on SDK Level 31 due to [some issues](https://github.com/chrisbanes/haze/issues/77) found in testing, therefore only enables blurring on SDK Level 32 and above.
 
-You can override this by setting the `blurEnabled` property in the `hazeChild` block, like so:
+You can override this by setting the `blurEnabled` property in the `hazeEffect` block, like so:
 
 ```kotlin
-Modifier.hazeChild(...) {
+Modifier.hazeEffect(...) {
     // Enable blur everywhere where it is technically possible...
     blurEnabled = true
 }

--- a/docs/materials.md
+++ b/docs/materials.md
@@ -34,7 +34,7 @@ Class reference: [CupertinoMaterials](../api/haze-materials/dev.chrisbanes.haze.
 
 ### FluentMaterials
 
-These implement 'material' styles similar to those available on Windows platforms. The values used are taken from the WinUI 3 Figma file published by Microsoft. 
+These implement 'material' styles similar to those available on Windows platforms. The values used are taken from the WinUI 3 Figma file published by Microsoft.
 
 The primary use case for using these is for when aiming for consistency with native UI (i.e. for when mixing Compose Multiplatform content alongside WinUI content).
 
@@ -52,7 +52,7 @@ Box {
 
   LargeTopAppBar(
     modifier = Modifier
-      .hazeChild(
+      .hazeEffect(
         ...
         style = HazeMaterials.thin(),
       ),

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,7 +8,7 @@ You can provide an input scale value which determines how much the content is sc
 
 In terms of the performance benefit which scaling provides, it's fairly small. In our Android benchmark tests, using an `inputScale` set to `0.5` reduced the _cost of Haze_ by **5-20%**. You can read more about this below.
 
-!!! abstract "Cost of Haze" 
+!!! abstract "Cost of Haze"
     Just to call out: the percentage that I mentioned is a reduction in the cost of Haze, not the total frame duration. Haze itself introduces a cost, which you can read more about below. The reduction in total frame duration duration will be in the region of 3-5%.
 
 ## Benchmarks
@@ -21,8 +21,8 @@ We currently have 4 benchmark scenarios, each of them is one of the samples in t
 
 - **Scaffold**. The simple example, where the app bar and bottom navigation bar are blurred, with a scrollable list. This example uses rectangular haze areas.
 - **Scaffold, with progressive**. Same as Scaffold, but using a progressive blur.
-- **Images List**. Each item in the list has it's own `haze` and `hazeChild`. As each item has it's own `haze`, the internal haze state does not change all that much (the list item content moves, but the `hazeChild` doesn't in terms of local coordinates). This is more about multiple testing `RenderNode`s. This example uses rounded rectangle haze areas (i.e. we use `clipPath`).
-- **Credit Card**. A simple example, where the user can drag the `hazeChild`. This tests how fast Haze's internal state invalidates and propogates to the `RenderNode`s. This example uses rounded rectangle haze areas like 'Images List'.
+- **Images List**. Each item in the list has it's own `hazeSource` and `hazeEffect`. As each item has it's own `hazeSource`, the internal haze state does not change all that much (the list item content moves, but the `hazeEffect` doesn't in terms of local coordinates). This is more about multiple testing `RenderNode`s. This example uses rounded rectangle haze areas (i.e. we use `clipPath`).
+- **Credit Card**. A simple example, where the user can drag the `hazeEffect`. This tests how fast Haze's internal state invalidates and propogates to the `RenderNode`s. This example uses rounded rectangle haze areas like 'Images List'.
 
 !!! abstract "Test setup"
     All of the tests were ran with 16 iterations on a Pixel 6, running the latest version of Android available.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -3,8 +3,8 @@
 
 Blurring the content behind app bars is a common use case, so how can we use Haze with `Scaffold`? It's pretty much the same as above:
 
-!!! tip "Multiple hazeChilds"
-    Note: We are using multiple `hazeChild`s in this example. You can actually use an abitrary number of `hazeChild`s.
+!!! tip "Multiple hazeEffects"
+    Note: We are using multiple `hazeEffect`s in this example. You can actually use an abitrary number of `hazeEffect`s.
 
 ``` kotlin
 val hazeState = remember { HazeState() }
@@ -15,7 +15,7 @@ Scaffold(
       // Need to make app bar transparent to see the content behind
       colors = TopAppBarDefaults.largeTopAppBarColors(Color.Transparent),
       modifier = Modifier
-        .hazeChild(state = hazeState)
+        .hazeEffect(state = hazeState)
         .fillMaxWidth(),
     ) {
       /* todo */
@@ -25,7 +25,7 @@ Scaffold(
     NavigationBar(
       containerColor = Color.Transparent,
       modifier = Modifier
-        .hazeChild(state = hazeState)
+        .hazeEffect(state = hazeState)
         .fillMaxWidth(),
     ) {
       /* todo */
@@ -34,7 +34,7 @@ Scaffold(
 ) {
   LazyVerticalGrid(
     modifier = Modifier
-      .haze(
+      .hazeSource(
         state = hazeState,
         style = HazeDefaults.style(backgroundColor = MaterialTheme.colorScheme.surface),
       ),
@@ -48,9 +48,9 @@ Scaffold(
 
 The `stickyHeader` functionality on `LazyColumn` and friends is very useful, but unfortunately the limitations of Haze means that blurring the list contents for the header background is tricky.
 
-Since we can not use `Modifier.haze` on the `LazyColumn` and `Modifier.hazeChild` on items, as we would get into recursive drawing, we need to get a bit more creative.
+Since we can not use `Modifier.hazeSource` on the `LazyColumn` and `Modifier.hazeEffect` on items, as we would get into recursive drawing, we need to get a bit more creative.
 
-Since we can have multiple nodes using `Modifier.haze`, we can use the modifier on all non-header items, and then use `hazeChild` as normal on the `stickyHeader`:
+Since we can have multiple nodes using `Modifier.hazeSource`, we can use the modifier on all non-header items, and then use `hazeEffect` as normal on the `stickyHeader`:
 
 ```kotlin
 val hazeState = remember { HazeState() }
@@ -59,14 +59,14 @@ LazyColumn(...) {
   stickyHeader {
     Header(
       modifier = Modifier
-        .hazeChild(state = hazeState),
+        .hazeEffect(state = hazeState),
     )
   }
 
   items(list) { item ->
     Foo(
       modifier = Modifier
-        .haze(hazeState),
+        .hazeSource(hazeState),
     )
   }
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-Haze is implemented through two Compose Modifiers: [Modifier.haze](../api/haze/dev.chrisbanes.haze/haze.html) and [Modifier.hazeChild](../api/haze/dev.chrisbanes.haze/haze-child.html).
+Haze is implemented through two Compose Modifiers: [Modifier.hazeSource](../api/haze/dev.chrisbanes.haze/haze-source.html) and [Modifier.hazeEffect](../api/haze/dev.chrisbanes.haze/haze-effect.html).
 
 The most basic usage would be something like:
 
@@ -10,7 +10,7 @@ Box {
     modifier = Modifier
       .fillMaxSize()
       // Pass it the HazeState we stored above
-      .haze(state = hazeState)
+      .hazeSource(state = hazeState)
   ) {
     // todo
   }
@@ -19,9 +19,9 @@ Box {
     // Need to make app bar transparent to see the content behind
     colors = TopAppBarDefaults.largeTopAppBarColors(Color.Transparent),
     modifier = Modifier
-      // We use hazeChild on anything where we want the background
+      // We use hazeEffect on anything where we want the background
       // blurred.
-      .hazeChild(state = hazeState)
+      .hazeEffect(state = hazeState)
       .fillMaxWidth(),
   )
 }
@@ -29,17 +29,17 @@ Box {
 
 ## Styling
 
-Haze has support for customizing the resulting effect, which is performed via the [HazeStyle](../api/haze/dev.chrisbanes.haze/-haze-style/) class, or the lambda block provided to `hazeChild`.
+Haze has support for customizing the resulting effect, which is performed via the [HazeStyle](../api/haze/dev.chrisbanes.haze/-haze-style/) class, or the lambda block provided to `hazeEffect`.
 
 Styles can be provided in a number of different ways:
 
 - [LocalHazeStyle](../api/haze/dev.chrisbanes.haze/-local-haze-style.html) composition local.
-- The style parameter on [Modifier.hazeChild](../api/haze/dev.chrisbanes.haze/haze-child.html).
-- By setting the relevant property in the optional [HazeChildScope](../api/haze/dev.chrisbanes.haze/-haze-child-scope/index.html) lambda `block`, passed into [Modifier.hazeChild](../api/haze/dev.chrisbanes.haze/haze-child.html).
+- The style parameter on [Modifier.hazeEffect](../api/haze/dev.chrisbanes.haze/haze-effect.html).
+- By setting the relevant property in the optional [HazeEffectScope](../api/haze/dev.chrisbanes.haze/-haze-effect-scope/) lambda `block`, passed into [Modifier.hazeEffect](../api/haze/dev.chrisbanes.haze/haze-effect.html).
 
-### HazeChildScope
+### HazeEffectScope
 
-We now have a parameter on `Modifier.hazeChild` which allow you to provide a lambda block, for controlling all of Haze's styling parameters. It is similar to concept to `Modifier.graphicsLayer { ... }`.
+We now have a parameter on `Modifier.hazeEffect` which allow you to provide a lambda block, for controlling all of Haze's styling parameters. It is similar to concept to `Modifier.graphicsLayer { ... }`.
 
 It's useful for when you need to update styling parameters, using values derived from other state. Here's an example which fades the effect as the user scrolls:
 
@@ -47,7 +47,7 @@ It's useful for when you need to update styling parameters, using values derived
 FooAppBar(
   ...
   modifier = Modifier
-    .hazeChild(state = hazeState) {
+    .hazeEffect(state = hazeState) {
       alpha = if (listState.firstVisibleItemIndex == 0) {
         listState.layoutInfo.visibleItemsInfo.first().let {
           (it.offset / it.size.height.toFloat()).absoluteValue
@@ -65,8 +65,8 @@ As we a few different ways to set styling properties, it's important to know how
 
 Each styling property (such as `blurRadius`) is resolved seperately, and the order of precedence for each property is as follows, in order:
 
-- Value set in [HazeChildScope](../api/haze/dev.chrisbanes.haze/-haze-child-scope/index.html), if specified.
-- Value set in style provided to hazeChild (or HazeChildScope.style), if specified.
+- Value set in [HazeEffectScope](../api/haze/dev.chrisbanes.haze/-haze-effect-scope/), if specified.
+- Value set in style provided to hazeEffect (or HazeEffectScope.style), if specified.
 - Value set in the [LocalHazeStyle](../api/haze/dev.chrisbanes.haze/-local-haze-style.html) composition local.
 
 ### Styling properties
@@ -89,12 +89,12 @@ Progressive blurs allow you to provide a visual effect where the blur radius is 
 
 ![type:video](./media/progressive.mp4)
 
-Progressive blurs can be enabled by setting the `progressive` property on [HazeChildScope](../api/haze/dev.chrisbanes.haze/-haze-child-scope/index.html). The API is very similar to the Brush gradient APIs, so it should feel familiar.
+Progressive blurs can be enabled by setting the `progressive` property on [HazeEffectScope](../api/haze/dev.chrisbanes.haze/-haze-child-scope/index.html). The API is very similar to the Brush gradient APIs, so it should feel familiar.
 
 ```kotlin
 LargeTopAppBar(
   // ...
-  modifier = Modifier.hazeChild(hazeState) {
+  modifier = Modifier.hazeEffect(hazeState) {
     progressive = HazeProgressive.verticalGradient(startIntensity = 1f, endIntensity = 0f)
   }
 )
@@ -113,7 +113,7 @@ You can provide any `Brush`, which will be used as a mask when the final effect 
 ```kotlin
 LargeTopAppBar(
   // ...
-  modifier = Modifier.hazeChild(hazeState) {
+  modifier = Modifier.hazeEffect(hazeState) {
     mask = Brush.verticalGradient(...)
   }
 )
@@ -132,7 +132,7 @@ You can provide an input scale value which determines how much the content is sc
 ```kotlin
 LargeTopAppBar(
   // ...
-  modifier = Modifier.hazeChild(hazeState) {
+  modifier = Modifier.hazeEffect(hazeState) {
     inputScale = HazeInputScale.Auto
   }
 )
@@ -150,15 +150,15 @@ If you're looking for a good value to experiment with, `0.66` results in a reduc
 
 The minimum value I would realistically use is somewhere in the region of `0.33`, which results in the total pixel count of only 11% of the original content. This is likely to be visually different to no scaling, but depending on the styling parameters, it will be visually pleasing to the user.
 
-## Using both Modifier.haze and Modifier.hazeChild
+## Using both Modifier.haze and Modifier.hazeEffect
 
-A layout node can use both a `Modifier.hazeChild`, drawing a blurred effect from other areas, _and_ use `Modifier.haze` to draw itself for other `hazeChild` users.
+A layout node can use both a `Modifier.hazeEffect`, drawing a blurred effect from other areas, _and_ use `Modifier.hazeSource` to draw itself for other `hazeEffect` users.
 
 This nested functionality sounds complicated, but in reality it enables a simple use case: overlapping blurred layout nodes.
 
 ![](./media/overlap.webp)
 
-This code to implement this is like below. You'll notice that the `CreditCard()` nodes use both the `haze` and `hazeChild` modifiers. **Pay attention to the modifier order here.**
+This code to implement this is like below. You'll notice that the `CreditCard()` nodes use both the `hazeSource` and `hazeEffect` modifiers. **Pay attention to the modifier order here.**
 
 ``` kotlin
 Box {
@@ -166,47 +166,47 @@ Box {
 
   Background(
     modifier = Modifier
-      .haze(hazeState, zIndex = 0f)
+      .hazeSource(hazeState, zIndex = 0f)
   )
 
   // Rear card
   CreditCard(
     modifier = Modifier
-      .haze(hazeState, zIndex = 1f)
-      .hazeChild(hazeState)
+      .hazeSource(hazeState, zIndex = 1f)
+      .hazeEffect(hazeState)
   )
 
   // Middle card
   CreditCard(
     modifier = Modifier
-      .haze(hazeState, zIndex = 2f)
-      .hazeChild(hazeState),
+      .hazeSource(hazeState, zIndex = 2f)
+      .hazeEffect(hazeState),
   )
 
   // Front card
   CreditCard(
     modifier = Modifier
-      .haze(hazeState, zIndex = 3f)
-      .hazeChild(hazeState)
+      .hazeSource(hazeState, zIndex = 3f)
+      .hazeEffect(hazeState)
   )
 }
 ```
 
-You will notice that there's something different here, the `zIndex` parameter. 
+You will notice that there's something different here, the `zIndex` parameter.
 
-For this to work you need to pass in the `zIndex` parameter of the node. It doesn't matter if you use `Modifier.zIndex`, or the implicit ordering from the layout, you need to explicitly pass in a valid `zIndex` value. 
+For this to work you need to pass in the `zIndex` parameter of the node. It doesn't matter if you use `Modifier.zIndex`, or the implicit ordering from the layout, you need to explicitly pass in a valid `zIndex` value.
 
 ### zIndex
 
-Internally, the zIndex value is how Haze knows which layers to draw in which nodes. By default, `hazeChild` will draw all layers with a `zIndex` less than the value of the sibling `Modifier.haze`. So in the example above, the middle card (`zIndex` of 2) will draw the rear card (`zIndex` of 1) and background (`zIndex` of 0).
+Internally, the zIndex value is how Haze knows which layers to draw in which nodes. By default, `hazeEffect` will draw all layers with a `zIndex` less than the value of the sibling `Modifier.hazeSource`. So in the example above, the middle card (`zIndex` of 2) will draw the rear card (`zIndex` of 1) and background (`zIndex` of 0).
 
 This default behavior is usually the correct behavior for all use cases, but you can modify this behavior via the `canDrawArea` parameter, which acts as a filter when set:
 
 ``` kotlin
 CreditCard(
   modifier = Modifier
-    .haze(hazeState, zIndex = 2f, key = "foo")
-    .hazeChild(hazeState) {
+    .hazeSource(hazeState, zIndex = 2f, key = "foo")
+    .hazeEffect(hazeState) {
       canDrawArea = { area ->
         // return true to draw
         area.key != "foo"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -89,7 +89,7 @@ Progressive blurs allow you to provide a visual effect where the blur radius is 
 
 ![type:video](./media/progressive.mp4)
 
-Progressive blurs can be enabled by setting the `progressive` property on [HazeEffectScope](../api/haze/dev.chrisbanes.haze/-haze-child-scope/index.html). The API is very similar to the Brush gradient APIs, so it should feel familiar.
+Progressive blurs can be enabled by setting the `progressive` property on [HazeEffectScope](../api/haze/dev.chrisbanes.haze/-haze-effect-scope/). The API is very similar to the Brush gradient APIs, so it should feel familiar.
 
 ```kotlin
 LargeTopAppBar(

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -19,16 +19,31 @@ package dev.chrisbanes.haze {
   }
 
   public final class HazeChildKt {
-    method @Deprecated public static androidx.compose.ui.Modifier hazeChild(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, androidx.compose.ui.graphics.Shape shape, dev.chrisbanes.haze.HazeStyle style);
-    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeChild(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>? block);
+    method @Deprecated @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeChild(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
+    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
   }
 
-  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeChildNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode dev.chrisbanes.haze.HazeChildScope androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.modifier.ModifierLocalModifierNode androidx.compose.ui.node.ObserverModifierNode {
-    ctor public HazeChildNode(dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>? block);
+  @Deprecated public interface HazeChildScope extends dev.chrisbanes.haze.HazeEffectScope {
+  }
+
+  public final class HazeDefaults {
+    method public boolean blurEnabled();
+    method public float getBlurRadius();
+    method public dev.chrisbanes.haze.HazeStyle style(long backgroundColor, optional dev.chrisbanes.haze.HazeTint tint, optional float blurRadius, optional float noiseFactor);
+    method @Deprecated public dev.chrisbanes.haze.HazeStyle style(optional long backgroundColor, long tint, optional float blurRadius, optional float noiseFactor);
+    method public dev.chrisbanes.haze.HazeTint tint(long color);
+    property public final float blurRadius;
+    field public static final dev.chrisbanes.haze.HazeDefaults INSTANCE;
+    field public static final float noiseFactor = 0.15f;
+    field public static final float tintAlpha = 0.7f;
+  }
+
+  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeEffectNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode dev.chrisbanes.haze.HazeEffectScope androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.modifier.ModifierLocalModifierNode androidx.compose.ui.node.ObserverModifierNode {
+    ctor public HazeEffectNode(dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeStyle style, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
     method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
     method public float getAlpha();
     method public long getBackgroundColor();
-    method public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>? getBlock();
+    method public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? getBlock();
     method public boolean getBlurEnabled();
     method public float getBlurRadius();
     method public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeArea,java.lang.Boolean>? getCanDrawArea();
@@ -44,7 +59,7 @@ package dev.chrisbanes.haze {
     method public void onObservedReadsChanged();
     method public void setAlpha(float);
     method public void setBackgroundColor(long);
-    method public void setBlock(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>?);
+    method public void setBlock(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>?);
     method public void setBlurEnabled(boolean);
     method public void setBlurRadius(float);
     method public void setCanDrawArea(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeArea,java.lang.Boolean>?);
@@ -58,7 +73,7 @@ package dev.chrisbanes.haze {
     method public void setTints(java.util.List<dev.chrisbanes.haze.HazeTint>);
     property public float alpha;
     property public long backgroundColor;
-    property public final kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeChildScope,kotlin.Unit>? block;
+    property public final kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block;
     property public boolean blurEnabled;
     property public float blurRadius;
     property public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeArea,java.lang.Boolean>? canDrawArea;
@@ -71,10 +86,10 @@ package dev.chrisbanes.haze {
     property public final dev.chrisbanes.haze.HazeState state;
     property public dev.chrisbanes.haze.HazeStyle style;
     property public java.util.List<dev.chrisbanes.haze.HazeTint> tints;
-    field public static final String TAG = "HazeChild";
+    field public static final String TAG = "HazeEffect";
   }
 
-  public interface HazeChildScope {
+  public interface HazeEffectScope {
     method public float getAlpha();
     method public long getBackgroundColor();
     method public boolean getBlurEnabled();
@@ -113,18 +128,6 @@ package dev.chrisbanes.haze {
     property public abstract java.util.List<dev.chrisbanes.haze.HazeTint> tints;
   }
 
-  public final class HazeDefaults {
-    method public boolean blurEnabled();
-    method public float getBlurRadius();
-    method public dev.chrisbanes.haze.HazeStyle style(long backgroundColor, optional dev.chrisbanes.haze.HazeTint tint, optional float blurRadius, optional float noiseFactor);
-    method @Deprecated public dev.chrisbanes.haze.HazeStyle style(optional long backgroundColor, long tint, optional float blurRadius, optional float noiseFactor);
-    method public dev.chrisbanes.haze.HazeTint tint(long color);
-    property public final float blurRadius;
-    field public static final dev.chrisbanes.haze.HazeDefaults INSTANCE;
-    field public static final float noiseFactor = 0.15f;
-    field public static final float tintAlpha = 0.7f;
-  }
-
   @dev.chrisbanes.haze.ExperimentalHazeApi public sealed interface HazeInputScale {
     field public static final dev.chrisbanes.haze.HazeInputScale.Companion Companion;
   }
@@ -149,26 +152,8 @@ package dev.chrisbanes.haze {
   }
 
   public final class HazeKt {
-    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier haze(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, optional float zIndex, optional Object? key);
-  }
-
-  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.modifier.ModifierLocalModifierNode androidx.compose.ui.node.ObserverModifierNode {
-    ctor public HazeNode(dev.chrisbanes.haze.HazeState state, optional float zIndex, optional Object? key);
-    method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
-    method public Object? getKey();
-    method public dev.chrisbanes.haze.HazeState getState();
-    method public float getZIndex();
-    method public void onGloballyPositioned(androidx.compose.ui.layout.LayoutCoordinates coordinates);
-    method public void onObservedReadsChanged();
-    method public void setKey(Object?);
-    method public void setState(dev.chrisbanes.haze.HazeState);
-    method public void setZIndex(float);
-    property public final Object? key;
-    property public androidx.compose.ui.modifier.ModifierLocalMap providedValues;
-    property public boolean shouldAutoInvalidate;
-    property public final dev.chrisbanes.haze.HazeState state;
-    property public final float zIndex;
-    field public static final String TAG = "HazeNode";
+    method @Deprecated @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier haze(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state);
+    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeSource(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState state, optional float zIndex, optional Object? key);
   }
 
   public sealed interface HazeProgressive {
@@ -201,6 +186,25 @@ package dev.chrisbanes.haze {
     property public final boolean preferPerformance;
     property public final long start;
     property public final float startIntensity;
+  }
+
+  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeSourceNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.modifier.ModifierLocalModifierNode androidx.compose.ui.node.ObserverModifierNode {
+    ctor public HazeSourceNode(dev.chrisbanes.haze.HazeState state, optional float zIndex, optional Object? key);
+    method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
+    method public Object? getKey();
+    method public dev.chrisbanes.haze.HazeState getState();
+    method public float getZIndex();
+    method public void onGloballyPositioned(androidx.compose.ui.layout.LayoutCoordinates coordinates);
+    method public void onObservedReadsChanged();
+    method public void setKey(Object?);
+    method public void setState(dev.chrisbanes.haze.HazeState);
+    method public void setZIndex(float);
+    property public final Object? key;
+    property public androidx.compose.ui.modifier.ModifierLocalMap providedValues;
+    property public boolean shouldAutoInvalidate;
+    property public final dev.chrisbanes.haze.HazeState state;
+    property public final float zIndex;
+    field public static final String TAG = "HazeSource";
   }
 
   @androidx.compose.runtime.Stable public final class HazeState {

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeChildNode.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeChildNode.android.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.LocalGraphicsContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.takeOrElse
-import dev.chrisbanes.haze.HazeChildNode.Companion.TAG
+import dev.chrisbanes.haze.HazeEffectNode.Companion.TAG
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
@@ -22,7 +22,7 @@ import kotlin.math.min
 private const val USE_RUNTIME_SHADER = true
 
 @RequiresApi(31)
-internal actual fun HazeChildNode.drawLinearGradientProgressiveEffect(
+internal actual fun HazeEffectNode.drawLinearGradientProgressiveEffect(
   drawScope: DrawScope,
   progressive: HazeProgressive.LinearGradient,
   contentLayer: GraphicsLayer,
@@ -53,7 +53,7 @@ internal actual fun HazeChildNode.drawLinearGradientProgressiveEffect(
   }
 }
 
-private fun HazeChildNode.drawLinearGradientProgressiveEffectUsingLayers(
+private fun HazeEffectNode.drawLinearGradientProgressiveEffectUsingLayers(
   drawScope: DrawScope,
   progressive: HazeProgressive.LinearGradient,
   contentLayer: GraphicsLayer,

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeNode.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeNode.android.kt
@@ -7,7 +7,7 @@ import android.os.Build
 
 /**
  * By default we only enable blurring on SDK Level 32 and above, at the moment. You can override
- * this via [HazeChildScope.blurEnabled] if required.
+ * this via [HazeEffectScope.blurEnabled] if required.
  *
  * See https://github.com/chrisbanes/haze/issues/77 for more details.
  */

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -87,8 +87,15 @@ class HazeArea {
   }
 }
 
+@Deprecated(
+  message = "Renamed to Modifier.hazeSource()",
+  replaceWith = ReplaceWith("hazeSource(state)", "dev.chrisbanes.haze.hazeSource"),
+)
+@Stable
+fun Modifier.haze(state: HazeState): Modifier = hazeSource(state)
+
 /**
- * Draw background content for [hazeChild] child nodes, which will be drawn with a blur
+ * Captures background content for [hazeEffect] child nodes, which will be drawn with a blur
  * in a 'glassmorphism' style.
  *
  * When running on Android 12 devices (and newer), usage of this API renders the corresponding composable
@@ -96,10 +103,14 @@ class HazeArea {
  * instead.
  */
 @Stable
-fun Modifier.haze(state: HazeState, zIndex: Float = 0f, key: Any? = null): Modifier = this then HazeNodeElement(state, zIndex)
+fun Modifier.hazeSource(
+  state: HazeState,
+  zIndex: Float = 0f,
+  key: Any? = null,
+): Modifier = this then HazeSourceElement(state, zIndex, key)
 
 /**
- * Default values for the [haze] modifiers.
+ * Default values for the [hazeSource] and [hazeEffect] modifiers.
  */
 @Suppress("ktlint:standard:property-naming")
 object HazeDefaults {
@@ -138,7 +149,7 @@ object HazeDefaults {
   ): HazeStyle = HazeStyle(backgroundColor, tint(backgroundColor), blurRadius, noiseFactor)
 
   /**
-   * Default [HazeStyle] for usage with [Modifier.haze].
+   * Default [HazeStyle] for usage with [Modifier.hazeSource].
    *
    * @param backgroundColor Color to draw behind the blurred content. Ideally should be opaque
    * so that the original content is not visible behind. Typically this would be
@@ -157,7 +168,7 @@ object HazeDefaults {
   ): HazeStyle = HazeStyle(backgroundColor, tint, blurRadius, noiseFactor)
 
   /**
-   * Default values for [HazeChildScope.blurEnabled]. This function only returns `true` on
+   * Default values for [HazeEffectScope.blurEnabled]. This function only returns `true` on
    * platforms where we know blurring works reliably.
    *
    * This is not the same as everywhere where it technically works. The key omission here
@@ -169,22 +180,22 @@ object HazeDefaults {
   fun blurEnabled(): Boolean = isBlurEnabledByDefault()
 }
 
-internal data class HazeNodeElement(
+internal data class HazeSourceElement(
   val state: HazeState,
   val zIndex: Float = 0f,
   val key: Any? = null,
-) : ModifierNodeElement<HazeNode>() {
+) : ModifierNodeElement<HazeSourceNode>() {
 
-  override fun create(): HazeNode = HazeNode(state = state, zIndex = zIndex, key = key)
+  override fun create(): HazeSourceNode = HazeSourceNode(state = state, zIndex = zIndex, key = key)
 
-  override fun update(node: HazeNode) {
+  override fun update(node: HazeSourceNode) {
     node.state = state
     node.zIndex = zIndex
     node.key = key
   }
 
   override fun InspectorInfo.inspectableProperties() {
-    name = "haze"
+    name = "hazeSource"
     properties["zIndex"] = zIndex
     properties["key"] = key
   }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
@@ -5,16 +5,23 @@ package dev.chrisbanes.haze
 
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.Dp
 import kotlin.jvm.JvmInline
 
-interface HazeChildScope {
+@Deprecated(
+  message = "Renamed to HazeEffectScope",
+  replaceWith = ReplaceWith(
+    "HazeEffectScope",
+    "dev.chrisbanes.haze.HazeEffectScope",
+  ),
+)
+interface HazeChildScope : HazeEffectScope
+
+interface HazeEffectScope {
 
   /**
    * Whether the blur effect is enabled or not, when running on platforms which support blurring.
@@ -32,13 +39,13 @@ interface HazeChildScope {
   var alpha: Float
 
   /**
-   * Style set on this specific [HazeChildNode].
+   * Style set on this specific [HazeEffectNode].
    *
    * There are precedence rules to how each styling property is applied. The order of precedence
    * for each property are as follows:
    *
-   *  - Property value set in [HazeChildScope], if specified.
-   *  - Value set here in [HazeChildScope.style], if specified.
+   *  - Property value set in [HazeEffectScope], if specified.
+   *  - Value set here in [HazeEffectScope.style], if specified.
    *  - Value set in the [LocalHazeStyle] composition local.
    */
   var style: HazeStyle
@@ -151,7 +158,7 @@ interface HazeChildScope {
 }
 
 /**
- * Value classes used for [HazeChildScope.inputScale].
+ * Value classes used for [HazeEffectScope.inputScale].
  */
 @ExperimentalHazeApi
 sealed interface HazeInputScale {
@@ -190,54 +197,43 @@ sealed interface HazeInputScale {
   }
 }
 
-/**
- * Mark this composable as being a Haze child composable.
- *
- * This will update the given [HazeState] whenever the layout is placed, enabling any layouts using
- * [Modifier.haze] to blur any content behind the host composable.
- *
- * @param shape The shape of the content. This will affect the the bounds and outline of
- * the content. Please be aware that using non-rectangular shapes has an effect on performance,
- * since we need to use path clipping.
- * @param style The [HazeStyle] to use on this content. Any specified values in the given
- * style will override that value from the default style, provided to [haze].
- */
 @Deprecated(
-  message = "Shape clipping is no longer necessary with Haze. You can use `Modifier.clip` or similar.",
-  replaceWith = ReplaceWith("clip(shape).hazeChild(state, style)"),
+  message = "Renamed to Modifier.hazeEffect()",
+  replaceWith = ReplaceWith("hazeEffect(state, style, block)", "dev.chrisbanes.haze.hazeEffect"),
 )
-fun Modifier.hazeChild(
-  state: HazeState,
-  shape: Shape,
-  style: HazeStyle,
-): Modifier = clip(shape).hazeChild(state, style)
-
-/**
- * Mark this composable as being a Haze child composable.
- *
- * This will update the given [HazeState] whenever the layout is placed, enabling any layouts using
- * [Modifier.haze] to blur any content behind the host composable.
- *
- * @param style The [HazeStyle] to use on this content. Any specified values in the given
- * style will override that value from the default style, provided to [haze].
- * @param block block on HazeChildScope where you define the styling and visual properties.
- */
 @Stable
 fun Modifier.hazeChild(
   state: HazeState,
   style: HazeStyle = HazeStyle.Unspecified,
-  block: (HazeChildScope.() -> Unit)? = null,
-): Modifier = this then HazeChildNodeElement(state, style, block)
+  block: (HazeEffectScope.() -> Unit)? = null,
+): Modifier = hazeEffect(state, style, block)
 
-private data class HazeChildNodeElement(
+/**
+ * Mark this composable as being a Haze child composable.
+ *
+ * This will update the given [HazeState] whenever the layout is placed, enabling any layouts using
+ * [Modifier.hazeSource] to blur any content behind the host composable.
+ *
+ * @param style The [HazeStyle] to use on this content. Any specified values in the given
+ * style will override that value from the default style, provided to [hazeSource].
+ * @param block block on HazeChildScope where you define the styling and visual properties.
+ */
+@Stable
+fun Modifier.hazeEffect(
+  state: HazeState,
+  style: HazeStyle = HazeStyle.Unspecified,
+  block: (HazeEffectScope.() -> Unit)? = null,
+): Modifier = this then HazeEffectNodeElement(state, style, block)
+
+private data class HazeEffectNodeElement(
   val state: HazeState,
   val style: HazeStyle = HazeStyle.Unspecified,
-  val block: (HazeChildScope.() -> Unit)? = null,
-) : ModifierNodeElement<HazeChildNode>() {
+  val block: (HazeEffectScope.() -> Unit)? = null,
+) : ModifierNodeElement<HazeEffectNode>() {
 
-  override fun create(): HazeChildNode = HazeChildNode(state, style, block)
+  override fun create(): HazeEffectNode = HazeEffectNode(state, style, block)
 
-  override fun update(node: HazeChildNode) {
+  override fun update(node: HazeEffectNode) {
     node.state = state
     node.style = style
     node.block = block
@@ -245,6 +241,6 @@ private data class HazeChildNodeElement(
   }
 
   override fun InspectorInfo.inspectableProperties() {
-    name = "HazeChild"
+    name = "HazeEffect"
   }
 }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -7,8 +7,6 @@ package dev.chrisbanes.haze
 
 import androidx.compose.animation.core.EaseIn
 import androidx.compose.animation.core.Easing
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -56,16 +54,16 @@ import io.github.reactivecircus.cache4k.Cache
 internal val ModifierLocalCurrentHazeZIndex = modifierLocalOf<Float?> { null }
 
 /**
- * The [Modifier.Node] implementation used by [Modifier.hazeChild].
+ * The [Modifier.Node] implementation used by [Modifier.hazeEffect].
  *
  * This is public API in order to aid custom extensible modifiers, _but_ we reserve the right
  * to be able to change the API in the future, hence why it is marked as experimental forever.
  */
 @ExperimentalHazeApi
-class HazeChildNode(
+class HazeEffectNode(
   var state: HazeState,
   style: HazeStyle = HazeStyle.Unspecified,
-  var block: (HazeChildScope.() -> Unit)? = null,
+  var block: (HazeEffectScope.() -> Unit)? = null,
 ) : Modifier.Node(),
   CompositionLocalConsumerModifierNode,
   GlobalPositionAwareModifierNode,
@@ -73,7 +71,7 @@ class HazeChildNode(
   ObserverModifierNode,
   DrawModifierNode,
   ModifierLocalModifierNode,
-  HazeChildScope {
+  HazeEffectScope {
 
   override val shouldAutoInvalidate: Boolean = false
 
@@ -494,7 +492,7 @@ class HazeChildNode(
   }
 
   internal companion object {
-    const val TAG = "HazeChild"
+    const val TAG = "HazeEffect"
   }
 }
 
@@ -620,7 +618,7 @@ internal class RenderEffectParams(
 )
 
 @ExperimentalHazeApi
-internal fun HazeChildNode.calculateInputScaleFactor(
+internal fun HazeEffectNode.calculateInputScaleFactor(
   blurRadius: Dp = resolveBlurRadius(),
 ): Float = when (val s = inputScale) {
   HazeInputScale.None -> 1f
@@ -640,7 +638,7 @@ internal fun HazeChildNode.calculateInputScaleFactor(
 }
 
 @OptIn(ExperimentalHazeApi::class)
-internal fun HazeChildNode.getOrCreateRenderEffect(
+internal fun HazeEffectNode.getOrCreateRenderEffect(
   inputScale: Float = calculateInputScaleFactor(),
   blurRadius: Dp = resolveBlurRadius().takeOrElse { 0.dp } * inputScale,
   noiseFactor: Float = resolveNoiseFactor(),
@@ -664,52 +662,52 @@ internal fun HazeChildNode.getOrCreateRenderEffect(
 )
 
 internal fun CompositionLocalConsumerModifierNode.getOrCreateRenderEffect(params: RenderEffectParams): RenderEffect? {
-  log(HazeChildNode.TAG) { "getOrCreateRenderEffect: $params" }
+  log(HazeEffectNode.TAG) { "getOrCreateRenderEffect: $params" }
   val cached = renderEffectCache.get(params)
   if (cached != null) {
-    log(HazeChildNode.TAG) { "getOrCreateRenderEffect. Returning cached: $params" }
+    log(HazeEffectNode.TAG) { "getOrCreateRenderEffect. Returning cached: $params" }
     return cached
   }
 
-  log(HazeChildNode.TAG) { "getOrCreateRenderEffect. Creating: $params" }
+  log(HazeEffectNode.TAG) { "getOrCreateRenderEffect. Creating: $params" }
   return createRenderEffect(params)
     ?.also { renderEffectCache.put(params, it) }
 }
 
 internal expect fun CompositionLocalConsumerModifierNode.createRenderEffect(params: RenderEffectParams): RenderEffect?
 
-internal expect fun HazeChildNode.drawLinearGradientProgressiveEffect(
+internal expect fun HazeEffectNode.drawLinearGradientProgressiveEffect(
   drawScope: DrawScope,
   progressive: HazeProgressive.LinearGradient,
   contentLayer: GraphicsLayer,
 )
 
-internal fun HazeChildNode.resolveBackgroundColor(): Color {
+internal fun HazeEffectNode.resolveBackgroundColor(): Color {
   return backgroundColor
     .takeOrElse { style.backgroundColor }
     .takeOrElse { compositionLocalStyle.backgroundColor }
 }
 
-internal fun HazeChildNode.resolveBlurRadius(): Dp {
+internal fun HazeEffectNode.resolveBlurRadius(): Dp {
   return blurRadius
     .takeOrElse { style.blurRadius }
     .takeOrElse { compositionLocalStyle.blurRadius }
 }
 
-internal fun HazeChildNode.resolveTints(): List<HazeTint> {
+internal fun HazeEffectNode.resolveTints(): List<HazeTint> {
   return tints.takeIf { it.isNotEmpty() }
     ?: style.tints.takeIf { it.isNotEmpty() }
     ?: compositionLocalStyle.tints.takeIf { it.isNotEmpty() }
     ?: emptyList()
 }
 
-internal fun HazeChildNode.resolveFallbackTint(): HazeTint {
+internal fun HazeEffectNode.resolveFallbackTint(): HazeTint {
   return fallbackTint.takeIf { it.isSpecified }
     ?: style.fallbackTint.takeIf { it.isSpecified }
     ?: compositionLocalStyle.fallbackTint
 }
 
-internal fun HazeChildNode.resolveNoiseFactor(): Float {
+internal fun HazeEffectNode.resolveNoiseFactor(): Float {
   return noiseFactor
     .takeOrElse { style.noiseFactor }
     .takeOrElse { compositionLocalStyle.noiseFactor }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -35,13 +35,13 @@ import androidx.compose.ui.unit.toSize
 annotation class ExperimentalHazeApi
 
 /**
- * The [Modifier.Node] implementation used by [Modifier.haze].
+ * The [Modifier.Node] implementation used by [Modifier.hazeSource].
  *
  * This is public API in order to aid custom extensible modifiers, _but_ we reserve the right
  * to be able to change the API in the future, hence why it is marked as experimental forever.
  */
 @ExperimentalHazeApi
-class HazeNode(
+class HazeSourceNode(
   var state: HazeState,
   zIndex: Float = 0f,
   key: Any? = null,
@@ -179,7 +179,7 @@ class HazeNode(
   }
 
   private companion object {
-    const val TAG = "HazeNode"
+    const val TAG = "HazeSource"
   }
 }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeStyle.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeStyle.kt
@@ -13,14 +13,14 @@ import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
 
 /**
- * A [ProvidableCompositionLocal] which provides the default [HazeStyle] for all [hazeChild]
+ * A [ProvidableCompositionLocal] which provides the default [HazeStyle] for all [hazeEffect]
  * layout nodes placed within this composition local's content.
  *
  * There are precedence rules to how each styling property is applied. The order of precedence
  * for each property are as follows:
  *
- *  - Value set in [HazeChildScope], if specified.
- *  - Value set in style provided to [hazeChild] (or [HazeChildScope.style]), if specified.
+ *  - Value set in [HazeEffectScope], if specified.
+ *  - Value set in style provided to [hazeEffect] (or [HazeEffectScope.style]), if specified.
  *  - Value set in this composition local.
  */
 val LocalHazeStyle: ProvidableCompositionLocal<HazeStyle> = compositionLocalOf { HazeStyle.Unspecified }
@@ -28,7 +28,7 @@ val LocalHazeStyle: ProvidableCompositionLocal<HazeStyle> = compositionLocalOf {
 /**
  * A holder for the style properties used by Haze.
  *
- * Can be set via [haze] and [hazeChild].
+ * Can be set via [hazeSource] and [hazeEffect].
  *
  * @property backgroundColor Color to draw behind the blurred content. Ideally should be opaque
  * so that the original content is not visible behind. Typically this would be

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeTest.kt
@@ -36,9 +36,9 @@ class HazeTest {
       runComposeUiTest {
         setContent {
           val hazeState = remember { HazeState() }
-          Box(Modifier.haze(hazeState)) {
+          Box(Modifier.hazeSource(hazeState)) {
             Spacer(
-              Modifier.hazeChild(hazeState, HazeDefaults.style(Color.Blue)) {
+              Modifier.hazeEffect(hazeState, HazeDefaults.style(Color.Blue)) {
                 canDrawArea = { true }
               },
             )

--- a/haze/src/screenshotTest/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
+++ b/haze/src/screenshotTest/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
@@ -47,7 +47,7 @@ internal fun CreditCardSample(
     Box(
       Modifier
         .fillMaxSize()
-        .haze(state = hazeState, zIndex = 0f),
+        .hazeSource(state = hazeState, zIndex = 0f),
     ) {
       Spacer(
         Modifier
@@ -75,11 +75,11 @@ internal fun CreditCardSample(
           .align(Alignment.Center)
           .offset { IntOffset(x = 0, y = reverseIndex * -100) }
           // We add 1 to the zIndex as the background content is zIndex 0f
-          .haze(hazeState, zIndex = 1f + index)
+          .hazeSource(hazeState, zIndex = 1f + index)
           .clip(shape)
           .then(
             if (enabled) {
-              Modifier.hazeChild(state = hazeState) {
+              Modifier.hazeEffect(state = hazeState) {
                 this.blurEnabled = blurEnabled
                 this.style = style
                 this.backgroundColor = surfaceColor

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeChildNode.skiko.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeChildNode.skiko.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 
-internal actual fun HazeChildNode.drawLinearGradientProgressiveEffect(
+internal actual fun HazeEffectNode.drawLinearGradientProgressiveEffect(
   drawScope: DrawScope,
   progressive: HazeProgressive.LinearGradient,
   contentLayer: GraphicsLayer,

--- a/sample/android/src/main/kotlin/dev/chrisbanes/haze/sample/android/ExoPlayerSample.kt
+++ b/sample/android/src/main/kotlin/dev/chrisbanes/haze/sample/android/ExoPlayerSample.kt
@@ -22,8 +22,8 @@ import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 import dev.chrisbanes.haze.sample.Navigator
@@ -64,7 +64,7 @@ fun ExoPlayerSample(navigator: Navigator) {
       },
       modifier = Modifier
         .fillMaxSize()
-        .haze(hazeState),
+        .hazeSource(hazeState),
     )
 
     Spacer(
@@ -72,7 +72,7 @@ fun ExoPlayerSample(navigator: Navigator) {
         .fillMaxSize(0.5f)
         .align(Alignment.Center)
         .clip(MaterialTheme.shapes.large)
-        .hazeChild(hazeState, HazeMaterials.ultraThin()),
+        .hazeEffect(hazeState, HazeMaterials.ultraThin()),
     )
   }
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -43,8 +42,8 @@ import dev.chrisbanes.haze.HazeDefaults
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 
 @Composable
 fun CreditCardSample(navigator: Navigator) {
@@ -55,7 +54,7 @@ fun CreditCardSample(navigator: Navigator) {
     Box(
       modifier = Modifier
         .fillMaxSize()
-        .haze(state = hazeState),
+        .hazeSource(state = hazeState),
     ) {
       Spacer(
         Modifier
@@ -108,9 +107,9 @@ fun CreditCardSample(navigator: Navigator) {
             },
           )
           // We add 1 to the zIndex as the background content is zIndex 0f
-          .haze(hazeState, zIndex = 1f + index)
+          .hazeSource(hazeState, zIndex = 1f + index)
           .clip(RoundedCornerShape(16.dp))
-          .hazeChild(state = hazeState, style = cardStyle),
+          .hazeEffect(state = hazeState, style = cardStyle),
       ) {
         Column(Modifier.padding(32.dp)) {
           Text("Bank of Haze")

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -72,7 +72,7 @@ fun DialogSample(navigator: Navigator) {
           contentColor = MaterialTheme.colorScheme.onSurface,
         ) {
           Box(
-            Modifier.hazeChild(state = hazeState, style = HazeMaterials.regular()),
+            Modifier.hazeEffect(state = hazeState, style = HazeMaterials.regular()),
           ) {
             // empty
           }
@@ -81,7 +81,7 @@ fun DialogSample(navigator: Navigator) {
     }
 
     LazyVerticalGrid(
-      modifier = Modifier.haze(state = hazeState),
+      modifier = Modifier.hazeSource(state = hazeState),
       columns = GridCells.Fixed(4),
       contentPadding = innerPadding,
       verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -77,7 +77,7 @@ fun ImagesList(navigator: Navigator) {
                 contentScale = ContentScale.Crop,
                 contentDescription = null,
                 modifier = Modifier
-                  .haze(state = hazeState)
+                  .hazeSource(state = hazeState)
                   .fillMaxSize(),
               )
 
@@ -86,7 +86,7 @@ fun ImagesList(navigator: Navigator) {
                   .fillMaxSize(0.8f)
                   .align(Alignment.Center)
                   .clip(RoundedCornerShape(4.dp))
-                  .hazeChild(state = hazeState, style = HazeMaterials.thin()),
+                  .hazeEffect(state = hazeState, style = HazeMaterials.thin()),
               ) {
                 Text(
                   "Image $index",

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -61,7 +61,7 @@ fun ListOverImage(navigator: Navigator) {
           contentScale = ContentScale.Crop,
           contentDescription = null,
           modifier = Modifier
-            .haze(state = hazeState)
+            .hazeSource(state = hazeState)
             .fillMaxSize(),
         )
 
@@ -87,7 +87,7 @@ fun ListOverImage(navigator: Navigator) {
                   .fillMaxSize(0.8f)
                   .align(Alignment.Center)
                   .clip(RoundedCornerShape(4.dp))
-                  .hazeChild(state = hazeState, style = HazeMaterials.thin()),
+                  .hazeEffect(state = hazeState, style = HazeMaterials.thin()),
               ) {
                 Text(
                   "Item $index",

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
@@ -21,9 +21,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
@@ -32,8 +30,8 @@ import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -77,7 +75,7 @@ fun ListWithStickyHeaders(navigator: Navigator) {
           Box(
             modifier = Modifier
               .fillMaxWidth()
-              .hazeChild(state = hazeState, style = style) {
+              .hazeEffect(state = hazeState, style = style) {
                 this.inputScale = HazeInputScale.Auto
               },
           ) {
@@ -88,7 +86,7 @@ fun ListWithStickyHeaders(navigator: Navigator) {
         items(groupSize) { index ->
           Box(
             modifier = Modifier
-              .haze(hazeState)
+              .hazeSource(hazeState)
               .fillParentMaxWidth(),
           ) {
             AsyncImage(

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.CupertinoMaterials
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.FluentMaterials
@@ -47,7 +47,7 @@ fun MaterialsSample(@Suppress("UNUSED_PARAMETER") navigator: Navigator) {
       contentScale = ContentScale.Crop,
       contentDescription = null,
       modifier = Modifier
-        .haze(state = hazeState)
+        .hazeSource(state = hazeState)
         .fillMaxSize(),
     )
 
@@ -316,7 +316,7 @@ private fun MaterialsCard(
     Box(
       Modifier
         .fillMaxSize()
-        .hazeChild(state = state, style = style)
+        .hazeEffect(state = state, style = style)
         .padding(16.dp),
     ) {
       Text(name)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -43,8 +43,8 @@ import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.haze
-import dev.chrisbanes.haze.hazeChild
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 
@@ -90,7 +90,7 @@ fun ScaffoldSample(
           scrolledContainerColor = Color.Transparent,
         ),
         modifier = Modifier
-          .hazeChild(state = hazeState, style = style) {
+          .hazeEffect(state = hazeState, style = style) {
             this.inputScale = inputScale
 
             when (mode) {
@@ -120,7 +120,7 @@ fun ScaffoldSample(
           selectedIndex = selectedIndex,
           onItemClicked = { selectedIndex = it },
           modifier = Modifier
-            .hazeChild(state = hazeState, style = style) {
+            .hazeEffect(state = hazeState, style = style) {
               this.inputScale = inputScale
             }
             .fillMaxWidth(),
@@ -138,7 +138,7 @@ fun ScaffoldSample(
       modifier = Modifier
         .fillMaxSize()
         .testTag("lazy_grid")
-        .haze(state = hazeState),
+        .hazeSource(state = hazeState),
     ) {
       items(50) { index ->
         ImageItem(


### PR DESCRIPTION
- `haze` to `hazeSource`
- `Modifier.hazeChild` -> `Modifier.hazeEffect`
- `HazeNode` -> `HazeSourceNode`
- `HazeChildNode` -> `HazeEffectNode`
- `HazeChildScope` -> `HazeEffectScope`

See #451 for more information