### PR TITLE
Fix v2 migration docs and harden effect lifecycle internals

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           distribution: 'zulu'
           java-version: 21
 
-      - uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v5
 
       - name: Deploy to Sonatype
         run: ./gradlew publish --no-configuration-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All blur-related properties now require a `blurEffect {}` wrapper:
 Modifier.hazeEffect(state = hazeState) {
   blurEffect {
     blurRadius = 20.dp
-    tints = listOf(HazeTint(...))
+    colorEffects = listOf(HazeColorEffect.tint(...))
   }
 }
 ```
@@ -44,12 +44,12 @@ New `positionStrategy` parameter on `rememberHazeState()` to control how effect 
 ### Breaking Changes
 
 - **New module dependency:** Blur functionality now requires the `haze-blur` module
-- **API nesting:** Blur properties (`blurRadius`, `tints`, `style`, `noiseFactor`, `progressive`, `mask`, etc.) now require `blurEffect {}` wrapper
+- **API nesting:** Blur properties (`blurRadius`, `colorEffects`, `style`, `noiseFactor`, `progressive`, `mask`, etc.) now require `blurEffect {}` wrapper
 - **Package changes:** Blur classes moved to `dev.chrisbanes.haze.blur` package:
-  - `HazeStyle` → `dev.chrisbanes.haze.blur.HazeStyle`
-  - `HazeTint` → `dev.chrisbanes.haze.blur.HazeTint`
+  - `HazeStyle` → `dev.chrisbanes.haze.blur.HazeBlurStyle`
+  - `HazeTint` → `dev.chrisbanes.haze.blur.HazeColorEffect`
   - `HazeProgressive` → `dev.chrisbanes.haze.blur.HazeProgressive`
-  - `LocalHazeStyle` → `dev.chrisbanes.haze.blur.LocalHazeStyle`
+  - `LocalHazeStyle` → `dev.chrisbanes.haze.blur.LocalHazeBlurStyle`
 - **Removed APIs:** `rememberHazeState(blurEnabled)` parameter removed (use `blurEffect { blurEnabled = ... }`)
 - **Internal API renames:** `create*ImageFilter` functions renamed to `create*RenderEffect` (only affects custom effect authors using `@InternalHazeApi`)
 - **Dropped targets:** `iosX64` and `macosX64` targets removed, following Compose Multiplatform 1.11. These Intel-based targets are no longer supported upstream.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@
 
 Check out the website for more information: https://chrisbanes.github.io/haze
 
+## v2 (alpha) quickstart
+
+Haze `2.0.0-alpha01` splits blur into a separate module.
+
+```kotlin
+dependencies {
+  implementation("dev.chrisbanes.haze:haze:2.0.0-alpha01")
+  implementation("dev.chrisbanes.haze:haze-blur:2.0.0-alpha01")
+}
+```
+
+```kotlin
+Modifier.hazeEffect(state = hazeState) {
+  blurEffect {
+    blurRadius = 20.dp
+    colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.5f)))
+  }
+}
+```
+
+See migration docs: `docs/migrating-2.0.md`.
+
 ## License
 
 ```

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -30,8 +30,8 @@ In addition to the core `haze` module, you now need to explicitly add the `haze-
 
 ```kotlin
 dependencies {
-  implementation("dev.chrisbanes.haze:haze:2.0.0")
-  implementation("dev.chrisbanes.haze:haze-blur:2.0.0") // NEW in v2
+  implementation("dev.chrisbanes.haze:haze:2.0.0-alpha01")
+  implementation("dev.chrisbanes.haze:haze-blur:2.0.0-alpha01") // NEW in v2
 }
 ```
 
@@ -49,10 +49,10 @@ import dev.chrisbanes.haze.LocalHazeStyle
 
 **V2 imports:**
 ```kotlin
-import dev.chrisbanes.haze.blur.HazeStyle
-import dev.chrisbanes.haze.blur.HazeTint
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.HazeColorEffect
 import dev.chrisbanes.haze.blur.HazeProgressive
-import dev.chrisbanes.haze.blur.LocalHazeStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
 import dev.chrisbanes.haze.blur.blurEffect // NEW: extension function
 ```
 
@@ -67,7 +67,7 @@ All blur-related properties that were previously set directly on `HazeEffectScop
     ```kotlin
     Modifier.hazeEffect(state = hazeState) {
       blurRadius = 20.dp
-      tints = listOf(HazeTint(Color.Black.copy(alpha = 0.7f)))
+      colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.7f)))
       noiseFactor = 0.15f
     }
     ```
@@ -78,7 +78,7 @@ All blur-related properties that were previously set directly on `HazeEffectScop
     Modifier.hazeEffect(state = hazeState) {
       blurEffect {  // NEW: wrap blur properties
         blurRadius = 20.dp
-        tints = listOf(HazeTint(Color.Black.copy(alpha = 0.7f)))
+        colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.7f)))
         noiseFactor = 0.15f
       }
     }
@@ -177,7 +177,7 @@ All blur-related properties that were previously set directly on `HazeEffectScop
 
     ``` kotlin
     Modifier.hazeEffect {
-      tints = listOf(HazeTint(Color.Black.copy(alpha = 0.5f)))
+      colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.5f)))
       progressive = HazeProgressive.verticalGradient(...)
     }
     ```
@@ -187,7 +187,7 @@ All blur-related properties that were previously set directly on `HazeEffectScop
     ``` kotlin
     Modifier.hazeEffect {
       blurEffect {
-        tints = listOf(HazeTint(Color.Black.copy(alpha = 0.5f)))
+        colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.5f)))
         progressive = HazeProgressive.verticalGradient(...)
       }
     }
@@ -198,7 +198,7 @@ All blur-related properties that were previously set directly on `HazeEffectScop
 | V1 Location | V2 Location | Notes |
 |-------------|-------------|-------|
 | `HazeEffectScope.blurRadius` | `BlurVisualEffect.blurRadius` | Inside `blurEffect {}` |
-| `HazeEffectScope.tints` | `BlurVisualEffect.tints` | Inside `blurEffect {}` |
+| `HazeEffectScope.tints` | `BlurVisualEffect.colorEffects` | Inside `blurEffect {}` |
 | `HazeEffectScope.noiseFactor` | `BlurVisualEffect.noiseFactor` | Inside `blurEffect {}` |
 | `HazeEffectScope.progressive` | `BlurVisualEffect.progressive` | Inside `blurEffect {}` |
 | `HazeEffectScope.mask` | `BlurVisualEffect.mask` | Inside `blurEffect {}` |
@@ -218,26 +218,26 @@ All blur-related properties that were previously set directly on `HazeEffectScop
 | `VisualEffectContext.rootBoundsOnScreen` | `VisualEffectContext.rootBounds` | Renamed |
 | *N/A* | `HazeState.positionStrategy` | New — configurable position calculation |
 | *N/A* | `rememberHazeState(positionStrategy)` | New parameter, defaults to `Auto` |
-| `dev.chrisbanes.haze.HazeStyle` | `dev.chrisbanes.haze.blur.HazeStyle` | Package change |
-| `dev.chrisbanes.haze.HazeTint` | `dev.chrisbanes.haze.blur.HazeTint` | Package change |
+| `dev.chrisbanes.haze.HazeStyle` | `dev.chrisbanes.haze.blur.HazeBlurStyle` | Renamed + package change |
+| `dev.chrisbanes.haze.HazeTint` | `dev.chrisbanes.haze.blur.HazeColorEffect` | Renamed + package change |
 | `dev.chrisbanes.haze.HazeProgressive` | `dev.chrisbanes.haze.blur.HazeProgressive` | Package change |
-| `dev.chrisbanes.haze.LocalHazeStyle` | `dev.chrisbanes.haze.blur.LocalHazeStyle` | Package change |
+| `dev.chrisbanes.haze.LocalHazeStyle` | `dev.chrisbanes.haze.blur.LocalHazeBlurStyle` | Renamed + package change |
 
 ## Step-by-Step Migration
 
 **Update dependencies** in your `build.gradle.kts`:
 
    ```kotlin
-   implementation("dev.chrisbanes.haze:haze:2.0.0")
-   implementation("dev.chrisbanes.haze:haze-blur:2.0.0") // Add this
+    implementation("dev.chrisbanes.haze:haze:2.0.0-alpha01")
+    implementation("dev.chrisbanes.haze:haze-blur:2.0.0-alpha01") // Add this
    ```
 
 **Update imports** for blur-related classes:
 
-  - Change `dev.chrisbanes.haze.HazeStyle` → `dev.chrisbanes.haze.blur.HazeStyle`
-  - Change `dev.chrisbanes.haze.HazeTint` → `dev.chrisbanes.haze.blur.HazeTint`
+  - Change `dev.chrisbanes.haze.HazeStyle` → `dev.chrisbanes.haze.blur.HazeBlurStyle`
+  - Change `dev.chrisbanes.haze.HazeTint` → `dev.chrisbanes.haze.blur.HazeColorEffect`
   - Change `dev.chrisbanes.haze.HazeProgressive` → `dev.chrisbanes.haze.blur.HazeProgressive`
-  - Change `dev.chrisbanes.haze.LocalHazeStyle` → `dev.chrisbanes.haze.blur.LocalHazeStyle`
+  - Change `dev.chrisbanes.haze.LocalHazeStyle` → `dev.chrisbanes.haze.blur.LocalHazeBlurStyle`
   - Add `import dev.chrisbanes.haze.blur.blurEffect`
 
 **Wrap blur properties** in `blurEffect {}`:

--- a/haze-blur/api/api.txt
+++ b/haze-blur/api/api.txt
@@ -11,7 +11,7 @@ package dev.chrisbanes.haze {
 
 package dev.chrisbanes.haze.blur {
 
-  public final class BlurVisualEffect implements dev.chrisbanes.haze.VisualEffect {
+  @androidx.compose.runtime.Stable public final class BlurVisualEffect implements dev.chrisbanes.haze.VisualEffect {
     ctor public BlurVisualEffect();
     method public void draw(androidx.compose.ui.graphics.drawscope.DrawScope, dev.chrisbanes.haze.VisualEffectContext context);
     method public float getAlpha();

--- a/haze-blur/build.gradle.kts
+++ b/haze-blur/build.gradle.kts
@@ -66,6 +66,7 @@ kotlin {
 
     commonTest {
       dependencies {
+        implementation(libs.assertk)
         implementation(kotlin("test"))
       }
     }

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurDirtyFields.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurDirtyFields.kt
@@ -32,11 +32,8 @@ internal object BlurDirtyFields {
 
   const val InvalidateFlags: Int =
     RenderEffectAffectingFlags or
-      BlurEnabled or
       BackgroundColor or
-      Progressive or
-      Alpha or
-      BlurredEdgeTreatment
+      Alpha
 
   fun stringify(dirtyTracker: Bitmask): String {
     val params = buildList {
@@ -45,8 +42,8 @@ internal object BlurDirtyFields {
       if (NoiseFactor in dirtyTracker) add("NoiseFactor")
       if (Mask in dirtyTracker) add("Mask")
       if (BackgroundColor in dirtyTracker) add("BackgroundColor")
-      if (ColorEffects in dirtyTracker) add("Tints")
-      if (FallbackColorEffect in dirtyTracker) add("FallbackTint")
+      if (ColorEffects in dirtyTracker) add("ColorEffects")
+      if (FallbackColorEffect in dirtyTracker) add("FallbackColorEffect")
       if (Alpha in dirtyTracker) add("Alpha")
       if (Progressive in dirtyTracker) add("Progressive")
       if (BlurredEdgeTreatment in dirtyTracker) add("BlurredEdgeTreatment")

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -49,6 +49,8 @@ import dev.chrisbanes.haze.VisualEffectContext
 @Stable
 public class BlurVisualEffect : VisualEffect {
 
+  private var isAttached: Boolean = false
+
   internal var dirtyTracker: Bitmask by mutableStateOf(Bitmask())
     private set
 
@@ -56,13 +58,29 @@ public class BlurVisualEffect : VisualEffect {
     set(value) {
       if (value != field) {
         HazeLogger.d(TAG) { "delegate changed. Current $field. New: $value" }
-        // attach new delegate
-        value.attach()
-        // detach old delegate
-        field.detach()
+        if (isAttached) {
+          // attach new delegate
+          value.attach()
+          // detach old delegate
+          field.detach()
+        }
         field = value
       }
     }
+
+  override fun attach(context: VisualEffectContext) {
+    if (!isAttached) {
+      isAttached = true
+      delegate.attach()
+    }
+  }
+
+  override fun detach() {
+    if (isAttached) {
+      isAttached = false
+      delegate.detach()
+    }
+  }
 
   override fun update(context: VisualEffectContext) {
     compositionLocalStyle = context.currentValueOf(LocalHazeBlurStyle)

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.blur
 
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -45,6 +46,7 @@ import dev.chrisbanes.haze.VisualEffectContext
  * }
  * ```
  */
+@Stable
 public class BlurVisualEffect : VisualEffect {
 
   internal var dirtyTracker: Bitmask by mutableStateOf(Bitmask())
@@ -86,7 +88,9 @@ public class BlurVisualEffect : VisualEffect {
   }
 
   override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel): Unit =
-    delegate.onTrimMemory(context, level)
+    delegate.onTrimMemory(context, level).also {
+      clearRenderEffectCache()
+    }
 
   override fun shouldClip(): Boolean = blurredEdgeTreatment.shape != null
 

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
@@ -64,6 +64,10 @@ private val renderEffectCache by lazy(mode = LazyThreadSafetyMode.NONE) {
   LruCache<RenderEffectParams, RenderEffect>(maxSize = 50)
 }
 
+internal fun clearRenderEffectCache() {
+  renderEffectCache.evictAll()
+}
+
 @Poko
 internal class RenderEffectParams(
   val blurRadius: Dp,
@@ -92,7 +96,7 @@ private fun getOrCreateRenderEffect(context: VisualEffectContext, params: Render
     context = context.requirePlatformContext(),
     density = context.requireDensity(),
     params = params,
-  )?.also { effect ->
+  ).also { effect ->
     renderEffectCache.put(params, effect)
   }
 }

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
@@ -60,12 +60,18 @@ internal fun BlurVisualEffect.getOrCreateRenderEffect(
   )
 }
 
-private val renderEffectCache by lazy(mode = LazyThreadSafetyMode.NONE) {
+private val renderEffectCache = lazy(mode = LazyThreadSafetyMode.NONE) {
   LruCache<RenderEffectParams, RenderEffect>(maxSize = 50)
 }
 
 internal fun clearRenderEffectCache() {
-  renderEffectCache.evictAll()
+  clearIfInitialized(renderEffectCache) { it.evictAll() }
+}
+
+internal inline fun <T> clearIfInitialized(lazyValue: Lazy<T>, clear: (T) -> Unit) {
+  if (lazyValue.isInitialized()) {
+    clear(lazyValue.value)
+  }
 }
 
 @Poko
@@ -85,7 +91,7 @@ internal class RenderEffectParams(
 @OptIn(ExperimentalHazeApi::class)
 private fun getOrCreateRenderEffect(context: VisualEffectContext, params: RenderEffectParams): RenderEffect? {
   HazeLogger.d(BlurVisualEffect.TAG) { "getOrCreateRenderEffect: $params" }
-  val cached = renderEffectCache[params]
+  val cached = renderEffectCache.value[params]
   if (cached != null) {
     HazeLogger.d(BlurVisualEffect.TAG) { "getOrCreateRenderEffect. Returning cached: $params" }
     return cached
@@ -97,6 +103,6 @@ private fun getOrCreateRenderEffect(context: VisualEffectContext, params: Render
     density = context.requireDensity(),
     params = params,
   ).also { effect ->
-    renderEffectCache.put(params, effect)
+    renderEffectCache.value.put(params, effect)
   }
 }

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurDirtyFieldsTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurDirtyFieldsTest.kt
@@ -3,9 +3,10 @@
 
 package dev.chrisbanes.haze.blur
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import dev.chrisbanes.haze.Bitmask
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class BlurDirtyFieldsTest {
 
@@ -16,13 +17,13 @@ class BlurDirtyFieldsTest {
         BlurDirtyFields.BackgroundColor or
         BlurDirtyFields.Alpha
 
-    assertEquals(expected, BlurDirtyFields.InvalidateFlags)
+    assertThat(BlurDirtyFields.InvalidateFlags).isEqualTo(expected)
   }
 
   @Test
   fun stringify_shouldIncludeModernColorEffectsName() {
     val names = BlurDirtyFields.stringify(Bitmask(BlurDirtyFields.ColorEffects))
 
-    assertEquals("[ColorEffects]", names)
+    assertThat(names).isEqualTo("[ColorEffects]")
   }
 }

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurDirtyFieldsTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurDirtyFieldsTest.kt
@@ -1,0 +1,28 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import dev.chrisbanes.haze.Bitmask
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BlurDirtyFieldsTest {
+
+  @Test
+  fun invalidateFlags_shouldIncludeAllExpectedFlagsWithoutRedundantOnes() {
+    val expected =
+      BlurDirtyFields.RenderEffectAffectingFlags or
+        BlurDirtyFields.BackgroundColor or
+        BlurDirtyFields.Alpha
+
+    assertEquals(expected, BlurDirtyFields.InvalidateFlags)
+  }
+
+  @Test
+  fun stringify_shouldIncludeModernColorEffectsName() {
+    val names = BlurDirtyFields.stringify(Bitmask(BlurDirtyFields.ColorEffects))
+
+    assertEquals("[ColorEffects]", names)
+  }
+}

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
@@ -1,0 +1,130 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import androidx.compose.runtime.CompositionLocal
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.Density
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.chrisbanes.haze.HazeArea
+import dev.chrisbanes.haze.HazeInputScale
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.PlatformContext
+import dev.chrisbanes.haze.VisualEffect
+import dev.chrisbanes.haze.VisualEffectContext
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlinx.coroutines.CoroutineScope
+
+class BlurVisualEffectLifecycleTest {
+
+  @Test
+  fun attachAndDetach_areIdempotent() {
+    val effect = BlurVisualEffect()
+    val delegate = TrackingDelegate()
+
+    effect.delegate = delegate
+
+    assertThat(delegate.attachCount).isEqualTo(0)
+    assertThat(delegate.detachCount).isEqualTo(0)
+
+    effect.attach(FakeVisualEffectContext)
+    effect.attach(FakeVisualEffectContext)
+
+    assertThat(delegate.attachCount).isEqualTo(1)
+    assertThat(delegate.detachCount).isEqualTo(0)
+
+    effect.detach()
+    effect.detach()
+
+    assertThat(delegate.attachCount).isEqualTo(1)
+    assertThat(delegate.detachCount).isEqualTo(1)
+  }
+
+  @Test
+  fun changingDelegateWhileAttached_detachesOldAndAttachesNew() {
+    val effect = BlurVisualEffect()
+    val oldDelegate = TrackingDelegate()
+    val newDelegate = TrackingDelegate()
+
+    effect.delegate = oldDelegate
+    effect.attach(FakeVisualEffectContext)
+
+    effect.delegate = newDelegate
+
+    assertThat(oldDelegate.attachCount).isEqualTo(1)
+    assertThat(oldDelegate.detachCount).isEqualTo(1)
+    assertThat(newDelegate.attachCount).isEqualTo(1)
+    assertThat(newDelegate.detachCount).isEqualTo(0)
+
+    effect.detach()
+
+    assertThat(newDelegate.detachCount).isEqualTo(1)
+  }
+
+  @Test
+  fun blurRadius_prefersDirectThenStyleThenCompositionLocal() {
+    val effect = BlurVisualEffect()
+
+    effect.compositionLocalStyle = HazeBlurStyle(
+      colorEffects = emptyList(),
+      blurRadius = HazeBlurDefaults.blurRadius,
+    )
+    assertThat(effect.blurRadius).isEqualTo(HazeBlurDefaults.blurRadius)
+
+    effect.style = HazeBlurStyle(
+      colorEffects = emptyList(),
+      blurRadius = HazeBlurDefaults.blurRadius * 2,
+    )
+    assertThat(effect.blurRadius).isEqualTo(HazeBlurDefaults.blurRadius * 2)
+
+    effect.blurRadius = HazeBlurDefaults.blurRadius * 3
+    assertThat(effect.blurRadius).isEqualTo(HazeBlurDefaults.blurRadius * 3)
+  }
+}
+
+private data object FakeVisualEffectContext : VisualEffectContext {
+  override val position: Offset = Offset.Zero
+  override val size: Size = Size.Zero
+  override val layerSize: Size = Size.Zero
+  override val layerOffset: Offset = Offset.Zero
+  override val rootBounds: Rect = Rect.Zero
+  override val inputScale: HazeInputScale = HazeInputScale.None
+  override val windowId: Any? = null
+  override val areas: List<HazeArea> = emptyList()
+  override val state: HazeState? = null
+  override val visualEffect: VisualEffect = VisualEffect.Empty
+  override val coroutineScope: CoroutineScope = object : CoroutineScope {
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext
+  }
+
+  override fun requirePlatformContext(): PlatformContext = error("Unused in lifecycle tests")
+  override fun requireDensity(): Density = Density(1f)
+  override fun <T> currentValueOf(local: CompositionLocal<T>): T = error("Unused in lifecycle tests")
+  override fun requireGraphicsContext(): GraphicsContext = error("Unused in lifecycle tests")
+  override fun invalidateDraw() = Unit
+}
+
+private class TrackingDelegate : BlurVisualEffect.Delegate {
+  var attachCount: Int = 0
+    private set
+  var detachCount: Int = 0
+    private set
+
+  override fun attach() {
+    attachCount++
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) = Unit
+
+  override fun detach() {
+    detachCount++
+  }
+}

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtilsTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtilsTest.kt
@@ -1,0 +1,43 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import androidx.collection.LruCache
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class BlurVisualEffectUtilsTest {
+
+  @Test
+  fun clearIfInitialized_doesNotInitializeLazyValue() {
+    var initialized = false
+    val lazyCache = lazy(mode = LazyThreadSafetyMode.NONE) {
+      initialized = true
+      LruCache<Int, Int>(1)
+    }
+
+    clearIfInitialized(lazyCache) { it.evictAll() }
+
+    assertThat(initialized).isFalse()
+  }
+
+  @Test
+  fun clearIfInitialized_clearsInitializedValue() {
+    val lazyCache = lazy(mode = LazyThreadSafetyMode.NONE) {
+      LruCache<Int, Int>(2)
+    }
+    lazyCache.value.put(1, 1)
+
+    var cleared = false
+    clearIfInitialized(lazyCache) {
+      cleared = true
+      it.evictAll()
+    }
+
+    assertThat(cleared).isTrue()
+    assertThat(lazyCache.value[1] == null).isTrue()
+  }
+}

--- a/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/PlatformContext.kt
+++ b/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/PlatformContext.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.LocalContext
 
+@InternalHazeApi
 public actual typealias PlatformContext = Context
 
 @InternalHazeApi

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -5,13 +5,12 @@ package dev.chrisbanes.haze {
   }
 
   @androidx.compose.runtime.Stable public final class HazeArea {
-    ctor public HazeArea();
     method public androidx.compose.ui.graphics.layer.GraphicsLayer? getContentLayer();
     method public Object? getKey();
     method public Object? getWindowId();
     method public float getZIndex();
     method public boolean isContentDrawing();
-    property public androidx.compose.ui.graphics.layer.GraphicsLayer? contentLayer;
+    property @dev.chrisbanes.haze.InternalHazeApi public androidx.compose.ui.graphics.layer.GraphicsLayer? contentLayer;
     property @dev.chrisbanes.haze.InternalHazeApi public boolean isContentDrawing;
     property public Object? key;
     property public androidx.compose.ui.geometry.Offset position;
@@ -26,8 +25,7 @@ package dev.chrisbanes.haze {
   }
 
   @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeEffectNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode dev.chrisbanes.haze.HazeEffectScope androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.node.ObserverModifierNode androidx.compose.ui.node.TraversableNode {
-    ctor public HazeEffectNode();
-    ctor public HazeEffectNode(optional dev.chrisbanes.haze.HazeState? state, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
+    ctor public HazeEffectNode(dev.chrisbanes.haze.HazeState? state, kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
     method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
     method public java.util.List<dev.chrisbanes.haze.HazeArea> getAreas();
     method public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? getBlock();
@@ -67,7 +65,6 @@ package dev.chrisbanes.haze {
     property public dev.chrisbanes.haze.HazeState? state;
     property public Object traverseKey;
     property public dev.chrisbanes.haze.VisualEffect visualEffect;
-    field public static final String TAG = "HazeEffect";
   }
 
   public interface HazeEffectScope {
@@ -169,12 +166,22 @@ package dev.chrisbanes.haze {
   @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.SOURCE) @kotlin.annotation.Target(allowedTargets=kotlin.annotation.AnnotationTarget.CLASS) public @interface Poko {
   }
 
-  @dev.chrisbanes.haze.ExperimentalHazeApi public interface VisualEffect {
+  public enum TrimMemoryLevel {
+    method public int getSeverity();
+    property public int severity;
+    enum_constant public static final dev.chrisbanes.haze.TrimMemoryLevel BACKGROUND;
+    enum_constant public static final dev.chrisbanes.haze.TrimMemoryLevel COMPLETE;
+    enum_constant public static final dev.chrisbanes.haze.TrimMemoryLevel MODERATE;
+    enum_constant public static final dev.chrisbanes.haze.TrimMemoryLevel UI_HIDDEN;
+  }
+
+  @androidx.compose.runtime.Stable @dev.chrisbanes.haze.ExperimentalHazeApi public interface VisualEffect {
     method public default void attach(dev.chrisbanes.haze.VisualEffectContext context);
     method public default float calculateInputScaleFactor(dev.chrisbanes.haze.HazeInputScale scale);
     method public default androidx.compose.ui.geometry.Rect calculateLayerBounds(androidx.compose.ui.geometry.Rect rect, androidx.compose.ui.unit.Density density);
     method public default void detach();
     method public void draw(androidx.compose.ui.graphics.drawscope.DrawScope, dev.chrisbanes.haze.VisualEffectContext context);
+    method public default void onTrimMemory(dev.chrisbanes.haze.VisualEffectContext context, dev.chrisbanes.haze.TrimMemoryLevel level);
     method public default boolean preferClipToAreaBounds();
     method public default boolean requireInvalidation();
     method public default boolean shouldClip();

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -65,7 +65,7 @@ internal fun resolvePositionStrategy(
 }
 
 @Stable
-public class HazeArea {
+public class HazeArea internal constructor() {
 
   public var position: Offset by mutableStateOf(Offset.Unspecified)
     internal set
@@ -85,8 +85,11 @@ public class HazeArea {
   internal val preDrawListeners = mutableStateSetOf<OnPreDrawListener>()
 
   /**
-   * The content [GraphicsLayer].
+   * Internal content [GraphicsLayer] used when capturing source content for effects.
+   *
+   * This is exposed for effect implementations and is not a stable public contract.
    */
+  @InternalHazeApi
   public var contentLayer: GraphicsLayer? by mutableStateOf(null)
     internal set
 
@@ -106,9 +109,7 @@ public class HazeArea {
     append("HazeArea(")
     append("position=$position, ")
     append("size=$size, ")
-    append("zIndex=$zIndex, ")
-    append("contentLayer=$contentLayer, ")
-    append("isContentDrawing=$isContentDrawing")
+    append("zIndex=$zIndex")
     append(")")
   }
 }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -45,8 +45,8 @@ public interface HazeEffectScope {
   /**
    * A block which controls whether this [hazeEffect] should draw the given [HazeArea].
    *
-   * When null, the default behavior is that this effect will only draw areas with a
-   * [HazeArea.zIndex] the nearest ancestor [HazeSourceNode].
+   * When null, the default behavior is that this effect only draws areas with [HazeArea.zIndex]
+   * less than the nearest ancestor [hazeSource] modifier's z-index.
    */
   @ExperimentalHazeApi
   public var canDrawArea: ((HazeArea) -> Boolean)?
@@ -145,7 +145,7 @@ public sealed interface HazeInputScale {
  * Modifier.hazeEffect(state, effect = effect) {
  *   visualEffect = BlurVisualEffect().apply {
  *     blurRadius = 20.dp
- *     tints = listOf(HazeTint(Color.Black.copy(alpha = 0.5f)))
+ *     colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.5f)))
  *   }
  * }
  * ```

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -43,8 +43,8 @@ import kotlinx.coroutines.DisposableHandle
  */
 @ExperimentalHazeApi
 public class HazeEffectNode(
-  public var state: HazeState?,
-  public var block: (HazeEffectScope.() -> Unit)?,
+  public var state: HazeState? = null,
+  public var block: (HazeEffectScope.() -> Unit)? = null,
 ) : Modifier.Node(),
   CompositionLocalConsumerModifierNode,
   GlobalPositionAwareModifierNode,

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -43,8 +43,8 @@ import kotlinx.coroutines.DisposableHandle
  */
 @ExperimentalHazeApi
 public class HazeEffectNode(
-  public var state: HazeState? = null,
-  public var block: (HazeEffectScope.() -> Unit)? = null,
+  public var state: HazeState?,
+  public var block: (HazeEffectScope.() -> Unit)?,
 ) : Modifier.Node(),
   CompositionLocalConsumerModifierNode,
   GlobalPositionAwareModifierNode,
@@ -53,6 +53,12 @@ public class HazeEffectNode(
   DrawModifierNode,
   TraversableNode,
   HazeEffectScope {
+
+  @Deprecated(
+    message = "For binary compatibility only. Use the hazeEffect modifier APIs.",
+    level = DeprecationLevel.HIDDEN,
+  )
+  public constructor() : this(state = null, block = null)
 
   override val traverseKey: Any
     get() = HazeTraversableNodeKeys.Effect
@@ -230,7 +236,16 @@ public class HazeEffectNode(
   override fun onDetach() {
     trimMemoryCallbackDisposable?.dispose()
     trimMemoryCallbackDisposable = null
+    contentDrawArea.releaseLayer()
     visualEffect.detach()
+  }
+
+  private fun HazeArea.releaseLayer() {
+    contentLayer?.let { layer ->
+      HazeLogger.d(TAG) { "Releasing content layer: $layer" }
+      requireGraphicsContext().releaseGraphicsLayer(layer)
+    }
+    contentLayer = null
   }
 
   override fun onObservedReadsChanged() {
@@ -494,8 +509,8 @@ public class HazeEffectNode(
     }
   }
 
-  internal companion object {
-    const val TAG = "HazeEffect"
+  private companion object {
+    private const val TAG = "HazeEffect"
   }
 }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze
 
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.Density
@@ -15,6 +16,7 @@ import androidx.compose.ui.unit.Density
  * to the underlying node implementation.
  */
 @ExperimentalHazeApi
+@Stable
 public interface VisualEffect {
   /**
    * Draws the effect.
@@ -67,8 +69,10 @@ public interface VisualEffect {
   public fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel): Unit = Unit
 
   /**
-   * Returns whether the content should be drawn behind the effect for foreground blurring.
-   * This is called during drawing to determine draw order.
+   * Returns whether the source content should be drawn before the effect in foreground mode.
+   *
+   * This is called during drawing to determine draw order when [VisualEffectContext.state]
+   * is null.
    *
    * @param context The context providing access to geometry, configuration, and platform
    * capabilities.

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffectContext.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffectContext.kt
@@ -111,7 +111,10 @@ public interface VisualEffectContext {
   public fun requireGraphicsContext(): GraphicsContext
 
   /**
-   * CoroutineScope to launch coroutines from
+   * CoroutineScope tied to the effect node lifecycle.
+   *
+   * Any jobs launched in this scope are cancelled when the owning node detaches.
+   * Use this for short-lived effect work that should not outlive the node.
    */
   public val coroutineScope: CoroutineScope
 

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
@@ -121,7 +121,7 @@ class HazeComposeUnitTests : ContextTest() {
 
   @Test
   fun testResolvePositionStrategy_autoPromotesToScreenForCrossWindow() {
-    val area = HazeArea().apply { windowId = "dialog-window" }
+    val area = HazeAreaTestFactory.create(windowId = "dialog-window")
 
     val resolved = resolvePositionStrategy(
       configured = HazePositionStrategy.Auto,
@@ -131,4 +131,8 @@ class HazeComposeUnitTests : ContextTest() {
 
     assertThat(resolved).isEqualTo(HazePositionStrategy.Screen)
   }
+}
+
+internal object HazeAreaTestFactory {
+  fun create(windowId: Any?): HazeArea = HazeArea().also { it.windowId = windowId }
 }

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectNodeConstructorTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectNodeConstructorTest.kt
@@ -1,0 +1,30 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+@OptIn(ExperimentalHazeApi::class)
+class HazeEffectNodeConstructorTest {
+
+  @Test
+  fun constructor_supportsStateOnlyCallSite() {
+    val state = HazeState()
+    val node = HazeEffectNode(state = state)
+
+    assertThat(node.state).isEqualTo(state)
+    assertThat(node.block).isEqualTo(null)
+  }
+
+  @Test
+  fun constructor_supportsBlockOnlyCallSite() {
+    val block: HazeEffectScope.() -> Unit = {}
+    val node = HazeEffectNode(block = block)
+
+    assertThat(node.state).isEqualTo(null)
+    assertThat(node.block).isEqualTo(block)
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes a foreground `contentDrawArea` layer leak by releasing the layer in `HazeEffectNode.onDetach`, and hardens related internal/API visibility and stability annotations.
- Aligns v2 migration docs/changelog/readme examples to canonical v2 naming (`colorEffects`, `HazeBlurStyle`, `HazeColorEffect`, `LocalHazeBlurStyle`) and updates CI Gradle setup action usage.
- Improves `haze-blur` internals by tightening dirty flags, adding render effect cache clearing on trim-memory, and adds `BlurDirtyFieldsTest` with assertk assertions.