### PR TITLE
Fix NPE race between RenderScriptContext.applyBlur() and release()

### DIFF
--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptContext.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptContext.kt
@@ -15,6 +15,8 @@ import android.view.Surface
 import androidx.compose.ui.unit.IntSize
 import androidx.core.graphics.createBitmap
 import dev.chrisbanes.haze.HazeLogger
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.trySendBlocking
 
@@ -22,6 +24,7 @@ internal class RenderScriptContext(
   val rs: RenderScript,
   val size: IntSize,
 ) {
+  private val lock = ReentrantLock()
   private val blurScript: ScriptIntrinsicBlur
 
   private val inputAlloc: Allocation
@@ -61,29 +64,33 @@ internal class RenderScriptContext(
   }
 
   fun applyBlur(blurRadius: Float) {
-    require(blurRadius in 1f..25f) {
-      "blurRadius needs to be >= 1 and <= 25"
-    }
-    if (isDestroyed) return
+    lock.withLock {
+      require(blurRadius in 1f..25f) {
+        "blurRadius needs to be >= 1 and <= 25"
+      }
+      if (isDestroyed) return@withLock
 
-    blurScript.setRadius(blurRadius.coerceAtMost(25f))
-    blurScript.forEach(outputAlloc)
+      blurScript.setRadius(blurRadius.coerceAtMost(25f))
+      blurScript.forEach(outputAlloc)
 
-    if (!isDestroyed) {
-      outputAlloc.copyTo(outputBitmap)
+      if (!isDestroyed) {
+        outputAlloc.copyTo(outputBitmap)
+      }
     }
   }
 
   suspend fun awaitSurfaceWritten() = channel.receive()
 
   fun release() {
-    HazeLogger.d(TAG) { "Release resources" }
-    isDestroyed = true
+    lock.withLock {
+      HazeLogger.d(TAG) { "Release resources" }
+      isDestroyed = true
 
-    blurScript.destroy()
-    inputAlloc.destroy()
-    outputAlloc.destroy()
-    // Note: rs (RenderScript) is NOT destroyed here — the delegate owns its lifecycle.
+      blurScript.destroy()
+      inputAlloc.destroy()
+      outputAlloc.destroy()
+      // Note: rs (RenderScript) is NOT destroyed here — the delegate owns its lifecycle.
+    }
   }
 
   private companion object {


### PR DESCRIPTION
## Summary
Fixes #961 — an NPE crash when `RenderScriptContext.applyBlur()` runs on a `Dispatchers.Default` worker after `release()` has already destroyed the underlying RenderScript, nulling AOSP's internal `Script.mRS` reference.

## Root Cause
`applyBlur()` (called from `Dispatchers.Default`) and `release()` (called from main thread during detach/trim) had no synchronization. The interleaving:
1. Worker reads `isDestroyed == false`, passes guard
2. Detach fires → `release()` calls `blurScript.destroy()` → AOSP sets `mRS = null`
3. Worker calls `blurScript.forEach()` → NPE in `mRS.validate()`

## Fix
Added a `ReentrantLock` guarding both `applyBlur()` and `release()` via `lock.withLock { }`. This serializes them so they can never interleave — `release()` waits for in-flight `applyBlur()` to complete before destroying resources.

## Testing
- `./gradlew :haze-blur:build` passes
- `./gradlew spotlessApply` passes
- The fix is structural (lock discipline), not timing-dependent — no flaky test needed 