### PR TITLE
Clarify Liquid Glass publishing status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,12 +60,7 @@ Changes since 2.0.0-alpha01.
 
 A new `haze-liquidglass` module adds an iOS-style liquid glass refraction effect. It renders refraction, depth blur, specular highlights, Fresnel ambient lift, chromatic aberration, and soft tinted glass through a custom AGSL runtime shader, with a Canvas-based fallback for platforms without runtime shader support.
 
-The module is gated behind `@ExperimentalHazeApi` and publishing is disabled until the API stabilizes.
-
-```kotlin
-implementation("dev.chrisbanes.haze:haze:2.0.0-alpha02")
-implementation("dev.chrisbanes.haze:haze-liquidglass:2.0.0-alpha02")
-```
+The module is gated behind `@ExperimentalHazeApi` and **is not yet published to Maven Central**. It exists in the repository for internal development and testing only.
 
 Usage:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,7 @@ haze (core)
 ```
 
 Future effects will follow the same pattern:
-- **haze-liquidglass** - Refraction-based liquid glass effect with rounded-shape SDF and optional chromatic aberration
+- **haze-liquidglass** (source-only, not yet published) - Refraction-based liquid glass effect with rounded-shape SDF and optional chromatic aberration
 - Custom third-party effect modules
 
 ## Effect Registration Pattern

--- a/docs/effects/liquid-glass.md
+++ b/docs/effects/liquid-glass.md
@@ -1,5 +1,8 @@
 # Liquid Glass
 
+!!! danger "Not yet published"
+    This module is currently under active development and is **not published to Maven Central**. It exists in the repository for experimentation and internal development only. Do not attempt to add it as a Gradle dependency.
+
 A refraction-driven glass effect inspired by iOS "liquid" glass. It combines refraction, depth blur, tint, Fresnel/ambient lift, and specular highlights with optional rounded shapes and dispersion.
 
 !!! warning "Experimental"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,8 +23,6 @@ nav:
     - "Materials": blur/materials.md
     - "FAQs": blur/faq.md
     - "Platforms": blur/platforms.md
-  - "Effects":
-    - "Liquid Glass": effects/liquid-glass.md
   - "Custom Effects": custom-effects.md
   - "Performance": performance.md
   - "Recipes": recipes.md


### PR DESCRIPTION
## Summary

- Remove the invalid `haze-liquidglass` dependency coordinate from the changelog.
- Hide the Liquid Glass docs page from the main docs navigation while the module is source-only.
- Add explicit warnings that Liquid Glass is not published to Maven Central.

## Why

Issue #988 reports that the docs/changelog point users at `dev.chrisbanes.haze:haze-liquidglass`, but the module is intentionally not published. The module's publishing plugin and POM metadata are disabled, so the docs should not present it as an installable artifact.

Closes #988

## Validation

- `rtk git diff --check`
- `rtk ./scripts/build_docs.sh build`