### PR TITLE
Disable local Gradle build cache on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
           java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
 
       - name: Compile iOS arm64 target and run simulator tests
         run: ./gradlew compileKotlinIosArm64 iosSimulatorArm64Test -Phaze.enableAppleTests
@@ -69,6 +72,9 @@ jobs:
           java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
 
       - name: Assemble and check
         run: ./gradlew check assembleDebug -Phaze.disableAppleTargets -Pandroidx.baselineprofile.skipgeneration
@@ -103,6 +109,9 @@ jobs:
           java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
 
       - name: Enable KVM
         run: |
@@ -153,6 +162,9 @@ jobs:
           java-version: 21
 
       - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
 
       - name: Deploy to Sonatype
         run: ./gradlew publish --no-configuration-cache

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -61,17 +61,24 @@ val remoteBuildCacheUrl = gradleProperty("remoteBuildCacheUrl")
 val remoteBuildCacheUsername = gradleProperty("remoteBuildCacheUsername")
 val remoteBuildCachePassword = gradleProperty("remoteBuildCachePassword")
 val isRemoteBuildCachePushEnabled = gradleBooleanProperty("remoteBuildCachePush")
+val isRemoteBuildCacheEnabled =
+  remoteBuildCacheUrl != null &&
+    remoteBuildCacheUsername != null &&
+    remoteBuildCachePassword != null
 
 buildCache {
+  local {
+    isEnabled = !isCi || !isRemoteBuildCacheEnabled
+    if (!isEnabled) {
+      logger.lifecycle("Local build cache disabled because remote build cache is enabled on CI")
+    }
+  }
+
   remote<HttpBuildCache> {
-    if (
-      remoteBuildCacheUrl != null &&
-      remoteBuildCacheUsername != null &&
-      remoteBuildCachePassword != null
-    ) {
+    if (isRemoteBuildCacheEnabled) {
       isEnabled = true
       isPush = isRemoteBuildCachePushEnabled
-      url = uri(remoteBuildCacheUrl)
+      url = uri(checkNotNull(remoteBuildCacheUrl))
       credentials {
         username = remoteBuildCacheUsername
         password = remoteBuildCachePassword


### PR DESCRIPTION
## Summary

- Exclude `caches/build-cache-1` from `gradle/actions/setup-gradle` caching in CI jobs that use the remote build cache.
- Disable Gradle's local build cache on CI only when the remote build cache is fully configured.
- Keep the local build cache enabled for normal local development and CI runs without remote cache credentials.

## Why

Gradle recommends disabling the local build cache for GitHub Actions builds when a remote build cache is available. This avoids persisting local build-cache state through the GitHub Actions cache and keeps CI focused on populating and reading the shared remote cache.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "build.yml ok"'`
- `git diff --check`
- `CI=true ./gradlew help --no-scan --no-configuration-cache -PremoteBuildCacheUrl=https://example.com/cache -PremoteBuildCacheUsername=user -PremoteBuildCachePassword=pass -PremoteBuildCachePush=false`
