### PR TITLE
Improve RenderScript blur performance and latency

### DIFF
--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/RenderScriptContext.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/RenderScriptContext.kt
@@ -1,0 +1,70 @@
+package dev.chrisbanes.haze
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.renderscript.Allocation
+import android.renderscript.Element
+import android.renderscript.RenderScript
+import android.renderscript.ScriptIntrinsicBlur
+import android.renderscript.Type
+import android.util.Log
+import android.view.Surface
+import androidx.compose.ui.unit.IntSize
+import androidx.core.graphics.createBitmap
+
+@Suppress("DEPRECATION")
+class RenderScriptContext(
+    context: Context,
+    val size: IntSize,
+    private val onDataReceived: RenderScriptContext.() -> Unit,
+) {
+
+  val inputSurface: Surface
+    get() = inputAlloc.surface
+
+  private val rs: RenderScript = RenderScript.create(context)
+  private var inputAlloc: Allocation
+  private var outputAlloc: Allocation
+  var outputBitmap: Bitmap
+    private set
+  private var blurScript: ScriptIntrinsicBlur
+
+  init {
+    val type = Type.Builder(rs, Element.U8_4(rs))
+      .setX(size.width)
+      .setY(size.height)
+      .create()
+    val flags = Allocation.USAGE_SCRIPT or Allocation.USAGE_IO_INPUT
+
+    inputAlloc = Allocation.createTyped(rs, type, flags).apply {
+      setOnBufferAvailableListener { allocation ->
+        allocation.ioReceive()
+        onDataReceived()
+      }
+    }
+
+    outputBitmap = createBitmap(size.width, size.height)
+    outputAlloc = Allocation.createFromBitmap(rs, outputBitmap)
+
+    blurScript = ScriptIntrinsicBlur.create(rs, Element.U8_4(rs)).apply {
+      setInput(inputAlloc)
+    }
+  }
+
+  fun applyBlur(blurRadius: Float) {
+    blurScript.let { bs ->
+      bs.setRadius(blurRadius.coerceAtMost(25f))
+      bs.forEach(outputAlloc)
+    }
+    outputAlloc.copyTo(outputBitmap)
+  }
+
+  fun release() {
+    Log.d("RenderScriptContext", "Releasing resources")
+    inputAlloc.destroy()
+    outputAlloc.destroy()
+    outputBitmap.recycle()
+    blurScript.destroy()
+    rs.destroy()
+  }
+}


### PR DESCRIPTION
# Improve RenderScript performance and latency:

## PR Details

-   Introduced `RenderScriptContext` class to encapsulate RenderScript resources (RenderScript, Allocations, ScriptIntrinsicBlur) and manage their lifecycle.
- The output bitmap is no longer re-created every time, but reused.

Old:

https://github.com/user-attachments/assets/0a979c0d-9f91-4899-9ec3-879d94c11096

New:

https://github.com/user-attachments/assets/320f3f53-99af-4ce4-b35b-f2ea7bf9b951