### PR TITLE
Add workaround for positionOnScreen throwing

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -257,20 +257,18 @@ class HazeEffectNode(
     // up to the first draw. We usually need onGloballyPositioned which tends to happen after
     // the first pass
     if (positionOnScreen.isUnspecified) {
-      log(TAG) { "onPlaced: positionOnScreen=${coordinates.positionOnScreen()}" }
-      onPositioned(coordinates)
+      onPositioned(coordinates, "onPlaced")
     }
   }
 
   override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
-    log(TAG) { "onGloballyPositioned: positionOnScreen=${coordinates.positionOnScreen()}" }
-    onPositioned(coordinates)
+    onPositioned(coordinates, "onGloballyPositioned")
   }
 
-  private fun onPositioned(coordinates: LayoutCoordinates) {
-    positionOnScreen = coordinates.positionOnScreen()
+  private fun onPositioned(coordinates: LayoutCoordinates, source: String) {
+    positionOnScreen = coordinates.positionOnScreenCatching()
     size = coordinates.size.toSize()
-
+    log(TAG) { "$source: positionOnScreen=$positionOnScreen, size=$size" }
     updateEffect()
   }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -120,28 +120,24 @@ class HazeSourceNode(
     // the first pass
     Snapshot.withoutReadObservation {
       if (area.positionOnScreen.isUnspecified) {
-        log(TAG) {
-          "onPlaced: " +
-            "positionOnScreen=${coordinates.positionOnScreen()}, " +
-            "area=$area"
-        }
-        onPositioned(coordinates)
+        onPositioned(coordinates, "onPlaced")
       }
     }
   }
 
   override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
-    log(TAG) {
-      "onGloballyPositioned: " +
-        "positionOnScreen=${coordinates.positionOnScreen()}, " +
-        "content positionOnScreens=${area.positionOnScreen}"
-    }
-    onPositioned(coordinates)
+    onPositioned(coordinates, "onGloballyPositioned")
   }
 
-  private fun onPositioned(coordinates: LayoutCoordinates) {
-    area.positionOnScreen = coordinates.positionOnScreen()
+  private fun onPositioned(coordinates: LayoutCoordinates, source: String) {
+    area.positionOnScreen = coordinates.positionOnScreenCatching()
     area.size = coordinates.size.toSize()
+
+    log(TAG) {
+      "$source: positionOnScreen=${area.positionOnScreen}, " +
+        "size=${area.size}, " +
+        "positionOnScreens=${area.positionOnScreen}"
+    }
   }
 
   override fun ContentDrawScope.draw() {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
@@ -8,6 +8,8 @@ package dev.chrisbanes.haze
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.takeOrElse
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.positionOnScreen
 import kotlin.math.hypot
 
 internal fun calculateLength(
@@ -33,4 +35,15 @@ internal inline val Offset.orZero: Offset get() = takeOrElse { Offset.Zero }
 
 internal inline fun <T> unsynchronizedLazy(noinline initializer: () -> T): Lazy<T> {
   return lazy(mode = LazyThreadSafetyMode.NONE, initializer)
+}
+
+/**
+ * Workaround for https://youtrack.jetbrains.com/issue/CMP-7380
+ */
+internal fun LayoutCoordinates.positionOnScreenCatching(): Offset {
+  return try {
+    positionOnScreen()
+  } catch (t: Throwable) {
+    Offset.Unspecified
+  }
 }


### PR DESCRIPTION
Root cause: https://youtrack.jetbrains.com/issue/CMP-7380/ Easily worked around by wrapping all callers in
a try-catch and returning Offset.Unspecified.

Fixes #471