### PR TITLE
Update CHANGELOG for 2.0.0-alpha02, fix docs publish, and add release notes template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,3 @@
+changelog:
+  template: |
+    See [CHANGELOG.md](https://github.com/chrisbanes/haze/blob/main/CHANGELOG.md) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.0.0-alpha02 (WIP) { id="2.0.0-alpha02" }
+## 2.0.0-alpha02 <small>2026-05-08</small> { id="2.0.0-alpha02" }
 
-Work in progress. Changes since 2.0.0-alpha01.
+Changes since 2.0.0-alpha01.
 
 ### Breaking Changes
 
@@ -16,6 +16,25 @@ Work in progress. Changes since 2.0.0-alpha01.
 - **Method renames:** `DrawScope.shouldDrawContentBehind(context)` is now `shouldDrawContentBehind(context)`.
 - **Method renames:** `shouldClip()` is now `shouldClipToNodeBounds()`, and `preferClipToAreaBounds()` is now `shouldPreferClipToAreaBounds()`.
 - **Removed APIs:** `calculateInputScaleFactor()` and `requireInvalidation()` were removed from `VisualEffect`.
+
+### Key Dependencies
+
+- Kotlin 2.3.20
+- Compose Multiplatform 1.11.0-rc01
+- Jetpack Compose 1.11.1
+- kotlinx-coroutines 1.11.0
+
+### Changed
+* Refine `VisualEffect` lifecycle API, enforce single-owner semantics in #916
+* Migrate to Compose v2 test APIs in #924
+
+### Added
+* Add recomposition testing (count + loop detection + instrumentation) in #919
+
+### Fixed
+* Fix `IllegalStateException` from `currentValueOf` on unattached node in #921
+
+**Full Changelog**: https://github.com/chrisbanes/haze/compare/2.0.0-alpha01...2.0.0-alpha02
 
 ## 2.0.0-alpha01 <small>2026-04-28</small> { id="2.0.0-alpha01" }
 

--- a/scripts/delete_old_version_docs.sh
+++ b/scripts/delete_old_version_docs.sh
@@ -1,24 +1,52 @@
 #!/bin/zsh
 
-versions=($(mike list | tr ' ' '\n'))
+# Parse mike list output. Format: "version [alias1, alias2]  title"
+# We only care about version names (first column) and aliases.
+# Aliases like 'latest' and 'dev' must never be deleted.
+
+latest_alias_version=""
+dev_alias_version=""
+bare_versions=()
+
+while IFS= read -r line; do
+  version=$(echo "$line" | awk '{print $1}')
+  aliases=$(echo "$line" | grep -o '\[.*\]' | tr -d '[]' | tr ',' '\n' | xargs)
+
+  bare_versions+=("$version")
+
+  if echo "$aliases" | grep -qw "latest"; then
+    latest_alias_version="$version"
+  fi
+  if echo "$aliases" | grep -qw "dev"; then
+    dev_alias_version="$version"
+  fi
+done < <(mike list)
 
 declare -A major_latest
 
-# Find latest per X.Y
-for v in "${versions[@]}"; do
+for v in "${bare_versions[@]}"; do
   major="${v%.*}"
   if [[ -z "${major_latest[$major]}" ]]; then
     major_latest[$major]="$v"
   else
-    latest="${major_latest[$major]}"
-    # Use version sort (-V) to compare
-    greater=$(printf "%s\n%s\n" "$latest" "$v" | sort -V | tail -n1)
+    prev="${major_latest[$major]}"
+    greater=$(printf "%s\n%s\n" "$prev" "$v" | sort -V | tail -n1)
     major_latest[$major]="$greater"
   fi
 done
 
 to_delete=()
-for v in "${versions[@]}"; do
+for v in "${bare_versions[@]}"; do
+  # Never delete the version holding the 'latest' or 'dev' alias
+  if [[ "$v" == "$latest_alias_version" ]]; then
+    echo "Keeping $v (holds 'latest' alias)"
+    continue
+  fi
+  if [[ "$v" == "$dev_alias_version" ]]; then
+    echo "Keeping $v (holds 'dev' alias)"
+    continue
+  fi
+
   major="${v%.*}"
   if [[ "$v" != "${major_latest[$major]}" ]]; then
     to_delete+=("$v")


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for 2.0.0-alpha02 release
- Fix delete_old_version_docs.sh to protect latest/dev aliases
- Add GitHub release notes template (.github/release.yml)

## Details

**CHANGELOG:** Filled in the WIP entry for 2.0.0-alpha02 with release date, key dependencies, and categorized changes.

**delete_old_version_docs.sh:** The old script parsed mike list output incorrectly, allowing it to delete the version holding the `latest` alias — which caused a 404 on the docs site. The updated script explicitly tracks aliases and skips any version holding `latest` or `dev`.

**release.yml:** Configures GitHub's auto-generated release notes to just link to the changelog.

Fixes #927