### PR TITLE
Hide internal functions

### DIFF
--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -106,14 +106,6 @@ package dev.chrisbanes.haze {
     field public static final String TAG = "HazeEffect";
   }
 
-  public final class HazeEffectNode_androidKt {
-    method public static boolean invalidateOnHazeAreaPreDraw();
-  }
-
-  public final class HazeEffectNode_skikoKt {
-    method public static boolean invalidateOnHazeAreaPreDraw();
-  }
-
   public interface HazeEffectScope {
     method public float getAlpha();
     method public long getBackgroundColor();
@@ -343,24 +335,6 @@ package dev.chrisbanes.haze {
   }
 
   @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.SOURCE) @kotlin.annotation.Target(allowedTargets=kotlin.annotation.AnnotationTarget.CLASS) public @interface Poko {
-  }
-
-  public final class Trace_androidKt {
-    method public static inline <R> R trace(String sectionName, kotlin.jvm.functions.Function0<? extends R> block);
-    method public static suspend inline <R> Object? traceAsync(String sectionName, int cookie, kotlin.jvm.functions.Function1<? super kotlin.coroutines.Continuation<? super R>,? extends java.lang.Object?> block, kotlin.coroutines.Continuation<? super R>);
-  }
-
-  public final class Trace_skikoKt {
-    method public static inline <R> R trace(String sectionName, kotlin.jvm.functions.Function0<? extends R> block);
-    method public static suspend inline <R> Object? traceAsync(String sectionName, int cookie, kotlin.jvm.functions.Function1<? super kotlin.coroutines.Continuation<? super R>,? extends java.lang.Object?> block, kotlin.coroutines.Continuation<? super R>);
-  }
-
-  public final class Utils_androidKt {
-    method public static Object? getWindowId(androidx.compose.ui.node.CompositionLocalConsumerModifierNode);
-  }
-
-  public final class Utils_skikoKt {
-    method public static Object? getWindowId(androidx.compose.ui.node.CompositionLocalConsumerModifierNode);
   }
 
 }

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.android.kt
@@ -48,4 +48,4 @@ internal actual fun HazeEffectNode.updateBlurEffectIfNeeded(drawScope: DrawScope
  *   with RenderNodes not automatically re-painting. We workaround it by manually invalidating.
  * - Anything below API 31 does not have RenderEffect so we need to force invalidations.
  */
-actual fun invalidateOnHazeAreaPreDraw(): Boolean = Build.VERSION.SDK_INT < 32
+internal actual fun invalidateOnHazeAreaPreDraw(): Boolean = Build.VERSION.SDK_INT < 32

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Trace.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Trace.android.kt
@@ -3,11 +3,11 @@
 
 package dev.chrisbanes.haze
 
-actual inline fun <R> trace(sectionName: String, block: () -> R): R {
+internal actual inline fun <R> trace(sectionName: String, block: () -> R): R {
   return androidx.tracing.trace(sectionName, block)
 }
 
-actual suspend inline fun <R> traceAsync(
+internal actual suspend inline fun <R> traceAsync(
   sectionName: String,
   cookie: Int,
   crossinline block: suspend () -> R,

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Utils.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/Utils.android.kt
@@ -15,6 +15,6 @@ import androidx.compose.ui.platform.LocalView
  */
 internal actual fun LayoutCoordinates.positionForHaze(): Offset = positionOnScreen()
 
-actual fun CompositionLocalConsumerModifierNode.getWindowId(): Any? {
+internal actual fun CompositionLocalConsumerModifierNode.getWindowId(): Any? {
   return currentValueOf(LocalView).windowId
 }

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.skiko.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.skiko.kt
@@ -20,4 +20,4 @@ internal actual fun HazeEffectNode.updateBlurEffectIfNeeded(drawScope: DrawScope
   }
 }
 
-actual fun invalidateOnHazeAreaPreDraw(): Boolean = false
+internal actual fun invalidateOnHazeAreaPreDraw(): Boolean = false

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/Trace.skiko.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/Trace.skiko.kt
@@ -3,11 +3,11 @@
 
 package dev.chrisbanes.haze
 
-actual inline fun <R> trace(sectionName: String, block: () -> R): R {
+internal actual inline fun <R> trace(sectionName: String, block: () -> R): R {
   return androidx.compose.ui.util.trace(sectionName, block)
 }
 
-actual suspend inline fun <R> traceAsync(
+internal actual suspend inline fun <R> traceAsync(
   sectionName: String,
   cookie: Int,
   crossinline block: suspend () -> R,

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/Utils.skiko.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/Utils.skiko.kt
@@ -18,4 +18,4 @@ internal actual fun LayoutCoordinates.positionForHaze(): Offset = try {
   Offset.Unspecified
 }
 
-actual fun CompositionLocalConsumerModifierNode.getWindowId(): Any? = null
+internal actual fun CompositionLocalConsumerModifierNode.getWindowId(): Any? = null


### PR DESCRIPTION
These should never have been public. Turns out that expect/actual doesn't honor the visibility of the `expect` function.