### PR TITLE
Auto-release Maven Central deployments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,7 @@ roborazzi.test.verify=true
 
 SONATYPE_HOST=CENTRAL_PORTAL
 RELEASE_SIGNING_ENABLED=true
+mavenCentralAutomaticPublishing=true
 
 GROUP=dev.chrisbanes.haze
 VERSION_NAME=2.0.1-SNAPSHOT


### PR DESCRIPTION
Enable the vanniktech-maven-publish-plugin's `mavenCentralAutomaticPublishing` so `./gradlew publish` uploads **and** releases artifacts in one step.

Previously, CI ran `./gradlew publish` which only uploads to the Central Portal staging area, requiring a manual `Publish` click in https://central.sonatype.com/publishing/deployments after every release. With `mavenCentralAutomaticPublishing=true`, the plugin handles the release step automatically.

Refs: https://vanniktech.github.io/gradle-maven-publish-plugin/central/#uploading-with-automatic-publishing