### PR TITLE
Scale the noise texture appropriately

### DIFF
--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/RenderScriptBlurEffect.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/RenderScriptBlurEffect.kt
@@ -114,15 +114,15 @@ internal class RenderScriptBlurEffect(
       layer.record(size = contentLayer.size) {
         drawLayer(contentLayer)
 
-        val contentSize = floor(node.size * scaleFactor)
-        val contentOffset = offset * scaleFactor
+        val contentSize = ceil(node.size * scaleFactor)
+        val contentOffset = (offset * scaleFactor).round()
 
         translate(contentOffset) {
           // Draw the noise on top...
           val noiseFactor = node.resolveNoiseFactor()
           if (noiseFactor > 0f) {
             PaintPool.usePaint { paint ->
-              val texture = context.getNoiseTexture(noiseFactor)
+              val texture = context.getNoiseTexture(noiseFactor, scaleFactor)
               paint.shader = BitmapShader(texture, REPEAT, REPEAT)
               drawContext.canvas.drawRect(contentSize.toRect(), paint)
             }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -586,9 +586,11 @@ private val renderEffectCache by unsynchronizedLazy {
 internal class RenderEffectParams(
   val blurRadius: Dp,
   val noiseFactor: Float,
+  val scale: Float,
+  val contentSize: Size,
+  val contentOffset: Offset,
   val tints: List<HazeTint> = emptyList(),
   val tintAlphaModulate: Float = 1f,
-  val contentBounds: Rect,
   val mask: Brush? = null,
   val progressive: HazeProgressive? = null,
 )
@@ -616,21 +618,23 @@ internal fun HazeEffectNode.calculateInputScaleFactor(
 @OptIn(ExperimentalHazeApi::class)
 internal fun HazeEffectNode.getOrCreateRenderEffect(
   inputScale: Float = calculateInputScaleFactor(),
-  blurRadius: Dp = resolveBlurRadius().takeOrElse { 0.dp } * inputScale,
+  blurRadius: Dp = resolveBlurRadius().takeOrElse { 0.dp },
   noiseFactor: Float = resolveNoiseFactor(),
   tints: List<HazeTint> = resolveTints(),
   tintAlphaModulate: Float = 1f,
-  contentSize: Size = this.size * inputScale,
-  contentOffset: Offset = this.layerOffset * inputScale,
+  contentSize: Size = this.size,
+  contentOffset: Offset = this.layerOffset,
   mask: Brush? = this.mask,
   progressive: HazeProgressive? = null,
 ): RenderEffect? = getOrCreateRenderEffect(
   RenderEffectParams(
     blurRadius = blurRadius,
     noiseFactor = noiseFactor,
+    scale = inputScale,
     tints = tints,
     tintAlphaModulate = tintAlphaModulate,
-    contentBounds = Rect(contentOffset, contentSize),
+    contentSize = contentSize,
+    contentOffset = contentOffset,
     mask = mask,
     progressive = progressive,
   ),

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
@@ -11,10 +11,11 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.takeOrElse
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
-import kotlin.math.floor
+import kotlin.math.ceil
 import kotlin.math.hypot
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 internal fun calculateLength(
   start: Offset,
@@ -52,4 +53,5 @@ internal fun Rect.expandToInclude(other: Rect): Rect = Rect(
   bottom = max(bottom, other.bottom),
 )
 
-internal fun floor(size: Size): Size = Size(width = floor(size.width), height = floor(size.height))
+internal fun ceil(size: Size): Size = Size(width = ceil(size.width), height = ceil(size.height))
+internal fun Offset.round(): Offset = Offset(x.roundToInt().toFloat(), y.roundToInt().toFloat())


### PR DESCRIPTION
This stops the noise being artificially drawn too large when the input scale is used, either explicitly, or implicitly on RenderScript when we need to scale the content to honour the given blur radius.