### PR TITLE
Guard VisualEffect attach/detach until HazeEffectNode is attached

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -175,9 +175,11 @@ public class HazeEffectNode(
     set(value) {
       if (value != field) {
         HazeLogger.d(TAG) { "visualEffect changed. Current $field. New: $value" }
-        runCatching { detachVisualEffect(field) }
+        if (isAttached) {
+          runCatching { detachVisualEffect(field) }
+          attachVisualEffect(value)
+        }
         field = value
-        attachVisualEffect(value)
       }
     }
 

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -313,6 +313,25 @@ class VisualEffectLifecycleTest : ContextTest() {
     assertThat(effect.detachCalls).isEqualTo(5)
     assertThat(effect.updateCalls).isGreaterThan(0)
   }
+
+  /**
+   * Verifies that the [HazeEffectNode.visualEffect] setter guards [VisualEffect.attach]
+   * and [VisualEffect.detach] with [isAttached]. A custom effect that reads
+   * node-bound resources (e.g. [CompositionLocal]s) during [attach] must not crash
+   * when the property is set before the node lifecycle allows those reads.
+   */
+  @Test
+  fun visualEffect_setterDefersAttachUntilNodeAttached() {
+    val effect = NodeBoundContextReadingVisualEffect()
+    val node = HazeEffectNode()
+
+    // Should not throw even though the node is unattached and the effect
+    // reads node-bound CompositionLocal values during attach()
+    node.visualEffect = effect
+
+    assertThat(effect.attachCalls).isEqualTo(0)
+    assertThat(effect.detachCalls).isEqualTo(0)
+  }
 }
 
 internal class RecordingVisualEffect : VisualEffect {
@@ -424,6 +443,30 @@ internal class CompositionLocalReadingVisualEffect : VisualEffect {
     updateCalls++
     context.currentValueOf(TestCompositionLocal)
   }
+
+  override fun DrawScope.draw(context: VisualEffectContext) = Unit
+}
+
+/**
+ * A [VisualEffect] whose [attach] reads a [CompositionLocal] through the context.
+ * Used to verify that the [HazeEffectNode.visualEffect] setter guards attach/detach
+ * until the node is actually attached.
+ */
+internal class NodeBoundContextReadingVisualEffect : VisualEffect {
+  var attachCalls = 0
+  var detachCalls = 0
+
+  override fun attach(context: VisualEffectContext) {
+    attachCalls++
+    // This would throw if called on an unattached node
+    context.currentValueOf(TestCompositionLocal)
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    detachCalls++
+  }
+
+  override fun update(context: VisualEffectContext) = Unit
 
   override fun DrawScope.draw(context: VisualEffectContext) = Unit
 }


### PR DESCRIPTION
## Motivation

The public `HazeEffectNode.visualEffect` setter unconditionally detached the old effect and attached the new one, even when the modifier node itself was not yet attached to the composition. This caused custom effects that read node-bound resources (e.g. CompositionLocals) during `attach()` to crash, because `HazeEffectNodeVisualEffectContext` delegates reads to the unattached node.

This is distinct from the previously fixed detached-update path reported in #920.

## Changes

- Guarded `detachVisualEffect` and `attachVisualEffect` in the setter with `isAttached`, matching the lifecycle pattern already used by `BlurVisualEffect` and `LiquidGlassVisualEffect` for their internal delegates.
- Attachment is now deferred to `onAttach()`, which already calls `attachVisualEffect(visualEffect)`.

## Testing

- Added `NodeBoundContextReadingVisualEffect` and `visualEffect_setterDefersAttachUntilNodeAttached` test to verify that setting `visualEffect` on an unattached node does not crash and defers attachment until the node is actually attached.

## Affected modules

- `haze`

Fixes #942