### PR TITLE
Fix Haze not drawing any effects in previews

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ androidx-test-ext-junit = { module = "androidx.test.ext:junit-ktx", version.ref 
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.3.0"
 
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "jetpack-compose" }
+androidx-compose-ui-preview = { module = "androidx.compose.ui:ui-tooling", version.ref = "jetpack-compose" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "jetpack-compose" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "jetpack-compose" }
 
 assertk = { module = "com.willowtreeapps.assertk:assertk", version.ref = "assertk" }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -439,7 +439,7 @@ class HazeEffectNode(
   }
 
   private fun updateRenderEffectIfDirty() {
-    if (dirtyTracker.any(DirtyFields.RenderEffectAffectingFlags)) {
+    if (renderEffect == null || dirtyTracker.any(DirtyFields.RenderEffectAffectingFlags)) {
       renderEffect = getOrCreateRenderEffect()
     }
   }

--- a/sample/android/build.gradle.kts
+++ b/sample/android/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
   implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.profileinstaller)
 
+  implementation(libs.androidx.compose.ui.tooling)
+  implementation(libs.androidx.compose.ui.preview)
+
   implementation(libs.androidx.media3.exoplayer)
   implementation(libs.androidx.media3.ui)
 

--- a/sample/android/src/main/kotlin/dev/chrisbanes/haze/sample/android/Previews.kt
+++ b/sample/android/src/main/kotlin/dev/chrisbanes/haze/sample/android/Previews.kt
@@ -1,0 +1,15 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample.android
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import dev.chrisbanes.haze.sample.CreditCardSample
+import dev.chrisbanes.haze.sample.Navigator
+
+@Composable
+@Preview
+fun PreviewCardSample() {
+  CreditCardSample(Navigator())
+}


### PR DESCRIPTION
Regression in 1.2.0. I have absolutely no idea why the code doesn't work in the Android Studio Preview, but our screenshot tests work fine. Oh well, easy fix.

<img width="626" alt="Screenshot 2025-01-13 at 12 27 48" src="https://github.com/user-attachments/assets/0a3aa793-a153-4183-8b0e-834f22c6c1da" />

Fixes #468