### PR TITLE
Add LiquidGlass override clear APIs

### DIFF
--- a/haze-liquidglass/api/api.txt
+++ b/haze-liquidglass/api/api.txt
@@ -196,8 +196,11 @@ package dev.chrisbanes.haze.liquidglass {
     ctor public LiquidGlassVisualEffect();
     ctor public LiquidGlassVisualEffect(dev.chrisbanes.haze.liquidglass.LiquidGlassVisualEffect other);
     method public boolean canDrawRetainedOutput(dev.chrisbanes.haze.VisualEffectContext context);
+    method public void clearChromaticAberrationModeOverride();
     method public void clearProgressiveOverride();
     method public void clearRetainedOutput();
+    method public void clearShapeOverride();
+    method public void clearSurfaceProfileOverride();
     method public void draw(androidx.compose.ui.graphics.drawscope.DrawScope, dev.chrisbanes.haze.VisualEffectContext context);
     method @InaccessibleFromKotlin public float getAlpha();
     method @InaccessibleFromKotlin public float getAmbientResponse();
@@ -271,3 +274,4 @@ package dev.chrisbanes.haze.liquidglass {
   }
 
 }
+

--- a/haze-liquidglass/src/commonMain/kotlin/dev/chrisbanes/haze/liquidglass/LiquidGlassVisualEffect.kt
+++ b/haze-liquidglass/src/commonMain/kotlin/dev/chrisbanes/haze/liquidglass/LiquidGlassVisualEffect.kt
@@ -48,9 +48,9 @@ public class LiquidGlassVisualEffect() : VisualEffect, RetainedOutputVisualEffec
     blurRadius = other.blurRadius
     refractionHeight = other.refractionHeight
     chromaticAberrationStrength = other.chromaticAberrationStrength
-    surfaceProfile = other.surfaceProfile
-    chromaticAberrationMode = other.chromaticAberrationMode
-    shape = other.shape
+    _surfaceProfile = other._surfaceProfile
+    _chromaticAberrationMode = other._chromaticAberrationMode
+    _shape = other._shape
     alpha = other.alpha
     contrast = other.contrast
     whitePoint = other.whitePoint
@@ -461,6 +461,18 @@ public class LiquidGlassVisualEffect() : VisualEffect, RetainedOutputVisualEffec
     }
 
   /**
+   * Clears the direct [surfaceProfile] override and restores inherited values from [style] and
+   * [LocalLiquidGlassStyle].
+   */
+  public fun clearSurfaceProfileOverride() {
+    if (_surfaceProfile != null) {
+      HazeLogger.d(TAG) { "surfaceProfile override cleared. Current: $_surfaceProfile" }
+      _surfaceProfile = null
+      dirtyTracker += LiquidGlassDirtyFields.SurfaceProfile
+    }
+  }
+
+  /**
    * Quality mode for chromatic aberration (color dispersion).
    *
    * There are precedence rules to how this styling property is applied:
@@ -482,6 +494,18 @@ public class LiquidGlassVisualEffect() : VisualEffect, RetainedOutputVisualEffec
     }
 
   /**
+   * Clears the direct [chromaticAberrationMode] override and restores inherited values from [style]
+   * and [LocalLiquidGlassStyle].
+   */
+  public fun clearChromaticAberrationModeOverride() {
+    if (_chromaticAberrationMode != null) {
+      HazeLogger.d(TAG) { "chromaticAberrationMode override cleared. Current: $_chromaticAberrationMode" }
+      _chromaticAberrationMode = null
+      dirtyTracker += LiquidGlassDirtyFields.ChromaticAberrationMode
+    }
+  }
+
+  /**
    * Shape applied to the glass. Defaults to [RoundedCornerShape] with 16.dp corners.
    *
    * There are precedence rules to how this styling property is applied:
@@ -501,6 +525,18 @@ public class LiquidGlassVisualEffect() : VisualEffect, RetainedOutputVisualEffec
         dirtyTracker += LiquidGlassDirtyFields.Shape
       }
     }
+
+  /**
+   * Clears the direct [shape] override and restores inherited values from [style] and
+   * [LocalLiquidGlassStyle].
+   */
+  public fun clearShapeOverride() {
+    if (_shape != null) {
+      HazeLogger.d(TAG) { "shape override cleared. Current: $_shape" }
+      _shape = null
+      dirtyTracker += LiquidGlassDirtyFields.Shape
+    }
+  }
 
   /**
    * Overall opacity for the effect, in the range `0f..1f`.

--- a/haze-liquidglass/src/commonTest/kotlin/dev/chrisbanes/haze/liquidglass/LiquidGlassVisualEffectOverrideTest.kt
+++ b/haze-liquidglass/src/commonTest/kotlin/dev/chrisbanes/haze/liquidglass/LiquidGlassVisualEffectOverrideTest.kt
@@ -1,0 +1,168 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.liquidglass
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class LiquidGlassVisualEffectOverrideTest {
+
+  private val localSurfaceProfile = SurfaceProfile.Concave
+  private val styleSurfaceProfile = SurfaceProfile.Squircle
+  private val directSurfaceProfile = SurfaceProfile.Circle
+
+  private val localChromaticAberrationMode = ChromaticAberrationMode.Full
+  private val styleChromaticAberrationMode = ChromaticAberrationMode.Simple
+  private val directChromaticAberrationMode = ChromaticAberrationMode.Full
+
+  private val localShape = RoundedCornerShape(8.dp)
+  private val styleShape = RoundedCornerShape(16.dp)
+  private val directShape = RoundedCornerShape(24.dp)
+
+  @Test
+  fun objectOverrides_clearDirectValuesRestoreInheritedValues() {
+    val effect = LiquidGlassVisualEffect().apply {
+      compositionLocalStyle = LiquidGlassStyle(
+        shape = localShape,
+        rendering = LiquidGlassRendering(
+          surfaceProfile = localSurfaceProfile,
+          chromaticAberrationMode = localChromaticAberrationMode,
+        ),
+      )
+      style = LiquidGlassStyle(
+        shape = styleShape,
+        rendering = LiquidGlassRendering(
+          surfaceProfile = styleSurfaceProfile,
+          chromaticAberrationMode = styleChromaticAberrationMode,
+        ),
+      )
+      surfaceProfile = directSurfaceProfile
+      chromaticAberrationMode = directChromaticAberrationMode
+      shape = directShape
+    }
+
+    assertThat(effect.surfaceProfile).isEqualTo(directSurfaceProfile)
+    assertThat(effect.chromaticAberrationMode).isEqualTo(directChromaticAberrationMode)
+    assertThat(effect.shape).isEqualTo(directShape)
+
+    effect.clearSurfaceProfileOverride()
+    effect.clearChromaticAberrationModeOverride()
+    effect.clearShapeOverride()
+
+    assertThat(effect.surfaceProfile).isEqualTo(styleSurfaceProfile)
+    assertThat(effect.chromaticAberrationMode).isEqualTo(styleChromaticAberrationMode)
+    assertThat(effect.shape).isEqualTo(styleShape)
+  }
+
+  @Test
+  fun objectOverrides_clearDirectValuesRestoreLocalValuesWhenStyleUnspecified() {
+    val effect = LiquidGlassVisualEffect().apply {
+      compositionLocalStyle = LiquidGlassStyle(
+        shape = localShape,
+        rendering = LiquidGlassRendering(
+          surfaceProfile = localSurfaceProfile,
+          chromaticAberrationMode = localChromaticAberrationMode,
+        ),
+      )
+      surfaceProfile = directSurfaceProfile
+      chromaticAberrationMode = styleChromaticAberrationMode
+      shape = directShape
+    }
+
+    effect.clearSurfaceProfileOverride()
+    effect.clearChromaticAberrationModeOverride()
+    effect.clearShapeOverride()
+
+    assertThat(effect.surfaceProfile).isEqualTo(localSurfaceProfile)
+    assertThat(effect.chromaticAberrationMode).isEqualTo(localChromaticAberrationMode)
+    assertThat(effect.shape).isEqualTo(localShape)
+  }
+
+  @Test
+  fun objectOverrides_copyConstructorPreservesInheritedValues() {
+    val effect = LiquidGlassVisualEffect().apply {
+      compositionLocalStyle = LiquidGlassStyle(
+        shape = localShape,
+        rendering = LiquidGlassRendering(
+          surfaceProfile = localSurfaceProfile,
+          chromaticAberrationMode = localChromaticAberrationMode,
+        ),
+      )
+    }
+
+    val copy = LiquidGlassVisualEffect(effect)
+
+    assertThat(copy.surfaceProfile).isEqualTo(localSurfaceProfile)
+    assertThat(copy.chromaticAberrationMode).isEqualTo(localChromaticAberrationMode)
+    assertThat(copy.shape).isEqualTo(localShape)
+
+    copy.compositionLocalStyle = LiquidGlassStyle(
+      shape = styleShape,
+      rendering = LiquidGlassRendering(
+        surfaceProfile = styleSurfaceProfile,
+        chromaticAberrationMode = styleChromaticAberrationMode,
+      ),
+    )
+
+    assertThat(copy.surfaceProfile).isEqualTo(styleSurfaceProfile)
+    assertThat(copy.chromaticAberrationMode).isEqualTo(styleChromaticAberrationMode)
+    assertThat(copy.shape).isEqualTo(styleShape)
+  }
+
+  @Test
+  fun objectOverrides_copyConstructorPreservesDirectOverrides() {
+    val effect = LiquidGlassVisualEffect().apply {
+      compositionLocalStyle = LiquidGlassStyle(
+        shape = localShape,
+        rendering = LiquidGlassRendering(
+          surfaceProfile = localSurfaceProfile,
+          chromaticAberrationMode = localChromaticAberrationMode,
+        ),
+      )
+      surfaceProfile = directSurfaceProfile
+      chromaticAberrationMode = directChromaticAberrationMode
+      shape = directShape
+    }
+
+    val copy = LiquidGlassVisualEffect(effect)
+
+    assertThat(copy.surfaceProfile).isEqualTo(directSurfaceProfile)
+    assertThat(copy.chromaticAberrationMode).isEqualTo(directChromaticAberrationMode)
+    assertThat(copy.shape).isEqualTo(directShape)
+
+    copy.compositionLocalStyle = LiquidGlassStyle(
+      shape = styleShape,
+      rendering = LiquidGlassRendering(
+        surfaceProfile = styleSurfaceProfile,
+        chromaticAberrationMode = styleChromaticAberrationMode,
+      ),
+    )
+
+    assertThat(copy.surfaceProfile).isEqualTo(directSurfaceProfile)
+    assertThat(copy.chromaticAberrationMode).isEqualTo(directChromaticAberrationMode)
+    assertThat(copy.shape).isEqualTo(directShape)
+  }
+
+  @Test
+  fun objectOverrides_clearDirectValuesMarkDirtyFields() {
+    val effect = LiquidGlassVisualEffect().apply {
+      surfaceProfile = directSurfaceProfile
+      chromaticAberrationMode = directChromaticAberrationMode
+      shape = directShape
+    }
+
+    effect.clearSurfaceProfileOverride()
+    effect.clearChromaticAberrationModeOverride()
+    effect.clearShapeOverride()
+
+    val dirtyFields = LiquidGlassDirtyFields.stringify(effect.dirtyTracker)
+    assertThat(dirtyFields).contains("SurfaceProfile")
+    assertThat(dirtyFields).contains("ChromaticAberrationMode")
+    assertThat(dirtyFields).contains("Shape")
+  }
+}


### PR DESCRIPTION
## Summary
- Add explicit clear APIs for `surfaceProfile`, `chromaticAberrationMode`, and `shape` direct overrides.
- Preserve inherited-vs-direct state for those properties in `LiquidGlassVisualEffect` copies.
- Add regression coverage for reset precedence, copy behavior, and dirty-field tracking.

## Root Cause
`LiquidGlassVisualEffect` used nullable private backing fields to represent unspecified object/enum overrides, but only exposed non-null public setters. Once callers set these values directly, they could not restore inherited `style` or `LocalLiquidGlassStyle` values without replacing the effect instance.

Fixes #1017

## Test Plan
- `./gradlew :haze-liquidglass:jvmTest`
- `./gradlew :haze-liquidglass:check`