### PR TITLE
Fix haze library review issues

### DIFF
--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurDefaults.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurDefaults.kt
@@ -68,9 +68,8 @@ public object HazeBlurDefaults {
    * Default values for [BlurVisualEffect.blurEnabled]. This function only returns `true` on
    * platforms where we know blurring works reliably.
    *
-   * This is not the same as everywhere where it technically works. The key omission here
-   * is Android SDK Level 31, which is known to have some issues with
-   * RenderNode invalidation.
+   * This is not the same as everywhere where it technically works. Some platforms may
+   * still need extra invalidation workarounds for reliable redraws.
    *
    * The devices excluded by this function may change in the future.
    */

--- a/haze-materials/build.gradle.kts
+++ b/haze-materials/build.gradle.kts
@@ -35,13 +35,6 @@ kotlin {
       dependencies {
         implementation(kotlin("test"))
         implementation(libs.assertk)
-        implementation(libs.compose.ui.test)
-      }
-    }
-
-    jvmTest {
-      dependencies {
-        implementation(compose.desktop.currentOs)
       }
     }
   }

--- a/haze-materials/build.gradle.kts
+++ b/haze-materials/build.gradle.kts
@@ -16,6 +16,8 @@ plugins {
 kotlin {
   android {
     namespace = "dev.chrisbanes.haze.materials"
+
+    withHostTest {}
   }
 
   addDefaultHazeTargets(project)
@@ -26,6 +28,20 @@ kotlin {
       dependencies {
         api(projects.hazeBlur)
         implementation(libs.compose.material3)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(kotlin("test"))
+        implementation(libs.assertk)
+        implementation(libs.compose.ui.test)
+      }
+    }
+
+    jvmTest {
+      dependencies {
+        implementation(compose.desktop.currentOs)
       }
     }
   }

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterials.kt
@@ -91,7 +91,11 @@ public object FluentMaterials {
   @ReadOnlyComposable
   public fun acrylicBase(
     isDark: Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5f,
-  ): HazeBlurStyle = hazeAcrylicMaterial(
+  ): HazeBlurStyle = acrylicBaseStyle(isDark)
+
+  internal fun acrylicBaseStyle(
+    isDark: Boolean,
+  ): HazeBlurStyle = hazeAcrylicMaterialStyle(
     containerColor = if (isDark) {
       Color(0xFF202020)
     } else {
@@ -186,6 +190,28 @@ public object FluentMaterials {
     lightLuminosityOpacity: Float,
     darkTintOpacity: Float,
     darkLuminosityOpacity: Float,
+  ): HazeBlurStyle = hazeMaterialStyle(
+    containerColor = containerColor,
+    fallbackColor = fallbackColor,
+    isDark = isDark,
+    blurRadius = blurRadius,
+    noiseFactor = noiseFactor,
+    lightTintOpacity = lightTintOpacity,
+    lightLuminosityOpacity = lightLuminosityOpacity,
+    darkTintOpacity = darkTintOpacity,
+    darkLuminosityOpacity = darkLuminosityOpacity,
+  )
+
+  private fun hazeMaterialStyle(
+    containerColor: Color,
+    isDark: Boolean,
+    fallbackColor: Color,
+    blurRadius: Dp,
+    noiseFactor: Float,
+    lightTintOpacity: Float,
+    lightLuminosityOpacity: Float,
+    darkTintOpacity: Float,
+    darkLuminosityOpacity: Float,
   ): HazeBlurStyle = HazeBlurStyle(
     blurRadius = blurRadius,
     noiseFactor = noiseFactor,
@@ -217,7 +243,25 @@ public object FluentMaterials {
     lightLuminosityOpacity: Float,
     darkTintOpacity: Float,
     darkLuminosityOpacity: Float,
-  ): HazeBlurStyle = hazeMaterial(
+  ): HazeBlurStyle = hazeAcrylicMaterialStyle(
+    containerColor = containerColor,
+    fallbackColor = fallbackColor,
+    isDark = isDark,
+    lightTintOpacity = lightTintOpacity,
+    lightLuminosityOpacity = lightLuminosityOpacity,
+    darkTintOpacity = darkTintOpacity,
+    darkLuminosityOpacity = darkLuminosityOpacity,
+  )
+
+  private fun hazeAcrylicMaterialStyle(
+    containerColor: Color,
+    fallbackColor: Color = containerColor,
+    isDark: Boolean = containerColor.luminance() < 0.5f,
+    lightTintOpacity: Float,
+    lightLuminosityOpacity: Float,
+    darkTintOpacity: Float,
+    darkLuminosityOpacity: Float,
+  ): HazeBlurStyle = hazeMaterialStyle(
     containerColor = containerColor,
     fallbackColor = fallbackColor,
     isDark = isDark,

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterials.kt
@@ -34,9 +34,9 @@ public object FluentMaterials {
     isDark: Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5f,
   ): HazeBlurStyle = hazeAcrylicMaterial(
     containerColor = if (isDark) {
-      Color(0x545454)
+      Color(0xFF545454)
     } else {
-      Color(0xD3D3D3)
+      Color(0xFFD3D3D3)
     },
     fallbackColor = if (isDark) {
       Color(0x545454, 0.64f)
@@ -93,14 +93,14 @@ public object FluentMaterials {
     isDark: Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5f,
   ): HazeBlurStyle = hazeAcrylicMaterial(
     containerColor = if (isDark) {
-      Color(0x202020)
+      Color(0xFF202020)
     } else {
-      Color(0xF3F3F3)
+      Color(0xFFF3F3F3)
     },
     fallbackColor = if (isDark) {
-      Color(0x1C1C1C)
+      Color(0xFF1C1C1C)
     } else {
-      Color(0xEEEEEE)
+      Color(0xFFEEEEEE)
     },
     isDark = isDark,
     lightTintOpacity = 0f,
@@ -118,14 +118,14 @@ public object FluentMaterials {
     isDark: Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5f,
   ): HazeBlurStyle = hazeAcrylicMaterial(
     containerColor = if (isDark) {
-      Color(0x2C2C2C)
+      Color(0xFF2C2C2C)
     } else {
-      Color(0xFCFCFC)
+      Color(0xFFFCFCFC)
     },
     fallbackColor = if (isDark) {
-      Color(0x2C2C2C)
+      Color(0xFF2C2C2C)
     } else {
-      Color(0xF9F9F9)
+      Color(0xFFF9F9F9)
     },
     isDark = isDark,
     lightTintOpacity = 0f,
@@ -143,9 +143,9 @@ public object FluentMaterials {
     isDark: Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5f,
   ): HazeBlurStyle = hazeMicaMaterial(
     containerColor = if (isDark) {
-      Color(0x202020)
+      Color(0xFF202020)
     } else {
-      Color(0xF3F3F3)
+      Color(0xFFF3F3F3)
     },
     isDark = isDark,
     lightTintOpacity = 0.5f,
@@ -163,9 +163,9 @@ public object FluentMaterials {
     isDark: Boolean = MaterialTheme.colorScheme.surface.luminance() < 0.5f,
   ): HazeBlurStyle = hazeMicaMaterial(
     containerColor = if (isDark) {
-      Color(0x0A0A0A)
+      Color(0xFF0A0A0A)
     } else {
-      Color(0xDADADA)
+      Color(0xFFDADADA)
     },
     isDark = isDark,
     lightTintOpacity = 0.5f,

--- a/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterialsTest.kt
+++ b/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterialsTest.kt
@@ -4,26 +4,16 @@
 package dev.chrisbanes.haze.blur.materials
 
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.v2.runComposeUiTest
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
 
-@OptIn(ExperimentalTestApi::class)
 class FluentMaterialsTest {
 
   @Test
-  fun acrylicBaseUsesOpaqueContainerAndFallbackColors() = runComposeUiTest {
-    lateinit var lightStyle: dev.chrisbanes.haze.blur.HazeBlurStyle
-    lateinit var darkStyle: dev.chrisbanes.haze.blur.HazeBlurStyle
-
-    setContent {
-      lightStyle = FluentMaterials.acrylicBase(isDark = false)
-      darkStyle = FluentMaterials.acrylicBase(isDark = true)
-    }
-
-    waitForIdle()
+  fun acrylicBaseUsesOpaqueContainerAndFallbackColors() {
+    val lightStyle = FluentMaterials.acrylicBaseStyle(isDark = false)
+    val darkStyle = FluentMaterials.acrylicBaseStyle(isDark = true)
 
     assertThat(lightStyle.backgroundColor.alpha).isEqualTo(1f)
     assertThat(darkStyle.backgroundColor.alpha).isEqualTo(1f)

--- a/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterialsTest.kt
+++ b/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterialsTest.kt
@@ -1,0 +1,36 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur.materials
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class FluentMaterialsTest {
+
+  @Test
+  fun acrylicBaseUsesOpaqueContainerAndFallbackColors() = runComposeUiTest {
+    lateinit var lightStyle: dev.chrisbanes.haze.blur.HazeBlurStyle
+    lateinit var darkStyle: dev.chrisbanes.haze.blur.HazeBlurStyle
+
+    setContent {
+      lightStyle = FluentMaterials.acrylicBase(isDark = false)
+      darkStyle = FluentMaterials.acrylicBase(isDark = true)
+    }
+
+    waitForIdle()
+
+    assertThat(lightStyle.backgroundColor.alpha).isEqualTo(1f)
+    assertThat(darkStyle.backgroundColor.alpha).isEqualTo(1f)
+    assertThat(lightStyle.fallbackColorEffect.color.alpha).isEqualTo(1f)
+    assertThat(darkStyle.fallbackColorEffect.color.alpha).isEqualTo(1f)
+  }
+}
+
+private val dev.chrisbanes.haze.blur.HazeColorEffect.color: Color
+  get() = (this as dev.chrisbanes.haze.blur.HazeColorEffect.TintColor).color

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -152,6 +152,7 @@ internal fun HazeArea.reset() {
   coordinates.localPosition = Offset.Unspecified
   coordinates.screenPosition = Offset.Unspecified
   size = Size.Unspecified
+  windowId = null
   contentDrawing = false
 }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -111,6 +111,7 @@ public class HazeEffectNode(
     }
 
   private val areaOffsets = MutableObjectLongMap<HazeArea>()
+  private val areaZIndexes = MutableObjectLongMap<HazeArea>()
 
   private var _size: Size = Size.Unspecified
     set(value) {
@@ -206,8 +207,8 @@ public class HazeEffectNode(
       if (value != field) {
         HazeLogger.d(TAG) { "visualEffect changed. Current $field. New: $value" }
         if (isAttached) {
-          runCatching { detachVisualEffect(field) }
           attachVisualEffect(value)
+          runCatching { detachVisualEffect(field) }
         }
         field = value
       }
@@ -277,6 +278,8 @@ public class HazeEffectNode(
     trimMemoryCallbackDisposable?.dispose()
     trimMemoryCallbackDisposable = null
     resetPendingInvalidations()
+    _areas = emptyList()
+    areaZIndexes.clear()
     contentDrawArea.releaseLayer()
     clearRetainedOutput()
     detachVisualEffect(visualEffect)
@@ -426,7 +429,7 @@ public class HazeEffectNode(
       // We copy toList() because stateAreas is a SnapshotStateList reference
       // and would otherwise mutate lastSeenStateAreas in place.
       val currentStateAreas = stateAreas.toList()
-      if (currentStateAreas != lastSeenStateAreas) {
+      if (currentStateAreas != lastSeenStateAreas || haveAreaZIndexesChanged(currentStateAreas)) {
         lastSeenStateAreas = currentStateAreas
         dirtyTracker += DirtyFields.Areas
       }
@@ -464,8 +467,10 @@ public class HazeEffectNode(
         if (unfilteredAreas.isNotEmpty() && filteredAreas.isEmpty()) {
           clearRetainedOutput()
         }
+        updateAreaZIndexes(currentStateAreas)
       }
     } else {
+      areaZIndexes.clear()
       // Foreground (content) blur: always update contentDrawArea since its size,
       // position, and windowId may change every frame with no dirty flag.
       contentDrawArea.size = size
@@ -604,6 +609,20 @@ public class HazeEffectNode(
         val offset = position - areaPosition
         areaOffsets[area] = offset.packedValue
       }
+    }
+  }
+
+  private fun haveAreaZIndexesChanged(stateAreas: List<HazeArea>): Boolean {
+    if (areaZIndexes.size != stateAreas.size) return true
+    return stateAreas.any { area ->
+      !areaZIndexes.contains(area) || areaZIndexes[area] != area.zIndex.toRawBits().toLong()
+    }
+  }
+
+  private fun updateAreaZIndexes(stateAreas: List<HazeArea>) {
+    areaZIndexes.clear()
+    stateAreas.forEach { area ->
+      areaZIndexes[area] = area.zIndex.toRawBits().toLong()
     }
   }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -229,7 +229,11 @@ public class HazeSourceNode(
       area.contentDrawing = false
       HazeLogger.d(TAG) { "end draw()" }
 
-      launchPreDraw()
+      Snapshot.withoutReadObservation {
+        if (area.preDrawListeners.isNotEmpty()) {
+          enablePreDrawListener()
+        }
+      }
     }
   }
 
@@ -242,6 +246,7 @@ public class HazeSourceNode(
 
   override fun onReset() {
     HazeLogger.d(TAG) { "onReset. Resetting HazeArea: $area" }
+    area.releaseLayer()
     area.reset()
   }
 

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
@@ -1,0 +1,63 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import kotlin.test.Test
+
+@OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
+class HazeSourceNodeTest {
+
+  @Test
+  fun onResetReleasesLayerAndClearsWindowId() = runComposeUiTest {
+    val state = HazeState()
+    val node = HazeSourceNode(state)
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .testHazeSourceNode(node),
+      )
+    }
+
+    waitForIdle()
+    assertThat(node.area.contentLayer).isNotNull()
+
+    runOnIdle {
+      node.onReset()
+    }
+
+    assertThat(node.area.contentLayer).isEqualTo(null)
+    assertThat(node.area.windowId).isEqualTo(null)
+  }
+}
+
+private fun Modifier.testHazeSourceNode(
+  node: HazeSourceNode,
+): Modifier = this then TestHazeSourceNodeElement(node)
+
+@OptIn(ExperimentalHazeApi::class)
+private data class TestHazeSourceNodeElement(
+  val node: HazeSourceNode,
+) : ModifierNodeElement<HazeSourceNode>() {
+
+  override fun create(): HazeSourceNode = node
+
+  override fun update(node: HazeSourceNode) = Unit
+
+  override fun InspectorInfo.inspectableProperties() {
+    name = "testHazeSourceNode"
+  }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -332,6 +332,65 @@ class VisualEffectLifecycleTest : ContextTest() {
     assertThat(effect.attachCalls).isEqualTo(0)
     assertThat(effect.detachCalls).isEqualTo(0)
   }
+
+  @Test
+  fun hazeEffect_detachRemovesPreDrawListenerFromSourceAreas() = runComposeUiTest {
+    val hazeState = HazeState()
+    val showEffect = mutableStateOf(true)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.size(100.dp).hazeSource(hazeState))
+        if (showEffect.value) {
+          Spacer(
+            Modifier
+              .size(100.dp)
+              .hazeEffect(hazeState) {
+                forceInvalidateOnPreDraw = true
+              },
+          )
+        }
+      }
+    }
+
+    waitForIdle()
+    val area = hazeState.areas.single()
+    assertThat(area.preDrawListeners.size).isEqualTo(1)
+
+    showEffect.value = false
+    waitForIdle()
+
+    assertThat(area.preDrawListeners.size).isEqualTo(0)
+  }
+
+  @Test
+  fun hazeEffect_zIndexChangeRebuildsAreaOrder() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = AreaOrderRecordingVisualEffect()
+    val firstZIndex = mutableStateOf(0f)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.size(100.dp).hazeSource(hazeState, zIndex = firstZIndex.value))
+        Spacer(Modifier.size(100.dp).hazeSource(hazeState, zIndex = 1f))
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.updateZIndexes).isEqualTo(listOf(0f, 1f))
+
+    firstZIndex.value = 2f
+    waitForIdle()
+
+    assertThat(effect.updateZIndexes).isEqualTo(listOf(1f, 2f))
+  }
 }
 
 internal class RecordingVisualEffect : VisualEffect {
@@ -374,6 +433,16 @@ internal class DrawBehindProbeVisualEffect(
   override fun shouldDrawContentBehind(context: VisualEffectContext): Boolean {
     shouldDrawContentBehindCalls++
     return returnValue
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) = Unit
+}
+
+internal class AreaOrderRecordingVisualEffect : VisualEffect {
+  var updateZIndexes: List<Float> = emptyList()
+
+  override fun update(context: VisualEffectContext) {
+    updateZIndexes = context.areas.map(HazeArea::zIndex)
   }
 
   override fun DrawScope.draw(context: VisualEffectContext) = Unit

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
@@ -14,10 +14,11 @@ import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
-class HazeSourceNodeTest {
+class HazeSourceNodeTest : ContextTest() {
 
   @Test
   fun onResetReleasesLayerAndClearsWindowId() = runComposeUiTest {


### PR DESCRIPTION
## Summary

Fixes the smaller issues found during the library review pass:

- remove retained pre-draw listeners when haze effects detach, and avoid scheduling source pre-draw callbacks when no listeners are registered
- release/reset retained source area state during node reset, including stale `windowId`
- refresh background haze area ordering when a source `zIndex` changes
- make visual effect replacement attach the new effect before detaching the old one, so a failed replacement does not leave the node without its previous effect attached
- correct Fluent material color literals that accidentally created transparent colors
- update the `HazeBlurDefaults.blurEnabled()` docs to avoid a stale Android 31-specific claim

## Validation

- `./gradlew :haze:allTests :haze-materials:allTests spotlessCheck`
- `git diff --check`

Fixes #1014.