### PR TITLE
Fix v2 documentation inconsistencies and add VisualEffect lifecycle tests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,16 +13,16 @@ The `VisualEffect` interface is the base contract for all visual effects. Implem
 ```kotlin
 interface VisualEffect {
     fun attach(context: VisualEffectContext)
-    fun update(context: VisualEffectContext, scope: HazeEffectScope)
+    fun update(context: VisualEffectContext)
     fun detach()
-    fun draw(canvas: Canvas, context: VisualEffectContext)
+    fun DrawScope.draw(context: VisualEffectContext)
 }
 ```
 
 - **attach**: Called when the effect is first attached to a composable. Implementations can initialize platform-specific resources.
-- **update**: Called whenever styling parameters change (from `HazeEffectScope`).
+- **update**: Called whenever the effect should update its state from composition locals or other sources.
 - **detach**: Called when the effect is removed. Implementations should clean up resources.
-- **draw**: Renders the effect to the provided canvas.
+- **draw**: Renders the effect using the `DrawScope` receiver.
 
 ### HazeEffectScope
 
@@ -88,15 +88,25 @@ modifier = Modifier.hazeEffect(state) {
 
 ## Platform Support
 
-Haze provides a `VisualEffectContext` that gives effects access to platform-specific capabilities:
+Haze provides a `VisualEffectContext` that gives effects access to geometry, configuration, and platform capabilities:
 
 ```kotlin
 interface VisualEffectContext {
-    val size: IntSize
-    val density: Float
-    val layoutDirection: LayoutDirection
-    val coroutineScope: CoroutineScope
-    // Platform-specific rendering utilities
+    val position: Offset               // Position of the effect node
+    val size: Size                     // Size of the effect area
+    val layerSize: Size                // Size of the graphics layer (may differ from size)
+    val layerOffset: Offset            // Graphics layer offset relative to node position
+    val rootBounds: Rect               // Bounds of the root layout coordinates on screen
+    val inputScale: HazeInputScale     // Input scale factor configuration
+    val windowId: Any?                 // Identifier for the containing window
+    val areas: List<HazeArea>          // Source areas this effect should process
+    val state: HazeState?              // Associated HazeState (null for foreground blur)
+    val coroutineScope: CoroutineScope // CoroutineScope tied to the node lifecycle
+
+    fun requireDensity(): Density
+    fun <T> currentValueOf(local: CompositionLocal<T>): T
+    fun requireGraphicsContext(): GraphicsContext
+    fun invalidateDraw()
 }
 ```
 
@@ -119,16 +129,16 @@ class CustomVisualEffect : VisualEffect {
         // Initialize resources
     }
 
-    override fun update(context: VisualEffectContext, scope: HazeEffectScope) {
-        // Update with new styling parameters
+    override fun update(context: VisualEffectContext) {
+        // Update state from composition locals or snapshot state
     }
 
     override fun detach() {
         // Clean up resources
     }
 
-    override fun draw(canvas: Canvas, context: VisualEffectContext) {
-        // Render the effect
+    override fun DrawScope.draw(context: VisualEffectContext) {
+        // Render the effect using the DrawScope receiver
     }
 }
 
@@ -146,7 +156,7 @@ When multiple sources of styling are provided, Haze resolves values using the fo
 
 1. Value set directly in the effect builder (e.g., `blurEffect { }`)
 2. Value set via the `style` property
-3. Value set via `LocalHazeStyle` composition local
+3. Value set via `LocalHazeBlurStyle` composition local
 4. Default value
 
 This allows flexible composition of styles from different sources while maintaining predictable behavior.

--- a/docs/blur/faq.md
+++ b/docs/blur/faq.md
@@ -1,4 +1,3 @@
-
 ## What's the difference between this and Modifier.blur?
 
 The [Modifier.blur](https://developer.android.com/reference/kotlin/androidx/compose/ui/Modifier#(androidx.compose.ui.Modifier).blur(androidx.compose.ui.unit.Dp,androidx.compose.ui.unit.Dp,androidx.compose.ui.draw.BlurredEdgeTreatment)) modifier and Haze may sound similar, but what they provide is different.

--- a/docs/blur/index.md
+++ b/docs/blur/index.md
@@ -66,7 +66,7 @@ For more detailed usage patterns, see the [Blur Usage](usage.md) guide.
 
 ## Styling
 
-The appearance of the blur effect is controlled through the [HazeStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-haze-style/index.html) class:
+The appearance of the blur effect is controlled through the [HazeBlurStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-haze-blur-style/index.html) class:
 
 - **Blur Radius**: Controls the strength of the blur
 - **Tint**: Applies a color overlay for contrast

--- a/docs/blur/materials.md
+++ b/docs/blur/materials.md
@@ -84,13 +84,13 @@ blurEffect {
 
 ## Custom Styles
 
-To create custom blur styles, use the [HazeStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-haze-style/index.html) data class:
+To create custom blur styles, use the [HazeBlurStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-haze-blur-style/index.html) data class:
 
 ```kotlin
-val customStyle = HazeStyle(
+val customStyle = HazeBlurStyle(
   blurRadius = 15.dp,
-  tints = listOf(Color.Black.copy(alpha = 0.2f)),
-  noise = 0.1f
+  colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.2f))),
+  noiseFactor = 0.1f
 )
 
 blurEffect {
@@ -103,7 +103,7 @@ Or set properties directly in the `blurEffect` block:
 ```kotlin
 blurEffect {
   blurRadius = 15.dp
-  tints = listOf(Color.Black.copy(alpha = 0.2f))
-  noise = 0.1f
+  colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.2f)))
+  noiseFactor = 0.1f
 }
 ```

--- a/docs/blur/platforms.md
+++ b/docs/blur/platforms.md
@@ -24,14 +24,16 @@ Only linear gradient [HazeProgressive](../api/haze-blur/dev.chrisbanes.haze.blur
 
 You can disable this behavior by setting the [preferPerformance](../api/haze-blur/dev.chrisbanes.haze.blur/-haze-progressive/-companion/index.html) property. When set to true, the progressive 'effect' will instead be drawn via a mask:
 
-```kotlin hl_lines="6"
+```kotlin hl_lines="7"
 LargeTopAppBar(
   // ...
   modifier = Modifier.hazeEffect(hazeState) {
-    progressive = HazeProgressive.verticalGradient(
-      // ...
-      preferPerformance = true,
-    )
+    blurEffect {
+      progressive = HazeProgressive.verticalGradient(
+        // ...
+        preferPerformance = true,
+      )
+    }
   }
 )
 ```

--- a/docs/blur/usage.md
+++ b/docs/blur/usage.md
@@ -57,11 +57,11 @@ fun HazeExample(modifier: Modifier = Modifier) {
 
 ## Styling
 
-Blur appearance is controlled via the [HazeStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-haze-style/index.html) class or properties in the `blurEffect` block:
+Blur appearance is controlled via the [HazeBlurStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-haze-blur-style/index.html) class or properties in the `blurEffect` block:
 
 Styles can be provided in multiple ways:
 
-- [LocalHazeStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-local-haze-style.html) composition local
+- [LocalHazeBlurStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-local-haze-blur-style.html) composition local
 - `style` property inside `blurEffect {}` block
 - Individual properties in the `blurEffect {}` block
 
@@ -92,7 +92,7 @@ Each styling property is resolved using the following precedence:
 
 1. Value set in `blurEffect {}` block (if specified)
 2. Value set via `style` property in `blurEffect {}` (if specified)
-3. Value set in [LocalHazeStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-local-haze-style.html) composition local
+3. Value set in [LocalHazeBlurStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-local-haze-blur-style.html) composition local
 4. Default value
 
 ### Styling Properties
@@ -109,13 +109,13 @@ blurEffect {
 
 #### Tint
 
-A tint effect is applied primarily to maintain contrast and legibility. By default, the provided background color is used at 70% opacity. You can provide multiple tints applied in sequence:
+A tint effect is applied primarily to maintain contrast and legibility. By default, the provided background color is used at 70% opacity. You can provide multiple color effects applied in sequence:
 
 ```kotlin
 blurEffect {
-  tints = listOf(
-    Color.Black.copy(alpha = 0.2f),
-    Color.Blue.copy(alpha = 0.1f)
+  colorEffects = listOf(
+    HazeColorEffect.tint(Color.Black.copy(alpha = 0.2f)),
+    HazeColorEffect.tint(Color.Blue.copy(alpha = 0.1f))
   )
 }
 ```
@@ -126,7 +126,7 @@ Visual noise provides tactility. Defaults to `0.15f` (15% strength). Disable by 
 
 ```kotlin
 blurEffect {
-  noise = 0f  // Disable noise
+  noiseFactor = 0f  // Disable noise
 }
 ```
 

--- a/docs/custom-effects.md
+++ b/docs/custom-effects.md
@@ -129,7 +129,7 @@ interface VisualEffectContext {
 
 ## HazeEffectScope
 
-The effect receives the `HazeEffectScope` which provides common properties applicable to all effects:
+The `Modifier.hazeEffect { ... }` configuration lambda receives `HazeEffectScope` as its receiver, providing common properties applicable to all effects:
 
 ```kotlin
 interface HazeEffectScope {

--- a/docs/custom-effects.md
+++ b/docs/custom-effects.md
@@ -27,9 +27,9 @@ class CustomVisualEffect : VisualEffect {
         // Initialize any platform-specific resources here
     }
 
-    override fun update(context: VisualEffectContext, scope: HazeEffectScope) {
-        // Called when styling properties change
-        // Update internal state based on scope properties
+    override fun update(context: VisualEffectContext) {
+        // Called when the effect should update its state from composition locals
+        // or other sources. You can safely read snapshot state here.
     }
 
     override fun detach() {
@@ -37,9 +37,9 @@ class CustomVisualEffect : VisualEffect {
         // Clean up any resources allocated in attach()
     }
 
-    override fun draw(canvas: Canvas, context: VisualEffectContext) {
+    override fun DrawScope.draw(context: VisualEffectContext) {
         // Called to render the effect
-        // Draw the effect to the provided canvas
+        // Draw the effect using the DrawScope receiver
     }
 }
 ```
@@ -56,22 +56,22 @@ Called once when the effect is first attached to a composable. Use this to:
 ```kotlin
 override fun attach(context: VisualEffectContext) {
     // Example: Initialize a platform-specific shader
-    myShader = createShader(context.size, context.density)
+    myShader = createShader(context.size, context.requireDensity())
 }
 ```
 
-#### update(context: VisualEffectContext, scope: HazeEffectScope)
+#### update(context: VisualEffectContext)
 
-Called whenever styling parameters change (when `HazeEffectScope` properties are updated). Use this to:
-- Update effect parameters from `HazeEffectScope`
-- Recalculate values based on new properties
-- Update platform-specific rendering parameters
+Called whenever the effect should update its state from composition locals or other sources. You can safely read snapshot state in this function. When any snapshot state read in this function is mutated, this function will be re-invoked.
 
 ```kotlin
-override fun update(context: VisualEffectContext, scope: HazeEffectScope) {
-    // Update effect from scope properties
-    myIntensity = scope.alpha
-    myInputScale = scope.inputScale
+override fun update(context: VisualEffectContext) {
+    // Example: read a composition local and trigger invalidation if needed
+    val someLocal = context.currentValueOf(MyCompositionLocal)
+    if (someLocal != cachedLocal) {
+        cachedLocal = someLocal
+        context.invalidateDraw()
+    }
 }
 ```
 
@@ -89,15 +89,17 @@ override fun detach() {
 }
 ```
 
-#### draw(canvas: Canvas, context: VisualEffectContext)
+#### draw(context: VisualEffectContext)
 
 Called to render the effect. This is where the actual effect rendering happens.
 
 ```kotlin
-override fun draw(canvas: Canvas, context: VisualEffectContext) {
-    // Draw the effect to canvas
-    canvas.drawRect(0f, 0f, context.size.width.toFloat(),
-                   context.size.height.toFloat(), myPaint)
+override fun DrawScope.draw(context: VisualEffectContext) {
+    // Draw the effect using the DrawScope receiver
+    drawRect(
+        color = Color.Black.copy(alpha = 0.5f),
+        size = context.size,
+    )
 }
 ```
 
@@ -107,23 +109,37 @@ The context provided to effect methods gives you access to:
 
 ```kotlin
 interface VisualEffectContext {
-    val size: IntSize                    // Size of the effect area
-    val density: Float                  // Screen pixel density
-    val layoutDirection: LayoutDirection // Text layout direction
-    val coroutineScope: CoroutineScope  // For async operations
+    val position: Offset               // Position of the effect node
+    val size: Size                    // Size of the effect area
+    val layerSize: Size              // Size of the graphics layer (may differ from size)
+    val layerOffset: Offset          // Graphics layer offset relative to node position
+    val rootBounds: Rect             // Bounds of the root layout coordinates on screen
+    val inputScale: HazeInputScale   // Input scale factor configuration
+    val windowId: Any?               // Identifier for the containing window
+    val areas: List<HazeArea>        // Source areas this effect should process
+    val state: HazeState?            // Associated HazeState (null for foreground blur)
+    val coroutineScope: CoroutineScope // CoroutineScope tied to the node lifecycle
+
+    fun requireDensity(): Density
+    fun <T> currentValueOf(local: CompositionLocal<T>): T
+    fun requireGraphicsContext(): GraphicsContext
+    fun invalidateDraw()
 }
 ```
 
 ## HazeEffectScope
 
-The effect receives the `HazeEffectScope` which provides common properties:
+The effect receives the `HazeEffectScope` which provides common properties applicable to all effects:
 
 ```kotlin
 interface HazeEffectScope {
-    var alpha: Float                    // Overall effect opacity
-    var inputScale: HazeInputScale      // Performance optimization
-    var drawContentBehind: Boolean      // Whether to draw source content
-    var canDrawArea: ((DrawArea) -> Boolean)? // Layer filtering
+    var visualEffect: VisualEffect        // The current visual effect implementation
+    var inputScale: HazeInputScale        // Performance optimization via resolution scaling
+    var drawContentBehind: Boolean        // Whether to draw source content behind the effect
+    var clipToAreasBounds: Boolean?      // Whether to clip to total area bounds
+    var expandLayerBounds: Boolean?       // Whether to expand layer bounds for edge consistency
+    var forceInvalidateOnPreDraw: Boolean // Force invalidation from pre-draw events
+    var canDrawArea: ((HazeArea) -> Boolean)? // Optional filter to control which areas are drawn
 }
 ```
 
@@ -159,7 +175,7 @@ Effects often need platform-specific code. Use `expect`/`actual` to provide plat
 
 **commonMain:**
 ```kotlin
-expect fun createCustomShader(size: IntSize): Shader
+expect fun createCustomShader(size: Size): Shader
 
 class CustomVisualEffect : VisualEffect {
     private lateinit var shader: Shader
@@ -172,14 +188,14 @@ class CustomVisualEffect : VisualEffect {
 
 **androidMain:**
 ```kotlin
-actual fun createCustomShader(size: IntSize): Shader {
+actual fun createCustomShader(size: Size): Shader {
     // Android-specific shader creation
 }
 ```
 
 **desktopMain:**
 ```kotlin
-actual fun createCustomShader(size: IntSize): Shader {
+actual fun createCustomShader(size: Size): Shader {
     // Skiko-based shader creation
 }
 ```
@@ -215,28 +231,22 @@ class TintVisualEffect : VisualEffect {
     var color: Color = Color.Black
     var alpha: Float = 0.2f
 
-    private val paint = Paint().apply {
-        isAntiAlias = true
-    }
-
     override fun attach(context: VisualEffectContext) {
         // No resources to allocate for a simple tint
     }
 
-    override fun update(context: VisualEffectContext, scope: HazeEffectScope) {
-        paint.color = color.copy(alpha = scope.alpha * alpha).toArgb()
+    override fun update(context: VisualEffectContext) {
+        // Nothing to update from composition locals
     }
 
     override fun detach() {
         // Nothing to clean up
     }
 
-    override fun draw(canvas: Canvas, context: VisualEffectContext) {
-        canvas.drawRect(
-            0f, 0f,
-            context.size.width.toFloat(),
-            context.size.height.toFloat(),
-            paint
+    override fun DrawScope.draw(context: VisualEffectContext) {
+        drawRect(
+            color = color.copy(alpha = alpha),
+            size = context.size,
         )
     }
 }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -35,7 +35,7 @@ The numbers listed below the P90 frame durations in milliseconds, which tend to 
 
 We can also measure the rough cost of using Haze in the same samples. Here we've ran the same tests, with Haze being completely disabled:
 
-| Test          | 1.0.x (disabled)  | 1.0.x      | Difference   |
+| Test          | v1.x (disabled)  | v1.x      | Difference   |
 | ------------- | ------------------| -----------| ------------ |
 | Scaffold      | 7.5 ms            | 9.7 ms     | +29%         |
 | Images List   | 6.6 ms            | 9.6 ms     | +45%         |

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -44,7 +44,6 @@ Scaffold(
     modifier = Modifier
       .hazeSource(
         state = hazeState,
-        style = HazeDefaults.style(backgroundColor = MaterialTheme.colorScheme.surface),
       ),
   ) {
     // todo

--- a/docs/using-snapshot-version.md
+++ b/docs/using-snapshot-version.md
@@ -15,7 +15,7 @@ dependencies {
     // Check the latest SNAPSHOT version from the link above
     // Core infrastructure (required)
     implementation("dev.chrisbanes.haze:haze:XXX-SNAPSHOT")
-    
+
     // For blur effects (most users will need this)
     implementation("dev.chrisbanes.haze:haze-blur:XXX-SNAPSHOT")
 }

--- a/docs/using-snapshot-version.md
+++ b/docs/using-snapshot-version.md
@@ -13,7 +13,11 @@ repositories {
 
 dependencies {
     // Check the latest SNAPSHOT version from the link above
+    // Core infrastructure (required)
     implementation("dev.chrisbanes.haze:haze:XXX-SNAPSHOT")
+    
+    // For blur effects (most users will need this)
+    implementation("dev.chrisbanes.haze:haze-blur:XXX-SNAPSHOT")
 }
 ```
 

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
@@ -211,20 +211,6 @@ class HazeComposeUnitTests : ContextTest() {
 
     assertThat(resolved).isEqualTo(HazePositionStrategy.Local)
   }
-
-  @Test
-  fun testResolvePositionStrategy_crossWindowWithExplicitLocalStillLocal() {
-    // Even if cross-window, explicit Local should stay Local
-    val area = HazeAreaTestFactory.create(windowId = "dialog-window")
-
-    val resolved = resolvePositionStrategy(
-      configured = HazePositionStrategy.Local,
-      areas = listOf(area),
-      windowId = "host-window",
-    )
-
-    assertThat(resolved).isEqualTo(HazePositionStrategy.Local)
-  }
 }
 
 internal object HazeAreaTestFactory {

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
@@ -131,6 +131,100 @@ class HazeComposeUnitTests : ContextTest() {
 
     assertThat(resolved).isEqualTo(HazePositionStrategy.Screen)
   }
+
+  @Test
+  fun testResolvePositionStrategy_autoResolvesToLocalForNullWindowIdAreas() {
+    val area1 = HazeAreaTestFactory.create(windowId = null)
+    val area2 = HazeAreaTestFactory.create(windowId = null)
+
+    val resolved = resolvePositionStrategy(
+      configured = HazePositionStrategy.Auto,
+      areas = listOf(area1, area2),
+      windowId = "host-window",
+    )
+
+    assertThat(resolved).isEqualTo(HazePositionStrategy.Local)
+  }
+
+  @Test
+  fun testResolvePositionStrategy_autoResolvesToLocalForMatchingWindowId() {
+    val area = HazeAreaTestFactory.create(windowId = "host-window")
+
+    val resolved = resolvePositionStrategy(
+      configured = HazePositionStrategy.Auto,
+      areas = listOf(area),
+      windowId = "host-window",
+    )
+
+    // Same window is treated as local
+    assertThat(resolved).isEqualTo(HazePositionStrategy.Local)
+  }
+
+  @Test
+  fun testResolvePositionStrategy_passesThroughExplicitLocal() {
+    val area = HazeAreaTestFactory.create(windowId = "dialog-window")
+
+    val resolved = resolvePositionStrategy(
+      configured = HazePositionStrategy.Local,
+      areas = listOf(area),
+      windowId = "host-window",
+    )
+
+    assertThat(resolved).isEqualTo(HazePositionStrategy.Local)
+  }
+
+  @Test
+  fun testResolvePositionStrategy_passesThroughExplicitScreen() {
+    val area = HazeAreaTestFactory.create(windowId = null)
+
+    val resolved = resolvePositionStrategy(
+      configured = HazePositionStrategy.Screen,
+      areas = listOf(area),
+      windowId = "host-window",
+    )
+
+    assertThat(resolved).isEqualTo(HazePositionStrategy.Screen)
+  }
+
+  @Test
+  fun testResolvePositionStrategy_autoPromotesToScreenForMixedWindowIds() {
+    val area1 = HazeAreaTestFactory.create(windowId = "dialog-window")
+    val area2 = HazeAreaTestFactory.create(windowId = "host-window")
+
+    val resolved = resolvePositionStrategy(
+      configured = HazePositionStrategy.Auto,
+      areas = listOf(area1, area2),
+      windowId = "host-window",
+    )
+
+    // One area is in a different window — promote to Screen
+    assertThat(resolved).isEqualTo(HazePositionStrategy.Screen)
+  }
+
+  @Test
+  fun testResolvePositionStrategy_emptyAreasResolvesToLocal() {
+    val resolved = resolvePositionStrategy(
+      configured = HazePositionStrategy.Auto,
+      areas = emptyList(),
+      windowId = "host-window",
+    )
+
+    assertThat(resolved).isEqualTo(HazePositionStrategy.Local)
+  }
+
+  @Test
+  fun testResolvePositionStrategy_crossWindowWithExplicitLocalStillLocal() {
+    // Even if cross-window, explicit Local should stay Local
+    val area = HazeAreaTestFactory.create(windowId = "dialog-window")
+
+    val resolved = resolvePositionStrategy(
+      configured = HazePositionStrategy.Local,
+      areas = listOf(area),
+      windowId = "host-window",
+    )
+
+    assertThat(resolved).isEqualTo(HazePositionStrategy.Local)
+  }
 }
 
 internal object HazeAreaTestFactory {

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isTrue
+import assertk.assertions.isGreaterThan
 import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
@@ -173,7 +173,7 @@ class VisualEffectLifecycleTest {
 
     waitForIdle()
     // drawContentBehind changed, which should trigger update
-    assertThat(effect.updateCalls).isTrue()
+    assertThat(effect.updateCalls).isGreaterThan(0)
   }
 
   @Test
@@ -232,6 +232,7 @@ internal data object FakeVisualEffectContext : VisualEffectContext {
 
   override fun requireDensity(): androidx.compose.ui.unit.Density = error("Fake")
   override fun <T> currentValueOf(local: androidx.compose.runtime.CompositionLocal<T>): T = error("Fake")
+  override fun requirePlatformContext(): PlatformContext = error("Unused in lifecycle tests")
   override fun requireGraphicsContext(): androidx.compose.ui.graphics.GraphicsContext = error("Fake")
   override fun invalidateDraw() {}
 }

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -6,6 +6,7 @@ package dev.chrisbanes.haze
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -53,28 +54,30 @@ class VisualEffectLifecycleTest : ContextTest() {
   fun visualEffect_detachCalledOnNodeDetach() = runComposeUiTest {
     val hazeState = HazeState()
     val effect = RecordingVisualEffect()
+    val showContent = mutableStateOf(true)
 
     setContent {
-      Box(
-        modifier = Modifier
-          .size(100.dp)
-          .hazeSource(hazeState),
-      ) {
-        Spacer(
-          Modifier
+      if (showContent.value) {
+        Box(
+          modifier = Modifier
             .size(100.dp)
-            .hazeEffect(hazeState) {
-              visualEffect = effect
-            },
-        )
+            .hazeSource(hazeState),
+        ) {
+          Spacer(
+            Modifier
+              .size(100.dp)
+              .hazeEffect(hazeState) {
+                visualEffect = effect
+              },
+          )
+        }
       }
     }
 
     waitForIdle()
     assertThat(effect.attachCalls).isEqualTo(1)
 
-    // Remove the content
-    setContent { }
+    showContent.value = false
     waitForIdle()
 
     assertThat(effect.detachCalls).isEqualTo(1)
@@ -85,6 +88,7 @@ class VisualEffectLifecycleTest : ContextTest() {
     val hazeState = HazeState()
     val effect1 = RecordingVisualEffect()
     val effect2 = RecordingVisualEffect()
+    val useSecondEffect = mutableStateOf(false)
 
     setContent {
       Box(
@@ -96,7 +100,7 @@ class VisualEffectLifecycleTest : ContextTest() {
           Modifier
             .size(100.dp)
             .hazeEffect(hazeState) {
-              visualEffect = effect1
+              visualEffect = if (useSecondEffect.value) effect2 else effect1
             },
         )
       }
@@ -106,24 +110,9 @@ class VisualEffectLifecycleTest : ContextTest() {
     assertThat(effect1.attachCalls).isEqualTo(1)
     assertThat(effect1.detachCalls).isEqualTo(0)
 
-    // Replace the effect
-    setContent {
-      Box(
-        modifier = Modifier
-          .size(100.dp)
-          .hazeSource(hazeState),
-      ) {
-        Spacer(
-          Modifier
-            .size(100.dp)
-            .hazeEffect(hazeState) {
-              visualEffect = effect2
-            },
-        )
-      }
-    }
-
+    useSecondEffect.value = true
     waitForIdle()
+
     assertThat(effect1.detachCalls).isEqualTo(1)
     assertThat(effect2.attachCalls).isEqualTo(1)
     assertThat(effect2.detachCalls).isEqualTo(0)
@@ -133,6 +122,7 @@ class VisualEffectLifecycleTest : ContextTest() {
   fun visualEffect_updateCalledWhenRecomposed() = runComposeUiTest {
     val hazeState = HazeState()
     val effect = RecordingVisualEffect()
+    val drawBehind = mutableStateOf(false)
 
     setContent {
       Box(
@@ -144,6 +134,7 @@ class VisualEffectLifecycleTest : ContextTest() {
           Modifier
             .size(100.dp)
             .hazeEffect(hazeState) {
+              drawContentBehind = drawBehind.value
               visualEffect = effect
             },
         )
@@ -151,36 +142,17 @@ class VisualEffectLifecycleTest : ContextTest() {
     }
 
     waitForIdle()
-    // update may be called during initial composition
     val initialUpdateCount = effect.updateCalls
 
-    // Trigger recomposition by changing something that affects the effect scope
-    setContent {
-      Box(
-        modifier = Modifier
-          .size(100.dp)
-          .hazeSource(hazeState),
-      ) {
-        Spacer(
-          Modifier
-            .size(100.dp)
-            .hazeEffect(hazeState) {
-              drawContentBehind = true
-              visualEffect = effect
-            },
-        )
-      }
-    }
-
+    drawBehind.value = true
     waitForIdle()
-    // drawContentBehind changed, which should trigger update
-    assertThat(effect.updateCalls).isGreaterThan(0)
+
+    assertThat(effect.updateCalls).isGreaterThan(initialUpdateCount)
   }
 
   @Test
   fun emptyVisualEffect_doesNothing() {
     val empty = VisualEffect.Empty
-    // Just verify it doesn't throw
     empty.attach(FakeVisualEffectContext)
     empty.update(FakeVisualEffectContext)
     empty.detach()

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -1,0 +1,237 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class VisualEffectLifecycleTest {
+
+  @Test
+  fun visualEffect_attachCalledWhenSet() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = RecordingVisualEffect()
+
+    setContent {
+      Box(
+        modifier = Modifier
+          .size(100.dp)
+          .hazeSource(hazeState),
+      ) {
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.attachCalls).isEqualTo(1)
+    assertThat(effect.detachCalls).isEqualTo(0)
+  }
+
+  @Test
+  fun visualEffect_detachCalledOnNodeDetach() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = RecordingVisualEffect()
+
+    setContent {
+      Box(
+        modifier = Modifier
+          .size(100.dp)
+          .hazeSource(hazeState),
+      ) {
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.attachCalls).isEqualTo(1)
+
+    // Remove the content
+    setContent { }
+    waitForIdle()
+
+    assertThat(effect.detachCalls).isEqualTo(1)
+  }
+
+  @Test
+  fun visualEffect_detachOldAndAttachNewWhenReplaced() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect1 = RecordingVisualEffect()
+    val effect2 = RecordingVisualEffect()
+
+    setContent {
+      Box(
+        modifier = Modifier
+          .size(100.dp)
+          .hazeSource(hazeState),
+      ) {
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect1
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect1.attachCalls).isEqualTo(1)
+    assertThat(effect1.detachCalls).isEqualTo(0)
+
+    // Replace the effect
+    setContent {
+      Box(
+        modifier = Modifier
+          .size(100.dp)
+          .hazeSource(hazeState),
+      ) {
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect2
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect1.detachCalls).isEqualTo(1)
+    assertThat(effect2.attachCalls).isEqualTo(1)
+    assertThat(effect2.detachCalls).isEqualTo(0)
+  }
+
+  @Test
+  fun visualEffect_updateCalledWhenRecomposed() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = RecordingVisualEffect()
+
+    setContent {
+      Box(
+        modifier = Modifier
+          .size(100.dp)
+          .hazeSource(hazeState),
+      ) {
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    // update may be called during initial composition
+    val initialUpdateCount = effect.updateCalls
+
+    // Trigger recomposition by changing something that affects the effect scope
+    setContent {
+      Box(
+        modifier = Modifier
+          .size(100.dp)
+          .hazeSource(hazeState),
+      ) {
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              drawContentBehind = true
+              visualEffect = effect
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    // drawContentBehind changed, which should trigger update
+    assertThat(effect.updateCalls).isTrue()
+  }
+
+  @Test
+  fun emptyVisualEffect_doesNothing() {
+    val empty = VisualEffect.Empty
+    // Just verify it doesn't throw
+    empty.attach(FakeVisualEffectContext)
+    empty.update(FakeVisualEffectContext)
+    empty.detach()
+    assertThat(empty.shouldClip()).isEqualTo(false)
+    assertThat(empty.requireInvalidation()).isEqualTo(false)
+    assertThat(empty.preferClipToAreaBounds()).isEqualTo(false)
+  }
+}
+
+internal class RecordingVisualEffect : VisualEffect {
+  var attachCalls = 0
+  var detachCalls = 0
+  var updateCalls = 0
+  var drawCalls = 0
+  var trimMemoryCalls = 0
+
+  override fun attach(context: VisualEffectContext) {
+    attachCalls++
+  }
+
+  override fun update(context: VisualEffectContext) {
+    updateCalls++
+  }
+
+  override fun detach() {
+    detachCalls++
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    drawCalls++
+  }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    trimMemoryCalls++
+  }
+}
+
+internal data object FakeVisualEffectContext : VisualEffectContext {
+  override val position: Offset = Offset.Zero
+  override val size: Size = Size.Zero
+  override val layerSize: Size = Size.Zero
+  override val layerOffset: Offset = Offset.Zero
+  override val rootBounds: Rect = Rect.Zero
+  override val inputScale: HazeInputScale = HazeInputScale.None
+  override val windowId: Any? = null
+  override val areas: List<HazeArea> = emptyList()
+  override val state: HazeState? = null
+  override val visualEffect: VisualEffect = VisualEffect.Empty
+  override val coroutineScope: kotlinx.coroutines.CoroutineScope = kotlinx.coroutines.CoroutineScope(kotlin.coroutines.EmptyCoroutineContext)
+
+  override fun requireDensity(): androidx.compose.ui.unit.Density = error("Fake")
+  override fun <T> currentValueOf(local: androidx.compose.runtime.CompositionLocal<T>): T = error("Fake")
+  override fun requireGraphicsContext(): androidx.compose.ui.graphics.GraphicsContext = error("Fake")
+  override fun invalidateDraw() {}
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -17,10 +17,11 @@ import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
-class VisualEffectLifecycleTest {
+class VisualEffectLifecycleTest : ContextTest() {
 
   @Test
   fun visualEffect_attachCalledWhenSet() = runComposeUiTest {


### PR DESCRIPTION
## Summary

Fixes documentation and test gaps identified during a pre-alpha v2 review against the v1 branch.

### Documentation fixes

- **custom-effects.md / architecture.md**: Aligned `VisualEffect` interface signatures with actual v2 API — `update(context)` not `update(context, scope)`, `DrawScope.draw(context)` not `draw(canvas, context)`. Corrected `VisualEffectContext` property list and `HazeEffectScope` properties.
- **blur/usage.md**: Fixed stale `HazeStyle`/`LocalHazeStyle` references and `tints`/`noise` property names in code samples.
- **blur/index.md / blur/materials.md**: Fixed renamed API doc links (`HazeBlurStyle`, `LocalHazeBlurStyle`).
- **blur/platforms.md**: Wrapped progressive blur example inside `blurEffect {}` block.
- **recipes.md**: Removed dead `style` parameter from `hazeSource` call.
- **performance.md**: Updated benchmark labels from `1.0.x` → `v1.x`.
- **using-snapshot-version.md**: Added `haze-blur` artifact mention.

### Tests added

- **VisualEffectLifecycleTest.kt** (new, 237 lines): Compose UI tests covering VisualEffect `attach`/`detach`/`replace` lifecycle semantics and `EmptyVisualEffect` no-op behavior.
- **HazeComposeUnitTests.kt** (+94 lines): 7 `resolvePositionStrategy` edge-case tests — cross-window promotion, null/matching/mixed windowIds, empty areas, explicit pass-through.

### Verification

- `./gradlew spotlessCheck` — passes
- `./gradlew :haze:compileKotlinMetadata` — passes
- `./gradlew :haze-blur:compileKotlinMetadata` — passes