### PR TITLE
Clarify Scaffold guidance for edge-to-edge Haze sources

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -40,9 +40,11 @@ Scaffold(
       /* todo */
     }
   },
-) {
+) { contentPadding ->
   LazyVerticalGrid(
+    contentPadding = contentPadding,
     modifier = Modifier
+      .fillMaxSize()
       .hazeSource(
         state = hazeState,
       ),
@@ -51,6 +53,8 @@ Scaffold(
   }
 }
 ```
+
+Keep `contentPadding` inside the scrollable content so interactive items remain clear of the app bars. Applying the padding as an outer modifier would shrink the viewport and its Haze source, leaving no source pixels behind the translucent bars. Scaffold-like layouts that measure content beside or above their chrome require an application-level overlay or custom layout to achieve an edge-to-edge translucent effect.
 
 ## Sticky Headers
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -54,7 +54,7 @@ Scaffold(
 }
 ```
 
-Keep `contentPadding` inside the scrollable content so interactive items remain clear of the app bars. Applying the padding as an outer modifier would shrink the viewport and its Haze source, leaving no source pixels behind the translucent bars. Scaffold-like layouts that measure content beside or above their chrome require an application-level overlay or custom layout to achieve an edge-to-edge translucent effect.
+The same guidance applies to other scaffold composables that provide content padding: pass that padding to the scrollable content rather than applying it as an outer modifier. This keeps interactive items clear of the chrome while preserving a full-size Haze source with pixels behind translucent bars. Scaffold-like layouts that measure content beside or above their chrome require an application-level overlay or custom layout to achieve an edge-to-edge translucent effect.
 
 ## Sticky Headers
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -54,7 +54,15 @@ Scaffold(
 }
 ```
 
-The same guidance applies to other scaffold composables that provide content padding: pass that padding to the scrollable content rather than applying it as an outer modifier. This keeps interactive items clear of the chrome while preserving a full-size Haze source with pixels behind translucent bars. Scaffold-like layouts that measure content beside or above their chrome require an application-level overlay or custom layout to achieve an edge-to-edge translucent effect.
+Common scaffold composables include:
+
+- [`Scaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/Scaffold.composable), which provides content padding for app bars and other chrome.
+- [`BottomSheetScaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/BottomSheetScaffold.composable), which provides content padding for its top bar and bottom sheet.
+- [`NavigationSuiteScaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/adaptive/navigationsuite/NavigationSuiteScaffold.composable), which places adaptive navigation beside or below its content.
+- [`ListDetailPaneScaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/adaptive/layout/ListDetailPaneScaffold.composable), which arranges list, detail, and optional extra panes.
+- [`SupportingPaneScaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/adaptive/layout/SupportingPaneScaffold.composable), which arranges main, supporting, and optional extra panes.
+
+For scaffold composables that provide content padding, pass that padding to the scrollable content rather than applying it as an outer modifier. This keeps interactive items clear of the chrome while preserving a full-size Haze source with pixels behind translucent bars. Scaffold-like layouts that measure content beside or above their chrome require an application-level overlay or custom layout to achieve an edge-to-edge translucent effect.
 
 ## Sticky Headers
 


### PR DESCRIPTION
## Summary

- update the Scaffold recipe to pass Scaffold padding into LazyVerticalGrid contentPadding
- keep the lazy viewport and Haze source full-size behind translucent app bars
- explain when outer padding or physically separated chrome requires an overlay or custom layout

## Verification

- mkdocs build --no-strict --site-dir /tmp/haze-issue-1054-publish
- git diff --check

Closes #1054