### PR TITLE
Fix clamping blur effect on edges

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.takeOrElse
 import androidx.compose.ui.unit.toIntSize
 import androidx.compose.ui.unit.toSize
+import androidx.compose.ui.util.fastFold
 import kotlin.jvm.JvmInline
 
 /**
@@ -412,8 +413,8 @@ class HazeEffectNode(
 
     if (backgroundBlurring && areas.isNotEmpty() && size.isSpecified && positionOnScreen.isSpecified) {
       // The rect which covers all areas
-      val areasRect = areas.fold(Rect.Zero) { acc, area ->
-        acc.expandToInclude(area.bounds ?: Rect.Zero)
+      val areasRect = areas.fastFold(Rect.Inverted) { acc, area ->
+        area.bounds?.let { acc.expandToInclude(it) } ?: acc
       }
 
       val blurRadiusPx = with(currentValueOf(LocalDensity)) {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
@@ -55,3 +55,11 @@ internal fun Rect.expandToInclude(other: Rect): Rect = Rect(
 
 internal fun ceil(size: Size): Size = Size(width = ceil(size.width), height = ceil(size.height))
 internal fun Offset.round(): Offset = Offset(x.roundToInt().toFloat(), y.roundToInt().toFloat())
+
+internal val Rect.Companion.Inverted: Rect
+  get() = InvertedRect
+
+private val InvertedRect = Rect(
+  topLeft = Offset(x = Float.POSITIVE_INFINITY, y = Float.POSITIVE_INFINITY),
+  bottomRight = Offset(x = Float.NEGATIVE_INFINITY, y = Float.NEGATIVE_INFINITY),
+)


### PR DESCRIPTION
A silly bug from using `Rect.Zero` as the initial value in a fold.

Fixes #628 