### PR TITLE
Fix Haze'd dialogs not blurring background content

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -102,12 +102,10 @@ class HazeSourceNode(
     state.addArea(area)
     clearHazeAreaLayerOnStop()
 
-    if (invalidateOnHazeAreaPreDraw()) {
-      preDrawDisposable = doOnPreDraw {
-        HazeLogger.d(TAG) { "onPreDraw" }
-        for (listener in area.preDrawListeners) {
-          listener()
-        }
+    preDrawDisposable = doOnPreDraw {
+      HazeLogger.d(TAG) { "onPreDraw" }
+      for (listener in area.preDrawListeners) {
+        listener()
       }
     }
   }


### PR DESCRIPTION
It worked on Android SDK 32 and below, but not above.