### PR TITLE
Refactor screenshot tests

### DIFF
--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurDirtyFields.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurDirtyFields.kt
@@ -8,7 +8,7 @@ import dev.chrisbanes.haze.InternalHazeApi
 
 @Suppress("ConstPropertyName", "ktlint:standard:property-naming")
 @OptIn(InternalHazeApi::class)
-internal object DirtyFields {
+internal object BlurDirtyFields {
   const val BlurEnabled: Int = 0b1
   const val BlurRadius: Int = BlurEnabled shl 1
   const val NoiseFactor: Int = BlurRadius shl 1

--- a/haze-screenshot-tests/src/commonMain/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
+++ b/haze-screenshot-tests/src/commonMain/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
@@ -31,15 +31,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import dev.chrisbanes.haze.blur.HazeBlurDefaults
-import dev.chrisbanes.haze.blur.HazeProgressive
-import dev.chrisbanes.haze.blur.HazeStyle
-import dev.chrisbanes.haze.blur.HazeTint
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.blur.BlurVisualEffect
 import haze_root.haze_screenshot_tests.generated.resources.Res
 import haze_root.haze_screenshot_tests.generated.resources.photo
 import kotlin.math.roundToInt
@@ -47,17 +42,10 @@ import org.jetbrains.compose.resources.painterResource
 
 @Composable
 internal fun CreditCardSample(
+  visualEffect: BlurVisualEffect,
   backgroundColors: List<Color> = listOf(Color.Blue, Color.Cyan),
-  style: HazeStyle = HazeStyle.Unspecified,
-  tint: HazeTint = HazeTint.Unspecified,
-  blurRadius: Dp = Dp.Unspecified,
-  noiseFactor: Float = -1f,
   shape: RoundedCornerShape = RoundedCornerShape(16.dp),
   enabled: Boolean = true,
-  blurEnabled: Boolean = HazeBlurDefaults.blurEnabled(),
-  mask: Brush? = null,
-  progressive: HazeProgressive? = null,
-  alpha: Float = 1f,
   numberCards: Int = 1,
 ) {
   val hazeState = remember { HazeState() }
@@ -71,8 +59,6 @@ internal fun CreditCardSample(
         .hazeSource(state = hazeState, zIndex = 0f),
     )
 
-    val surfaceColor = MaterialTheme.colorScheme.surface
-
     repeat(numberCards) { index ->
       // Our card
       val reverseIndex = (numberCards - 1 - index)
@@ -83,15 +69,7 @@ internal fun CreditCardSample(
         index = index,
         shape = shape,
         enabled = enabled,
-        blurEnabled = blurEnabled,
-        style = style,
-        surfaceColor = surfaceColor,
-        noiseFactor = noiseFactor,
-        tint = tint,
-        blurRadius = blurRadius,
-        mask = mask,
-        alpha = alpha,
-        progressive = progressive,
+        visualEffect = visualEffect,
         modifier = Modifier
           .align(Alignment.Center),
       )
@@ -101,16 +79,9 @@ internal fun CreditCardSample(
 
 @Composable
 internal fun CreditCardContentBlurring(
+  visualEffect: BlurVisualEffect,
   backgroundColors: List<Color> = listOf(Color.Blue, Color.Cyan),
-  style: HazeStyle = HazeStyle.Unspecified,
-  tint: HazeTint = HazeTint.Unspecified,
-  blurRadius: Dp = Dp.Unspecified,
-  noiseFactor: Float = -1f,
-  blurEnabled: Boolean = HazeBlurDefaults.blurEnabled(),
-  mask: Brush? = null,
-  progressive: HazeProgressive? = null,
   drawContentBehind: Boolean = false,
-  alpha: Float = 1f,
 ) {
   Box(Modifier.background(backgroundColors.first())) {
     // Background content
@@ -120,18 +91,7 @@ internal fun CreditCardContentBlurring(
         .fillMaxSize()
         .hazeEffect {
           this.drawContentBehind = drawContentBehind
-
-          blurEffect {
-            this.blurEnabled = blurEnabled
-            this.style = style
-            this.backgroundColor = backgroundColors.first()
-            this.noiseFactor = noiseFactor
-            this.tints = listOfNotNull(tint.takeIf(HazeTint::isSpecified))
-            this.blurRadius = blurRadius
-            this.mask = mask
-            this.alpha = alpha
-            this.progressive = progressive
-          }
+          this.visualEffect = visualEffect
         },
     )
   }
@@ -139,18 +99,11 @@ internal fun CreditCardContentBlurring(
 
 @Composable
 internal fun CreditCardPagerSample(
+  visualEffect: BlurVisualEffect,
   pagerPosition: Float,
   backgroundColors: List<Color> = listOf(Color.Blue, Color.Cyan),
-  style: HazeStyle = HazeStyle.Unspecified,
-  tint: HazeTint = HazeTint.Unspecified,
-  blurRadius: Dp = Dp.Unspecified,
-  noiseFactor: Float = -1f,
   shape: RoundedCornerShape = RoundedCornerShape(16.dp),
   enabled: Boolean = true,
-  blurEnabled: Boolean = HazeBlurDefaults.blurEnabled(),
-  mask: Brush? = null,
-  progressive: HazeProgressive? = null,
-  alpha: Float = 1f,
   numberCards: Int = 2,
 ) {
   val hazeState = remember { HazeState() }
@@ -163,8 +116,6 @@ internal fun CreditCardPagerSample(
         .fillMaxSize()
         .hazeSource(state = hazeState, zIndex = 0f),
     )
-
-    val surfaceColor = MaterialTheme.colorScheme.surface
     val positionIndex = pagerPosition.roundToInt()
     val pagerState = PagerState(positionIndex, pagerPosition - positionIndex) {
       numberCards
@@ -182,16 +133,8 @@ internal fun CreditCardPagerSample(
         index = index,
         shape = shape,
         enabled = enabled,
-        blurEnabled = blurEnabled,
-        style = style,
-        surfaceColor = surfaceColor,
-        noiseFactor = noiseFactor,
-        tint = tint,
-        blurRadius = blurRadius,
-        mask = mask,
-        alpha = alpha,
-        progressive = progressive,
-        baseWidth = .9f,
+        visualEffect = visualEffect,
+        baseWidth = 0.9f,
       )
     }
   }
@@ -224,15 +167,7 @@ private fun CreditCard(
   index: Int,
   shape: RoundedCornerShape,
   enabled: Boolean,
-  blurEnabled: Boolean,
-  style: HazeStyle,
-  surfaceColor: Color,
-  noiseFactor: Float,
-  tint: HazeTint,
-  blurRadius: Dp,
-  mask: Brush?,
-  alpha: Float,
-  progressive: HazeProgressive?,
+  visualEffect: BlurVisualEffect,
   modifier: Modifier = Modifier,
   baseWidth: Float = .7f,
 ) {
@@ -247,17 +182,7 @@ private fun CreditCard(
       .then(
         if (enabled) {
           Modifier.hazeEffect(state = hazeState) {
-            blurEffect {
-              this.blurEnabled = blurEnabled
-              this.style = style
-              this.backgroundColor = surfaceColor
-              this.noiseFactor = noiseFactor
-              this.tints = listOfNotNull(tint.takeIf(HazeTint::isSpecified))
-              this.blurRadius = blurRadius
-              this.mask = mask
-              this.alpha = alpha
-              this.progressive = progressive
-            }
+            this.visualEffect = visualEffect
           }
         } else {
           Modifier
@@ -272,7 +197,7 @@ private fun CreditCard(
 
 @Composable
 fun OverlayingContent(
-  blurEnabled: Boolean = true,
+  visualEffect: BlurVisualEffect,
   topOffset: DpOffset = DpOffset.Zero,
 ) {
   val hazeState = rememberHazeState()
@@ -321,10 +246,7 @@ fun OverlayingContent(
         }
         .align(Alignment.Center)
         .hazeEffect(state = hazeState) {
-          blurEffect {
-            this.blurEnabled = blurEnabled
-            blurRadius = 20.dp
-          }
+          this.visualEffect = visualEffect
         }
         .padding(16.dp),
     )
@@ -332,10 +254,7 @@ fun OverlayingContent(
 }
 
 @Composable
-fun ContentAtEdges(
-  blurEnabled: Boolean = true,
-  style: HazeStyle = HazeStyle.Unspecified,
-) {
+fun ContentAtEdges(visualEffect: BlurVisualEffect) {
   val hazeState = rememberHazeState()
 
   Box(modifier = Modifier.fillMaxSize()) {
@@ -353,10 +272,7 @@ fun ContentAtEdges(
         .align(Alignment.BottomCenter)
         .fillMaxSize()
         .hazeEffect(state = hazeState) {
-          blurEffect {
-            this.blurEnabled = blurEnabled
-            this.style = style
-          }
+          this.visualEffect = visualEffect
         },
     ) {
       Text(

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeContentBlurringScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeContentBlurringScreenshotTest.kt
@@ -5,13 +5,12 @@ package dev.chrisbanes.haze
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import dev.chrisbanes.haze.blur.HazeBlurDefaults
+import dev.chrisbanes.haze.blur.BlurVisualEffect
 import dev.chrisbanes.haze.blur.HazeProgressive
 import dev.chrisbanes.haze.blur.HazeStyle
 import dev.chrisbanes.haze.blur.HazeTint
@@ -24,9 +23,13 @@ import kotlin.test.Test
 class HazeContentBlurringScreenshotTest : ScreenshotTest() {
   @Test
   fun creditCard() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(tint = DefaultTint, blurRadius = 8.dp)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -34,9 +37,10 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_noStyle() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect()
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring()
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -44,31 +48,37 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_blurEnabled() = runScreenshotTest {
-    var blurEnabled by mutableStateOf(HazeBlurDefaults.blurEnabled())
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
 
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(tint = DefaultTint, blurRadius = 8.dp, blurEnabled = blurEnabled)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
 
     waitForIdle()
     captureRoot("default")
 
-    blurEnabled = false
+    blurVisualEffect.blurEnabled = false
     waitForIdle()
     captureRoot("disabled")
 
-    blurEnabled = true
+    blurVisualEffect.blurEnabled = true
     waitForIdle()
     captureRoot("enabled")
   }
 
   @Test
   fun creditCard_style() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      style = OverrideStyle
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(style = OverrideStyle)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -76,10 +86,13 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_compositionLocalStyle() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      blurRadius = 8.dp
+    }
     setContent {
       ScreenshotTheme {
         CompositionLocalProvider(LocalHazeStyle provides OverrideStyle) {
-          CreditCardContentBlurring(blurRadius = 8.dp)
+          CreditCardContentBlurring(visualEffect = blurVisualEffect)
         }
       }
     }
@@ -88,9 +101,13 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_transparentTint() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      blurRadius = 8.dp
+      tints = listOf(HazeTint(Color.Transparent))
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(blurRadius = 8.dp, tint = HazeTint(Color.Transparent))
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -98,9 +115,12 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_zeroBlurRadius() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      blurRadius = 0.dp
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(blurRadius = 0.dp)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -108,9 +128,14 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_mask() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      mask = VerticalMask
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(tint = DefaultTint, mask = VerticalMask, blurRadius = 8.dp)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -118,34 +143,39 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_alpha() = runScreenshotTest {
-    var alpha by mutableFloatStateOf(0.5f)
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      alpha = 0.5f
+    }
 
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(tint = DefaultTint, blurRadius = 8.dp, alpha = alpha)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
 
     captureRoot()
 
-    alpha = 0.2f
+    blurVisualEffect.alpha = 0.2f
     waitForIdle()
     captureRoot("20")
 
-    alpha = 0.7f
+    blurVisualEffect.alpha = 0.7f
     waitForIdle()
     captureRoot("70")
   }
 
   @Test
   fun creditCard_progressive_horiz() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.horizontalGradient()
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.horizontalGradient(),
-        )
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -153,13 +183,14 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_progressive_horiz_preferMask() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.horizontalGradient(preferPerformance = true)
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.horizontalGradient(preferPerformance = true),
-        )
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -167,13 +198,14 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_progressive_vertical() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.verticalGradient()
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.verticalGradient(),
-        )
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -181,13 +213,14 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_progressive_radial() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.RadialGradient()
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.RadialGradient(),
-        )
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -195,15 +228,16 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_progressive_shader() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.Brush(
+        Brush.sweepGradient(colors = listOf(Color.Transparent, Color.Black)),
+      )
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.Brush(
-            Brush.sweepGradient(colors = listOf(Color.Transparent, Color.Black)),
-          ),
-        )
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -211,35 +245,40 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_childTint() = runScreenshotTest {
-    var tint by mutableStateOf(
-      HazeTint(Color.Magenta.copy(alpha = 0.5f)),
-    )
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(HazeTint(Color.Magenta.copy(alpha = 0.5f)))
+      blurRadius = 8.dp
+    }
 
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(tint = tint, blurRadius = 8.dp)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
 
     waitForIdle()
     captureRoot("magenta")
 
-    tint = HazeTint(Color.Yellow.copy(alpha = 0.5f))
+    blurVisualEffect.tints = listOf(HazeTint(Color.Yellow.copy(alpha = 0.5f)))
     waitForIdle()
     captureRoot("yellow")
 
-    tint = HazeTint(Color.Red.copy(alpha = 0.5f))
+    blurVisualEffect.tints = listOf(HazeTint(Color.Red.copy(alpha = 0.5f)))
     waitForIdle()
     captureRoot("red")
   }
 
   @Test
   fun creditCard_sourceContentChange() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
     var backgroundColors by mutableStateOf(listOf(Color.Blue, Color.Cyan))
 
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(backgroundColors = backgroundColors, blurRadius = 8.dp, tint = DefaultTint)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect, backgroundColors = backgroundColors)
       }
     }
 
@@ -257,9 +296,13 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_brushTint() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(BrushTint)
+      blurRadius = 8.dp
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(tint = BrushTint, blurRadius = 8.dp)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -267,9 +310,14 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_brushTint_mask() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(BrushTint)
+      blurRadius = 8.dp
+      mask = VerticalMask
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(tint = BrushTint, blurRadius = 8.dp, mask = VerticalMask)
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -277,13 +325,14 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_brushTint_progressive() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(BrushTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.verticalGradient()
+    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(
-          tint = BrushTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.verticalGradient(),
-        )
+        CreditCardContentBlurring(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -20,6 +19,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.blur.BlurVisualEffect
 import dev.chrisbanes.haze.blur.HazeBlurDefaults
 import dev.chrisbanes.haze.blur.HazeProgressive
 import dev.chrisbanes.haze.blur.HazeStyle
@@ -29,14 +29,26 @@ import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 class HazeScreenshotTest : ScreenshotTest() {
+
+  @BeforeTest
+  fun before() {
+    HazeLogger.enabled = true
+  }
+
   @Test
   fun creditCard() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = DefaultTint, blurRadius = 8.dp)
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -44,9 +56,11 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_noStyle() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect()
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample()
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -54,9 +68,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_multiple() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = DefaultTint, blurRadius = 8.dp, numberCards = 3)
+        CreditCardSample(visualEffect = blurVisualEffect, numberCards = 3)
       }
     }
     captureRoot()
@@ -64,31 +83,38 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_blurEnabled() = runScreenshotTest {
-    var blurEnabled by mutableStateOf(HazeBlurDefaults.blurEnabled())
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = DefaultTint, blurRadius = 8.dp, blurEnabled = blurEnabled)
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
 
     waitForIdle()
     captureRoot("default")
 
-    blurEnabled = false
+    blurVisualEffect.blurEnabled = false
     waitForIdle()
     captureRoot("disabled")
 
-    blurEnabled = true
+    blurVisualEffect.blurEnabled = true
     waitForIdle()
     captureRoot("enabled")
   }
 
   @Test
   fun creditCard_style() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      style = OverrideStyle
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(style = OverrideStyle)
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -96,10 +122,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_compositionLocalStyle() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
         CompositionLocalProvider(LocalHazeStyle provides OverrideStyle) {
-          CreditCardSample(blurRadius = 8.dp)
+          CreditCardSample(visualEffect = blurVisualEffect)
         }
       }
     }
@@ -108,9 +138,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_transparentTint() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      blurRadius = 8.dp
+      tints = listOf(HazeTint(Color.Transparent))
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(blurRadius = 8.dp, tint = HazeTint(Color.Transparent))
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -118,9 +153,13 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_zeroBlurRadius() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      blurRadius = 0.dp
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(blurRadius = 0.dp)
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -128,9 +167,15 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_mask() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      mask = VerticalMask
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = DefaultTint, mask = VerticalMask, blurRadius = 8.dp)
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -138,34 +183,40 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_alpha() = runScreenshotTest {
-    var alpha by mutableFloatStateOf(0.5f)
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      alpha = 0.5f
+    }
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = DefaultTint, blurRadius = 8.dp, alpha = alpha)
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
 
     captureRoot()
 
-    alpha = 0.2f
+    blurVisualEffect.alpha = 0.2f
     waitForIdle()
     captureRoot("20")
 
-    alpha = 0.7f
+    blurVisualEffect.alpha = 0.7f
     waitForIdle()
     captureRoot("70")
   }
 
   @Test
   fun creditCard_progressive_horiz() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.horizontalGradient()
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.horizontalGradient(),
-        )
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -173,13 +224,15 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_progressive_horiz_preferMask() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.horizontalGradient(preferPerformance = true)
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.horizontalGradient(preferPerformance = true),
-        )
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -187,13 +240,15 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_progressive_vertical() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.verticalGradient()
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.verticalGradient(),
-        )
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -201,14 +256,15 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_progressive_vertical_multiple() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.verticalGradient()
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.verticalGradient(),
-          numberCards = 3,
-        )
+        CreditCardSample(visualEffect = blurVisualEffect, numberCards = 3)
       }
     }
     captureRoot()
@@ -216,13 +272,15 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_progressive_radial() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.RadialGradient()
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.RadialGradient(),
-        )
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -230,15 +288,17 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_progressive_shader() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.Brush(
+        Brush.sweepGradient(colors = listOf(Color.Transparent, Color.Black)),
+      )
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(
-          tint = DefaultTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.Brush(
-            Brush.sweepGradient(colors = listOf(Color.Transparent, Color.Black)),
-          ),
-        )
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -246,24 +306,25 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_childTint() = runScreenshotTest {
-    var tint by mutableStateOf(
-      HazeTint(Color.Magenta.copy(alpha = 0.5f)),
-    )
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(HazeTint(Color.Magenta.copy(alpha = 0.5f)))
+      blurRadius = 8.dp
+    }
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = tint, blurRadius = 8.dp)
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
 
     waitForIdle()
     captureRoot("magenta")
 
-    tint = HazeTint(Color.Yellow.copy(alpha = 0.5f))
+    blurVisualEffect.tints = listOf(HazeTint(Color.Yellow.copy(alpha = 0.5f)))
     waitForIdle()
     captureRoot("yellow")
 
-    tint = HazeTint(Color.Red.copy(alpha = 0.5f))
+    blurVisualEffect.tints = listOf(HazeTint(Color.Red.copy(alpha = 0.5f)))
     waitForIdle()
     captureRoot("red")
   }
@@ -290,11 +351,15 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_conditional() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
     var enabled by mutableStateOf(true)
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = DefaultTint, blurRadius = 8.dp, enabled = enabled)
+        CreditCardSample(visualEffect = blurVisualEffect, enabled = enabled)
       }
     }
 
@@ -311,9 +376,14 @@ class HazeScreenshotTest : ScreenshotTest() {
   }
 
   private fun roundedCornerTest(roundedCornerShape: RoundedCornerShape) = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = DefaultTint, blurRadius = 8.dp, shape = roundedCornerShape)
+        CreditCardSample(visualEffect = blurVisualEffect, shape = roundedCornerShape)
       }
     }
     captureRoot()
@@ -332,11 +402,15 @@ class HazeScreenshotTest : ScreenshotTest() {
    */
   @Test
   fun creditCard_sourceContentChange() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
     var backgroundColors by mutableStateOf(listOf(Color.Blue, Color.Cyan))
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(backgroundColors = backgroundColors, blurRadius = 8.dp, tint = DefaultTint)
+        CreditCardSample(visualEffect = blurVisualEffect, backgroundColors = backgroundColors)
       }
     }
 
@@ -354,9 +428,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_brushTint() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(BrushTint)
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = BrushTint, blurRadius = 8.dp)
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -364,9 +443,15 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_brushTint_mask() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(BrushTint)
+      blurRadius = 8.dp
+      mask = VerticalMask
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(tint = BrushTint, blurRadius = 8.dp, mask = VerticalMask)
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -374,13 +459,15 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_brushTint_progressive() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(BrushTint)
+      blurRadius = 8.dp
+      progressive = HazeProgressive.verticalGradient()
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardSample(
-          tint = BrushTint,
-          blurRadius = 8.dp,
-          progressive = HazeProgressive.verticalGradient(),
-        )
+        CreditCardSample(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()
@@ -388,13 +475,18 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun nested_content() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
         Box(Modifier.fillMaxSize()) {
           val outerHazeState = remember { HazeState() }
 
           Box(Modifier.hazeSource(outerHazeState)) {
-            CreditCardSample(tint = DefaultTint, blurRadius = 8.dp)
+            CreditCardSample(visualEffect = blurVisualEffect)
           }
 
           Box(
@@ -420,9 +512,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun horizontalPager_quarter() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardPagerSample(.25f, tint = DefaultTint, blurRadius = 8.dp)
+        CreditCardPagerSample(visualEffect = blurVisualEffect, pagerPosition = .25f)
       }
     }
     captureRoot()
@@ -430,9 +527,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun horizontalPager_half() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardPagerSample(.5f, tint = DefaultTint, blurRadius = 8.dp)
+        CreditCardPagerSample(visualEffect = blurVisualEffect, pagerPosition = .5f)
       }
     }
     captureRoot()
@@ -440,9 +542,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun horizontalPager_three_quarters() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardPagerSample(.75f, tint = DefaultTint, blurRadius = 8.dp, numberCards = 3)
+        CreditCardPagerSample(visualEffect = blurVisualEffect, pagerPosition = .75f, numberCards = 3)
       }
     }
     captureRoot()
@@ -450,9 +557,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun horizontalPager_one_and_three_quarters() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      blurRadius = 8.dp
+    }
+
     setContent {
       ScreenshotTheme {
-        CreditCardPagerSample(1.75f, tint = DefaultTint, blurRadius = 8.dp, numberCards = 3)
+        CreditCardPagerSample(visualEffect = blurVisualEffect, pagerPosition = 1.75f, numberCards = 3)
       }
     }
     captureRoot()
@@ -461,10 +573,11 @@ class HazeScreenshotTest : ScreenshotTest() {
   @Test
   fun layerTransformations() = runScreenshotTest {
     var offset by mutableStateOf(DpOffset.Zero)
+    val blurVisualEffect = BlurVisualEffect()
 
     setContent {
       ScreenshotTheme {
-        OverlayingContent(topOffset = offset)
+        OverlayingContent(visualEffect = blurVisualEffect, topOffset = offset)
       }
     }
 
@@ -485,11 +598,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
   @Test
   fun edges() = runScreenshotTest {
+    val blurVisualEffect = BlurVisualEffect().apply {
+      tints = listOf(DefaultTint)
+      backgroundColor = Color.Transparent
+    }
+
     setContent {
       ScreenshotTheme {
-        ContentAtEdges(
-          style = HazeBlurDefaults.style(tint = DefaultTint, backgroundColor = Color.Transparent),
-        )
+        ContentAtEdges(visualEffect = blurVisualEffect)
       }
     }
     captureRoot()

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
@@ -36,6 +36,12 @@ public interface VisualEffect {
   /**
    * Called when the effect should update its state from composition locals or other sources.
    *
+   * You can safely read snapshot state in this function. When any snapshot state read in this
+   * function is mutated, this function will be re-invoked.
+   *
+   * Commonly, this function will need to call [VisualEffectContext.invalidateDraw] when it detects
+   * a scenario where the effect needs to be re-drawn.
+   *
    * @param context The context providing access to composition locals and other state.
    */
   public fun update(context: VisualEffectContext): Unit = Unit


### PR DESCRIPTION
They are now built by passing in a `VisualEffect`, meaning that we can re-use them for different effects in the future.