### PR TITLE
[Android] Optimize noise texture

### DIFF
--- a/haze-screenshot-tests/build.gradle.kts
+++ b/haze-screenshot-tests/build.gradle.kts
@@ -21,6 +21,7 @@ android {
       isIncludeAndroidResources = true
 
       all {
+        it.useJUnitPlatform()
         it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware"
       }
     }


### PR DESCRIPTION
We now use a single bitmap and scale/transform it at draw time instead.