### PR TITLE
Fix issues with missing effects in LazyLayouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ captures
 .idea/androidTestResultsUserPreferences.xml
 .idea/appInsightsSettings.xml
 .idea/artifacts
+.idea/AndroidProjectSystem.xml
 gradle.xml
 *.iml
 ios-app/Tivi/.idea/*

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,8 @@ mavenpublish = { id = "com.vanniktech.maven.publish", version = "0.30.0" }
 androidx-benchmark-macro = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidx-benchmark" }
 androidx-core = "androidx.core:core-ktx:1.13.1"
 androidx-activity-compose = "androidx.activity:activity-compose:1.9.3"
-androidx-compose-ui-test-manifest = "androidx.compose.ui:ui-test-manifest:1.7.6"
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "jetpack-compose" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "jetpack-compose" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidx-media3" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }
 androidx-profileinstaller = "androidx.profileinstaller:profileinstaller:1.4.1"

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -65,7 +65,7 @@ kotlin {
       dependsOn(skikoMain)
     }
 
-    named("wasmJsMain") {
+    wasmJsMain {
       dependsOn(skikoMain)
 
       dependencies {
@@ -73,7 +73,7 @@ kotlin {
       }
     }
 
-    named("jsMain") {
+    jsMain {
       dependsOn(skikoMain)
     }
 
@@ -84,6 +84,8 @@ kotlin {
 
         @OptIn(ExperimentalComposeLibrary::class)
         implementation(compose.uiTest)
+
+        implementation(projects.internal.contextTest)
       }
     }
 
@@ -103,6 +105,11 @@ kotlin {
       dependsOn(screenshotTest)
     }
   }
+}
+
+// https://youtrack.jetbrains.com/issue/CMP-4906
+tasks.named("jsBrowserTest").configure {
+  enabled = false
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>>().configureEach {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -42,7 +42,7 @@ annotation class ExperimentalHazeApi
  */
 @ExperimentalHazeApi
 class HazeSourceNode(
-  var state: HazeState,
+  state: HazeState,
   zIndex: Float = 0f,
   key: Any? = null,
 ) : Modifier.Node(),
@@ -58,6 +58,20 @@ class HazeSourceNode(
   private val area = HazeArea()
 
   var zIndex: Float by mutableStateOf(zIndex)
+
+  var state: HazeState = state
+    set(value) {
+      val attachedToState = area in field.areas
+      if (attachedToState) {
+        // Detach ourselves from the old HazeState
+        field.removeArea(area)
+      }
+      field = value
+      if (attachedToState) {
+        // Finally re-attach ourselves to the new state
+        value.addArea(area)
+      }
+    }
 
   var key: Any?
     get() = area.key

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
@@ -1,0 +1,48 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
+import dev.chrisbanes.haze.test.ContextTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class HazeComposeUnitTests : ContextTest() {
+  @Test
+  fun testChangingHazeState() = runComposeUiTest {
+    val hazeState1 = HazeState()
+    val hazeState2 = HazeState()
+
+    val selectedHazeState = mutableStateOf(hazeState1)
+
+    setContent {
+      Box(Modifier.hazeSource(selectedHazeState.value)) {
+        Spacer(
+          Modifier.hazeEffect(selectedHazeState.value, HazeDefaults.style(Color.Blue)),
+        )
+      }
+    }
+
+    // Assert that the HazeArea is in hazeState1
+    assertThat(hazeState1.areas).hasSize(1)
+    assertThat(hazeState2.areas).isEmpty()
+
+    // Update the selected HazeState and wait for idle
+    selectedHazeState.value = hazeState2
+    waitForIdle()
+
+    // Assert that the HazeArea moved to hazeState2
+    assertThat(hazeState1.areas).isEmpty()
+    assertThat(hazeState2.areas).hasSize(1)
+  }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeTest.kt
@@ -5,13 +5,18 @@ package dev.chrisbanes.haze
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEmpty
 import assertk.assertions.isFalse
 import kotlin.test.Test
 
@@ -46,5 +51,33 @@ class HazeTest {
         }
       }
     }
+  }
+
+  @Test
+  fun testChangingHazeState() = runComposeUiTest {
+    val hazeState1 = HazeState()
+    val hazeState2 = HazeState()
+
+    val selectedHazeState = mutableStateOf(hazeState1)
+
+    setContent {
+      Box(Modifier.hazeSource(selectedHazeState.value)) {
+        Spacer(
+          Modifier.hazeEffect(selectedHazeState.value, HazeDefaults.style(Color.Blue)),
+        )
+      }
+    }
+
+    // Assert that the HazeArea is in hazeState1
+    assertThat(hazeState1.areas).hasSize(1)
+    assertThat(hazeState2.areas).isEmpty()
+
+    // Update the selected HazeState and wait for idle
+    selectedHazeState.value = hazeState2
+    waitForIdle()
+
+    // Assert that the HazeArea moved to hazeState2
+    assertThat(hazeState1.areas).isEmpty()
+    assertThat(hazeState2.areas).hasSize(1)
   }
 }

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeTest.kt
@@ -5,18 +5,13 @@ package dev.chrisbanes.haze
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import assertk.assertFailure
 import assertk.assertThat
-import assertk.assertions.hasSize
-import assertk.assertions.isEmpty
 import assertk.assertions.isFalse
 import kotlin.test.Test
 
@@ -51,33 +46,5 @@ class HazeTest {
         }
       }
     }
-  }
-
-  @Test
-  fun testChangingHazeState() = runComposeUiTest {
-    val hazeState1 = HazeState()
-    val hazeState2 = HazeState()
-
-    val selectedHazeState = mutableStateOf(hazeState1)
-
-    setContent {
-      Box(Modifier.hazeSource(selectedHazeState.value)) {
-        Spacer(
-          Modifier.hazeEffect(selectedHazeState.value, HazeDefaults.style(Color.Blue)),
-        )
-      }
-    }
-
-    // Assert that the HazeArea is in hazeState1
-    assertThat(hazeState1.areas).hasSize(1)
-    assertThat(hazeState2.areas).isEmpty()
-
-    // Update the selected HazeState and wait for idle
-    selectedHazeState.value = hazeState2
-    waitForIdle()
-
-    // Assert that the HazeArea moved to hazeState2
-    assertThat(hazeState1.areas).isEmpty()
-    assertThat(hazeState2.areas).hasSize(1)
   }
 }

--- a/internal/context-test/build.gradle.kts
+++ b/internal/context-test/build.gradle.kts
@@ -1,0 +1,33 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+
+plugins {
+  id("dev.chrisbanes.android.library")
+  id("dev.chrisbanes.kotlin.multiplatform")
+}
+
+android {
+  namespace = "dev.chrisbanes.haze.internal.context"
+}
+
+kotlin {
+  sourceSets {
+    val androidMain by getting {
+      dependencies {
+        implementation(libs.androidx.test.ext.junit)
+        implementation(libs.robolectric)
+      }
+    }
+  }
+
+  targets.configureEach {
+    compilations.configureEach {
+      compileTaskProvider {
+        compilerOptions {
+          freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
+      }
+    }
+  }
+}

--- a/internal/context-test/src/androidMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
+++ b/internal/context-test/src/androidMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
@@ -1,0 +1,10 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.test
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+actual abstract class ContextTest

--- a/internal/context-test/src/commonMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
+++ b/internal/context-test/src/commonMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
@@ -1,0 +1,6 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.test
+
+expect abstract class ContextTest()

--- a/internal/context-test/src/iosMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
+++ b/internal/context-test/src/iosMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
@@ -1,0 +1,6 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.test
+
+actual abstract class ContextTest

--- a/internal/context-test/src/jsMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
+++ b/internal/context-test/src/jsMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
@@ -1,0 +1,6 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.test
+
+actual abstract class ContextTest

--- a/internal/context-test/src/jvmMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
+++ b/internal/context-test/src/jvmMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
@@ -1,0 +1,6 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.test
+
+actual abstract class ContextTest

--- a/internal/context-test/src/wasmJsMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
+++ b/internal/context-test/src/wasmJsMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
@@ -1,0 +1,6 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.test
+
+actual abstract class ContextTest

--- a/internal/screenshot-test/build.gradle.kts
+++ b/internal/screenshot-test/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
+        api(projects.internal.contextTest)
 
         api(compose.components.resources)
         api(compose.foundation)

--- a/internal/screenshot-test/src/androidMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
+++ b/internal/screenshot-test/src/androidMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
@@ -10,21 +10,18 @@ import androidx.compose.ui.test.AndroidComposeUiTestEnvironment
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.RoborazziRule
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.github.takahirom.roborazzi.roboOutputName
 import org.junit.Rule
-import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
-@RunWith(AndroidJUnit4::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [28, 32, 35], qualifiers = RobolectricDeviceQualifiers.Pixel5)
-actual abstract class ScreenshotTest {
+actual abstract class ScreenshotTest : ContextTest() {
   @get:Rule
   val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 

--- a/internal/screenshot-test/src/commonJvmMain/kotlin/dev/chrisbanes/haze/test/HazeRoborazziDefaults.kt
+++ b/internal/screenshot-test/src/commonJvmMain/kotlin/dev/chrisbanes/haze/test/HazeRoborazziDefaults.kt
@@ -4,10 +4,8 @@
 package dev.chrisbanes.haze.test
 
 import com.dropbox.differ.SimpleImageComparator
-import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziOptions
 
-@OptIn(ExperimentalRoborazziApi::class)
 object HazeRoborazziDefaults {
   val roborazziOptions = RoborazziOptions(
     compareOptions = RoborazziOptions.CompareOptions(

--- a/internal/screenshot-test/src/iosMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
+++ b/internal/screenshot-test/src/iosMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
@@ -3,7 +3,7 @@
 
 package dev.chrisbanes.haze.test
 
-actual abstract class ScreenshotTest
+actual abstract class ScreenshotTest : ContextTest()
 
 actual fun ScreenshotTest.runScreenshotTest(
   block: ScreenshotUiTest.() -> Unit,

--- a/internal/screenshot-test/src/jsMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
+++ b/internal/screenshot-test/src/jsMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
@@ -3,7 +3,7 @@
 
 package dev.chrisbanes.haze.test
 
-actual abstract class ScreenshotTest
+actual abstract class ScreenshotTest : ContextTest()
 
 actual fun ScreenshotTest.runScreenshotTest(
   block: ScreenshotUiTest.() -> Unit,

--- a/internal/screenshot-test/src/jvmMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
+++ b/internal/screenshot-test/src/jvmMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
@@ -16,7 +16,7 @@ import com.github.takahirom.roborazzi.provideRoborazziContext
 import com.github.takahirom.roborazzi.roboOutputName
 import io.github.takahirom.roborazzi.captureRoboImage
 
-actual abstract class ScreenshotTest
+actual abstract class ScreenshotTest : ContextTest()
 
 actual val HazeRoborazziDefaults.outputDirectoryName: String get() = "desktop"
 

--- a/internal/screenshot-test/src/wasmJsMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
+++ b/internal/screenshot-test/src/wasmJsMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
@@ -3,7 +3,7 @@
 
 package dev.chrisbanes.haze.test
 
-actual abstract class ScreenshotTest
+actual abstract class ScreenshotTest : ContextTest()
 
 actual fun ScreenshotTest.runScreenshotTest(
   block: ScreenshotUiTest.() -> Unit,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,6 +59,7 @@ include(
   ":haze",
   ":haze-materials",
   ":internal:benchmark",
+  ":internal:context-test",
   ":internal:screenshot-test",
   ":sample:shared",
   ":sample:android",


### PR DESCRIPTION
Caused by the HazeState changing, due to the remembered HazeState not always being remembered across reused Lazy item compositions. We assumed that they always were, which resulted in `hazeSource` updating unused `HazeState`s.

Fixed by properly handling the `HazeState` changing.

Fixes #467 