### PR TITLE
Log remote build cache state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,6 @@ jobs:
           ORG_GRADLE_PROJECT_remoteBuildCacheUrl: ${{ secrets.GRADLE_REMOTE_CACHE_URL }}
           ORG_GRADLE_PROJECT_remoteBuildCacheUsername: ${{ secrets.GRADLE_REMOTE_CACHE_USERNAME }}
           ORG_GRADLE_PROJECT_remoteBuildCachePassword: ${{ secrets.GRADLE_REMOTE_CACHE_PASSWORD }}
-          ORG_GRADLE_PROJECT_remoteBuildCacheEnabled: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1') }}
           ORG_GRADLE_PROJECT_remoteBuildCachePush: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1') }}
 
       - name: Upload reports
@@ -77,7 +76,6 @@ jobs:
           ORG_GRADLE_PROJECT_remoteBuildCacheUrl: ${{ secrets.GRADLE_REMOTE_CACHE_URL }}
           ORG_GRADLE_PROJECT_remoteBuildCacheUsername: ${{ secrets.GRADLE_REMOTE_CACHE_USERNAME }}
           ORG_GRADLE_PROJECT_remoteBuildCachePassword: ${{ secrets.GRADLE_REMOTE_CACHE_PASSWORD }}
-          ORG_GRADLE_PROJECT_remoteBuildCacheEnabled: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1') }}
           ORG_GRADLE_PROJECT_remoteBuildCachePush: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1') }}
 
       - name: Upload reports + Roborazzi outputs
@@ -118,7 +116,6 @@ jobs:
           ORG_GRADLE_PROJECT_remoteBuildCacheUrl: ${{ secrets.GRADLE_REMOTE_CACHE_URL }}
           ORG_GRADLE_PROJECT_remoteBuildCacheUsername: ${{ secrets.GRADLE_REMOTE_CACHE_USERNAME }}
           ORG_GRADLE_PROJECT_remoteBuildCachePassword: ${{ secrets.GRADLE_REMOTE_CACHE_PASSWORD }}
-          ORG_GRADLE_PROJECT_remoteBuildCacheEnabled: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1') }}
           ORG_GRADLE_PROJECT_remoteBuildCachePush: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1') }}
         with:
           api-level: 34
@@ -168,5 +165,4 @@ jobs:
           ORG_GRADLE_PROJECT_remoteBuildCacheUrl: ${{ secrets.GRADLE_REMOTE_CACHE_URL }}
           ORG_GRADLE_PROJECT_remoteBuildCacheUsername: ${{ secrets.GRADLE_REMOTE_CACHE_USERNAME }}
           ORG_GRADLE_PROJECT_remoteBuildCachePassword: ${{ secrets.GRADLE_REMOTE_CACHE_PASSWORD }}
-          ORG_GRADLE_PROJECT_remoteBuildCacheEnabled: true
           ORG_GRADLE_PROJECT_remoteBuildCachePush: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,25 +60,31 @@ fun gradleBooleanProperty(name: String): Boolean =
 val remoteBuildCacheUrl = gradleProperty("remoteBuildCacheUrl")
 val remoteBuildCacheUsername = gradleProperty("remoteBuildCacheUsername")
 val remoteBuildCachePassword = gradleProperty("remoteBuildCachePassword")
-val isRemoteBuildCacheEnabled = gradleBooleanProperty("remoteBuildCacheEnabled")
+val isRemoteBuildCachePushEnabled = gradleBooleanProperty("remoteBuildCachePush")
 
 buildCache {
   remote<HttpBuildCache> {
     if (
-      isRemoteBuildCacheEnabled &&
       remoteBuildCacheUrl != null &&
       remoteBuildCacheUsername != null &&
       remoteBuildCachePassword != null
     ) {
       isEnabled = true
-      isPush = gradleBooleanProperty("remoteBuildCachePush")
+      isPush = isRemoteBuildCachePushEnabled
       url = uri(remoteBuildCacheUrl)
       credentials {
         username = remoteBuildCacheUsername
         password = remoteBuildCachePassword
       }
+      logger.lifecycle("Remote build cache enabled (push: $isRemoteBuildCachePushEnabled)")
     } else {
       isEnabled = false
+      logger.lifecycle(
+        "Remote build cache disabled " +
+          "(url present: ${remoteBuildCacheUrl != null}, " +
+          "username present: ${remoteBuildCacheUsername != null}, " +
+          "password present: ${remoteBuildCachePassword != null})",
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds lifecycle logging around the remote Gradle build cache decision in `settings.gradle.kts`.

The remote build cache is now enabled whenever the URL, username, and password properties are present. The separate `remoteBuildCacheEnabled` flag has been removed from both Gradle settings and CI, avoiding a second gate that could disable reads even when credentials are available.

`remoteBuildCachePush` remains as the write-control flag, so CI can read from the remote cache while writes stay limited to the configured protected branch pushes.

## Validation

- `git diff --check`

Gradle execution was not run locally because the sandbox blocked wrapper access to the normal Gradle home, and the isolated Gradle home path required a network download that was also blocked.