### PR TITLE
Fix blur material docs examples

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,9 +69,11 @@ Effect implementations provide builder extension functions on `HazeEffectScope` 
 
 ```kotlin
 // Blur effect example
+val style = HazeMaterials.thin()
+
 modifier = Modifier.hazeEffect(state) {
     blurEffect {
-        style = HazeMaterials.thin()
+        this.style = style
         progressive = HazeProgressive.verticalGradient(...)
     }
 }

--- a/docs/blur/index.md
+++ b/docs/blur/index.md
@@ -41,6 +41,7 @@ The blur effect is applied using the `blurEffect {}` builder within `Modifier.ha
 
 ```kotlin
 val hazeState = rememberHazeState()
+val style = HazeMaterials.thin()
 
 Box {
     LazyColumn(
@@ -55,7 +56,7 @@ Box {
         modifier = Modifier
             .hazeEffect(state = hazeState) {
                 blurEffect {
-                    style = HazeMaterials.thin()
+                    this.style = style
                 }
             }
     )

--- a/docs/blur/materials.md
+++ b/docs/blur/materials.md
@@ -28,6 +28,8 @@ Class reference: [HazeMaterials](../api/haze-materials/dev.chrisbanes.haze.blur.
 
 ```kotlin
 Box {
+  val style = HazeMaterials.thin()
+
   LazyColumn(
     modifier = Modifier.hazeSource(state = hazeState)
   ) {
@@ -37,7 +39,7 @@ Box {
   TopAppBar(
     modifier = Modifier.hazeEffect(state = hazeState) {
       blurEffect {
-        style = HazeMaterials.thin()
+        this.style = style
       }
     }
   )
@@ -59,8 +61,10 @@ Class reference: [CupertinoMaterials](../api/haze-materials/dev.chrisbanes.haze.
 ### Usage
 
 ```kotlin
+val style = CupertinoMaterials.thin()
+
 blurEffect {
-  style = CupertinoMaterials.thin()
+  this.style = style
 }
 ```
 
@@ -77,8 +81,10 @@ Class reference: [FluentMaterials](../api/haze-materials/dev.chrisbanes.haze.blu
 ### Usage
 
 ```kotlin
+val style = FluentMaterials.thin()
+
 blurEffect {
-  style = FluentMaterials.thin()
+  this.style = style
 }
 ```
 

--- a/docs/blur/usage.md
+++ b/docs/blur/usage.md
@@ -12,6 +12,7 @@ Blurs content from elsewhere in the UI that's marked with `hazeSource`:
 
 ```kotlin
 val hazeState = rememberHazeState()
+val style = HazeMaterials.thin()
 
 Box {
   LazyColumn(
@@ -26,7 +27,7 @@ Box {
     modifier = Modifier
       .hazeEffect(state = hazeState) {
         blurEffect {
-          style = HazeMaterials.thin()
+          this.style = style
         }
       }
       .fillMaxWidth(),
@@ -41,12 +42,14 @@ Blurs the content within the composable itself. No `HazeState` or `hazeSource` n
 ```kotlin
 @Composable
 fun HazeExample(modifier: Modifier = Modifier) {
+  val style = HazeMaterials.thin()
+
   Box(modifier = modifier) {
     Foreground(
       modifier = Modifier
         .hazeEffect {
           blurEffect {
-            style = HazeMaterials.thin()
+            this.style = style
           }
         }
         .fillMaxSize()
@@ -324,6 +327,7 @@ You can blur dialog backgrounds over content. **Important**: Tints display as a 
 ```kotlin
 val hazeState = rememberHazeState()
 var showDialog by remember { mutableStateOf(false) }
+val style = HazeMaterials.regular()
 
 Box {
   if (showDialog) {
@@ -339,7 +343,7 @@ Box {
         Box(
           Modifier.hazeEffect(state = hazeState) {
             blurEffect {
-              style = HazeMaterials.regular()
+              this.style = style
             }
           },
         ) {

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -41,10 +41,12 @@ Parameters:
 Applies a visual effect to a composable, drawing blurred content from areas marked with `Modifier.hazeSource`.
 
 ```kotlin
+val style = HazeMaterials.thin()
+
 TopAppBar(
     modifier = Modifier.hazeEffect(state = hazeState) {
         blurEffect {
-            style = HazeMaterials.thin()
+            this.style = style
         }
     }
 )

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -120,9 +120,11 @@ All blur-related properties that were previously set directly on `HazeEffectScop
 === "v2"
 
     ```kotlin
+    val style = HazeMaterials.ultraThin()
+
     Modifier.hazeEffect(state = hazeState) {
       blurEffect {
-        style = HazeMaterials.ultraThin()
+        this.style = style
       }
     }
     ```
@@ -330,7 +332,7 @@ LiquidGlassStyle(
 
 **Update Material style usage**:
 
-   - Change `hazeEffect(state, style = ...)` to `hazeEffect(state) { blurEffect { style = ... } }`
+   - Change `hazeEffect(state, style = style)` to `val style = ...` followed by `hazeEffect(state) { blurEffect { this.style = style } }`
    - Change the dependency from `haze-materials` to `haze-blur-materials`
 
 **Replace removed aliases**:

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -8,6 +8,7 @@ Blurring the content behind app bars is a common use case, so how can we use Haz
 
 ``` kotlin
 val hazeState = rememberHazeState()
+val style = HazeMaterials.thin()
 
 Scaffold(
   topBar = {
@@ -17,7 +18,7 @@ Scaffold(
       modifier = Modifier
         .hazeEffect(state = hazeState) {
           blurEffect {
-            style = HazeMaterials.thin()
+            this.style = style
           }
         }
         .fillMaxWidth(),
@@ -31,7 +32,7 @@ Scaffold(
       modifier = Modifier
         .hazeEffect(state = hazeState) {
           blurEffect {
-            style = HazeMaterials.thin()
+            this.style = style
           }
         }
         .fillMaxWidth(),
@@ -61,6 +62,7 @@ Since we can have multiple nodes using `Modifier.hazeSource`, we can use the mod
 
 ```kotlin
 val hazeState = rememberHazeState()
+val style = HazeMaterials.thin()
 
 LazyColumn(...) {
   stickyHeader {
@@ -68,7 +70,7 @@ LazyColumn(...) {
       modifier = Modifier
         .hazeEffect(state = hazeState) {
           blurEffect {
-            style = HazeMaterials.thin()
+            this.style = style
           }
         },
     )


### PR DESCRIPTION
## Summary

Fixes #993.

Updates blur material style examples so composable material presets are resolved before entering `hazeEffect { blurEffect { ... } }`. The docs now assign the preset to a local `style` value in composable scope, then pass that value into the non-composable effect configuration block.

Updated the migration guide, core concepts, architecture, blur docs, materials docs, usage docs, and recipes where the same pattern appeared.

## Validation

- Focused scan across published docs for direct material preset assignments inside `blurEffect`.
- `rtk mkdocs build --no-strict --site-dir /private/tmp/haze-docs-check`

Note: strict MkDocs validation was not used for this local check because this checkout does not contain generated `docs/api`, `docs/sample`, or `docs/changelog.md`; those are produced by `scripts/build_docs.sh` in the full docs build.