### PR TITLE
Check if node is attached from updateEffect

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -425,6 +425,8 @@ class HazeEffectNode(
   }
 
   private fun updateEffect(): Unit = trace("HazeEffectNode-updateEffect") {
+    if (!isAttached) return@trace
+
     compositionLocalStyle = currentValueOf(LocalHazeStyle)
     windowId = getWindowId()
 


### PR DESCRIPTION
Another Compose callback when we're apparently not attached.

Fixes #723 