### PR TITLE
Preserve Glass configuration semantics across styles, copies, and density

### DIFF
--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
@@ -28,7 +28,11 @@ public sealed interface GlassOptics {
    * A complete optical configuration with no geometry-dependent adjustment.
    *
    * Accepted values are resolved without geometry-dependent adjustment. [blurRadius] uses
-   * density-independent [Dp]. [refractionHeight] is a fraction of the material's shortest side.
+   * density-independent [Dp]. The current semantic blur renderer limits its effective radius to
+   * 38.5 full-resolution physical pixels, so the effective radius is the lesser of the requested
+   * `Dp` converted through the current density and 38.5 pixels. This is a renderer quality bound,
+   * not an input-validation limit; larger finite, non-negative values remain accepted.
+   * [refractionHeight] is a fraction of the material's shortest side.
    * [refractionScale] is a raw displacement in full-resolution effect pixels; it is not converted
    * through density and is scaled only when [dev.chrisbanes.haze.HazeInputScale] renders the
    * effect at reduced resolution.

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -54,22 +54,22 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
   /** Creates a new [GlassVisualEffect] copying all properties from [other]. */
   public constructor(other: GlassVisualEffect) : this() {
     _optics = other._optics
-    specularIntensity = other.specularIntensity
-    ambientResponse = other.ambientResponse
-    tint = other.tint
-    edgeSoftness = other.edgeSoftness
-    lightPosition = other.lightPosition
-    chromaticAberrationStrength = other.chromaticAberrationStrength
+    _specularIntensity = other._specularIntensity
+    _ambientResponse = other._ambientResponse
+    _tint = other._tint
+    _edgeSoftness = other._edgeSoftness
+    _lightPosition = other._lightPosition
+    _chromaticAberrationStrength = other._chromaticAberrationStrength
     _surfaceProfile = other._surfaceProfile
     _chromaticAberrationMode = other._chromaticAberrationMode
     _shape = other._shape
-    alpha = other.alpha
-    contrast = other.contrast
-    whitePoint = other.whitePoint
-    chromaMultiplier = other.chromaMultiplier
-    contentNormalBlend = other.contentNormalBlend
-    specularExponent = other.specularExponent
-    fresnelExponent = other.fresnelExponent
+    _alpha = other._alpha
+    _contrast = other._contrast
+    _whitePoint = other._whitePoint
+    _chromaMultiplier = other._chromaMultiplier
+    _contentNormalBlend = other._contentNormalBlend
+    _specularExponent = other._specularExponent
+    _fresnelExponent = other._fresnelExponent
     compositionLocalStyle = other.compositionLocalStyle
     style = other.style
     nextInteractionRevision = other.nextInteractionRevision
@@ -807,17 +807,17 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.specularIntensity] value set in [style], if specified.
    *  - [GlassStyle.specularIntensity] value set in the [LocalGlassStyle] composition local.
    */
-  public var specularIntensity: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleLighting.specularIntensity }
-        .takeOrElse { localLighting.specularIntensity }
-        .takeOrElse { GlassDefaults.specularIntensity }
-    }
+  private var _specularIntensity: Float = Float.NaN
+  public var specularIntensity: Float
+    get() = _specularIntensity
+      .takeOrElse { styleLighting.specularIntensity }
+      .takeOrElse { localLighting.specularIntensity }
+      .takeOrElse { GlassDefaults.specularIntensity }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "specularIntensity changed. Current: $field. New: $value" }
-        field = value.coerceIn(0f, 1f)
+      val normalized = value.coerceIn(0f, 1f)
+      if (!_specularIntensity.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) { "specularIntensity changed. Current: $_specularIntensity. New: $value" }
+        _specularIntensity = normalized
         dirtyTracker += GlassDirtyFields.SpecularIntensity
       }
     }
@@ -831,17 +831,17 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.ambientResponse] value set in [style], if specified.
    *  - [GlassStyle.ambientResponse] value set in the [LocalGlassStyle] composition local.
    */
-  public var ambientResponse: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleLighting.ambientResponse }
-        .takeOrElse { localLighting.ambientResponse }
-        .takeOrElse { GlassDefaults.ambientResponse }
-    }
+  private var _ambientResponse: Float = Float.NaN
+  public var ambientResponse: Float
+    get() = _ambientResponse
+      .takeOrElse { styleLighting.ambientResponse }
+      .takeOrElse { localLighting.ambientResponse }
+      .takeOrElse { GlassDefaults.ambientResponse }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "ambientResponse changed. Current: $field. New: $value" }
-        field = value.coerceIn(0f, 1f)
+      val normalized = value.coerceIn(0f, 1f)
+      if (!_ambientResponse.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) { "ambientResponse changed. Current: $_ambientResponse. New: $value" }
+        _ambientResponse = normalized
         dirtyTracker += GlassDirtyFields.AmbientResponse
       }
     }
@@ -855,17 +855,16 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.tint] value set in [style], if specified.
    *  - [GlassStyle.tint] value set in the [LocalGlassStyle] composition local.
    */
-  public var tint: Color = Color.Unspecified
-    get() {
-      return field
-        .takeOrElse { style.tint }
-        .takeOrElse { compositionLocalStyle.tint }
-        .takeOrElse { GlassDefaults.tint }
-    }
+  private var _tint: Color = Color.Unspecified
+  public var tint: Color
+    get() = _tint
+      .takeOrElse { style.tint }
+      .takeOrElse { compositionLocalStyle.tint }
+      .takeOrElse { GlassDefaults.tint }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "tint changed. Current: $field. New: $value" }
-        field = value
+      if (_tint != value) {
+        HazeLogger.d(TAG) { "tint changed. Current: $_tint. New: $value" }
+        _tint = value
         dirtyTracker += GlassDirtyFields.Tint
       }
     }
@@ -879,17 +878,16 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.edgeSoftness] value set in [style], if specified.
    *  - [GlassStyle.edgeSoftness] value set in the [LocalGlassStyle] composition local.
    */
-  public var edgeSoftness: Dp = Dp.Unspecified
-    get() {
-      return field
-        .takeOrElse { styleRendering.edgeSoftness }
-        .takeOrElse { localRendering.edgeSoftness }
-        .takeOrElse { GlassDefaults.edgeSoftness }
-    }
+  private var _edgeSoftness: Dp = Dp.Unspecified
+  public var edgeSoftness: Dp
+    get() = _edgeSoftness
+      .takeOrElse { styleRendering.edgeSoftness }
+      .takeOrElse { localRendering.edgeSoftness }
+      .takeOrElse { GlassDefaults.edgeSoftness }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "edgeSoftness changed. Current: $field. New: $value" }
-        field = value
+      if (_edgeSoftness != value) {
+        HazeLogger.d(TAG) { "edgeSoftness changed. Current: $_edgeSoftness. New: $value" }
+        _edgeSoftness = value
         dirtyTracker += GlassDirtyFields.EdgeSoftness
       }
     }
@@ -906,16 +904,15 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    * If no value is specified through any of the above, the delegate falls back to the
    * center of the layer at draw time.
    */
-  public var lightPosition: Offset = Offset.Unspecified
-    get() {
-      return field
-        .takeOrElse { styleLighting.lightPosition }
-        .takeOrElse { localLighting.lightPosition }
-    }
+  private var _lightPosition: Offset = Offset.Unspecified
+  public var lightPosition: Offset
+    get() = _lightPosition
+      .takeOrElse { styleLighting.lightPosition }
+      .takeOrElse { localLighting.lightPosition }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "lightPosition changed. Current: $field. New: $value" }
-        field = value
+      if (_lightPosition != value) {
+        HazeLogger.d(TAG) { "lightPosition changed. Current: $_lightPosition. New: $value" }
+        _lightPosition = value
         dirtyTracker += GlassDirtyFields.LightPosition
       }
     }
@@ -929,17 +926,19 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.chromaticAberrationStrength] value set in [style], if specified.
    *  - [GlassStyle.chromaticAberrationStrength] value set in the [LocalGlassStyle] composition local.
    */
-  public var chromaticAberrationStrength: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleRendering.chromaticAberrationStrength }
-        .takeOrElse { localRendering.chromaticAberrationStrength }
-        .takeOrElse { GlassDefaults.chromaticAberrationStrength }
-    }
+  private var _chromaticAberrationStrength: Float = Float.NaN
+  public var chromaticAberrationStrength: Float
+    get() = _chromaticAberrationStrength
+      .takeOrElse { styleRendering.chromaticAberrationStrength }
+      .takeOrElse { localRendering.chromaticAberrationStrength }
+      .takeOrElse { GlassDefaults.chromaticAberrationStrength }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "chromaticAberrationStrength changed. Current: $field. New: $value" }
-        field = value.coerceIn(0f, 1f)
+      val normalized = value.coerceIn(0f, 1f)
+      if (!_chromaticAberrationStrength.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) {
+          "chromaticAberrationStrength changed. Current: $_chromaticAberrationStrength. New: $value"
+        }
+        _chromaticAberrationStrength = normalized
         dirtyTracker += GlassDirtyFields.ChromaticAberration
       }
     }
@@ -1052,17 +1051,17 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.alpha] value set in [style], if specified.
    *  - [GlassStyle.alpha] value set in the [LocalGlassStyle] composition local.
    */
-  public var alpha: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleColor.alpha }
-        .takeOrElse { localColor.alpha }
-        .takeOrElse { GlassDefaults.alpha }
-    }
+  private var _alpha: Float = Float.NaN
+  public var alpha: Float
+    get() = _alpha
+      .takeOrElse { styleColor.alpha }
+      .takeOrElse { localColor.alpha }
+      .takeOrElse { GlassDefaults.alpha }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "alpha changed. Current: $field. New: $value" }
-        field = value.coerceIn(0f, 1f)
+      val normalized = value.coerceIn(0f, 1f)
+      if (!_alpha.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) { "alpha changed. Current: $_alpha. New: $value" }
+        _alpha = normalized
         dirtyTracker += GlassDirtyFields.Alpha
       }
     }
@@ -1076,17 +1075,17 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.contrast] value set in [style], if specified.
    *  - [GlassStyle.contrast] value set in the [LocalGlassStyle] composition local.
    */
-  public var contrast: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleColor.contrast }
-        .takeOrElse { localColor.contrast }
-        .takeOrElse { GlassDefaults.contrast }
-    }
+  private var _contrast: Float = Float.NaN
+  public var contrast: Float
+    get() = _contrast
+      .takeOrElse { styleColor.contrast }
+      .takeOrElse { localColor.contrast }
+      .takeOrElse { GlassDefaults.contrast }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "contrast changed. Current: $field. New: $value" }
-        field = value.coerceIn(-1f, 1f)
+      val normalized = value.coerceIn(-1f, 1f)
+      if (!_contrast.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) { "contrast changed. Current: $_contrast. New: $value" }
+        _contrast = normalized
         dirtyTracker += GlassDirtyFields.Contrast
       }
     }
@@ -1100,17 +1099,17 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.whitePoint] value set in [style], if specified.
    *  - [GlassStyle.whitePoint] value set in the [LocalGlassStyle] composition local.
    */
-  public var whitePoint: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleColor.whitePoint }
-        .takeOrElse { localColor.whitePoint }
-        .takeOrElse { GlassDefaults.whitePoint }
-    }
+  private var _whitePoint: Float = Float.NaN
+  public var whitePoint: Float
+    get() = _whitePoint
+      .takeOrElse { styleColor.whitePoint }
+      .takeOrElse { localColor.whitePoint }
+      .takeOrElse { GlassDefaults.whitePoint }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "whitePoint changed. Current: $field. New: $value" }
-        field = value.coerceIn(-1f, 1f)
+      val normalized = value.coerceIn(-1f, 1f)
+      if (!_whitePoint.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) { "whitePoint changed. Current: $_whitePoint. New: $value" }
+        _whitePoint = normalized
         dirtyTracker += GlassDirtyFields.WhitePoint
       }
     }
@@ -1124,17 +1123,17 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.chromaMultiplier] value set in [style], if specified.
    *  - [GlassStyle.chromaMultiplier] value set in the [LocalGlassStyle] composition local.
    */
-  public var chromaMultiplier: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleColor.chromaMultiplier }
-        .takeOrElse { localColor.chromaMultiplier }
-        .takeOrElse { GlassDefaults.chromaMultiplier }
-    }
+  private var _chromaMultiplier: Float = Float.NaN
+  public var chromaMultiplier: Float
+    get() = _chromaMultiplier
+      .takeOrElse { styleColor.chromaMultiplier }
+      .takeOrElse { localColor.chromaMultiplier }
+      .takeOrElse { GlassDefaults.chromaMultiplier }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "chromaMultiplier changed. Current: $field. New: $value" }
-        field = value.coerceIn(0f, 2f)
+      val normalized = value.coerceIn(0f, 2f)
+      if (!_chromaMultiplier.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) { "chromaMultiplier changed. Current: $_chromaMultiplier. New: $value" }
+        _chromaMultiplier = normalized
         dirtyTracker += GlassDirtyFields.ChromaMultiplier
       }
     }
@@ -1148,17 +1147,17 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.contentNormalBlend] value set in [style], if specified.
    *  - [GlassStyle.contentNormalBlend] value set in the [LocalGlassStyle] composition local.
    */
-  public var contentNormalBlend: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleRendering.contentNormalBlend }
-        .takeOrElse { localRendering.contentNormalBlend }
-        .takeOrElse { GlassDefaults.contentNormalBlend }
-    }
+  private var _contentNormalBlend: Float = Float.NaN
+  public var contentNormalBlend: Float
+    get() = _contentNormalBlend
+      .takeOrElse { styleRendering.contentNormalBlend }
+      .takeOrElse { localRendering.contentNormalBlend }
+      .takeOrElse { GlassDefaults.contentNormalBlend }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "contentNormalBlend changed. Current: $field. New: $value" }
-        field = value.coerceIn(0f, 1f)
+      val normalized = value.coerceIn(0f, 1f)
+      if (!_contentNormalBlend.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) { "contentNormalBlend changed. Current: $_contentNormalBlend. New: $value" }
+        _contentNormalBlend = normalized
         dirtyTracker += GlassDirtyFields.ContentNormalBlend
       }
     }
@@ -1172,17 +1171,17 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.specularExponent] value set in [style], if specified.
    *  - [GlassStyle.specularExponent] value set in the [LocalGlassStyle] composition local.
    */
-  public var specularExponent: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleLighting.specularExponent }
-        .takeOrElse { localLighting.specularExponent }
-        .takeOrElse { GlassDefaults.specularExponent }
-    }
+  private var _specularExponent: Float = Float.NaN
+  public var specularExponent: Float
+    get() = _specularExponent
+      .takeOrElse { styleLighting.specularExponent }
+      .takeOrElse { localLighting.specularExponent }
+      .takeOrElse { GlassDefaults.specularExponent }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "specularExponent changed. Current: $field. New: $value" }
-        field = value.coerceAtLeast(0f)
+      val normalized = value.coerceAtLeast(0f)
+      if (!_specularExponent.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) { "specularExponent changed. Current: $_specularExponent. New: $value" }
+        _specularExponent = normalized
         dirtyTracker += GlassDirtyFields.SpecularExponent
       }
     }
@@ -1196,17 +1195,17 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.fresnelExponent] value set in [style], if specified.
    *  - [GlassStyle.fresnelExponent] value set in the [LocalGlassStyle] composition local.
    */
-  public var fresnelExponent: Float = Float.NaN
-    get() {
-      return field
-        .takeOrElse { styleLighting.fresnelExponent }
-        .takeOrElse { localLighting.fresnelExponent }
-        .takeOrElse { GlassDefaults.fresnelExponent }
-    }
+  private var _fresnelExponent: Float = Float.NaN
+  public var fresnelExponent: Float
+    get() = _fresnelExponent
+      .takeOrElse { styleLighting.fresnelExponent }
+      .takeOrElse { localLighting.fresnelExponent }
+      .takeOrElse { GlassDefaults.fresnelExponent }
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "fresnelExponent changed. Current: $field. New: $value" }
-        field = value.coerceAtLeast(0f)
+      val normalized = value.coerceAtLeast(0f)
+      if (!_fresnelExponent.hasSameOverrideValueAs(normalized)) {
+        HazeLogger.d(TAG) { "fresnelExponent changed. Current: $_fresnelExponent. New: $value" }
+        _fresnelExponent = normalized
         dirtyTracker += GlassDirtyFields.FresnelExponent
       }
     }
@@ -1271,19 +1270,35 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
     if (old.optics != new.optics) {
       dirtyTracker += GlassDirtyFields.Optics
     }
-    if (old.lighting.specularIntensity != new.lighting.specularIntensity) {
+    if (
+      !old.lighting.specularIntensity.hasSameNormalizedOverrideValueAs(
+        new.lighting.specularIntensity,
+      ) { it.coerceIn(0f, 1f) }
+    ) {
       dirtyTracker += GlassDirtyFields.SpecularIntensity
     }
-    if (old.lighting.ambientResponse != new.lighting.ambientResponse) {
+    if (
+      !old.lighting.ambientResponse.hasSameNormalizedOverrideValueAs(
+        new.lighting.ambientResponse,
+      ) { it.coerceIn(0f, 1f) }
+    ) {
       dirtyTracker += GlassDirtyFields.AmbientResponse
     }
     if (old.lighting.lightPosition != new.lighting.lightPosition) {
       dirtyTracker += GlassDirtyFields.LightPosition
     }
-    if (old.lighting.specularExponent != new.lighting.specularExponent) {
+    if (
+      !old.lighting.specularExponent.hasSameNormalizedOverrideValueAs(
+        new.lighting.specularExponent,
+      ) { it.coerceAtLeast(0f) }
+    ) {
       dirtyTracker += GlassDirtyFields.SpecularExponent
     }
-    if (old.lighting.fresnelExponent != new.lighting.fresnelExponent) {
+    if (
+      !old.lighting.fresnelExponent.hasSameNormalizedOverrideValueAs(
+        new.lighting.fresnelExponent,
+      ) { it.coerceAtLeast(0f) }
+    ) {
       dirtyTracker += GlassDirtyFields.FresnelExponent
     }
     if (old.tint != new.tint) {
@@ -1292,28 +1307,50 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
     if (old.shape != new.shape) {
       dirtyTracker += GlassDirtyFields.Shape
     }
-    if (old.color.alpha != new.color.alpha) {
+    if (
+      !old.color.alpha.hasSameNormalizedOverrideValueAs(new.color.alpha) { it.coerceIn(0f, 1f) }
+    ) {
       dirtyTracker += GlassDirtyFields.Alpha
     }
-    if (old.color.contrast != new.color.contrast) {
+    if (
+      !old.color.contrast.hasSameNormalizedOverrideValueAs(new.color.contrast) {
+        it.coerceIn(-1f, 1f)
+      }
+    ) {
       dirtyTracker += GlassDirtyFields.Contrast
     }
-    if (old.color.whitePoint != new.color.whitePoint) {
+    if (
+      !old.color.whitePoint.hasSameNormalizedOverrideValueAs(new.color.whitePoint) {
+        it.coerceIn(-1f, 1f)
+      }
+    ) {
       dirtyTracker += GlassDirtyFields.WhitePoint
     }
-    if (old.color.chromaMultiplier != new.color.chromaMultiplier) {
+    if (
+      !old.color.chromaMultiplier.hasSameNormalizedOverrideValueAs(new.color.chromaMultiplier) {
+        it.coerceIn(0f, 2f)
+      }
+    ) {
       dirtyTracker += GlassDirtyFields.ChromaMultiplier
     }
     if (old.rendering.edgeSoftness != new.rendering.edgeSoftness) {
       dirtyTracker += GlassDirtyFields.EdgeSoftness
     }
-    if (old.rendering.contentNormalBlend != new.rendering.contentNormalBlend) {
+    if (
+      !old.rendering.contentNormalBlend.hasSameNormalizedOverrideValueAs(
+        new.rendering.contentNormalBlend,
+      ) { it.coerceIn(0f, 1f) }
+    ) {
       dirtyTracker += GlassDirtyFields.ContentNormalBlend
     }
     if (old.rendering.surfaceProfile != new.rendering.surfaceProfile) {
       dirtyTracker += GlassDirtyFields.SurfaceProfile
     }
-    if (old.rendering.chromaticAberrationStrength != new.rendering.chromaticAberrationStrength) {
+    if (
+      !old.rendering.chromaticAberrationStrength.hasSameNormalizedOverrideValueAs(
+        new.rendering.chromaticAberrationStrength,
+      ) { it.coerceIn(0f, 1f) }
+    ) {
       dirtyTracker += GlassDirtyFields.ChromaticAberration
     }
     if (old.rendering.chromaticAberrationMode != new.rendering.chromaticAberrationMode) {
@@ -1375,6 +1412,15 @@ private fun RoundedCornerShape.hasZeroCornerRadii(): Boolean {
 private inline fun Float.takeOrElse(default: () -> Float): Float {
   return if (this.isNaN()) default() else this
 }
+
+private fun Float.hasSameOverrideValueAs(other: Float): Boolean =
+  this == other || isNaN() && other.isNaN()
+
+private inline fun Float.hasSameNormalizedOverrideValueAs(
+  other: Float,
+  normalize: (Float) -> Float,
+): Boolean = hasSameOverrideValueAs(other) ||
+  isFinite() && other.isFinite() && normalize(this) == normalize(other)
 
 private fun reducedMotion(
   policy: GlassReducedMotionPolicy,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -24,41 +24,61 @@ import kotlin.test.assertFailsWith
 class GlassRenderParamsTest {
 
   @Test
-  fun resolvedStyle_canonicalizesSizingValuesEquallyAcrossAllPrecedenceLevels() {
-    val invalidRendering = GlassRendering(
+  fun resolvedStyle_canonicalizesAllScalarsEquallyAcrossPrecedenceLevels() {
+    val lighting = GlassLighting(
+      specularIntensity = 2f,
+      ambientResponse = -1f,
+      specularExponent = -1f,
+      fresnelExponent = -1f,
+    )
+    val color = GlassColor(
+      alpha = 2f,
+      contrast = 2f,
+      whitePoint = -2f,
+      chromaMultiplier = 3f,
+    )
+    val rendering = GlassRendering(
       edgeSoftness = Float.POSITIVE_INFINITY.dp,
+      contentNormalBlend = 2f,
       chromaticAberrationStrength = -1f,
+    )
+    val inheritedStyle = GlassStyle(
+      lighting = lighting,
+      color = color,
+      rendering = rendering,
     )
     val effects = listOf(
       GlassVisualEffect().apply {
-        edgeSoftness = Float.POSITIVE_INFINITY.dp
-        chromaticAberrationStrength = -1f
+        specularIntensity = lighting.specularIntensity
+        ambientResponse = lighting.ambientResponse
+        specularExponent = lighting.specularExponent
+        fresnelExponent = lighting.fresnelExponent
+        alpha = color.alpha
+        contrast = color.contrast
+        whitePoint = color.whitePoint
+        chromaMultiplier = color.chromaMultiplier
+        edgeSoftness = rendering.edgeSoftness
+        contentNormalBlend = rendering.contentNormalBlend
+        chromaticAberrationStrength = rendering.chromaticAberrationStrength
       },
-      GlassVisualEffect().apply {
-        style = GlassStyle(rendering = invalidRendering)
-      },
-      GlassVisualEffect().apply {
-        compositionLocalStyle = GlassStyle(rendering = invalidRendering)
-      },
+      GlassVisualEffect().apply { style = inheritedStyle },
+      GlassVisualEffect().apply { compositionLocalStyle = inheritedStyle },
     )
-
-    effects.forEach { effect ->
-      val resolved = resolveGlassStyle(
-        effect = effect,
-        materialSizePx = Size(100f, 80f),
-        density = Density(1f),
-        layoutDirection = LayoutDirection.Ltr,
-      )
-
-      assertThat(resolved.chromaticAberrationStrength).isEqualTo(0f)
-      assertThat(resolved.edgeSoftnessPx).isEqualTo(GlassDefaults.edgeSoftness.value)
+    val size = Size(100f, 80f)
+    val density = Density(1f)
+    val resolved = effects.map {
+      resolveGlassStyle(it, size, density, LayoutDirection.Ltr)
     }
 
-    val rect = Rect(0f, 0f, 100f, 80f)
-    val expectedBounds = effects.first().calculateLayerBounds(rect, Density(1f))
-    effects.drop(1).forEach { effect ->
-      assertThat(effect.calculateLayerBounds(rect, Density(1f))).isEqualTo(expectedBounds)
-    }
+    assertThat(resolved[1]).isEqualTo(resolved[0])
+    assertThat(resolved[2]).isEqualTo(resolved[0])
+    assertThat(resolved[0].chromaticAberrationStrength).isEqualTo(0f)
+    assertThat(resolved[0].edgeSoftnessPx).isEqualTo(GlassDefaults.edgeSoftness.value)
+
+    val rect = Rect(0f, 0f, size.width, size.height)
+    val bounds = effects.map { it.calculateLayerBounds(rect, density) }
+    assertThat(bounds[1]).isEqualTo(bounds[0])
+    assertThat(bounds[2]).isEqualTo(bounds[0])
   }
 
   @Test
@@ -306,6 +326,27 @@ class GlassRenderParamsTest {
       assertThat(resolved.progressive).isEqualTo(progressive)
       assertThat(resolved.toneGain).isEqualTo(1f)
       assertThat(resolved.neutralLiftWeight).isEqualTo(0f)
+    }
+  }
+
+  @Test
+  fun absoluteOptics_blurRadiusUsesCurrentPhysicalPixelCapAcrossDensities() {
+    val cases = listOf(
+      Triple(20.dp, Density(1f), 20f),
+      Triple(14.dp, Density(2.75f), 38.5f),
+      Triple(20.dp, Density(2f), 38.5f),
+      Triple(100.dp, Density(4f), 38.5f),
+    )
+
+    cases.forEach { (radius, density, expectedRadiusPx) ->
+      val resolved = resolveGlassOptics(
+        optics = GlassOptics.Absolute(blurRadius = radius),
+        materialSizePx = Size(200f, 100f),
+        density = density,
+        cornerRadiiPx = CornerRadii.zero,
+      )
+
+      assertThat(resolved.blurRadiusPx).isEqualTo(expectedRadiusPx)
     }
   }
 

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -33,6 +33,17 @@ import kotlinx.coroutines.CoroutineScope
 class GlassStyleTest {
 
   @Test
+  fun styleChange_dirtiesOnlyTheSpecifiedScalarAndStyleFields() {
+    val effect = GlassVisualEffect()
+    effect.resetDirtyTracker()
+
+    effect.style = GlassStyle(color = GlassColor(alpha = 0.5f))
+
+    assertThat(GlassDirtyFields.stringify(effect.dirtyTracker))
+      .isEqualTo("[Alpha, Style]")
+  }
+
+  @Test
   fun defaultsStyle_resolvesToGlassDefaults() {
     val effect = GlassVisualEffect().apply {
       compositionLocalStyle = GlassDefaults.style

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectOverrideTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectOverrideTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.contains
@@ -211,4 +212,261 @@ class GlassVisualEffectOverrideTest {
     assertThat(copy.interactionPositionAnimationSpec).isEqualTo(positionSpec)
     assertThat(copy.interactionReducedMotionPolicy).isEqualTo(GlassReducedMotionPolicy.Reduced)
   }
+
+  @Test
+  fun primitiveOverrides_replayingUnspecifiedValuesDoesNotMarkDirty() {
+    scalarOverrideCases.forEach { case ->
+      val effect = GlassVisualEffect()
+      effect.resetDirtyTracker()
+
+      case.set(effect, Float.NaN)
+
+      assertThat(
+        GlassDirtyFields.stringify(effect.dirtyTracker),
+        case.name,
+      ).isEqualTo("[]")
+    }
+  }
+
+  @Test
+  fun primitiveOverrides_equivalentNormalizedValuesDoNotMarkDirty() {
+    scalarOverrideCases.forEach { case ->
+      val effect = GlassVisualEffect()
+      case.set(effect, case.firstEquivalentInput)
+      effect.resetDirtyTracker()
+
+      case.set(effect, case.secondEquivalentInput)
+
+      assertThat(
+        GlassDirtyFields.stringify(effect.dirtyTracker),
+        case.name,
+      ).isEqualTo("[]")
+    }
+  }
+
+  @Test
+  fun primitiveOverrides_equivalentNormalizedStyleValuesDirtyOnlyStyle() {
+    scalarOverrideCases.forEach { case ->
+      val effect = GlassVisualEffect().apply {
+        style = case.style(case.firstEquivalentInput)
+      }
+      effect.resetDirtyTracker()
+
+      effect.style = case.style(case.secondEquivalentInput)
+
+      assertThat(
+        GlassDirtyFields.stringify(effect.dirtyTracker),
+        case.name,
+      ).isEqualTo("[Style]")
+    }
+  }
+
+  @Test
+  fun primitiveOverrides_equivalentNormalizedCompositionLocalValuesDoNotMarkDirty() {
+    scalarOverrideCases.forEach { case ->
+      val effect = GlassVisualEffect().apply {
+        compositionLocalStyle = case.style(case.firstEquivalentInput)
+      }
+      effect.resetDirtyTracker()
+
+      effect.compositionLocalStyle = case.style(case.secondEquivalentInput)
+
+      assertThat(
+        GlassDirtyFields.stringify(effect.dirtyTracker),
+        case.name,
+      ).isEqualTo("[]")
+    }
+  }
+
+  @Test
+  fun primitiveOverrides_copyConstructorPreservesInheritedSources() {
+    scalarOverrideCases.forEach { case ->
+      val original = GlassVisualEffect().apply {
+        style = case.style(0.2f)
+      }
+      val copy = GlassVisualEffect(original)
+
+      copy.style = case.style(0.8f)
+
+      assertThat(case.get(copy), case.name).isEqualTo(0.8f)
+    }
+  }
+
+  @Test
+  fun primitiveOverrides_copyConstructorPreservesCompositionLocalSources() {
+    scalarOverrideCases.forEach { case ->
+      val original = GlassVisualEffect().apply {
+        compositionLocalStyle = case.style(0.2f)
+      }
+      val copy = GlassVisualEffect(original)
+
+      copy.compositionLocalStyle = case.style(0.8f)
+
+      assertThat(case.get(copy), case.name).isEqualTo(0.8f)
+    }
+  }
+
+  @Test
+  fun primitiveOverrides_copyConstructorPreservesDirectOverrides() {
+    scalarOverrideCases.forEach { case ->
+      val original = GlassVisualEffect().apply {
+        style = case.style(0.2f)
+      }
+      case.set(original, 0.4f)
+      val copy = GlassVisualEffect(original)
+
+      copy.style = case.style(0.8f)
+
+      assertThat(case.get(copy), case.name).isEqualTo(0.4f)
+    }
+  }
+
+  @Test
+  fun valueOverrides_copyConstructorPreservesInheritedSources() {
+    val original = GlassVisualEffect().apply {
+      compositionLocalStyle = GlassStyle(
+        tint = Color.Red,
+        lighting = GlassLighting(lightPosition = Offset(1f, 2f)),
+        rendering = GlassRendering(edgeSoftness = 4.dp),
+      )
+    }
+    val copy = GlassVisualEffect(original)
+
+    copy.compositionLocalStyle = GlassStyle(
+      tint = Color.Blue,
+      lighting = GlassLighting(lightPosition = Offset(3f, 4f)),
+      rendering = GlassRendering(edgeSoftness = 8.dp),
+    )
+
+    assertThat(copy.tint).isEqualTo(Color.Blue)
+    assertThat(copy.lightPosition).isEqualTo(Offset(3f, 4f))
+    assertThat(copy.edgeSoftness).isEqualTo(8.dp)
+  }
+
+  @Test
+  fun valueOverrides_copyConstructorPreservesStyleSources() {
+    val original = GlassVisualEffect().apply {
+      style = GlassStyle(
+        tint = Color.Red,
+        lighting = GlassLighting(lightPosition = Offset(1f, 2f)),
+        rendering = GlassRendering(edgeSoftness = 4.dp),
+      )
+    }
+    val copy = GlassVisualEffect(original)
+
+    copy.style = GlassStyle(
+      tint = Color.Blue,
+      lighting = GlassLighting(lightPosition = Offset(3f, 4f)),
+      rendering = GlassRendering(edgeSoftness = 8.dp),
+    )
+
+    assertThat(copy.tint).isEqualTo(Color.Blue)
+    assertThat(copy.lightPosition).isEqualTo(Offset(3f, 4f))
+    assertThat(copy.edgeSoftness).isEqualTo(8.dp)
+  }
+
+  @Test
+  fun valueOverrides_copyConstructorPreservesDirectOverrides() {
+    val original = GlassVisualEffect().apply {
+      compositionLocalStyle = GlassStyle(
+        tint = Color.Red,
+        lighting = GlassLighting(lightPosition = Offset(1f, 2f)),
+        rendering = GlassRendering(edgeSoftness = 4.dp),
+      )
+      tint = Color.Green
+      lightPosition = Offset(5f, 6f)
+      edgeSoftness = 12.dp
+    }
+    val copy = GlassVisualEffect(original)
+
+    copy.compositionLocalStyle = GlassStyle(
+      tint = Color.Blue,
+      lighting = GlassLighting(lightPosition = Offset(3f, 4f)),
+      rendering = GlassRendering(edgeSoftness = 8.dp),
+    )
+
+    assertThat(copy.tint).isEqualTo(Color.Green)
+    assertThat(copy.lightPosition).isEqualTo(Offset(5f, 6f))
+    assertThat(copy.edgeSoftness).isEqualTo(12.dp)
+  }
 }
+
+private data class ScalarOverrideCase(
+  val name: String,
+  val set: (GlassVisualEffect, Float) -> Unit,
+  val get: (GlassVisualEffect) -> Float,
+  val style: (Float) -> GlassStyle,
+  val firstEquivalentInput: Float = 2f,
+  val secondEquivalentInput: Float = 3f,
+)
+
+private val scalarOverrideCases = listOf(
+  ScalarOverrideCase(
+    name = "specularIntensity",
+    set = { effect, value -> effect.specularIntensity = value },
+    get = { it.specularIntensity },
+    style = { GlassStyle(lighting = GlassLighting(specularIntensity = it)) },
+  ),
+  ScalarOverrideCase(
+    name = "ambientResponse",
+    set = { effect, value -> effect.ambientResponse = value },
+    get = { it.ambientResponse },
+    style = { GlassStyle(lighting = GlassLighting(ambientResponse = it)) },
+  ),
+  ScalarOverrideCase(
+    name = "chromaticAberrationStrength",
+    set = { effect, value -> effect.chromaticAberrationStrength = value },
+    get = { it.chromaticAberrationStrength },
+    style = {
+      GlassStyle(rendering = GlassRendering(chromaticAberrationStrength = it))
+    },
+  ),
+  ScalarOverrideCase(
+    name = "alpha",
+    set = { effect, value -> effect.alpha = value },
+    get = { it.alpha },
+    style = { GlassStyle(color = GlassColor(alpha = it)) },
+  ),
+  ScalarOverrideCase(
+    name = "contrast",
+    set = { effect, value -> effect.contrast = value },
+    get = { it.contrast },
+    style = { GlassStyle(color = GlassColor(contrast = it)) },
+  ),
+  ScalarOverrideCase(
+    name = "whitePoint",
+    set = { effect, value -> effect.whitePoint = value },
+    get = { it.whitePoint },
+    style = { GlassStyle(color = GlassColor(whitePoint = it)) },
+  ),
+  ScalarOverrideCase(
+    name = "chromaMultiplier",
+    set = { effect, value -> effect.chromaMultiplier = value },
+    get = { it.chromaMultiplier },
+    style = { GlassStyle(color = GlassColor(chromaMultiplier = it)) },
+    firstEquivalentInput = 3f,
+    secondEquivalentInput = 4f,
+  ),
+  ScalarOverrideCase(
+    name = "contentNormalBlend",
+    set = { effect, value -> effect.contentNormalBlend = value },
+    get = { it.contentNormalBlend },
+    style = { GlassStyle(rendering = GlassRendering(contentNormalBlend = it)) },
+  ),
+  ScalarOverrideCase(
+    name = "specularExponent",
+    set = { effect, value -> effect.specularExponent = value },
+    get = { it.specularExponent },
+    style = { GlassStyle(lighting = GlassLighting(specularExponent = it)) },
+    firstEquivalentInput = -1f,
+    secondEquivalentInput = -2f,
+  ),
+  ScalarOverrideCase(
+    name = "fresnelExponent",
+    set = { effect, value -> effect.fresnelExponent = value },
+    get = { it.fresnelExponent },
+    style = { GlassStyle(lighting = GlassLighting(fresnelExponent = it)) },
+    firstEquivalentInput = -1f,
+    secondEquivalentInput = -2f,
+  ),
+)

--- a/haze-screenshot-tests/build.gradle.kts
+++ b/haze-screenshot-tests/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
         implementation(libs.compose.ui.test)
         implementation(libs.compose.navigation3.ui)
 
+        implementation(projects.hazeUtils)
         implementation(projects.internal.contextTest)
         implementation(projects.internal.screenshotTest)
       }

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2025, Christopher Banes and the Haze project contributors
 // SPDX-License-Identifier: Apache-2.0
 
-@file:OptIn(ExperimentalHazeApi::class)
+@file:OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
 
 package dev.chrisbanes.haze
 
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,6 +22,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
@@ -202,6 +205,65 @@ class GlassScreenshotTest : ScreenshotTest() {
     }
 
     captureRoot()
+  }
+
+  @Test
+  fun creditCard_blurRadiusCapIsStableAcrossDensities() = runScreenshotTest {
+    // Android <33 uses the fallback delegate, which intentionally has no semantic blur.
+    if (!isRuntimeShaderRenderEffectSupported()) return@runScreenshotTest
+
+    val shape = RoundedCornerShape(0.dp)
+    val visualEffect = GlassVisualEffect().apply {
+      tint = Color.White.copy(alpha = 0.08f)
+      optics = GlassOptics.Absolute(
+        refractionStrength = 0f,
+        depth = 1f,
+        blurRadius = 0.dp,
+      )
+      specularIntensity = 0f
+      ambientResponse = 0f
+      edgeSoftness = 0.dp
+      this.shape = shape
+    }
+    var density by mutableStateOf(Density(1f))
+
+    setContent {
+      CompositionLocalProvider(LocalDensity provides density) {
+        ScreenshotTheme {
+          GlassBlurRadiusSample(
+            visualEffect = visualEffect,
+            shape = shape,
+            cardWidth = (520f / density.density).dp,
+            cardHeight = (320f / density.density).dp,
+            patternScale = 1f / density.density,
+          )
+        }
+      }
+    }
+
+    val zeroBlurPixels = captureRootPixels().snapshot()
+
+    visualEffect.optics = GlassOptics.Absolute(
+      refractionStrength = 0f,
+      depth = 1f,
+      blurRadius = 100.dp,
+    )
+    waitForIdle()
+    val densityOnePixels = captureRootPixels().snapshot()
+
+    assertTrue(
+      zeroBlurPixels.changedPixelRatio(densityOnePixels) > 0.01f,
+      "Expected capped blur to materially change the rendered pixels",
+    )
+
+    density = Density(3f)
+    waitForIdle()
+    val densityThreePixels = captureRootPixels().snapshot()
+
+    assertTrue(
+      densityOnePixels.changedPixelRatio(densityThreePixels) <= 0.001f,
+      "Expected above-cap blur to stay visually stable across densities",
+    )
   }
 
   @Test
@@ -429,6 +491,7 @@ internal fun GlassBlurRadiusSample(
   clipShape: Boolean = true,
   cardWidth: Dp = 520.dp,
   cardHeight: Dp = 320.dp,
+  patternScale: Float = 1f,
 ) {
   val hazeState = remember { HazeState() }
 
@@ -440,7 +503,7 @@ internal fun GlassBlurRadiusSample(
     ) {
       drawRect(Color(0xFF101820))
 
-      val stripeWidth = 18.dp.toPx()
+      val stripeWidth = 18.dp.toPx() * patternScale
       var x = 0f
       var stripeIndex = 0
       while (x < size.width) {
@@ -453,8 +516,8 @@ internal fun GlassBlurRadiusSample(
         stripeIndex++
       }
 
-      val lineSpacing = 34.dp.toPx()
-      val strokeWidth = 5.dp.toPx()
+      val lineSpacing = 34.dp.toPx() * patternScale
+      val strokeWidth = 5.dp.toPx() * patternScale
       var y = 0f
       while (y < size.height) {
         drawLine(


### PR DESCRIPTION
## Summary

- preserve raw Glass override state when copying effects so inherited style and composition-local values remain live
- make unspecified scalar replay NaN-aware and canonicalize direct, style, and composition-local values consistently
- document and test the semantic blur renderer's 38.5 physical-pixel cap across densities
- add focused override, dirty-field, render-parameter, and screenshot regression coverage

## Root cause

Scalar getters resolve inherited values, but the copy constructor previously wrote those resolved values back as direct overrides. Scalar setters also used ordinary inequality for NaN sentinels, while inherited style paths bypassed the normalization applied by direct setters. Finally, the physical-pixel blur cap was part of renderer behavior without an explicit public contract.

## Impact

Copied effects continue following their inherited configuration unless explicitly overridden. Equivalent values now produce consistent rendering, bounds, and invalidation behavior regardless of configuration source. Absolute blur behavior is documented and regression-tested across display densities.

## Validation

- `./gradlew :haze-glass:jvmTest :haze-glass:testAndroidHostTest`
- `./gradlew :haze-glass:spotlessCheck :haze-screenshot-tests:spotlessCheck`
- focused JVM and Android-host cross-density screenshot regression
- `git diff --check origin/main...HEAD`

Closes #1048
