### PR TITLE
Tweaks to Progressive support for RenderScript

### DIFF
--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/RenderScriptBlurEffect.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/RenderScriptBlurEffect.kt
@@ -105,7 +105,7 @@ internal class RenderScriptBlurEffect(
     node.withGraphicsLayer { layer ->
       layer.alpha = node.alpha
 
-      val mask = node.mask ?: node.progressive?.asBrush()
+      val mask = node.progressive?.asBrush() ?: node.mask
       if (mask != null) {
         // If we have a mask, this needs to be drawn offscreen
         layer.compositingStrategy = CompositingStrategy.Offscreen
@@ -130,7 +130,7 @@ internal class RenderScriptBlurEffect(
 
           // Then the tints...
           for (tint in node.resolveTints()) {
-            drawScrim(tint = tint, node = node, size = contentSize)
+            drawScrim(tint = tint, node = node, size = contentSize, mask = mask)
           }
 
           if (mask != null) {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/BlurEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/BlurEffect.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.LocalGraphicsContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntSize
 import androidx.compose.ui.unit.takeOrElse
 import androidx.compose.ui.unit.toIntSize
 import dev.chrisbanes.haze.HazeEffectNode.Companion.TAG
@@ -67,7 +68,7 @@ internal fun DrawScope.drawScrim(
     }
   } else {
     if (mask != null) {
-      drawRect(brush = mask, colorFilter = ColorFilter.tint(tint.color))
+      drawRect(brush = mask, size = size, colorFilter = ColorFilter.tint(tint.color))
     } else {
       drawRect(color = tint.color, blendMode = tint.blendMode)
     }
@@ -108,7 +109,7 @@ internal fun DrawScope.createScaledContentLayer(
   layerSize: Size,
   layerOffset: Offset,
 ): GraphicsLayer? {
-  val scaledSize = (layerSize * scaleFactor).toIntSize()
+  val scaledSize = (layerSize * scaleFactor).roundToIntSize()
 
   if (scaledSize.width <= 0 || scaledSize.height <= 0) {
     // If we have a 0px dimension we can't do anything so just return


### PR DESCRIPTION
- Progressive takes precedence over `mask`
- Scrim is now masked correctly