### PR TITLE
Fix iOS cross-root haze positioning

### DIFF
--- a/haze/src/iosMain/kotlin/dev/chrisbanes/haze/Utils.ios.kt
+++ b/haze/src/iosMain/kotlin/dev/chrisbanes/haze/Utils.ios.kt
@@ -1,0 +1,15 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.uikit.LocalUIView
+import platform.UIKit.UIView
+
+internal actual fun CompositionLocalConsumerModifierNode.getWindowId(): Any? {
+  return uikitWindowId(currentValueOf(LocalUIView))
+}
+
+internal fun uikitWindowId(view: UIView): Any = view

--- a/haze/src/iosTest/kotlin/dev/chrisbanes/haze/HazeComposeUIViewTest.ios.kt
+++ b/haze/src/iosTest/kotlin/dev/chrisbanes/haze/HazeComposeUIViewTest.ios.kt
@@ -1,0 +1,96 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.uikit.LocalUIView
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.hasSize
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSameInstanceAs
+import kotlin.test.Test
+import platform.UIKit.UIView
+
+@OptIn(ExperimentalTestApi::class)
+class HazeComposeUIViewTest {
+
+  @Test
+  fun autoPositionStrategyPromotesToScreenForDifferentUIKitHostViews() = runComposeUiTest {
+    val hazeState = HazeState()
+    val sourceView = UIView()
+    val effectView = UIView()
+    var effectWindowId: Any? = null
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        CompositionLocalProvider(LocalUIView provides sourceView) {
+          Spacer(
+            Modifier
+              .size(100.dp)
+              .hazeSource(hazeState),
+          )
+        }
+
+        CompositionLocalProvider(LocalUIView provides effectView) {
+          Spacer(
+            Modifier
+              .size(100.dp)
+              .captureWindowId { effectWindowId = it },
+          )
+        }
+      }
+    }
+
+    waitForIdle()
+
+    assertThat(hazeState.areas).hasSize(1)
+    assertThat(hazeState.areas.single().windowId).isSameInstanceAs(sourceView)
+    assertThat(effectWindowId).isSameInstanceAs(effectView)
+    assertThat(
+      resolvePositionStrategy(
+        configured = HazePositionStrategy.Auto,
+        areas = hazeState.areas,
+        windowId = effectWindowId,
+      ),
+    ).isEqualTo(HazePositionStrategy.Screen)
+  }
+}
+
+private fun Modifier.captureWindowId(
+  onWindowId: (Any?) -> Unit,
+): Modifier = this then CaptureWindowIdElement(onWindowId)
+
+private data class CaptureWindowIdElement(
+  val onWindowId: (Any?) -> Unit,
+) : ModifierNodeElement<CaptureWindowIdNode>() {
+
+  override fun create(): CaptureWindowIdNode = CaptureWindowIdNode(onWindowId)
+
+  override fun update(node: CaptureWindowIdNode) {
+    node.onWindowId = onWindowId
+  }
+
+  override fun InspectorInfo.inspectableProperties() {
+    name = "captureWindowId"
+  }
+}
+
+private class CaptureWindowIdNode(
+  var onWindowId: (Any?) -> Unit,
+) : Modifier.Node(), CompositionLocalConsumerModifierNode {
+
+  override fun onAttach() {
+    onWindowId(getWindowId())
+  }
+}

--- a/haze/src/iosTest/kotlin/dev/chrisbanes/haze/WindowIdTest.ios.kt
+++ b/haze/src/iosTest/kotlin/dev/chrisbanes/haze/WindowIdTest.ios.kt
@@ -1,0 +1,21 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import assertk.assertThat
+import assertk.assertions.isSameInstanceAs
+import kotlin.test.Test
+import platform.UIKit.UIView
+
+class WindowIdTest {
+
+  @Test
+  fun uikitWindowId_usesHostViewIdentity() {
+    val view1 = UIView()
+    val view2 = UIView()
+
+    assertThat(uikitWindowId(view1)).isSameInstanceAs(view1)
+    assertThat(uikitWindowId(view2)).isSameInstanceAs(view2)
+  }
+}

--- a/haze/src/jsMain/kotlin/dev/chrisbanes/haze/Utils.js.kt
+++ b/haze/src/jsMain/kotlin/dev/chrisbanes/haze/Utils.js.kt
@@ -1,4 +1,4 @@
-// Copyright 2025, Christopher Banes and the Haze project contributors
+// Copyright 2026, Christopher Banes and the Haze project contributors
 // SPDX-License-Identifier: Apache-2.0
 
 package dev.chrisbanes.haze

--- a/haze/src/jvmMain/kotlin/dev/chrisbanes/haze/Utils.jvm.kt
+++ b/haze/src/jvmMain/kotlin/dev/chrisbanes/haze/Utils.jvm.kt
@@ -1,0 +1,8 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+
+internal actual fun CompositionLocalConsumerModifierNode.getWindowId(): Any? = null

--- a/haze/src/macosMain/kotlin/dev/chrisbanes/haze/Utils.macos.kt
+++ b/haze/src/macosMain/kotlin/dev/chrisbanes/haze/Utils.macos.kt
@@ -1,0 +1,8 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+
+internal actual fun CompositionLocalConsumerModifierNode.getWindowId(): Any? = null

--- a/haze/src/wasmJsMain/kotlin/dev/chrisbanes/haze/Utils.wasmJs.kt
+++ b/haze/src/wasmJsMain/kotlin/dev/chrisbanes/haze/Utils.wasmJs.kt
@@ -1,0 +1,8 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+
+internal actual fun CompositionLocalConsumerModifierNode.getWindowId(): Any? = null


### PR DESCRIPTION
## Summary

Fixes the iOS `ComposeUIViewController` case from #977 where Haze could keep using root-local coordinates across separate UIKit-hosted Compose roots.

## Root cause

The shared Skiko `getWindowId()` actual always returned `null`. On iOS that meant `HazePositionStrategy.Auto` could not detect that a `hazeSource` and `hazeEffect` were attached under different UIKit host views, so it stayed in `Local` coordinates even when the source/effect roots were incompatible.

## Changes

- Add an iOS `getWindowId()` actual that uses `LocalUIView` host view identity.
- Move the old `null` Skiko behavior into leaf actuals for JVM, JS, WASM, and macOS so those targets keep their previous behavior.
- Add iOS tests for host view identity and cross-host `Auto -> Screen` resolution.

## Verification

- `./gradlew :haze:spotlessCheck`
- `./gradlew :haze:compileKotlinJvm :haze:compileKotlinJs :haze:compileKotlinWasmJs :haze:compileKotlinMacosArm64 :haze:compileTestKotlinIosSimulatorArm64 :haze:jvmTest`
- `./gradlew -I .tmp-enable-ios-tests.gradle.kts :haze:iosSimulatorArm64Test --tests 'dev.chrisbanes.haze.HazeComposeUIViewTest.autoPositionStrategyPromotesToScreenForDifferentUIKitHostViews' --rerun-tasks`

The iOS simulator test task is disabled by the project build script, so the last command used a temporary init script to force-enable only that test task locally.

Fixes #977