### PR TITLE
Add clipToAreasBounds flag

### DIFF
--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -57,6 +57,7 @@ package dev.chrisbanes.haze {
     method public float getBlurRadius();
     method public androidx.compose.ui.graphics.Shape getBlurredEdgeTreatment();
     method public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeArea,java.lang.Boolean>? getCanDrawArea();
+    method public Boolean? getClipToAreasBounds();
     method public boolean getDrawContentBehind();
     method public dev.chrisbanes.haze.HazeTint getFallbackTint();
     method public dev.chrisbanes.haze.HazeInputScale getInputScale();
@@ -76,6 +77,7 @@ package dev.chrisbanes.haze {
     method public void setBlurRadius(float);
     method public void setBlurredEdgeTreatment(androidx.compose.ui.graphics.Shape);
     method public void setCanDrawArea(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeArea,java.lang.Boolean>?);
+    method public void setClipToAreasBounds(Boolean?);
     method public void setDrawContentBehind(boolean);
     method public void setFallbackTint(dev.chrisbanes.haze.HazeTint);
     method public void setInputScale(dev.chrisbanes.haze.HazeInputScale);
@@ -92,6 +94,7 @@ package dev.chrisbanes.haze {
     property public float blurRadius;
     property public androidx.compose.ui.graphics.Shape blurredEdgeTreatment;
     property public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeArea,java.lang.Boolean>? canDrawArea;
+    property public Boolean? clipToAreasBounds;
     property public boolean drawContentBehind;
     property public dev.chrisbanes.haze.HazeTint fallbackTint;
     property public dev.chrisbanes.haze.HazeInputScale inputScale;
@@ -113,6 +116,7 @@ package dev.chrisbanes.haze {
     method public float getBlurRadius();
     method public androidx.compose.ui.graphics.Shape getBlurredEdgeTreatment();
     method public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeArea,java.lang.Boolean>? getCanDrawArea();
+    method public Boolean? getClipToAreasBounds();
     method public boolean getDrawContentBehind();
     method public dev.chrisbanes.haze.HazeTint getFallbackTint();
     method public dev.chrisbanes.haze.HazeInputScale getInputScale();
@@ -127,6 +131,7 @@ package dev.chrisbanes.haze {
     method public void setBlurRadius(float);
     method public void setBlurredEdgeTreatment(androidx.compose.ui.graphics.Shape);
     method public void setCanDrawArea(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeArea,java.lang.Boolean>?);
+    method public void setClipToAreasBounds(Boolean?);
     method public void setDrawContentBehind(boolean);
     method public void setFallbackTint(dev.chrisbanes.haze.HazeTint);
     method public void setInputScale(dev.chrisbanes.haze.HazeInputScale);
@@ -141,6 +146,7 @@ package dev.chrisbanes.haze {
     property public abstract float blurRadius;
     property public abstract androidx.compose.ui.graphics.Shape blurredEdgeTreatment;
     property public abstract kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeArea,java.lang.Boolean>? canDrawArea;
+    property public abstract Boolean? clipToAreasBounds;
     property public abstract boolean drawContentBehind;
     property public abstract dev.chrisbanes.haze.HazeTint fallbackTint;
     property public abstract dev.chrisbanes.haze.HazeInputScale inputScale;

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
@@ -190,6 +190,15 @@ interface HazeEffectScope {
    * This flag has no effect when used with background blurring.
    */
   var drawContentBehind: Boolean
+
+  /**
+   * Whether the drawn effect should be clipped to the total bounds which cover all of the
+   * areas provided via the [HazeState.areas].
+   *
+   * This defaults to `null` which means that Haze will decide whether to clip or not depending
+   * on other conditions.
+   */
+  var clipToAreasBounds: Boolean?
 }
 
 /**

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
@@ -45,3 +45,7 @@ internal expect fun CompositionLocalConsumerModifierNode.getWindowId(): Any?
 
 internal fun ceil(size: Size): Size = Size(width = ceil(size.width), height = ceil(size.height))
 internal fun Offset.round(): Offset = Offset(x.roundToInt().toFloat(), y.roundToInt().toFloat())
+
+internal inline fun <T> T.letIf(condition: Boolean, block: (T) -> T): T {
+  return if (condition) block(this) else this
+}


### PR DESCRIPTION
This PR adds in a new `clipToAreasBounds` flag for `HazeEffect` which allows developers to control whether the effect is clipped to the area(s) bounds.

Also tidied up the default value, so that we only clip by default when transparent/translucent background color is provided.

Fixes #738 