### PR TITLE
Add forceInvalidateOnPreDraw flag

### DIFF
--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -58,6 +58,7 @@ package dev.chrisbanes.haze {
     method public boolean getDrawContentBehind();
     method public Boolean? getExpandLayerBounds();
     method public dev.chrisbanes.haze.HazeTint getFallbackTint();
+    method public boolean getForceInvalidateOnPreDraw();
     method public dev.chrisbanes.haze.HazeInputScale getInputScale();
     method public androidx.compose.ui.graphics.Brush? getMask();
     method public float getNoiseFactor();
@@ -76,6 +77,7 @@ package dev.chrisbanes.haze {
     method public void setDrawContentBehind(boolean);
     method public void setExpandLayerBounds(Boolean?);
     method public void setFallbackTint(dev.chrisbanes.haze.HazeTint);
+    method public void setForceInvalidateOnPreDraw(boolean);
     method public void setInputScale(dev.chrisbanes.haze.HazeInputScale);
     method public void setMask(androidx.compose.ui.graphics.Brush?);
     method public void setNoiseFactor(float);
@@ -94,6 +96,7 @@ package dev.chrisbanes.haze {
     property public boolean drawContentBehind;
     property public Boolean? expandLayerBounds;
     property public dev.chrisbanes.haze.HazeTint fallbackTint;
+    property public boolean forceInvalidateOnPreDraw;
     property public dev.chrisbanes.haze.HazeInputScale inputScale;
     property public androidx.compose.ui.graphics.Brush? mask;
     property public float noiseFactor;
@@ -114,6 +117,7 @@ package dev.chrisbanes.haze {
     method public boolean getDrawContentBehind();
     method public Boolean? getExpandLayerBounds();
     method public dev.chrisbanes.haze.HazeTint getFallbackTint();
+    method public boolean getForceInvalidateOnPreDraw();
     method public dev.chrisbanes.haze.HazeInputScale getInputScale();
     method public androidx.compose.ui.graphics.Brush? getMask();
     method public float getNoiseFactor();
@@ -127,6 +131,7 @@ package dev.chrisbanes.haze {
     method public void setDrawContentBehind(boolean);
     method public void setExpandLayerBounds(Boolean?);
     method public void setFallbackTint(dev.chrisbanes.haze.HazeTint);
+    method public void setForceInvalidateOnPreDraw(boolean);
     method public void setInputScale(dev.chrisbanes.haze.HazeInputScale);
     method public void setMask(androidx.compose.ui.graphics.Brush?);
     method public void setNoiseFactor(float);
@@ -143,6 +148,7 @@ package dev.chrisbanes.haze {
     property public abstract boolean drawContentBehind;
     property public abstract Boolean? expandLayerBounds;
     property public abstract dev.chrisbanes.haze.HazeTint fallbackTint;
+    property public abstract boolean forceInvalidateOnPreDraw;
     property @dev.chrisbanes.haze.ExperimentalHazeApi public abstract dev.chrisbanes.haze.HazeInputScale inputScale;
     property public abstract androidx.compose.ui.graphics.Brush? mask;
     property public abstract float noiseFactor;

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeChild.kt
@@ -209,6 +209,29 @@ public interface HazeEffectScope {
    * areas.
    */
   public var expandLayerBounds: Boolean?
+
+  /**
+   * Force draw invalidation from pre-draw events of contributing [HazeArea]s.
+   *
+   * When enabled, Haze will register a pre-draw listener and invalidate this effect node
+   * whenever the source areas are about to be drawn. This helps ensure the blur stays in sync
+   * with rapidly changing or externally-invalidated content.
+   *
+   * Haze automatically enables this for scenarios where it knows we need it:
+   * - The source content is drawn in a different window than this effect (e.g. Dialogs/Popups),
+   *   so it's outside of this node's normal invalidation scope.
+   * - On some older Android versions where invalidation propagation is less reliable.
+   *
+   * However, there may be other use cases where invalidation does not work as expected, and
+   * the [hazeEffect] looks like it is 'stuck' or out of sync. By setting this flag to `true`,
+   * we use the pre-draw listener to force invalidations, and thus should fix the majority
+   * of issues.
+   *
+   * Notes:
+   * - Only has an effect when blurring is enabled.
+   * - May have a performance cost due to additional invalidations from the pre-draw listener.
+   */
+  public var forceInvalidateOnPreDraw: Boolean
 }
 
 /**


### PR DESCRIPTION
When enabled, Haze will register a pre-draw listener and invalidate this effect node whenever the source areas are about to be drawn. This helps ensure the blur stays in sync with rapidly changing or externally-invalidated content.

Haze automatically enables this for scenarios where it knows we need it:

* The source content is drawn in a different window than this effect (e.g. Dialogs/Popups), so it's outside of this node's normal invalidation scope.
* On some older Android versions where invalidation propagation is less reliable.

However, there may be other use cases where invalidation does not work as expected, and the [hazeEffect] looks like it is "stuck" or out of sync. By setting this flag to `true`, we use the pre-draw listener to force invalidations, and thus should fix the majority of issues.

**Notes:**

* Only has an effect when blurring is enabled.
* May have a performance cost due to additional invalidations from the pre-draw listener.