### PR TITLE
Add macos targets

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,7 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
+org.jetbrains.compose.experimental.macos.enabled=true
 
 # Required to publish to Nexus (see https://github.com/gradle/gradle/issues/11308)
 systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/KotlinMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/KotlinMultiplatformConventionPlugin.kt
@@ -29,6 +29,9 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
       iosArm64()
       iosSimulatorArm64()
 
+      macosX64()
+      macosArm64()
+
       @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
       wasmJs {
         browser()

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -60,6 +60,10 @@ kotlin {
       dependsOn(skikoMain)
     }
 
+    macosMain {
+      dependsOn(skikoMain)
+    }
+
     jvmMain {
       dependsOn(skikoMain)
     }

--- a/internal/context-test/src/macosMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
+++ b/internal/context-test/src/macosMain/kotlin/dev/chrisbanes/haze/test/ContextTest.kt
@@ -1,0 +1,6 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.test
+
+actual abstract class ContextTest

--- a/internal/screenshot-test/src/macosMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
+++ b/internal/screenshot-test/src/macosMain/kotlin/dev/chrisbanes/haze/test/ScreenshotTest.kt
@@ -1,0 +1,12 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.test
+
+actual abstract class ScreenshotTest : ContextTest()
+
+actual fun ScreenshotTest.runScreenshotTest(
+  block: ScreenshotUiTest.() -> Unit,
+) {
+  // no-op
+}

--- a/sample/macos/build.gradle.kts
+++ b/sample/macos/build.gradle.kts
@@ -1,0 +1,39 @@
+// Copyright 2023, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+
+plugins {
+  id("dev.chrisbanes.kotlin.multiplatform")
+  id("dev.chrisbanes.compose")
+}
+
+kotlin {
+  listOf(
+    macosX64(),
+    macosArm64()
+  ).forEach { macosTarget ->
+    macosTarget.binaries.executable {
+      entryPoint = "dev.chrisbanes.haze.sample.main"
+      freeCompilerArgs += listOf(
+        "-linker-option", "-framework", "-linker-option", "Metal"
+      )
+    }
+  }
+
+  sourceSets {
+    macosMain {
+      dependencies {
+        implementation(projects.sample.shared)
+      }
+    }
+  }
+}
+
+compose.desktop {
+  nativeApplication {
+    targets(
+      kotlin.targets.getByName("macosArm64"),
+      kotlin.targets.getByName("macosX64")
+    )
+  }
+}

--- a/sample/macos/build.gradle.kts
+++ b/sample/macos/build.gradle.kts
@@ -10,12 +10,12 @@ plugins {
 kotlin {
   listOf(
     macosX64(),
-    macosArm64()
+    macosArm64(),
   ).forEach { macosTarget ->
     macosTarget.binaries.executable {
       entryPoint = "dev.chrisbanes.haze.sample.main"
       freeCompilerArgs += listOf(
-        "-linker-option", "-framework", "-linker-option", "Metal"
+        "-linker-option", "-framework", "-linker-option", "Metal",
       )
     }
   }
@@ -33,7 +33,7 @@ compose.desktop {
   nativeApplication {
     targets(
       kotlin.targets.getByName("macosArm64"),
-      kotlin.targets.getByName("macosX64")
+      kotlin.targets.getByName("macosX64"),
     )
   }
 }

--- a/sample/macos/src/macosMain/kotlin/dev/chrisbanes/haze/sample/Main.kt
+++ b/sample/macos/src/macosMain/kotlin/dev/chrisbanes/haze/sample/Main.kt
@@ -1,0 +1,26 @@
+// Copyright 2023, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample
+
+import androidx.compose.ui.window.Window
+import platform.AppKit.NSApplication
+import platform.AppKit.NSApplicationActivationPolicy
+import platform.AppKit.NSApplicationDelegateProtocol
+import platform.darwin.NSObject
+
+fun main() {
+  val nsApplication = NSApplication.sharedApplication()
+  nsApplication.setActivationPolicy(NSApplicationActivationPolicy.NSApplicationActivationPolicyRegular)
+  nsApplication.delegate = object : NSObject(), NSApplicationDelegateProtocol {
+    override fun applicationShouldTerminateAfterLastWindowClosed(sender: NSApplication): Boolean {
+      return true
+    }
+  }
+  Window(
+    title = "Haze Sample",
+  ) {
+    Samples("Haze Samples")
+  }
+  nsApplication.run()
+}

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -55,6 +55,14 @@ kotlin {
       }
     }
 
+    macosMain {
+      dependsOn(skikoMain)
+
+      dependencies {
+        implementation(libs.ktor.darwin)
+      }
+    }
+
     jvmMain {
       dependsOn(skikoMain)
 

--- a/sample/shared/src/macosMain/kotlin/dev/chrisbanes/haze/sample/Platform.macos.kt
+++ b/sample/shared/src/macosMain/kotlin/dev/chrisbanes/haze/sample/Platform.macos.kt
@@ -1,0 +1,9 @@
+// Copyright 2024, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample
+
+import coil3.PlatformContext
+import okio.Path
+
+actual fun PlatformContext.cacheDirPath(): Path? = null

--- a/sample/shared/src/macosMain/kotlin/dev/chrisbanes/haze/sample/Samples.macos.kt
+++ b/sample/shared/src/macosMain/kotlin/dev/chrisbanes/haze/sample/Samples.macos.kt
@@ -1,0 +1,7 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample
+
+actual val Samples: List<Sample>
+  get() = CommonSamples

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -65,4 +65,5 @@ include(
   ":sample:android",
   ":sample:desktop",
   ":sample:web",
+  ":sample:macos",
 )


### PR DESCRIPTION
While CMP doesn't explicitly state support for macOS as a target platform, it seems to work well in most cases, so adding macOS support shouldn't pose any additional difficulties.

<img width="882" alt="截屏2025-05-21 15 18 29" src="https://github.com/user-attachments/assets/33305e0c-1381-463c-b718-7964e07816b8" />
<img width="815" alt="截屏2025-05-21 15 25 06" src="https://github.com/user-attachments/assets/037fc5ec-ff87-4c35-9800-5aea4f4197b4" />
<img width="812" alt="截屏2025-05-21 15 25 23" src="https://github.com/user-attachments/assets/6a2b4edc-d359-47e5-b92a-15274f304880" />
<img width="930" alt="截屏2025-05-21 15 25 52" src="https://github.com/user-attachments/assets/bfb45376-7519-4387-bd6c-6a8724b980fd" />

