### PR TITLE
Re-introduce expanded layer size

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
@@ -6,10 +6,13 @@
 package dev.chrisbanes.haze
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.takeOrElse
 import androidx.compose.ui.layout.LayoutCoordinates
 import kotlin.math.hypot
+import kotlin.math.max
+import kotlin.math.min
 
 internal fun calculateLength(
   start: Offset,
@@ -37,3 +40,10 @@ internal inline fun <T> unsynchronizedLazy(noinline initializer: () -> T): Lazy<
 }
 
 internal expect fun LayoutCoordinates.positionForHaze(): Offset
+
+internal fun Rect.expandToInclude(other: Rect): Rect = Rect(
+  left = min(left, other.left),
+  top = min(top, other.top),
+  right = max(right, other.right),
+  bottom = max(bottom, other.bottom),
+)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
@@ -3,14 +3,13 @@
 
 package dev.chrisbanes.haze.sample
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
@@ -28,7 +27,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
@@ -77,7 +75,6 @@ fun ListOverImage(navigator: Navigator) {
         )
 
         LazyColumn(
-          verticalArrangement = Arrangement.spacedBy(8.dp),
           contentPadding = contentPadding,
           modifier = Modifier
             .testTag("lazy_column")
@@ -95,9 +92,8 @@ fun ListOverImage(navigator: Navigator) {
             ) {
               Box(
                 modifier = Modifier
-                  .fillMaxSize(0.8f)
-                  .align(Alignment.Center)
-                  .clip(RoundedCornerShape(4.dp))
+                  .fillMaxSize()
+                  .padding(horizontal = 24.dp)
                   .hazeEffect(state = hazeState, style = HazeMaterials.thin()),
               ) {
                 Text(


### PR DESCRIPTION
This PR introduces the expanded layer size, which was removed in #461. 

The key difference in this implementation is that we now no longer expand the layer size beyond what the content bounds. This means that the edges are now either blurred using the expanded content, or the clamp edge treatment. The previous implementation would not allow the clamp edge treatment to work.

Fixes #516 