### PR TITLE
Fix flicker when using AndroidX Navigation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.9.0"
+androidx-activity = "1.10.1"
 androidx-benchmark = "1.3.3"
-androidx-lifecycle = "2.8.4"
 androidx-media3 = "1.5.1"
 androidx-test-ext-junit = "1.2.1"
 assertk = "0.28.1"
@@ -41,8 +41,8 @@ mavenpublish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }
 [libraries]
 androidx-benchmark-macro = { module = "androidx.benchmark:benchmark-macro-junit4", version.ref = "androidx-benchmark" }
 androidx-core = "androidx.core:core-ktx:1.15.0"
-androidx-activity-compose = "androidx.activity:activity-compose:1.10.1"
-androidx-lifecycle-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidx-media3" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }
 androidx-profileinstaller = "androidx.profileinstaller:profileinstaller:1.4.1"

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -42,17 +42,12 @@ kotlin {
       dependencies {
         api(compose.ui)
         implementation(compose.foundation)
-        implementation(libs.androidx.lifecycle.compose)
       }
     }
 
     androidMain {
       dependencies {
-        // Needed to upgrade Jetpack Compose
-        // Can remove this once CMP goes stable
-        api(libs.androidx.compose.ui)
-        implementation(libs.androidx.compose.foundation)
-        implementation(libs.androidx.core)
+        implementation(libs.androidx.activity)
       }
     }
 

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.android.kt
@@ -3,15 +3,19 @@
 
 package dev.chrisbanes.haze
 
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
 import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import kotlinx.coroutines.launch
 
 internal actual fun HazeSourceNode.clearHazeAreaLayerOnStop() {
-  val lifecycleOwner = currentValueOf(LocalLifecycleOwner)
+  // TODO: Move to LocalActivity in Compose 1.8.0
+  val activity = currentValueOf(LocalContext).findActivityOrNull() ?: return
   coroutineScope.launch {
-    lifecycleOwner.lifecycle.currentStateFlow.collect { state ->
+    activity.lifecycle.currentStateFlow.collect { state ->
       if (state <= Lifecycle.State.CREATED) {
         // When the UI host is stopped, release the GraphicsLayer. Android seems to have a issue
         // tracking layers re-paints after an Activity stop + start. Clearing the layer once
@@ -20,4 +24,10 @@ internal actual fun HazeSourceNode.clearHazeAreaLayerOnStop() {
       }
     }
   }
+}
+
+private tailrec fun Context.findActivityOrNull(): ComponentActivity? = when (this) {
+  is ComponentActivity -> this
+  is ContextWrapper -> baseContext.findActivityOrNull()
+  else -> null
 }


### PR DESCRIPTION
Caused by use observing the `LocalLifecycleOwner` to determine when to manually clear the graphics layer when the Activity is stopped. 

However, when using AndroidX Navigation the `LocalLifecycleOwner` is tied to the back stack entry, which isn't what we really want to observe. Fixed by just observing the Activity instead.

Fixes #559 