### PR TITLE
Fix zsh aliases variable conflict in delete_old_version_docs.sh

### DIFF
--- a/scripts/delete_old_version_docs.sh
+++ b/scripts/delete_old_version_docs.sh
@@ -10,14 +10,14 @@ bare_versions=()
 
 while IFS= read -r line; do
   version=$(echo "$line" | awk '{print $1}')
-  aliases=$(echo "$line" | grep -o '\[.*\]' | tr -d '[]' | tr ',' '\n' | xargs)
+  version_aliases=$(echo "$line" | grep -o '\[.*\]' | tr -d '[]' | tr ',' '\n' | xargs)
 
   bare_versions+=("$version")
 
-  if echo "$aliases" | grep -qw "latest"; then
+  if echo "$version_aliases" | grep -qw "latest"; then
     latest_alias_version="$version"
   fi
-  if echo "$aliases" | grep -qw "dev"; then
+  if echo "$version_aliases" | grep -qw "dev"; then
     dev_alias_version="$version"
   fi
 done < <(mike list)


### PR DESCRIPTION
## Problem

The `delete_old_version_docs.sh` script uses `#!/bin/zsh` and in commit `49f2bdfb` introduced a local variable named `aliases`.

In zsh, `aliases` is a reserved built-in associative array (the alias hash table). Assigning a scalar string to it causes:
```
scripts/delete_old_version_docs.sh:13: aliases: attempt to set slice of associative array
```

This causes the docs publish CI job to fail at the "Delete old doc versions" step.

## Fix

Renamed `aliases` → `version_aliases` throughout the script to avoid the zsh reserved name conflict.

## Related

This was broken since commit 49f2bdfb. The build workflow deploy job 401 Unauthorized is a separate credential issue.