### PR TITLE
Only enable pre-draw listeners when necessary

### DIFF
--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -239,7 +239,7 @@ package dev.chrisbanes.haze {
     property public float radiusIntensity;
   }
 
-  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeSourceNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.node.TraversableNode {
+  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeSourceNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.node.ObserverModifierNode androidx.compose.ui.node.TraversableNode {
     ctor public HazeSourceNode(dev.chrisbanes.haze.HazeState state, optional float zIndex, optional Object? key);
     method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
     method public Object? getKey();
@@ -247,6 +247,7 @@ package dev.chrisbanes.haze {
     method public Object getTraverseKey();
     method public float getZIndex();
     method public void onGloballyPositioned(androidx.compose.ui.layout.LayoutCoordinates coordinates);
+    method public void onObservedReadsChanged();
     method public void setKey(Object?);
     method public void setState(dev.chrisbanes.haze.HazeState);
     method public void setZIndex(float);

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -92,7 +93,7 @@ public class HazeArea {
   public var windowId: Any? = null
     internal set
 
-  internal val preDrawListeners = mutableSetOf<OnPreDrawListener>()
+  internal val preDrawListeners = mutableStateSetOf<OnPreDrawListener>()
 
   /**
    * The content [GraphicsLayer].


### PR DESCRIPTION
This PR changes Haze so that it only attaches the pre-draw listener to the host system when we actually need it. Currently we always attach it, and then skip the event if we don't need it, but that means that the host is still invoking us.