### PR TITLE
fix: Add onTrimMemory support to VisualEffect for memory pressure handling

### DIFF
--- a/docs/specs/2026-04-24-issue-891-trimmemory-design.md
+++ b/docs/specs/2026-04-24-issue-891-trimmemory-design.md
@@ -1,0 +1,88 @@
+# Fix: "drawRenderNode called on a context with no surface" crash (#891)
+
+## Context
+
+When a Haze-using app is backgrounded and Android issues `TRIM_MEMORY_COMPLETE` (or `onLowMemory`), the RenderScript blur delegate retains its `RenderScriptContext` and its cached `Surface`. When the app returns to the foreground, the next draw attempts to lock/unlock a Surface whose underlying hardware context has been destroyed, causing the fatal `drawRenderNode called on a context with no surface!` crash on Android 10.
+
+## Design
+
+### 1. `TrimMemoryLevel` enum (commonMain)
+
+A severity-ordered enum mapping Android `onTrimMemory(int)` levels to a platform-agnostic API:
+
+```kotlin
+@Suppress("unused")
+enum class TrimMemoryLevel {
+  UI_HIDDEN,
+  BACKGROUND,
+  MODERATE,
+  COMPLETE,
+}
+```
+
+`COMPLETE` is the highest severity and is also emitted when the platform calls `onLowMemory()`.
+
+### 2. `VisualEffect.onTrimMemory()`
+
+A new default method on `VisualEffect`:
+
+```kotlin
+public fun onTrimMemory(level: TrimMemoryLevel): Unit = Unit
+```
+
+Effects can override this to release heavy resources in response to memory pressure.
+
+### 3. Platform callback registration (`haze` module)
+
+An internal `expect`/`actual` helper registers/unregisters system trim-memory callbacks for the `HazeEffectNode` lifecycle:
+
+```kotlin
+// commonMain
+internal expect fun registerTrimMemoryCallback(
+  context: PlatformContext,
+  callback: (TrimMemoryLevel) -> Unit,
+): Cancellable
+
+// androidMain
+internal actual fun registerTrimMemoryCallback(...): Cancellable =
+  context.registerComponentCallbacks(object : ComponentCallbacks2 {
+    override fun onTrimMemory(level: Int) {
+      callback(level.toTrimMemoryLevel())
+    }
+    override fun onConfigurationChanged(newConfig: Configuration) = Unit
+    override fun onLowMemory() = callback(TrimMemoryLevel.COMPLETE)
+  })
+```
+
+`HazeEffectNode.onAttach` registers the callback; `onDetach` cancels it. On non-Android platforms the actual is a no-op.
+
+### 4. `RenderScriptBlurVisualEffectDelegate`
+
+- **`onTrimMemory`** (delegated from `BlurVisualEffect`):
+  - Releases `renderScriptContext` (which destroys the RenderScript allocations, bitmaps, and their stale `Surface`).
+  - Cancels `currentJob`.
+
+- **Defensive try-catch in `updateSurface`**:
+  Wrap `rs.inputSurface.drawGraphicsLayer(...)` in a `try/catch (IllegalStateException)`. If the surface is already destroyed, release the context, null it out, and return early so the next draw creates a fresh context. This is a last-resort guard for any races between the trim signal and the actual draw.
+
+## Files changed
+
+- `haze/src/commonMain/kotlin/dev/chrisbanes/haze/TrimMemoryLevel.kt` *(new)*
+- `haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt`
+- `haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt`
+- `haze/src/androidMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.kt` *(new)*
+- `haze/src/nonAndroidMain/…/TrimMemoryCallback.kt` *(new, no-op)*
+- `haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt`
+
+## Backwards compatibility
+
+`onTrimMemory` is a default interface method with an empty body; existing custom `VisualEffect` implementations require no changes.
+
+## Testing
+
+Manual reproduction steps from the issue:
+1. Navigate to a page using Haze
+2. Press home to background the app
+3. `adb shell am send-trim-memory <pkg> COMPLETE`
+4. Return to the app
+5. Expect: no crash; blur may have a one-frame stutter while rebuilding the context, but recovers gracefully.

--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.unit.toIntSize
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeLogger
 import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.PlatformContext
+import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.VisualEffectContext
 import dev.chrisbanes.haze.trace
 import dev.chrisbanes.haze.traceAsync
@@ -48,22 +50,26 @@ import kotlinx.coroutines.withContext
 internal class RenderScriptBlurVisualEffectDelegate(
   private val blurVisualEffect: BlurVisualEffect,
   private val graphicsContext: GraphicsContext,
-  androidContext: android.content.Context,
+  private val platformContext: PlatformContext,
 ) : BlurVisualEffect.Delegate {
 
-  private val renderScript = RenderScript.create(androidContext)
+  @Volatile
+  private var renderScript = RenderScript.create(platformContext)
 
+  @Volatile
   private var renderScriptContext: RenderScriptContext? = null
   private val drawScope = CanvasDrawScope()
 
   private var currentJob: Job? = null
   private var drawSkipped: Boolean = false
 
+  @Volatile
+  private var trimGeneration = 0
+
   private val contentLayer: GraphicsLayer = graphicsContext.createGraphicsLayer()
 
   override fun DrawScope.draw(context: VisualEffectContext) {
     val density = context.requireDensity()
-    val androidContext = context.requirePlatformContext()
     val offset = context.layerOffset
     var scaleFactor = blurVisualEffect.calculateInputScaleFactor(context.inputScale)
 
@@ -143,7 +149,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
             PaintPool.usePaint { paint ->
               paint.isAntiAlias = true
               paint.alpha = noiseFactor.coerceIn(0f, 1f)
-              val shader = BitmapShader(androidContext.getNoiseTexture(), REPEAT, REPEAT)
+              val shader = BitmapShader(platformContext.getNoiseTexture(), REPEAT, REPEAT)
               val normalizedScale = if (scaleFactor > 0f) scaleFactor else 1f
               if (abs(normalizedScale - 1f) >= 0.001f) {
                 val matrix = Matrix().apply {
@@ -193,20 +199,60 @@ internal class RenderScriptBlurVisualEffectDelegate(
     else -> false
   }
 
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    if (level.severity >= TrimMemoryLevel.MODERATE.severity) {
+      currentJob?.cancel()
+      renderScriptContext?.release()
+      renderScriptContext = null
+      // Destroy the old RenderScript and recreate it.
+      runCatching { renderScript.destroy() }
+      runCatching { renderScript = RenderScript.create(platformContext.applicationContext) }
+        .onFailure { HazeLogger.d(TAG) { "Failed to recreate RenderScript after trim" } }
+      // Bump generation so in-flight coroutines know their context is stale
+      trimGeneration++
+      // Force the next draw to recreate the layer from scratch
+      drawSkipped = true
+      context.invalidateDraw()
+    }
+  }
+
   private suspend fun updateSurface(
     content: GraphicsLayer,
     blurRadius: Float,
     context: VisualEffectContext,
     density: Density,
   ) {
+    val generationAtStart = trimGeneration
+
     traceAsync("Haze-RenderScriptBlurEffect-updateSurface", 0) {
+      // If a trim happened before we even started, bail out
+      if (trimGeneration != generationAtStart) return@traceAsync
+
       val rs = getRenderScriptContext(content.size)
+
+      // If a trim happened while we were getting the context, bail out
+      if (trimGeneration != generationAtStart) {
+        renderScriptContext?.release()
+        renderScriptContext = null
+        return@traceAsync
+      }
+
       traceAsync("Haze-RenderScriptBlurEffect-updateSurface-drawLayerToSurface", 0) {
-        // Draw the layer (this is async)
-        rs.inputSurface.drawGraphicsLayer(layer = content, density = density, drawScope = drawScope)
+        try {
+          // Draw the layer (this is async)
+          rs.inputSurface.drawGraphicsLayer(layer = content, density = density, drawScope = drawScope)
+        } catch (e: IllegalStateException) {
+          HazeLogger.d(TAG) { "Surface draw failed, likely destroyed. Releasing context." }
+          renderScriptContext?.release()
+          renderScriptContext = null
+          return@traceAsync
+        }
         // Wait for the layer to be written to the Surface
         rs.awaitSurfaceWritten()
       }
+
+      // If a trim happened during surface operations, bail out before using stale data
+      if (trimGeneration != generationAtStart) return@traceAsync
 
       if (blurRadius > 0f) {
         // Now apply the blur on a background thread
@@ -258,6 +304,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
     currentJob?.cancel()
     graphicsContext.releaseGraphicsLayer(contentLayer)
     renderScriptContext?.release()
+    runCatching { renderScript.destroy() }
   }
 
   internal companion object {
@@ -274,7 +321,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
           RenderScriptBlurVisualEffectDelegate(
             blurVisualEffect = effect,
             graphicsContext = context.requireGraphicsContext(),
-            androidContext = context.requirePlatformContext(),
+            platformContext = context.requirePlatformContext(),
           )
         }
           .onFailure { isEnabled = false }

--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
@@ -54,7 +54,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
 ) : BlurVisualEffect.Delegate {
 
   @Volatile
-  private var renderScript = RenderScript.create(platformContext)
+  private var renderScript = RenderScript.create(platformContext.applicationContext)
 
   @Volatile
   private var renderScriptContext: RenderScriptContext? = null
@@ -204,9 +204,14 @@ internal class RenderScriptBlurVisualEffectDelegate(
       currentJob?.cancel()
       renderScriptContext?.release()
       renderScriptContext = null
-      // Destroy the old RenderScript and recreate it.
-      runCatching { renderScript.destroy() }
-      runCatching { renderScript = RenderScript.create(platformContext.applicationContext) }
+      // Create the new RenderScript first, then destroy the old instance.
+      // This avoids leaving renderScript in a destroyed state if creation fails.
+      runCatching { RenderScript.create(platformContext.applicationContext) }
+        .onSuccess { newRs ->
+          val oldRs = renderScript
+          renderScript = newRs
+          runCatching { oldRs.destroy() }
+        }
         .onFailure { HazeLogger.d(TAG) { "Failed to recreate RenderScript after trim" } }
       // Bump generation so in-flight coroutines know their context is stale
       trimGeneration++

--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptContext.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptContext.kt
@@ -82,7 +82,7 @@ internal class RenderScriptContext(
     blurScript.destroy()
     inputAlloc.destroy()
     outputAlloc.destroy()
-    rs.destroy()
+    // Note: rs (RenderScript) is NOT destroyed here — the delegate owns its lifecycle.
   }
 
   private companion object {

--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptContext.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptContext.kt
@@ -34,6 +34,7 @@ internal class RenderScriptContext(
 
   private val channel = Channel<Unit>(Channel.CONFLATED)
 
+  @Volatile
   private var isDestroyed = false
 
   init {

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.takeOrElse
 import dev.chrisbanes.haze.Bitmask
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeLogger
+import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.VisualEffect
 import dev.chrisbanes.haze.VisualEffectContext
 
@@ -83,6 +84,9 @@ public class BlurVisualEffect : VisualEffect {
     updateDelegate(context, this)
     return delegate is ScrimBlurVisualEffectDelegate
   }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel): Unit =
+    delegate.onTrimMemory(context, level)
 
   override fun shouldClip(): Boolean = blurredEdgeTreatment.shape != null
 
@@ -373,6 +377,7 @@ public class BlurVisualEffect : VisualEffect {
     fun attach() = Unit
     fun DrawScope.draw(context: VisualEffectContext)
     fun detach() = Unit
+    fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) = Unit
   }
 
   internal companion object {

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.android.kt
@@ -1,0 +1,35 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:Suppress("ktlint:standard:argument-list-wrapping")
+
+package dev.chrisbanes.haze
+
+import android.content.ComponentCallbacks2
+import android.content.res.Configuration
+import kotlinx.coroutines.DisposableHandle
+
+internal actual fun registerTrimMemoryCallback(
+  context: PlatformContext,
+  callback: (TrimMemoryLevel) -> Unit,
+): DisposableHandle {
+  val cb = object : ComponentCallbacks2 {
+    override fun onTrimMemory(level: Int) {
+      callback(level.toTrimMemoryLevel())
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) = Unit
+    override fun onLowMemory() = callback(TrimMemoryLevel.COMPLETE)
+  }
+
+  context.registerComponentCallbacks(cb)
+  return DisposableHandle { context.unregisterComponentCallbacks(cb) }
+}
+
+private fun Int.toTrimMemoryLevel(): TrimMemoryLevel = when {
+  this >= ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> TrimMemoryLevel.COMPLETE
+  this >= ComponentCallbacks2.TRIM_MEMORY_MODERATE -> TrimMemoryLevel.MODERATE
+  this >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND -> TrimMemoryLevel.BACKGROUND
+  this >= ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> TrimMemoryLevel.UI_HIDDEN
+  else -> TrimMemoryLevel.UI_HIDDEN
+}

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.android.kt
@@ -31,5 +31,8 @@ private fun Int.toTrimMemoryLevel(): TrimMemoryLevel = when {
   this >= ComponentCallbacks2.TRIM_MEMORY_MODERATE -> TrimMemoryLevel.MODERATE
   this >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND -> TrimMemoryLevel.BACKGROUND
   this >= ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> TrimMemoryLevel.UI_HIDDEN
+  this >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> TrimMemoryLevel.COMPLETE
+  this >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> TrimMemoryLevel.MODERATE
+  this >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE -> TrimMemoryLevel.BACKGROUND
   else -> TrimMemoryLevel.UI_HIDDEN
 }

--- a/haze/src/appleMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.apple.kt
+++ b/haze/src/appleMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.apple.kt
@@ -1,0 +1,15 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import kotlinx.coroutines.DisposableHandle
+
+// TODO: Split appleMain into iosMain/macosMain and implement memory-pressure observers.
+// iOS: UIApplicationDidReceiveMemoryWarningNotification
+// macOS: DISPATCH_SOURCE_TYPE_MEMORYPRESSURE or NSProcessInfo.reactive
+
+internal actual fun registerTrimMemoryCallback(
+  context: PlatformContext,
+  callback: (TrimMemoryLevel) -> Unit,
+): DisposableHandle = DisposableHandle {}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.toIntSize
 import androidx.compose.ui.unit.toSize
 import kotlin.math.max
 import kotlin.math.min
+import kotlinx.coroutines.DisposableHandle
 
 /**
  * The [Modifier.Node] implementation used by [Modifier.hazeEffect].
@@ -216,12 +217,19 @@ public class HazeEffectNode(
     onObservedReadsChanged()
   }
 
+  private var trimMemoryCallbackDisposable: DisposableHandle? = null
+
   override fun onAttach() {
     visualEffect.attach(visualEffectContext)
+    trimMemoryCallbackDisposable = registerTrimMemoryCallback(
+      requirePlatformContext(),
+    ) { level -> visualEffect.onTrimMemory(visualEffectContext, level) }
     update()
   }
 
   override fun onDetach() {
+    trimMemoryCallbackDisposable?.dispose()
+    trimMemoryCallbackDisposable = null
     visualEffect.detach()
   }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.kt
@@ -1,0 +1,11 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import kotlinx.coroutines.DisposableHandle
+
+internal expect fun registerTrimMemoryCallback(
+  context: PlatformContext,
+  callback: (TrimMemoryLevel) -> Unit,
+): DisposableHandle

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/TrimMemoryLevel.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/TrimMemoryLevel.kt
@@ -1,0 +1,11 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+public enum class TrimMemoryLevel(public val severity: Int) {
+  UI_HIDDEN(severity = 10),
+  BACKGROUND(severity = 20),
+  MODERATE(severity = 40),
+  COMPLETE(severity = 80),
+}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
@@ -54,6 +54,19 @@ public interface VisualEffect {
   public fun detach(): Unit = Unit
 
   /**
+   * Called when the system is running low on memory, or the app is being backgrounded.
+   *
+   * Implementations should release any heavy resources ( such as cached bitmaps,
+   * off-screen buffers, or native contexts ) in response to the given [level].
+   *
+   * @param context The context providing access to geometry, configuration, and platform
+   * capabilities. Use [VisualEffectContext.invalidateDraw] to request a redraw after
+   * releasing resources.
+   * @param level The severity of the memory-pressure event.
+   */
+  public fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel): Unit = Unit
+
+  /**
    * Returns whether the content should be drawn behind the effect for foreground blurring.
    * This is called during drawing to determine draw order.
    *

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
@@ -56,8 +56,8 @@ public interface VisualEffect {
   /**
    * Called when the system is running low on memory, or the app is being backgrounded.
    *
-   * Implementations should release any heavy resources ( such as cached bitmaps,
-   * off-screen buffers, or native contexts ) in response to the given [level].
+   * Implementations should release any heavy resources (such as cached bitmaps,
+   * off-screen buffers, or native contexts) in response to the given [level].
    *
    * @param context The context providing access to geometry, configuration, and platform
    * capabilities. Use [VisualEffectContext.invalidateDraw] to request a redraw after

--- a/haze/src/jsMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.js.kt
+++ b/haze/src/jsMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.js.kt
@@ -1,0 +1,11 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import kotlinx.coroutines.DisposableHandle
+
+internal actual fun registerTrimMemoryCallback(
+  context: PlatformContext,
+  callback: (TrimMemoryLevel) -> Unit,
+): DisposableHandle = DisposableHandle {}

--- a/haze/src/jvmMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.jvm.kt
+++ b/haze/src/jvmMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.jvm.kt
@@ -1,0 +1,11 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import kotlinx.coroutines.DisposableHandle
+
+internal actual fun registerTrimMemoryCallback(
+  context: PlatformContext,
+  callback: (TrimMemoryLevel) -> Unit,
+): DisposableHandle = DisposableHandle {}

--- a/haze/src/wasmJsMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.wasmJs.kt
+++ b/haze/src/wasmJsMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.wasmJs.kt
@@ -1,0 +1,11 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import kotlinx.coroutines.DisposableHandle
+
+internal actual fun registerTrimMemoryCallback(
+  context: PlatformContext,
+  callback: (TrimMemoryLevel) -> Unit,
+): DisposableHandle = DisposableHandle {}


### PR DESCRIPTION
## Summary

- Add `onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel)` to the `VisualEffect` interface, giving implementations access to `invalidateDraw()` and other context methods when releasing resources under memory pressure
- `RenderScriptBlurVisualEffectDelegate` releases and recreates RenderScript on `MODERATE`+ trim events, with `@Volatile` state and generation-based coroutine safety to prevent race conditions
- Decouple `RenderScript` lifecycle from `RenderScriptContext` — the delegate now owns `RenderScript` destruction exclusively
- Use `PlatformContext` instead of `android.content.Context` in the RenderScript delegate for platform-agnostic code
- Use `applicationContext` when recreating RenderScript to avoid Activity context leaks after configuration changes
- Add `TrimMemoryLevel` enum with explicit `severity` values (no fragile ordinal comparison)
- Add `registerTrimMemoryCallback` using `kotlinx.coroutines.DisposableHandle`

## Affected modules

- `haze` — `VisualEffect` interface, `HazeEffectNode`, `TrimMemoryCallback`/`TrimMemoryLevel` (new)
- `haze-blur` — `BlurVisualEffect`, `RenderScriptBlurVisualEffectDelegate`, `RenderScriptContext`

Fixes #891