### PR TITLE
Fix dynamic area updates in HazeEffectNode

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -43,7 +43,7 @@ import kotlinx.coroutines.DisposableHandle
  */
 @ExperimentalHazeApi
 public class HazeEffectNode(
-  public var state: HazeState? = null,
+  state: HazeState? = null,
   public var block: (HazeEffectScope.() -> Unit)? = null,
 ) : Modifier.Node(),
   CompositionLocalConsumerModifierNode,
@@ -66,6 +66,15 @@ public class HazeEffectNode(
   override val shouldAutoInvalidate: Boolean = false
 
   internal var dirtyTracker = Bitmask(DirtyFields.Areas)
+
+  public var state: HazeState? = state
+    set(value) {
+      if (value != field) {
+        HazeLogger.d(TAG) { "state changed. Current: $field. New: $value" }
+        dirtyTracker += DirtyFields.Areas
+        field = value
+      }
+    }
 
   private var needsPreDrawInvalidation = false
 
@@ -139,6 +148,8 @@ public class HazeEffectNode(
   internal val visualEffectContext: VisualEffectContext by lazy(LazyThreadSafetyMode.NONE) {
     HazeEffectNodeVisualEffectContext(this)
   }
+
+  private var lastSeenStateAreas: List<HazeArea> = emptyList()
 
   private var _areas: List<HazeArea> = emptyList()
     set(value) {
@@ -362,8 +373,6 @@ public class HazeEffectNode(
   private fun updateEffect(): Unit = trace("HazeEffectNode-updateEffect") {
     if (!isAttached) return@trace
 
-    // Allow the current VisualEffect to update from CompositionLocals/state
-    visualEffect.update(visualEffectContext)
     windowId = getWindowId()
 
     // Read positionStrategy and resolvedStrategy to establish snapshot observation.
@@ -382,6 +391,18 @@ public class HazeEffectNode(
       // Always read state.areas to maintain snapshot observation on HazeState._areas
       // (mutableStateListOf), even when we skip recomputation below.
       val stateAreas = state.areas
+
+      // Detect membership changes in the observed state list. The snapshot
+      // observation fires when items are added or removed, but we gate the
+      // _areas rebuild behind DirtyFields.Areas. If the raw list has changed,
+      // mark ourselves dirty so the filtered / sorted _areas is refreshed.
+      // We copy toList() because stateAreas is a SnapshotStateList reference
+      // and would otherwise mutate lastSeenStateAreas in place.
+      val currentStateAreas = stateAreas.toList()
+      if (currentStateAreas != lastSeenStateAreas) {
+        lastSeenStateAreas = currentStateAreas
+        dirtyTracker += DirtyFields.Areas
+      }
 
       if (DirtyFields.Areas in dirtyTracker) {
         _areas.forEach { area ->
@@ -429,6 +450,9 @@ public class HazeEffectNode(
       )
       if (hazeState.resolvedStrategy != newResolved) {
         hazeState.resolvedStrategy = newResolved
+        // Allow the current VisualEffect to update before we return so it
+        // sees the freshly-computed areas on this pass.
+        visualEffect.update(visualEffectContext)
         // Strategy changes trigger source nodes to recompute area positions via state reads.
         // Exit now to avoid mixing coordinate systems in this frame.
         invalidateIfNeeded()
@@ -487,6 +511,9 @@ public class HazeEffectNode(
         _layerOffset = Offset.Zero
       }
     }
+
+    // Allow the current VisualEffect to update from CompositionLocals/state
+    visualEffect.update(visualEffectContext)
 
     invalidateIfNeeded()
   }

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
@@ -15,6 +16,7 @@ import assertk.assertThat
 import assertk.assertions.hasSize
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
@@ -211,6 +213,108 @@ class HazeComposeUnitTests : ContextTest() {
 
     assertThat(resolved).isEqualTo(HazePositionStrategy.Local)
   }
+
+  @Test
+  fun test_effect_areas_updated_when_source_added_after_first_draw() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = AreaCapturingVisualEffect()
+    val showSecondSource = mutableStateOf(false)
+
+    setContent {
+      Box {
+        Box(Modifier.hazeSource(hazeState)) { }
+        if (showSecondSource.value) {
+          Spacer(Modifier.hazeSource(hazeState).size(10.dp))
+        }
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.lastAreas).hasSize(1)
+
+    showSecondSource.value = true
+    waitForIdle()
+    assertThat(effect.lastAreas).hasSize(2)
+  }
+
+  @Test
+  fun test_effect_areas_updated_when_source_removed_after_first_draw() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = AreaCapturingVisualEffect()
+    val showSecondSource = mutableStateOf(true)
+
+    setContent {
+      Box {
+        Box(Modifier.hazeSource(hazeState)) { }
+        if (showSecondSource.value) {
+          Spacer(Modifier.hazeSource(hazeState).size(10.dp))
+        }
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.lastAreas).hasSize(2)
+
+    showSecondSource.value = false
+    waitForIdle()
+    assertThat(effect.lastAreas).hasSize(1)
+  }
+
+  @Test
+  fun test_effect_areas_updated_when_state_swapped_after_first_draw() = runComposeUiTest {
+    val state1 = HazeState()
+    val state2 = HazeState()
+    val effect = AreaCapturingVisualEffect()
+    val selectedState = mutableStateOf(state1)
+
+    setContent {
+      Box {
+        Spacer(Modifier.hazeSource(state1).size(10.dp))
+        Spacer(Modifier.hazeSource(state2).size(10.dp))
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(selectedState.value) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.lastAreas).hasSize(1)
+    val initialArea = effect.lastAreas.single()
+
+    selectedState.value = state2
+    waitForIdle()
+    assertThat(effect.lastAreas).hasSize(1)
+    val swappedArea = effect.lastAreas.single()
+    assertThat(swappedArea !== initialArea).isTrue()
+  }
+}
+
+internal class AreaCapturingVisualEffect : VisualEffect {
+  var lastAreas: List<HazeArea> = emptyList()
+
+  override fun update(context: VisualEffectContext) {
+    lastAreas = context.areas
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) = Unit
 }
 
 internal object HazeAreaTestFactory {


### PR DESCRIPTION
## Motivation

Fixes #948.

`HazeEffectNode` failed to react to three dynamic changes at runtime:

1. **Swapping `state`:** the constructor parameter was stored directly, so setting `state` to a different `HazeState` never marked `DirtyFields.Areas` and the effect kept drawing the old areas.
2. **Adding/removing sources:** `state.areas` is a `SnapshotStateList`, so reading it inside `observeReads` correctly triggered recomposition, but `_areas` was only rebuilt when `DirtyFields.Areas` was already set. Membership changes alone were silently ignored.
3. **Stale `VisualEffect` data:** `visualEffect.update()` was called *before* `_areas` was recomputed, so custom `VisualEffect` implementations received the previous frame's area list.

## Changes

- Convert `state` from a constructor parameter to a property with a custom setter that adds `DirtyFields.Areas` on change.
- Cache `lastSeenStateAreas` and compare `stateAreas.toList()` against it to detect `SnapshotStateList` membership changes.
- Move `visualEffect.update(visualEffectContext)` to the end of `updateEffect()` so it sees the freshly-computed areas, offsets, and layer bounds.

## Testing

Added three Compose UI tests in `haze/src/commonTest/kotlin/.../HazeComposeUnitTests.kt` that verify:

- Adding a source after first draw updates the effect areas.
- Removing a source after first draw updates the effect areas.
- Swapping `state` after first draw updates the effect areas.

## Affected modules

- `haze`