### PR TITLE
Filter internal docs from publishing

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -70,6 +70,8 @@ jobs:
           retention-days: 1
           path: |
             docs/
+            !docs/specs/**
+            !docs/superpowers/**
 
   deploy_docs:
     runs-on: macos-26
@@ -143,6 +145,9 @@ jobs:
 
           echo "version=$docs_version" >> "$GITHUB_OUTPUT"
           echo "aliases=$docs_aliases" >> "$GITHUB_OUTPUT"
+
+      - name: Remove checkout docs directory
+        run: rm -rf docs
 
       - name: Download docs builds
         uses: actions/download-artifact@v8

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,9 @@ remote_branch: gh-pages
 strict: true
 
 docs_dir: docs
+exclude_docs: |
+  specs/**
+  superpowers/**
 
 repo_name: "Haze"
 repo_url: "https://github.com/chrisbanes/haze"


### PR DESCRIPTION
## Summary

- Exclude `docs/specs/**` and `docs/superpowers/**` from MkDocs builds.
- Exclude those same internal planning paths from the docs artifact uploaded by CI.
- Remove the checked-out `docs/` directory before downloading the filtered artifact in the deploy job, so `mike deploy` only sees generated public docs.

## Why

The docs publish build was seeing internal specs and implementation plans under `docs/` and reporting them as pages outside the MkDocs nav. Those files should stay in the repository, but they should not be part of the published documentation surface.

## Validation

- `test -e docs/specs && test -e docs/superpowers`
- `mkdocs build --no-strict --site-dir /private/tmp/haze-mkdocs-site`
- `git diff --cached --check` before commit

Note: direct strict MkDocs was not used locally because generated `api`, `sample`, and `changelog` files are only staged by `scripts/build_docs.sh` in CI.