### PR TITLE
Update Android version references in platforms.md

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -6,13 +6,13 @@ Haze works on all platforms which [Compose Multiplatform](https://www.jetbrains.
 
 ## Android
 
-### Android 14+
+### Android 13+
 
 SDK Levels: 33+
 
 Haze is in its optimal environment for all use cases when running on recent versions of Android.
 
-### Android 12 & 13
+### Android 12 & 12L
 
 SDK Levels: 31 & 32
 
@@ -36,7 +36,7 @@ LargeTopAppBar(
 )
 ```
 
-All other progressive types will fallback to using a mask when running on Android 12 & 13.
+All other progressive types will fallback to using a mask when running on Android 12 & 12L.
 
 ### Android 12 and below
 


### PR DESCRIPTION
This pull request updates the documentation in `docs/platforms.md` to clarify Android version support and terminology for the Haze feature. The main changes are focused on correcting version references and naming conventions.

Android version support and terminology updates:

* Changed the section heading from "Android 14+" to "Android 13+" to accurately reflect supported versions for optimal Haze usage.
* Updated references from "Android 12 & 13" to "Android 12 & 12L" to use the correct Android version naming conventions in both section headings and descriptive text. [[1]](diffhunk://#diff-b78fb64d29a236212cca36c447704c8d2e362d6636222c01d51d02f93d21106eL9-R15) [[2]](diffhunk://#diff-b78fb64d29a236212cca36c447704c8d2e362d6636222c01d51d02f93d21106eL39-R39)

Based on this
<img width="267" height="168" alt="image" src="https://github.com/user-attachments/assets/e950b8a0-3f5b-410b-a0ae-14bf11951356" />
