### PR TITLE
Remove redundant apply call

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -373,7 +373,7 @@ class HazeEffectNode(
         }
       }
       .toMutableList()
-      .apply { sortBy(HazeArea::zIndex) }
+      .sortBy(HazeArea::zIndex)
 
     areaOffsets = areas.associateWith { area -> positionOnScreen - area.positionOnScreen }
     forcedInvalidationTick = areas.sumOf { it.forcedInvalidationTick.toLong() }


### PR DESCRIPTION
Simplify `list.apply { sortBy(HazeArea::zIndex) }` to `list.sortBy(HazeArea::zIndex)`.