### PR TITLE
Fix Cupertino material container color

### DIFF
--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterials.kt
@@ -86,30 +86,42 @@ public object CupertinoMaterials {
     darkForegroundColor = Color(color = 0x252525, alpha = 0.9f),
   )
 
-  @ReadOnlyComposable
-  @Composable
   private fun hazeMaterial(
-    containerColor: Color = MaterialTheme.colorScheme.surface,
-    isDark: Boolean = containerColor.luminance() < 0.5f,
+    containerColor: Color,
     lightBackgroundColor: Color,
     lightForegroundColor: Color,
     darkBackgroundColor: Color,
     darkForegroundColor: Color,
-  ): HazeBlurStyle = HazeBlurStyle(
-    blurRadius = 24.dp,
-    backgroundColor = MaterialTheme.colorScheme.surface,
-    colorEffects = listOf(
-      HazeColorEffect.tint(
-        color = if (isDark) darkBackgroundColor else lightBackgroundColor,
-        blendMode = if (isDark) BlendMode.Overlay else BlendMode.ColorDodge,
-      ),
-      HazeColorEffect.tint(
-        color = if (isDark) darkForegroundColor else lightForegroundColor,
-        blendMode = HazeColorEffect.DefaultBlendMode,
-      ),
-    ),
+  ): HazeBlurStyle = cupertinoMaterialStyle(
+    containerColor = containerColor,
+    lightBackgroundColor = lightBackgroundColor,
+    lightForegroundColor = lightForegroundColor,
+    darkBackgroundColor = darkBackgroundColor,
+    darkForegroundColor = darkForegroundColor,
   )
 }
+
+internal fun cupertinoMaterialStyle(
+  containerColor: Color,
+  isDark: Boolean = containerColor.luminance() < 0.5f,
+  lightBackgroundColor: Color,
+  lightForegroundColor: Color,
+  darkBackgroundColor: Color,
+  darkForegroundColor: Color,
+): HazeBlurStyle = HazeBlurStyle(
+  blurRadius = 24.dp,
+  backgroundColor = containerColor,
+  colorEffects = listOf(
+    HazeColorEffect.tint(
+      color = if (isDark) darkBackgroundColor else lightBackgroundColor,
+      blendMode = if (isDark) BlendMode.Overlay else BlendMode.ColorDodge,
+    ),
+    HazeColorEffect.tint(
+      color = if (isDark) darkForegroundColor else lightForegroundColor,
+      blendMode = HazeColorEffect.DefaultBlendMode,
+    ),
+  ),
+)
 
 private fun Color(color: Int, alpha: Float): Color {
   return Color(color).copy(alpha = alpha)

--- a/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterialsTest.kt
+++ b/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterialsTest.kt
@@ -1,0 +1,27 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur.materials
+
+import androidx.compose.ui.graphics.Color
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class CupertinoMaterialsTest {
+
+  @Test
+  fun cupertinoMaterialStyleUsesContainerColorAsBackground() {
+    val containerColor = Color(0xFF123456)
+
+    val style = cupertinoMaterialStyle(
+      containerColor = containerColor,
+      lightBackgroundColor = Color(0xFF111111),
+      lightForegroundColor = Color(0xFF222222),
+      darkBackgroundColor = Color(0xFF333333),
+      darkForegroundColor = Color(0xFF444444),
+    )
+
+    assertThat(style.backgroundColor).isEqualTo(containerColor)
+  }
+}


### PR DESCRIPTION
## Summary

- Make `CupertinoMaterials` use the supplied `containerColor` as the returned `HazeBlurStyle.backgroundColor`.
- Extract an internal `cupertinoMaterialStyle(...)` helper so the behavior can be covered by a common test.
- Add a regression test for custom container colors.

## Root cause

`CupertinoMaterials` accepted `containerColor` and used it for light/dark preset selection, but the constructed style hardcoded `backgroundColor` to `MaterialTheme.colorScheme.surface`. That made custom container colors affect luminance selection only, unlike the adjacent `HazeMaterials` helper.

Fixes #1016

## Verification

- `./gradlew :haze-materials:testAndroidHostTest`
- `./gradlew :haze-materials:check`