### PR TITLE
Promote Materials API to stable by removing `@ExperimentalHazeMaterialsApi`

### DIFF
--- a/haze-materials/api/api.txt
+++ b/haze-materials/api/api.txt
@@ -2,33 +2,30 @@
 package dev.chrisbanes.haze.blur.materials {
 
   public final class CupertinoMaterials {
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle regular(optional long containerColor);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle thick(optional long containerColor);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle thin(optional long containerColor);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle ultraThin(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle regular(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle thick(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle thin(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle ultraThin(optional long containerColor);
     field public static final dev.chrisbanes.haze.blur.materials.CupertinoMaterials INSTANCE;
   }
 
-  @kotlin.RequiresOptIn(message="Experimental Haze Materials API", level=kotlin.RequiresOptIn.Level.WARNING) public @interface ExperimentalHazeMaterialsApi {
-  }
-
-  @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public final class FluentMaterials {
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle accentAcrylicBase(optional long accentColor, optional boolean isDark);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle accentAcrylicDefault(optional long accentColor, optional boolean isDark);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle acrylicBase(optional boolean isDark);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle acrylicDefault(optional boolean isDark);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle mica(optional boolean isDark);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle micaAlt(optional boolean isDark);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle thinAcrylic(optional boolean isDark);
+  public final class FluentMaterials {
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle accentAcrylicBase(optional long accentColor, optional boolean isDark);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle accentAcrylicDefault(optional long accentColor, optional boolean isDark);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle acrylicBase(optional boolean isDark);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle acrylicDefault(optional boolean isDark);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle mica(optional boolean isDark);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle micaAlt(optional boolean isDark);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle thinAcrylic(optional boolean isDark);
     field public static final dev.chrisbanes.haze.blur.materials.FluentMaterials INSTANCE;
   }
 
   public final class HazeMaterials {
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle regular(optional long containerColor);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle thick(optional long containerColor);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle thin(optional long containerColor);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle ultraThick(optional long containerColor);
-    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi public dev.chrisbanes.haze.blur.HazeBlurStyle ultraThin(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle regular(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle thick(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle thin(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle ultraThick(optional long containerColor);
+    method @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public dev.chrisbanes.haze.blur.HazeBlurStyle ultraThin(optional long containerColor);
     field public static final dev.chrisbanes.haze.blur.materials.HazeMaterials INSTANCE;
   }
 

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterials.kt
@@ -27,7 +27,6 @@ public object CupertinoMaterials {
   /**
    * A [dev.chrisbanes.haze.blur.HazeBlurStyle] which implements a mostly translucent material.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun ultraThin(
@@ -44,7 +43,6 @@ public object CupertinoMaterials {
    * A [dev.chrisbanes.haze.blur.HazeBlurStyle] which implements a translucent material. More opaque than [ultraThin],
    * more translucent than [regular].
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun thin(
@@ -61,7 +59,6 @@ public object CupertinoMaterials {
    * A [dev.chrisbanes.haze.blur.HazeBlurStyle] which implements a somewhat opaque material. More opaque than [thin],
    * more translucent than [thick].
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun regular(
@@ -77,7 +74,6 @@ public object CupertinoMaterials {
   /**
    * A [dev.chrisbanes.haze.blur.HazeBlurStyle] which implements a mostly opaque material. More opaque than [regular].
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun thick(

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterials.kt
@@ -23,13 +23,11 @@ import dev.chrisbanes.haze.blur.HazeColorEffect
  * The primary use case for using these is for when aiming for consistency with native UI
  * (i.e. for when mixing Compose Multiplatform content alongside WinUI content).
  */
-@ExperimentalHazeMaterialsApi
 public object FluentMaterials {
 
   /**
    * A [HazeBlurStyle] which implements a mostly translucent material.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun thinAcrylic(
@@ -55,7 +53,6 @@ public object FluentMaterials {
   /**
    * A [HazeBlurStyle] which implements a translucent material used for the most translucent layer with accent color.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun accentAcrylicBase(
@@ -73,7 +70,6 @@ public object FluentMaterials {
   /**
    * A [HazeBlurStyle] which implements a translucent material used for the popup container background with accent color.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun accentAcrylicDefault(
@@ -91,7 +87,6 @@ public object FluentMaterials {
   /**
    * A [HazeBlurStyle] which implements a translucent material used for the most translucent layer.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun acrylicBase(
@@ -117,7 +112,6 @@ public object FluentMaterials {
   /**
    * A [HazeBlurStyle] which implements a translucent material used for the popup container background.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun acrylicDefault(
@@ -143,7 +137,6 @@ public object FluentMaterials {
   /**
    * A [HazeBlurStyle] which implements a translucent application background material.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun mica(
@@ -164,7 +157,6 @@ public object FluentMaterials {
   /**
    * A [HazeBlurStyle] which implements a translucent application background material used for the tab experience.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun micaAlt(

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/HazeMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/HazeMaterials.kt
@@ -17,25 +17,16 @@ import dev.chrisbanes.haze.blur.materials.HazeMaterials.thin
 import dev.chrisbanes.haze.blur.materials.HazeMaterials.ultraThick
 import dev.chrisbanes.haze.blur.materials.HazeMaterials.ultraThin
 
-@RequiresOptIn(
-  message = "Experimental Haze Materials API",
-  level = RequiresOptIn.Level.WARNING,
-)
-public annotation class ExperimentalHazeMaterialsApi
-
 /**
  * A class which contains functions to build [HazeBlurStyle]s which implement 'material-like' styles.
  * It is inspired by the material APIs available in SwiftUI, but it makes no attempt to provide
  * the exact effects provided in iOS.
- *
- * The functions are marked as experimental, as the effects provided are still being tweaked.
  */
 public object HazeMaterials {
 
   /**
    * A [HazeBlurStyle] which implements a mostly translucent material.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun ultraThin(
@@ -50,7 +41,6 @@ public object HazeMaterials {
    * A [HazeBlurStyle] which implements a translucent material. More opaque than [ultraThin],
    * more translucent than [regular].
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun thin(
@@ -65,7 +55,6 @@ public object HazeMaterials {
    * A [HazeBlurStyle] which implements a somewhat opaque material. More opaque than [thin],
    * more translucent than [thick].
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun regular(
@@ -80,7 +69,6 @@ public object HazeMaterials {
    * A [HazeBlurStyle] which implements a mostly opaque material. More opaque than [regular],
    * more translucent than [ultraThick].
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun thick(
@@ -94,7 +82,6 @@ public object HazeMaterials {
   /**
    * A [HazeBlurStyle] which implements a nearly opaque material.
    */
-  @ExperimentalHazeMaterialsApi
   @Composable
   @ReadOnlyComposable
   public fun ultraThick(

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/ExoPlayerSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/ExoPlayerSample.kt
@@ -22,14 +22,12 @@ import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import dev.chrisbanes.haze.sample.shared.R
 
-@OptIn(ExperimentalHazeMaterialsApi::class)
 @Composable
 fun ExoPlayerSample(blurEnabled: Boolean) {
   val hazeState = rememberHazeState()

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
@@ -36,13 +36,12 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BottomSheet(navController: NavHostController, blurEnabled: Boolean) {
   var imageIndex by remember { mutableIntStateOf(0) }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ContentBlurring.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ContentBlurring.kt
@@ -42,11 +42,10 @@ import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ContentBlurring(
   navController: NavHostController,

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
@@ -38,14 +38,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavHostController
 import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DialogSample(navController: NavHostController, blurEnabled: Boolean) {
   Scaffold(

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
@@ -30,13 +30,12 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ImagesList(navController: NavHostController, blurEnabled: Boolean) {
   MaterialTheme {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
@@ -33,13 +33,12 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ListOverImage(navController: NavHostController, blurEnabled: Boolean) {
   var imageIndex by remember { mutableIntStateOf(0) }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
@@ -30,7 +30,6 @@ import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
@@ -38,7 +37,6 @@ import dev.chrisbanes.haze.rememberHazeState
 
 @OptIn(
   ExperimentalMaterial3Api::class,
-  ExperimentalHazeMaterialsApi::class,
   ExperimentalHazeApi::class,
   ExperimentalFoundationApi::class,
 )

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -32,7 +32,6 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.blurEffect
 import dev.chrisbanes.haze.blur.materials.CupertinoMaterials
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.FluentMaterials
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
@@ -157,7 +156,7 @@ fun MaterialsSample(navController: NavHostController, blurEnabled: Boolean) {
   }
 }
 
-@OptIn(ExperimentalLayoutApi::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun HazeMaterialsRow(hazeState: HazeState, modifier: Modifier = Modifier) {
   FlowRow(
@@ -202,7 +201,7 @@ private fun HazeMaterialsRow(hazeState: HazeState, modifier: Modifier = Modifier
   }
 }
 
-@OptIn(ExperimentalLayoutApi::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun CupertinoMaterialsRow(hazeState: HazeState, modifier: Modifier = Modifier) {
   FlowRow(
@@ -240,7 +239,7 @@ private fun CupertinoMaterialsRow(hazeState: HazeState, modifier: Modifier = Mod
   }
 }
 
-@OptIn(ExperimentalLayoutApi::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun FluentMaterialsRow(hazeState: HazeState, modifier: Modifier = Modifier) {
   FlowRow(

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/PopupSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/PopupSample.kt
@@ -38,14 +38,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.navigation.NavHostController
 import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeMaterialsApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PopupSample(navController: NavHostController, blurEnabled: Boolean) {
   Scaffold(

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -44,7 +44,6 @@ import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.blur.HazeProgressive
 import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.blur.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
@@ -58,7 +57,6 @@ enum class ScaffoldSampleMode {
 
 @OptIn(
   ExperimentalMaterial3Api::class,
-  ExperimentalHazeMaterialsApi::class,
   ExperimentalHazeApi::class,
 )
 @Composable


### PR DESCRIPTION
This PR removes the `@ExperimentalHazeMaterialsApi` annotation from the Materials classes, officially promoting them to stable API.
## What's Changed
- **Removed** `@RequiresOptIn` annotation definition and `@ExperimentalHazeMaterialsApi` from:
  - `HazeMaterials` class and all 5 material functions
  - `FluentMaterials` class and all 6 material functions  
  - `CupertinoMaterials` class and all 4 material functions
- **Updated** all sample files to remove `@OptIn(ExperimentalHazeMaterialsApi::class)` annotations
- **Regenerated** API signature file to reflect the binary breaking change
## Why
The Materials APIs have been stable and battle-tested. Removing the experimental annotation:
- Signals API stability to users
- Removes friction (no more `@OptIn` needed)
- Aligns with the v2.0 architecture where blur effects are modular