### PR TITLE
Fix RenderScript blur temporary graphics layer leak on cancellation

### DIFF
--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
@@ -99,14 +99,17 @@ internal class RenderScriptBlurVisualEffectDelegate(
         layer.clip = blurVisualEffect.shouldClipToNodeBounds()
 
         currentJob = context.coroutineScope.launch(Dispatchers.Main.immediate) {
-          updateSurface(
-            content = layer,
-            blurRadius = blurRadiusPx,
-            context = context,
-            density = density,
-          )
-          // Release the graphics layer
-          graphicsContext.releaseGraphicsLayer(layer)
+          try {
+            updateSurface(
+              content = layer,
+              blurRadius = blurRadiusPx,
+              context = context,
+              density = density,
+            )
+          } finally {
+            // Release the graphics layer even if updateSurface was cancelled
+            graphicsContext.releaseGraphicsLayer(layer)
+          }
 
           if (drawSkipped) {
             // If any draws were skipped, let's trigger a draw invalidation


### PR DESCRIPTION
## Summary

In `RenderScriptBlurVisualEffectDelegate.draw()`, a temporary scaled `GraphicsLayer` was created and passed into a coroutine that calls `updateSurface()`. The layer was only released after `updateSurface()` returned normally. If the coroutine was cancelled (via `onTrimMemory()` or `detach()`) or if `updateSurface()` threw, the `releaseGraphicsLayer(layer)` call was skipped and the temporary layer leaked.

## Changes

- Wrap the `updateSurface()` call inside the launched coroutine in a `try/finally` and release the scaled layer from the `finally` block.

## Test Plan

- `./gradlew spotlessApply` — passed
- `./gradlew :haze-blur:test` — passed

Closes #945