### PR TITLE
Exclude VisualEffect.Empty from single-owner registration

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -555,6 +555,8 @@ internal fun HazeEffectNode.shouldClipToAreaBounds(): Boolean {
 private val attachedEffectOwners = mutableListOf<Pair<VisualEffect, HazeEffectNode>>()
 
 internal fun HazeEffectNode.attachVisualEffect(effect: VisualEffect) {
+  if (effect === EmptyVisualEffect) return // No-op singleton; no ownership needed
+
   val current = attachedEffectOwners
     .firstOrNull { (attachedEffect, _) -> attachedEffect === effect }
     ?.second
@@ -577,6 +579,8 @@ internal fun HazeEffectNode.attachVisualEffect(effect: VisualEffect) {
 }
 
 internal fun HazeEffectNode.detachVisualEffect(effect: VisualEffect) {
+  if (effect === EmptyVisualEffect) return // No-op singleton; no ownership needed
+
   try {
     effect.detach(visualEffectContext)
   } finally {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
@@ -116,6 +116,6 @@ public interface VisualEffect {
   }
 }
 
-private object EmptyVisualEffect : VisualEffect {
+internal object EmptyVisualEffect : VisualEffect {
   override fun DrawScope.draw(context: VisualEffectContext) = Unit
 }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
@@ -17,6 +17,9 @@ import androidx.compose.ui.unit.Density
  * VisualEffect instances are single-owner and must not be attached to multiple
  * `Modifier.hazeEffect` nodes at the same time. Reusing the same effect instance
  * across concurrently active nodes will throw an [IllegalStateException].
+ *
+ * The built-in [Empty] singleton is exempt from this restriction and may be shared
+ * safely across any number of nodes.
  */
 @ExperimentalHazeApi
 public interface VisualEffect {

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectNodeConstructorTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectNodeConstructorTest.kt
@@ -31,6 +31,22 @@ class HazeEffectNodeConstructorTest {
   }
 
   @Test
+  fun attachVisualEffect_emptyVisualEffectCanBeAttachedToMultipleNodes() {
+    val node1 = HazeEffectNode()
+    val node2 = HazeEffectNode()
+
+    // Both nodes use the default VisualEffect.Empty singleton.
+    // This should not throw.
+    node1.attachVisualEffect(VisualEffect.Empty)
+    try {
+      node2.attachVisualEffect(VisualEffect.Empty)
+    } finally {
+      node1.detachVisualEffect(VisualEffect.Empty)
+      node2.detachVisualEffect(VisualEffect.Empty)
+    }
+  }
+
+  @Test
   fun attachVisualEffect_usesInstanceIdentity_notEquals() {
     val node1 = HazeEffectNode()
     val node2 = HazeEffectNode()


### PR DESCRIPTION
## Summary

Every `HazeEffectNode` starts with the same `VisualEffect.Empty` singleton. The visual-effect ownership registry rejected attaching one visual-effect instance to multiple nodes, including this stateless no-op instance.

## Changes

- Made `EmptyVisualEffect` `internal` so the registry functions can reference it directly.
- Added early returns in `attachVisualEffect()` and `detachVisualEffect()` to skip the ownership registry entirely when the effect is `EmptyVisualEffect`.
- Added a test verifying two nodes can both use `VisualEffect.Empty` without throwing.

Fixes #946