### PR TITLE
Add retained output opt-out

### DIFF
--- a/docs/blur/usage.md
+++ b/docs/blur/usage.md
@@ -35,6 +35,21 @@ Box {
 }
 ```
 
+#### Retained Output
+
+Background blur may keep drawing the last captured output when all source areas disappear. This is
+intentional and helps source transitions avoid flashing to empty content. If the source may contain
+private content, disable retained output on the effect scope:
+
+```kotlin
+Modifier.hazeEffect(state = hazeState) {
+  retainOutputWhenSourceUnavailable = false
+  blurEffect {
+    // ...
+  }
+}
+```
+
 ### Foreground Blurring
 
 Blurs the content within the composable itself. No `HazeState` or `hazeSource` needed:

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -66,7 +66,8 @@ modifier = Modifier.hazeEffect(state = hazeState) {
     inputScale = HazeInputScale.Auto
     drawContentBehind = true
     canDrawArea = { area -> true }
-    
+    retainOutputWhenSourceUnavailable = true
+
     // Effect-specific configuration
     blurEffect {
         // ...
@@ -96,6 +97,22 @@ An optional filter function that controls which source areas should be included 
 canDrawArea = { area ->
     // return true to include, false to exclude
     area.key != "exclude_me"
+}
+```
+
+#### retainOutputWhenSourceUnavailable
+
+Some effects can retain and redraw their last output when all source areas disappear. This keeps
+source transitions visually smooth, for example when content is temporarily removed while an
+effect surface remains visible.
+
+The default is `true`. For privacy-sensitive UI, set this to `false` so stale source pixels are
+cleared as soon as there is no source content to draw:
+
+```kotlin
+Modifier.hazeEffect(state = hazeState) {
+    retainOutputWhenSourceUnavailable = false
+    blurEffect { /* ... */ }
 }
 ```
 

--- a/docs/effects/liquid-glass.md
+++ b/docs/effects/liquid-glass.md
@@ -84,6 +84,25 @@ Box(
 )
 ```
 
+### Retained Output
+
+Liquid glass can retain and redraw its last captured output when all source areas disappear. This
+keeps source transitions smooth, but can briefly preserve stale pixels from removed source content.
+For privacy-sensitive surfaces, disable retained output on the shared effect scope:
+
+```kotlin
+Box(
+  Modifier
+    .size(180.dp)
+    .hazeEffect(state = hazeState) {
+      retainOutputWhenSourceUnavailable = false
+      liquidGlassEffect {
+        style = HazeLiquidGlassMaterials.Card
+      }
+    }
+)
+```
+
 You can use a preset as a baseline and override individual values:
 
 ```kotlin

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -83,6 +83,7 @@ package dev.chrisbanes.haze {
     method @InaccessibleFromKotlin public Boolean? getExpandLayerBounds();
     method @InaccessibleFromKotlin public boolean getForceInvalidateOnPreDraw();
     method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeInputScale getInputScale();
+    method @InaccessibleFromKotlin public boolean getRetainOutputWhenSourceUnavailable();
     method @InaccessibleFromKotlin public dev.chrisbanes.haze.VisualEffect getVisualEffect();
     method @InaccessibleFromKotlin public void setCanDrawArea(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeArea,java.lang.Boolean>?);
     method @InaccessibleFromKotlin public void setClipToAreasBounds(Boolean?);
@@ -90,6 +91,7 @@ package dev.chrisbanes.haze {
     method @InaccessibleFromKotlin public void setExpandLayerBounds(Boolean?);
     method @InaccessibleFromKotlin public void setForceInvalidateOnPreDraw(boolean);
     method @InaccessibleFromKotlin public void setInputScale(dev.chrisbanes.haze.HazeInputScale);
+    method @InaccessibleFromKotlin public void setRetainOutputWhenSourceUnavailable(boolean);
     method @InaccessibleFromKotlin public void setVisualEffect(dev.chrisbanes.haze.VisualEffect);
     property @dev.chrisbanes.haze.ExperimentalHazeApi public abstract kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeArea,java.lang.Boolean>? canDrawArea;
     property public abstract Boolean? clipToAreasBounds;
@@ -97,6 +99,7 @@ package dev.chrisbanes.haze {
     property public abstract Boolean? expandLayerBounds;
     property public abstract boolean forceInvalidateOnPreDraw;
     property public abstract dev.chrisbanes.haze.HazeInputScale inputScale;
+    property public abstract boolean retainOutputWhenSourceUnavailable;
     property public abstract dev.chrisbanes.haze.VisualEffect visualEffect;
   }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -78,6 +78,18 @@ public interface HazeEffectScope {
   public var expandLayerBounds: Boolean?
 
   /**
+   * Whether this effect may continue drawing its last retained output after all source areas become
+   * unavailable.
+   *
+   * This defaults to `true`, which keeps source transitions visually smooth when source content is
+   * temporarily removed. Set this to `false` for privacy-sensitive surfaces where stale source
+   * pixels must be cleared as soon as there is no source content to draw.
+   *
+   * This only affects effects that support retained output.
+   */
+  public var retainOutputWhenSourceUnavailable: Boolean
+
+  /**
    * Force draw invalidation from pre-draw events of contributing [HazeArea]s.
    *
    * When enabled, Haze will register a pre-draw listener and invalidate this effect node

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -241,6 +241,20 @@ public class HazeEffectNode(
       }
     }
 
+  override var retainOutputWhenSourceUnavailable: Boolean = true
+    set(value) {
+      if (value != field) {
+        HazeLogger.d(TAG) {
+          "retainOutputWhenSourceUnavailable changed. Current $field. New: $value"
+        }
+        if (!value) {
+          clearRetainedOutput()
+        }
+        dirtyTracker += DirtyFields.RetainOutput
+        field = value
+      }
+    }
+
   override var forceInvalidateOnPreDraw: Boolean = false
     set(value) {
       if (value != field) {
@@ -362,8 +376,17 @@ public class HazeEffectNode(
 
       if (this@HazeEffectNode.size.isSpecified && this@HazeEffectNode.layerSize.isSpecified) {
         if (state != null) {
-          val shouldDrawRetainedOutput = shouldDrawRetainedOutput()
-          if (areas.isNotEmpty() || shouldDrawRetainedOutput) {
+          val hasDrawableSourceLayers = hasDrawableSourceLayers()
+          if (!retainOutputWhenSourceUnavailable && !hasDrawableSourceLayers) {
+            clearRetainedOutput()
+          }
+
+          val shouldDrawEffect = if (retainOutputWhenSourceUnavailable) {
+            areas.isNotEmpty() || shouldDrawRetainedOutput()
+          } else {
+            hasDrawableSourceLayers
+          }
+          if (shouldDrawEffect) {
             // If the state is not null and we have some areas, let's perform background blurring
             with(visualEffect) {
               draw(visualEffectContext)
@@ -464,7 +487,9 @@ public class HazeEffectNode(
           .apply { sortBy(HazeArea::zIndex) }
         _areas = filteredAreas
 
-        if (unfilteredAreas.isNotEmpty() && filteredAreas.isEmpty()) {
+        if (!retainOutputWhenSourceUnavailable && !hasDrawableSourceLayers()) {
+          clearRetainedOutput()
+        } else if (unfilteredAreas.isNotEmpty() && filteredAreas.isEmpty()) {
           clearRetainedOutput()
         }
         updateAreaZIndexes(currentStateAreas)
@@ -631,7 +656,16 @@ public class HazeEffectNode(
   }
 
   private fun shouldDrawRetainedOutput(): Boolean {
-    return (visualEffect as? RetainedOutputVisualEffect)?.shouldDrawRetainedOutput(visualEffectContext) == true
+    return retainOutputWhenSourceUnavailable &&
+      (visualEffect as? RetainedOutputVisualEffect)?.shouldDrawRetainedOutput(visualEffectContext) == true
+  }
+
+  private fun hasDrawableSourceLayers(): Boolean {
+    return areas.any { area ->
+      area.contentLayer
+        ?.takeUnless { it.isReleased }
+        ?.takeUnless { it.size.width <= 0 || it.size.height <= 0 } != null
+    }
   }
 
   private companion object {
@@ -724,7 +758,8 @@ internal object DirtyFields {
   const val DrawContentBehind: Int = LayerOffset shl 1
   const val ClipToAreas: Int = DrawContentBehind shl 1
   const val ExpandLayer: Int = ClipToAreas shl 1
-  const val ForcePreDraw: Int = ExpandLayer shl 1
+  const val RetainOutput: Int = ExpandLayer shl 1
+  const val ForcePreDraw: Int = RetainOutput shl 1
 
   const val InvalidateFlags: Int =
     InputScale or
@@ -737,6 +772,7 @@ internal object DirtyFields {
       DrawContentBehind or
       ClipToAreas or
       ExpandLayer or
+      RetainOutput or
       ForcePreDraw
 
   fun stringify(dirtyTracker: Bitmask): String {
@@ -752,6 +788,7 @@ internal object DirtyFields {
       if (DrawContentBehind in dirtyTracker) add("DrawContentBehind")
       if (ClipToAreas in dirtyTracker) add("ClipToAreas")
       if (ExpandLayer in dirtyTracker) add("ExpandLayer")
+      if (RetainOutput in dirtyTracker) add("RetainOutput")
       if (ForcePreDraw in dirtyTracker) add("ForcePreDraw")
     }
     return params.joinToString(separator = ", ", prefix = "[", postfix = "]")
@@ -771,4 +808,5 @@ internal val LayerBoundsDirtyFields: Int =
     DirtyFields.Size or
     DirtyFields.Areas or
     DirtyFields.ExpandLayer or
-    DirtyFields.ClipToAreas
+    DirtyFields.ClipToAreas or
+    DirtyFields.RetainOutput

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/VisualEffectRetainedOutputTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/VisualEffectRetainedOutputTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
@@ -106,6 +108,147 @@ class VisualEffectRetainedOutputTest : ContextTest() {
 
     assertThat(effect.drawCalls).isGreaterThan(beforeRemovalDraws)
     assertThat(effect.lastDrawAreaCount).isEqualTo(0)
+  }
+
+  @Test
+  fun visualEffect_retainedOutputNotDrawnWhenDisabled() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    val showSource = mutableStateOf(true)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        if (showSource.value) {
+          Spacer(Modifier.size(100.dp).hazeSource(hazeState))
+        }
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+              retainOutputWhenSourceUnavailable = false
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.drawCalls).isGreaterThan(0)
+    assertThat(effect.lastDrawAreaCount).isGreaterThan(0)
+
+    val beforeRemovalDraws = effect.drawCalls
+    showSource.value = false
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isGreaterThan(0)
+    assertThat(effect.drawCalls).isEqualTo(beforeRemovalDraws)
+    assertThat(effect.retainedOutputAvailable).isEqualTo(false)
+  }
+
+  @Test
+  fun visualEffect_pendingRetainedOutputNotDrawnWhenDisabled() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    val showSource = mutableStateOf(true)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        if (showSource.value) {
+          Spacer(Modifier.size(100.dp).hazeSource(hazeState))
+        }
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+              retainOutputWhenSourceUnavailable = false
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.drawCalls).isGreaterThan(0)
+    assertThat(effect.lastDrawAreaCount).isGreaterThan(0)
+
+    val beforeRemovalDraws = effect.drawCalls
+    effect.retainedOutputAvailable = false
+    effect.pendingRetainedOutput = true
+    showSource.value = false
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isGreaterThan(0)
+    assertThat(effect.drawCalls).isEqualTo(beforeRemovalDraws)
+    assertThat(effect.pendingRetainedOutput).isEqualTo(false)
+  }
+
+  @Test
+  fun visualEffect_retainedOutputNotDrawnWhenDisabledAndAreasHaveNoContentLayers() = runComposeUiTest {
+    val hazeState = HazeState()
+    val area = HazeArea().apply {
+      coordinates.localPosition = Offset.Zero
+      coordinates.screenPosition = Offset.Zero
+      size = Size(100f, 100f)
+    }
+    hazeState.addArea(area)
+    val effect = RetainedOutputRecordingVisualEffect().apply {
+      retainedOutputAvailable = true
+    }
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(100.dp)
+          .hazeEffect(hazeState) {
+            visualEffect = effect
+            retainOutputWhenSourceUnavailable = false
+          },
+      )
+    }
+
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isGreaterThan(0)
+    assertThat(effect.drawCalls).isEqualTo(0)
+    assertThat(effect.retainedOutputAvailable).isEqualTo(false)
+  }
+
+  @Test
+  fun visualEffect_retainedOutputClearedWhenDisabledAfterBeingAvailable() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    val showSource = mutableStateOf(true)
+    val retainOutput = mutableStateOf(true)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        if (showSource.value) {
+          Spacer(Modifier.size(100.dp).hazeSource(hazeState))
+        }
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+              retainOutputWhenSourceUnavailable = retainOutput.value
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.drawCalls).isGreaterThan(0)
+    assertThat(effect.retainedOutputAvailable).isEqualTo(true)
+
+    showSource.value = false
+    waitForIdle()
+    assertThat(effect.retainedOutputAvailable).isEqualTo(true)
+
+    retainOutput.value = false
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isGreaterThan(0)
+    assertThat(effect.retainedOutputAvailable).isEqualTo(false)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Add `HazeEffectScope.retainOutputWhenSourceUnavailable`, defaulting to the current retained-output behavior.
- Clear and suppress retained output when the flag is disabled and source areas are unavailable.
- Document retained-output privacy behavior for core concepts, blur, and liquid glass.

## Why

Retained output is useful for smooth source transitions, but it can preserve stale pixels from removed source content. This gives privacy-sensitive surfaces an explicit opt-out without changing the default behavior.

Fixes #1019

## Validation

- `rtk ./gradlew :haze:jvmTest --tests dev.chrisbanes.haze.VisualEffectRetainedOutputTest :haze:metalavaCheckCompatibility :haze:spotlessCheck`