### PR TITLE
Fix wrong blur rect after rotating

### DIFF
--- a/sample/android/src/main/AndroidManifest.xml
+++ b/sample/android/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
 
     <activity
       android:name=".MainActivity"
-      android:exported="true">
+      android:exported="true"
+      android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
This is a race condition, which only happens when the Activity is set to handle configuration changes itself.

The race condition is that we previously only updated the 'layer size' during the `effect node` being positioned. During that calculation we read the other HazeAreas to clip the resulting layer to be as small as possible. As we're reading state, we rely on state observation to restart the function, but we don't get that with `onPositioned`.

Easy fix, to move this logic to our state observing function.

Trying to write an automated test for this is going to be extremely hard without an emulator, so I've just updated the sample instead for easy manual testing.

Fixes #562 