### PR TITLE
Disable publishing for haze-liquidglass

### DIFF
--- a/haze-liquidglass/build.gradle.kts
+++ b/haze-liquidglass/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
   id("dev.chrisbanes.kotlin.multiplatform")
   id("dev.chrisbanes.compose")
   id("org.jetbrains.dokka")
-  id("com.vanniktech.maven.publish")
+  // Publishing is disabled until API and visual quality are finalized.
   id("dev.chrisbanes.metalava")
 }
 


### PR DESCRIPTION
## Summary

`./gradlew publish` was producing a Maven publication for `:haze-liquidglass` with an empty `<name>` element, causing the Central Portal to reject the 2.0.0-alpha03 upload with **"Project name is missing"**.

## Root cause

`haze-liquidglass/gradle.properties` has had `POM_ARTIFACT_ID` and `POM_NAME` commented out since 2026-05-11 ([#954](https://github.com/chrisbanes/haze/pull/954)) to disable publishing. But `haze-liquidglass/build.gradle.kts` still applied `id("com.vanniktech.maven.publish")`, so `./gradlew publish` still created a publication for the module. With no `POM_NAME` set, the Vanniktech plugin's `pomFromGradleProperties()` did not populate the `<name>` element, and the Central Portal validation failed.

The release script's `find_published_api_files()` correctly skipped the `api.txt` snapshot copy for this module, but it does not (and cannot) filter the Gradle `publish` task — that runs against every module with the plugin applied.

## Fix

Remove `id("com.vanniktech.maven.publish")` from `haze-liquidglass/build.gradle.kts`. `./gradlew :haze-liquidglass:tasks` confirms the maven-publish tasks are gone (only Android's internal `prepareLintJarForPublish` remains) and the project still configures.

## Verification

- [x] `./gradlew :haze-liquidglass:tasks` configures without error
- [x] No `publish*PublicationTo*MavenCentralRepository` tasks remain
- [ ] Re-run `./scripts/release.py` to confirm 2.0.0-alpha03 (or a fresh tag) uploads successfully

Fixes the un-published 2.0.0-alpha03 release.