### PR TITLE
Include Glass group-alpha composition in the render budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bound and reuse Glass group-alpha composition surfaces, including allocation-free zero-alpha drawing and predictable fallback for oversized output in #1062.
 - Reuse retained Glass stages, prepared render data, and runtime shaders during animation in #1045.
 - **Fix cross-window recomposition livelock** in #974. When a `HazeState` is shared between effects in different windows (e.g. a host composable and a `Dialog`), the previously-shared `HazeState.resolvedStrategy` oscillated between `Local` and `Screen`, causing an infinite recomposition loop. The resolved position strategy is now per-effect (`HazeEffectNode.resolvedPositionStrategy`), so effects in different windows no longer stomp on each other.
 - Fix sticky header haze scroll sync in #994. `HazeSourceNode` now refreshes local coordinates from every `onPlaced`, and observed area-position reads dirty `HazeEffectNode` area offsets so sticky headers blur the currently visible content while scrolling.

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/Canvas.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/Canvas.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.IntSize
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.VisualEffectContext
-import dev.chrisbanes.haze.withGraphicsLayer
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -159,22 +158,6 @@ internal fun DrawScope.drawScaledContent(
         block()
       }
     }
-  }
-}
-
-internal inline fun DrawScope.withAlpha(
-  alpha: Float,
-  context: VisualEffectContext,
-  crossinline block: DrawScope.() -> Unit,
-) {
-  if (alpha < 1f) {
-    context.withGraphicsLayer { layer ->
-      layer.alpha = alpha
-      layer.record { block() }
-      drawLayer(layer)
-    }
-  } else {
-    block()
   }
 }
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/Canvas.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/Canvas.kt
@@ -178,6 +178,17 @@ internal inline fun DrawScope.withAlpha(
   }
 }
 
+internal inline fun DrawScope.recordAndDrawGlassGroupAlpha(
+  layer: GraphicsLayer,
+  alpha: Float,
+  size: IntSize,
+  crossinline block: DrawScope.() -> Unit,
+) {
+  layer.alpha = alpha
+  layer.record(size = size) { block() }
+  drawLayer(layer)
+}
+
 internal inline fun DrawScope.translate(
   offset: Offset,
   block: DrawScope.() -> Unit,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
@@ -7,13 +7,16 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.roundToIntSize
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.VisualEffectContext
 import kotlin.math.max
 
@@ -25,6 +28,24 @@ internal class FallbackGlassDelegate(
   private var cachedShapePath: Path? = null
   private var cachedSize: Size = Size.Zero
   private var cachedRadii: CornerRadii = CornerRadii.zero
+  private val groupAlpha = RetainedGlassGroupAlphaLayer()
+  private var graphicsContext: GraphicsContext? = null
+
+  override fun DrawScope.prepareDraw(context: VisualEffectContext) {
+    val density = context.requireDensity()
+    val layoutDirection = context.currentValueOf(LocalLayoutDirection)
+    val style = resolveGlassStyle(effect, size, density, layoutDirection)
+    val groupSize = size.roundToIntSize()
+    val groupPlan = GlassRetainedLayerPlan(
+      layers = listOf(GlassRetainedLayer(GlassRetainedLayerKind.GroupComposite, groupSize)),
+    )
+    val currentGraphicsContext = context.requireGraphicsContext()
+    graphicsContext = currentGraphicsContext
+    groupAlpha.prepare(
+      required = requiresGlassGroupAlpha(style.alpha) && groupPlan.fitsGlassRenderBudget(),
+      graphicsContext = currentGraphicsContext,
+    )
+  }
 
   override fun DrawScope.draw(context: VisualEffectContext) {
     val density = context.requireDensity()
@@ -52,19 +73,22 @@ internal class FallbackGlassDelegate(
     }
     val shapePath = cachedShapePath
 
-    withAlpha(alpha = style.alpha, context = context) {
+    fun DrawScope.drawFallback(alphaMultiplier: Float) {
       if (shapePath != null) {
         clipPath(shapePath) {
-          drawRect(color = tint)
+          drawRect(color = tint.copy(alpha = tint.alpha * alphaMultiplier))
         }
       } else {
-        drawRect(color = tint)
+        drawRect(color = tint.copy(alpha = tint.alpha * alphaMultiplier))
       }
 
       // Specular-ish radial highlight
       if (highlightAlpha > 0f) {
         val highlightBrush = Brush.radialGradient(
-          colors = listOf(Color.White.copy(alpha = highlightAlpha), Color.Transparent),
+          colors = listOf(
+            Color.White.copy(alpha = highlightAlpha * alphaMultiplier),
+            Color.Transparent,
+          ),
           center = highlightCenter,
           radius = highlightRadius,
         )
@@ -87,7 +111,7 @@ internal class FallbackGlassDelegate(
         val stroke = Stroke(width = softness * 2f)
         val edgeBrush = Brush.linearGradient(
           colors = listOf(
-            Color.White.copy(alpha = edgeAlpha),
+            Color.White.copy(alpha = edgeAlpha * alphaMultiplier),
             Color.Transparent,
           ),
           start = Offset.Zero,
@@ -109,7 +133,32 @@ internal class FallbackGlassDelegate(
           size = size,
         ),
         shapePath = shapePath,
+        alphaMultiplier = alphaMultiplier,
       )
+    }
+
+    when {
+      style.alpha <= 0f -> return
+      style.alpha >= 1f -> drawFallback(alphaMultiplier = 1f)
+      groupAlpha.isAvailable -> recordAndDrawGlassGroupAlpha(
+        layer = checkNotNull(groupAlpha.layer),
+        alpha = style.alpha,
+        size = size.roundToIntSize(),
+      ) { drawFallback(alphaMultiplier = 1f) }
+      else -> drawFallback(alphaMultiplier = style.alpha)
+    }
+  }
+
+  override fun detach() {
+    groupAlpha.release(graphicsContext)
+    graphicsContext = null
+  }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    if (level == TrimMemoryLevel.UI_HIDDEN || level.severity >= TrimMemoryLevel.MODERATE.severity) {
+      groupAlpha.release(graphicsContext ?: context.requireGraphicsContext())
+      graphicsContext = null
+      context.invalidateDraw()
     }
   }
 }
@@ -130,11 +179,12 @@ internal fun resolveFallbackGlassInteraction(
 private fun DrawScope.drawInteractionLighting(
   interaction: GlassInteractionUniforms,
   shapePath: Path?,
+  alphaMultiplier: Float,
 ) {
   if (!interaction.hasLighting) return
   val brush = Brush.radialGradient(
     colors = listOf(
-      Color.White.copy(alpha = 0.32f * interaction.lightingIntensity),
+      Color.White.copy(alpha = 0.32f * interaction.lightingIntensity * alphaMultiplier),
       Color.Transparent,
     ),
     center = interaction.position,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
@@ -36,13 +36,10 @@ internal class FallbackGlassDelegate(
     val layoutDirection = context.currentValueOf(LocalLayoutDirection)
     val style = resolveGlassStyle(effect, size, density, layoutDirection)
     val groupSize = size.roundToIntSize()
-    val groupPlan = GlassRetainedLayerPlan(
-      layers = listOf(GlassRetainedLayer(GlassRetainedLayerKind.GroupComposite, groupSize)),
-    )
     val currentGraphicsContext = context.requireGraphicsContext()
     graphicsContext = currentGraphicsContext
     groupAlpha.prepare(
-      required = requiresGlassGroupAlpha(style.alpha) && groupPlan.fitsGlassRenderBudget(),
+      required = requiresGlassGroupAlpha(style.alpha) && groupSize.fitsGlassLayerBudget(),
       graphicsContext = currentGraphicsContext,
     )
   }
@@ -53,6 +50,7 @@ internal class FallbackGlassDelegate(
     val style = resolveGlassStyle(effect, size, density, layoutDirection)
     val tint = style.tint
     if (!tint.isSpecified) return
+    if (style.alpha <= 0f) return
 
     val edgeSoftnessPx = style.edgeSoftnessPx
     val edgeAlpha = fallbackEdgeAlpha(style.ambientResponse)
@@ -138,7 +136,6 @@ internal class FallbackGlassDelegate(
     }
 
     when {
-      style.alpha <= 0f -> return
       style.alpha >= 1f -> drawFallback(alphaMultiplier = 1f)
       groupAlpha.isAvailable -> recordAndDrawGlassGroupAlpha(
         layer = checkNotNull(groupAlpha.layer),
@@ -155,7 +152,7 @@ internal class FallbackGlassDelegate(
   }
 
   override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
-    if (level == TrimMemoryLevel.UI_HIDDEN || level.severity >= TrimMemoryLevel.MODERATE.severity) {
+    if (shouldReleaseRetainedGlass(level)) {
       groupAlpha.release(graphicsContext ?: context.requireGraphicsContext())
       graphicsContext = null
       context.invalidateDraw()

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassGroupAlphaLayer.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassGroupAlphaLayer.kt
@@ -1,0 +1,29 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass
+
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+
+internal class RetainedGlassGroupAlphaLayer {
+  var layer: GraphicsLayer? = null
+    private set
+
+  val isAvailable: Boolean get() = layer?.isReleased == false
+
+  fun prepare(required: Boolean, graphicsContext: GraphicsContext) {
+    if (required) {
+      layer = ensureLayer(layer, graphicsContext)
+    } else {
+      release(graphicsContext)
+    }
+  }
+
+  fun release(graphicsContext: GraphicsContext?) {
+    releaseLayer(layer, graphicsContext)
+    layer = null
+  }
+}
+
+internal fun requiresGlassGroupAlpha(alpha: Float): Boolean = alpha > 0f && alpha < 1f

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassLayers.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassLayers.kt
@@ -6,6 +6,11 @@ package dev.chrisbanes.haze.glass
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.unit.IntSize
+import dev.chrisbanes.haze.TrimMemoryLevel
+
+internal fun shouldReleaseRetainedGlass(level: TrimMemoryLevel): Boolean =
+  level == TrimMemoryLevel.UI_HIDDEN ||
+    level.severity >= TrimMemoryLevel.MODERATE.severity
 
 internal class GlassLayers {
   val groupAlpha = RetainedGlassGroupAlphaLayer()

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassLayers.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassLayers.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.unit.IntSize
 
 internal class GlassLayers {
+  val groupAlpha = RetainedGlassGroupAlphaLayer()
   var source: GraphicsLayer? = null
   var blurPrefiltered: GraphicsLayer? = null
   var blurHorizontal: GraphicsLayer? = null
@@ -36,7 +37,7 @@ internal class GlassLayers {
   val hasRim: Boolean get() = rim?.isReleased == false
 
   val isEmpty: Boolean
-    get() = source == null && blurPrefiltered == null && blurHorizontal == null && blurred == null &&
+    get() = groupAlpha.layer == null && source == null && blurPrefiltered == null && blurHorizontal == null && blurred == null &&
       depthMixed == null && optical == null && refractionDetail == null &&
       interactionOptical == null && interactionRefractionDetail == null &&
       interactionLighting == null && rim == null
@@ -135,6 +136,7 @@ internal class GlassLayers {
   }
 
   fun release(graphicsContext: GraphicsContext?) {
+    groupAlpha.release(graphicsContext)
     listOfNotNull(
       source,
       blurPrefiltered,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
@@ -30,6 +30,11 @@ internal data class GlassRetainedLayer(
   val size: IntSize,
 )
 
+internal fun IntSize.fitsGlassLayerBudget(): Boolean =
+  width in 1..MAX_GLASS_LAYER_DIMENSION_PX &&
+    height in 1..MAX_GLASS_LAYER_DIMENSION_PX &&
+    width.toLong() * height.toLong() <= MAX_GLASS_RETAINED_PIXELS
+
 internal data class GlassRetainedLayerPlan(
   val layers: List<GlassRetainedLayer>,
 ) {
@@ -48,10 +53,7 @@ internal data class GlassRetainedLayerPlan(
 
   fun fitsGlassRenderBudget(): Boolean =
     layers.isNotEmpty() &&
-      layers.all {
-        it.size.width <= MAX_GLASS_LAYER_DIMENSION_PX &&
-          it.size.height <= MAX_GLASS_LAYER_DIMENSION_PX
-      } &&
+      layers.all { it.size.fitsGlassLayerBudget() } &&
       (retainedPixelCountOrNull()?.let { it <= MAX_GLASS_RETAINED_PIXELS } == true)
 }
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
@@ -22,6 +22,7 @@ internal enum class GlassRetainedLayerKind {
   InteractionOptical,
   InteractionDetail,
   InteractionLighting,
+  GroupComposite,
 }
 
 internal data class GlassRetainedLayer(

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -794,6 +794,7 @@ internal data class GlassPreparedRender(
   val interactionUniforms: GlassInteractionUniforms,
   val plan: GlassRetainedLayerPlan,
   val alpha: Float,
+  val groupCompositeSize: IntSize?,
   val blurKey: GlassBlurEffectKey?,
   val opticalKey: GlassOpticalEffectKey,
   val refractionDetailKey: GlassRefractionDetailEffectKey?,
@@ -804,8 +805,10 @@ internal fun buildGlassPreparedRender(
   params: GlassRenderParams,
   interactionUniforms: GlassInteractionUniforms,
   alpha: Float,
+  outputSize: IntSize,
   previous: GlassPreparedRender? = null,
 ): GlassPreparedRender {
+  val groupCompositeSize = outputSize.takeIf { requiresGlassGroupAlpha(alpha) }
   val blurKey = if (params.depth > 0f && params.blurRadiusPx > 0f) {
     if (previous != null && previous.params.hasSameBlurEffectInputs(params)) {
       previous.blurKey ?: params.blurEffectKey()
@@ -839,7 +842,7 @@ internal fun buildGlassPreparedRender(
       blurKey = blurKey,
       refractionDetailKey = refractionDetailKey,
       rimKey = rimKey,
-      alpha = alpha,
+      groupCompositeSize = groupCompositeSize,
     )
   ) {
     previous.plan
@@ -853,8 +856,7 @@ internal fun buildGlassPreparedRender(
       rimActive = rimKey != null,
       interactionOpticsActive = interactionUniforms.hasOptics,
       interactionLightingActive = interactionUniforms.hasLighting,
-      groupCompositeSize = params.coordinates.materialSize.roundToIntSize()
-        .takeIf { requiresGlassGroupAlpha(alpha) },
+      groupCompositeSize = groupCompositeSize,
     )
   }
   return GlassPreparedRender(
@@ -862,6 +864,7 @@ internal fun buildGlassPreparedRender(
     interactionUniforms = interactionUniforms,
     plan = plan,
     alpha = alpha,
+    groupCompositeSize = groupCompositeSize,
     blurKey = blurKey,
     opticalKey = opticalKey,
     refractionDetailKey = refractionDetailKey,
@@ -923,7 +926,7 @@ private fun GlassPreparedRender.hasSameRetainedLayerPlanInputs(
   blurKey: GlassBlurEffectKey?,
   refractionDetailKey: GlassRefractionDetailEffectKey?,
   rimKey: GlassRimEffectKey?,
-  alpha: Float,
+  groupCompositeSize: IntSize?,
 ): Boolean =
   this.params.coordinates.sampleSize == params.coordinates.sampleSize &&
     this.blurKey?.plan?.workingSize == blurKey?.plan?.workingSize &&
@@ -934,5 +937,4 @@ private fun GlassPreparedRender.hasSameRetainedLayerPlanInputs(
     (this.rimKey != null) == (rimKey != null) &&
     this.interactionUniforms.hasOptics == interactionUniforms.hasOptics &&
     this.interactionUniforms.hasLighting == interactionUniforms.hasLighting &&
-    requiresGlassGroupAlpha(this.alpha) == requiresGlassGroupAlpha(alpha) &&
-    this.params.coordinates.materialSize == params.coordinates.materialSize
+    this.groupCompositeSize == groupCompositeSize

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -657,7 +657,6 @@ internal fun buildGlassRenderParams(
 internal fun buildGlassRetainedLayerPlan(
   params: GlassRenderParams,
   interaction: GlassInteractionUniforms,
-  groupCompositeSize: IntSize? = null,
 ): GlassRetainedLayerPlan {
   val sampleSize = params.coordinates.sampleSize.roundToIntSize()
   val blurActive = params.depth > 0f && params.blurRadiusPx > 0f
@@ -671,7 +670,7 @@ internal fun buildGlassRetainedLayerPlan(
     rimActive = params.specularIntensity > 0f,
     interactionOpticsActive = interaction.hasOptics,
     interactionLightingActive = interaction.hasLighting,
-    groupCompositeSize = groupCompositeSize,
+    groupCompositeSize = null,
   )
 }
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -657,7 +657,7 @@ internal fun buildGlassRenderParams(
 internal fun buildGlassRetainedLayerPlan(
   params: GlassRenderParams,
   interaction: GlassInteractionUniforms,
-  alpha: Float = 1f,
+  groupCompositeSize: IntSize? = null,
 ): GlassRetainedLayerPlan {
   val sampleSize = params.coordinates.sampleSize.roundToIntSize()
   val blurActive = params.depth > 0f && params.blurRadiusPx > 0f
@@ -671,8 +671,7 @@ internal fun buildGlassRetainedLayerPlan(
     rimActive = params.specularIntensity > 0f,
     interactionOpticsActive = interaction.hasOptics,
     interactionLightingActive = interaction.hasLighting,
-    groupCompositeSize = params.coordinates.materialSize.roundToIntSize()
-      .takeIf { requiresGlassGroupAlpha(alpha) },
+    groupCompositeSize = groupCompositeSize,
   )
 }
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -657,6 +657,7 @@ internal fun buildGlassRenderParams(
 internal fun buildGlassRetainedLayerPlan(
   params: GlassRenderParams,
   interaction: GlassInteractionUniforms,
+  alpha: Float = 1f,
 ): GlassRetainedLayerPlan {
   val sampleSize = params.coordinates.sampleSize.roundToIntSize()
   val blurActive = params.depth > 0f && params.blurRadiusPx > 0f
@@ -670,11 +671,14 @@ internal fun buildGlassRetainedLayerPlan(
     rimActive = params.specularIntensity > 0f,
     interactionOpticsActive = interaction.hasOptics,
     interactionLightingActive = interaction.hasLighting,
+    groupCompositeSize = params.coordinates.materialSize.roundToIntSize()
+      .takeIf { requiresGlassGroupAlpha(alpha) },
   )
 }
 
 internal fun buildGlassBudgetLayerPlan(
   sampleSize: IntSize,
+  groupCompositeSize: IntSize? = null,
   blurRadiusPx: Float,
   depth: Float,
   allowMultiscaleBlur: Boolean,
@@ -709,6 +713,7 @@ internal fun buildGlassBudgetLayerPlan(
     rimActive = rimActive,
     interactionOpticsActive = interactionOpticsActive,
     interactionLightingActive = interactionLightingActive,
+    groupCompositeSize = groupCompositeSize,
   )
 }
 
@@ -721,6 +726,7 @@ private fun buildGlassRetainedLayerPlan(
   rimActive: Boolean,
   interactionOpticsActive: Boolean,
   interactionLightingActive: Boolean,
+  groupCompositeSize: IntSize?,
 ): GlassRetainedLayerPlan = GlassRetainedLayerPlan(
   buildList {
     add(GlassRetainedLayer(GlassRetainedLayerKind.Source, sampleSize))
@@ -747,6 +753,9 @@ private fun buildGlassRetainedLayerPlan(
     }
     if (interactionLightingActive) {
       add(GlassRetainedLayer(GlassRetainedLayerKind.InteractionLighting, sampleSize))
+    }
+    if (groupCompositeSize != null) {
+      add(GlassRetainedLayer(GlassRetainedLayerKind.GroupComposite, groupCompositeSize))
     }
   },
 )
@@ -830,6 +839,7 @@ internal fun buildGlassPreparedRender(
       blurKey = blurKey,
       refractionDetailKey = refractionDetailKey,
       rimKey = rimKey,
+      alpha = alpha,
     )
   ) {
     previous.plan
@@ -843,6 +853,8 @@ internal fun buildGlassPreparedRender(
       rimActive = rimKey != null,
       interactionOpticsActive = interactionUniforms.hasOptics,
       interactionLightingActive = interactionUniforms.hasLighting,
+      groupCompositeSize = params.coordinates.materialSize.roundToIntSize()
+        .takeIf { requiresGlassGroupAlpha(alpha) },
     )
   }
   return GlassPreparedRender(
@@ -911,6 +923,7 @@ private fun GlassPreparedRender.hasSameRetainedLayerPlanInputs(
   blurKey: GlassBlurEffectKey?,
   refractionDetailKey: GlassRefractionDetailEffectKey?,
   rimKey: GlassRimEffectKey?,
+  alpha: Float,
 ): Boolean =
   this.params.coordinates.sampleSize == params.coordinates.sampleSize &&
     this.blurKey?.plan?.workingSize == blurKey?.plan?.workingSize &&
@@ -920,4 +933,6 @@ private fun GlassPreparedRender.hasSameRetainedLayerPlanInputs(
     (this.refractionDetailKey != null) == (refractionDetailKey != null) &&
     (this.rimKey != null) == (rimKey != null) &&
     this.interactionUniforms.hasOptics == interactionUniforms.hasOptics &&
-    this.interactionUniforms.hasLighting == interactionUniforms.hasLighting
+    this.interactionUniforms.hasLighting == interactionUniforms.hasLighting &&
+    requiresGlassGroupAlpha(this.alpha) == requiresGlassGroupAlpha(alpha) &&
+    this.params.coordinates.materialSize == params.coordinates.materialSize

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -652,6 +652,9 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       requestedScale = requestedScale,
       layerWidth = context.layerSize.width,
       layerHeight = context.layerSize.height,
+      materialWidth = context.size.width,
+      materialHeight = context.size.height,
+      requiresGroupAlpha = requiresGlassGroupAlpha(style.alpha),
       blurRadiusPx = optics.blurRadiusPx,
       depth = optics.depth,
       allowMultiscaleBlur = optics.progressive == null,
@@ -682,6 +685,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
         }
         buildGlassBudgetLayerPlan(
           sampleSize = coordinates.sampleSize.roundToIntSize(),
+          groupCompositeSize = context.size.roundToIntSize()
+            .takeIf { requiresGlassGroupAlpha(style.alpha) },
           blurRadiusPx = optics.blurRadiusPx * scaleFactor,
           depth = optics.depth,
           allowMultiscaleBlur = optics.progressive == null,
@@ -1440,6 +1445,9 @@ private data class GlassRenderBudgetStamp(
   val requestedScale: Float,
   val layerWidth: Float,
   val layerHeight: Float,
+  val materialWidth: Float,
+  val materialHeight: Float,
+  val requiresGroupAlpha: Boolean,
   val blurRadiusPx: Float,
   val depth: Float,
   val allowMultiscaleBlur: Boolean,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -751,6 +751,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       params = params,
       interactionUniforms = interactionUniforms,
       alpha = style.alpha,
+      outputSize = context.size.roundToIntSize(),
       previous = previousPrepared,
     )
     if (!exactPrepared.plan.fitsGlassRenderBudget()) {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -161,6 +161,10 @@ internal class RuntimeShaderGlassDelegate(
       lightingRequired = interactionLightingRequired,
       graphicsContext = currentGraphicsContext,
     )
+    layers.groupAlpha.prepare(
+      required = requiresGlassGroupAlpha(currentPreparedRender.alpha),
+      graphicsContext = currentGraphicsContext,
+    )
 
     layers.ensureSource(currentGraphicsContext)
     if (blurRequired) {
@@ -219,6 +223,10 @@ internal class RuntimeShaderGlassDelegate(
     val params = preparedParams ?: return
     val effects = preparedRenderEffects ?: return
     val interactionUniforms = preparedInteractionUniforms ?: return
+    if (render.alpha <= 0f) {
+      retainedOutputAvailable = false
+      return
+    }
     requireDrawableMaterialSize(params.coordinates.materialSize, ::clearRetainedOutput) ?: return
     var completed = false
     try {
@@ -323,11 +331,25 @@ internal class RuntimeShaderGlassDelegate(
           ::clearRetainedOutput,
         ) ?: return
       }
-      withAlpha(alpha = render.alpha, context = context) {
+      val drawCompletedOutput: DrawScope.() -> Unit = {
         drawCompletedLayer(completedOptical, context, params, alpha = 1f)
         if (completedRefractionDetail != null) {
           drawCompletedLayer(completedRefractionDetail, context, params, alpha = 1f)
         }
+      }
+      if (render.alpha >= 1f) {
+        drawCompletedOutput()
+      } else {
+        val groupAlpha = requireRetainedStage(
+          layers.groupAlpha.layer?.takeUnless { it.isReleased },
+          ::clearRetainedOutput,
+        ) ?: return
+        recordAndDrawGlassGroupAlpha(
+          layer = groupAlpha,
+          alpha = render.alpha,
+          size = params.coordinates.materialSize.roundToIntSize(),
+          block = drawCompletedOutput,
+        )
       }
       if (shouldRecordSource) {
         lastSuccessfulSourceSnapshot = sourceState.snapshot
@@ -365,6 +387,7 @@ internal class RuntimeShaderGlassDelegate(
     val interactionDetailRequired = interactionOpticsRequired && detailRequired
     val interactionLightingRequired = interactionUniforms?.hasLighting == true
     return retainedOutputAvailable && layers.hasOptical &&
+      (!requiresGlassGroupAlpha(preparedRender?.alpha ?: 1f) || layers.groupAlpha.isAvailable) &&
       (!detailRequired || layers.hasRefractionDetail) &&
       (!interactionOpticsRequired || layers.hasInteractionOptical) &&
       (!interactionDetailRequired || layers.hasInteractionRefractionDetail) &&

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -344,10 +344,14 @@ internal class RuntimeShaderGlassDelegate(
           layers.groupAlpha.layer?.takeUnless { it.isReleased },
           ::clearRetainedOutput,
         ) ?: return
+        val groupCompositeSize = requireRetainedStage(
+          render.groupCompositeSize,
+          ::clearRetainedOutput,
+        ) ?: return
         recordAndDrawGlassGroupAlpha(
           layer = groupAlpha,
           alpha = render.alpha,
-          size = params.coordinates.materialSize.roundToIntSize(),
+          size = groupCompositeSize,
           block = drawCompletedOutput,
         )
       }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -331,14 +331,8 @@ internal class RuntimeShaderGlassDelegate(
           ::clearRetainedOutput,
         ) ?: return
       }
-      val drawCompletedOutput: DrawScope.() -> Unit = {
-        drawCompletedLayer(completedOptical, context, params, alpha = 1f)
-        if (completedRefractionDetail != null) {
-          drawCompletedLayer(completedRefractionDetail, context, params, alpha = 1f)
-        }
-      }
       if (render.alpha >= 1f) {
-        drawCompletedOutput()
+        drawCompletedOutput(completedOptical, completedRefractionDetail, context, params)
       } else {
         val groupAlpha = requireRetainedStage(
           layers.groupAlpha.layer?.takeUnless { it.isReleased },
@@ -352,8 +346,7 @@ internal class RuntimeShaderGlassDelegate(
           layer = groupAlpha,
           alpha = render.alpha,
           size = groupCompositeSize,
-          block = drawCompletedOutput,
-        )
+        ) { drawCompletedOutput(completedOptical, completedRefractionDetail, context, params) }
       }
       if (shouldRecordSource) {
         lastSuccessfulSourceSnapshot = sourceState.snapshot
@@ -429,10 +422,6 @@ internal class RuntimeShaderGlassDelegate(
       context.invalidateDraw()
     }
   }
-
-  private fun shouldReleaseRetainedGlass(level: TrimMemoryLevel): Boolean =
-    level == TrimMemoryLevel.UI_HIDDEN ||
-      level.severity >= TrimMemoryLevel.MODERATE.severity
 
   private fun releaseRetainedResources(
     releaseContext: GraphicsContext? = graphicsContext,
@@ -786,6 +775,18 @@ internal class RuntimeShaderGlassDelegate(
       clip = effect.shouldClipToNodeBounds(),
     ) {
       drawLayer(layer)
+    }
+  }
+
+  private fun DrawScope.drawCompletedOutput(
+    optical: GraphicsLayer,
+    refractionDetail: GraphicsLayer?,
+    context: VisualEffectContext,
+    params: GlassRenderParams,
+  ) {
+    drawCompletedLayer(optical, context, params, alpha = 1f)
+    if (refractionDetail != null) {
+      drawCompletedLayer(refractionDetail, context, params, alpha = 1f)
     }
   }
 

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudgetTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudgetTest.kt
@@ -16,6 +16,25 @@ import kotlin.test.assertIs
 class GlassRenderBudgetTest {
 
   @Test
+  fun fractionalAlpha_addsMaterialSizedGroupCompositeToBudget() {
+    val plan = buildGlassBudgetLayerPlan(
+      sampleSize = IntSize(100, 100),
+      groupCompositeSize = IntSize(200, 300),
+      blurRadiusPx = 0f,
+      depth = 0f,
+      allowMultiscaleBlur = true,
+      refractionDetailActive = false,
+      rimActive = false,
+      interactionOpticsActive = false,
+      interactionLightingActive = false,
+    )
+
+    assertThat(plan.layers.last()).isEqualTo(
+      GlassRetainedLayer(GlassRetainedLayerKind.GroupComposite, IntSize(200, 300)),
+    )
+  }
+
+  @Test
   fun exactLimits_fitWithoutChangingRequestedScale() {
     val plan = GlassRetainedLayerPlan(
       listOf(GlassRetainedLayer(GlassRetainedLayerKind.Source, IntSize(4096, 4096))),

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntSize
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
@@ -158,6 +159,7 @@ class GlassRenderParamsTest {
         radiusFraction = 0f,
       ).uniforms(coordinates),
       alpha = style.alpha,
+      outputSize = coordinates.materialSize.roundToIntSize(),
     )
 
     assertThat(prepared.alpha).isEqualTo(GlassDefaults.alpha)

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
@@ -37,6 +38,20 @@ import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
 class GlassVisualEffectLifecycleTest {
+
+  @Test
+  fun prepareBudget_fractionalAlphaIncludesMaterialSizedGroupComposite() {
+    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+
+    val decision = effect.prepareRenderBudget(
+      context = TrackingVisualEffectContext(effectSize = Size(100f, 80f), layerSize = Size(120f, 100f)),
+      runtimeShaderSupported = false,
+    ) as GlassRenderBudgetDecision.Runtime
+
+    assertThat(decision.plan.layers.last()).isEqualTo(
+      GlassRetainedLayer(GlassRetainedLayerKind.GroupComposite, IntSize(100, 80)),
+    )
+  }
 
   @Test
   fun prepareBudget_safeGraphPreservesRequestedScale() {
@@ -201,7 +216,11 @@ class GlassVisualEffectLifecycleTest {
     assertSame(first.opticalKey, second.opticalKey)
     assertSame(first.refractionDetailKey, second.refractionDetailKey)
     assertSame(first.rimKey, second.rimKey)
-    assertSame(first.plan, second.plan)
+    assertThat(first.plan.layers.any { it.kind == GlassRetainedLayerKind.GroupComposite })
+      .isEqualTo(false)
+    assertThat(second.plan.layers.any { it.kind == GlassRetainedLayerKind.GroupComposite })
+      .isEqualTo(true)
+    assertNotSame(first.plan, second.plan)
   }
 
   @Test

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
@@ -1,0 +1,297 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import dev.chrisbanes.haze.HazeArea
+import dev.chrisbanes.haze.HazeInputScale
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.PlatformContext
+import dev.chrisbanes.haze.TrimMemoryLevel
+import dev.chrisbanes.haze.VisualEffect
+import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.hazeEffect
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import sun.misc.Unsafe
+
+@OptIn(ExperimentalTestApi::class)
+class FallbackGlassDelegateTest {
+
+  @Test
+  fun boundedFractionalAlpha_preparesAndReusesGroupLayer() {
+    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val delegate = FallbackGlassDelegate(effect)
+    val context = FallbackRecordingContext(size = Size(100f, 100f))
+
+    delegate.prepare(context)
+    val first = checkNotNull(delegate.groupAlphaForTest().layer)
+    delegate.prepare(context)
+
+    assertSame(first, delegate.groupAlphaForTest().layer)
+    assertThat(context.graphicsContext.createdLayers).isEqualTo(listOf(first))
+  }
+
+  @Test
+  fun alphaZero_releasesAndOwnsNoFallbackGroupLayer() {
+    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val delegate = FallbackGlassDelegate(effect)
+    val context = FallbackRecordingContext(size = Size(100f, 100f))
+    delegate.prepare(context)
+    val groupLayer = checkNotNull(delegate.groupAlphaForTest().layer)
+
+    effect.alpha = 0f
+    delegate.prepare(context)
+
+    assertThat(delegate.groupAlphaForTest().layer).isNull()
+    assertThat(groupLayer in context.graphicsContext.releasedLayers).isTrue()
+  }
+
+  @Test
+  fun fallbackGroup_exceedingDimension_usesDirectAlphaWithoutAllocation() {
+    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val delegate = FallbackGlassDelegate(effect)
+    val context = FallbackRecordingContext(size = Size(4097f, 1f))
+
+    delegate.prepare(context)
+
+    assertThat(delegate.groupAlphaForTest().isAvailable).isFalse()
+    assertThat(context.graphicsContext.createdLayers).isEqualTo(emptyList())
+  }
+
+  @Test
+  fun fallbackGroup_atExactPixelBoundary_isAllowed() {
+    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val delegate = FallbackGlassDelegate(effect)
+    val context = FallbackRecordingContext(size = Size(4096f, 4096f))
+
+    delegate.prepare(context)
+
+    assertThat(delegate.groupAlphaForTest().isAvailable).isTrue()
+  }
+
+  @Test
+  fun fallbackGroup_exceedingDimensionAndPixelLimit_usesDirectAlphaWithoutAllocation() {
+    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val delegate = FallbackGlassDelegate(effect)
+    val context = FallbackRecordingContext(size = Size(4096f, 4097f))
+
+    delegate.prepare(context)
+
+    assertThat(delegate.groupAlphaForTest().isAvailable).isFalse()
+    assertThat(context.graphicsContext.createdLayers).isEqualTo(emptyList())
+  }
+
+  @Test
+  fun directAlphaDegradation_scalesEveryFallbackContribution() = runComposeUiTest {
+    fun assertDirectAlphaHalvesContribution(
+      effect: GlassVisualEffect,
+      sample: Offset,
+      activateInteraction: Boolean = false,
+    ) {
+      val fallback = FallbackGlassDelegate(effect)
+      val visualEffect = FallbackOnlyVisualEffect(effect, fallback)
+      setContent { FallbackTestContent(visualEffect) }
+      waitForIdle()
+      if (activateInteraction) {
+        effect.setPressedForTest(sample)
+        waitForIdle()
+      }
+      val opaque = onNodeWithTag(FALLBACK_TAG).captureToImage().toPixelMap()[
+        sample.x.toInt(),
+        sample.y.toInt(),
+      ]
+
+      effect.alpha = 0.5f
+      visualEffect.disableGroupPreparation()
+      waitForIdle()
+      val direct = onNodeWithTag(FALLBACK_TAG).captureToImage().toPixelMap()[
+        sample.x.toInt(),
+        sample.y.toInt(),
+      ]
+
+      assertThat(fallback.groupAlphaForTest().isAvailable).isFalse()
+      assertTrue(opaque.alpha > 0.01f)
+      assertTrue(abs(direct.alpha - opaque.alpha / 2f) < 0.03f)
+    }
+
+    assertDirectAlphaHalvesContribution(
+      effect = GlassVisualEffect().apply {
+        tint = Color.Red
+        specularIntensity = 0f
+        edgeSoftness = 0.dp
+      },
+      sample = Offset(60f, 60f),
+    )
+    assertDirectAlphaHalvesContribution(
+      effect = GlassVisualEffect().apply {
+        tint = Color.Transparent
+        specularIntensity = 1f
+        edgeSoftness = 0.dp
+        lightPosition = Offset(60f, 60f)
+      },
+      sample = Offset(60f, 60f),
+    )
+    assertDirectAlphaHalvesContribution(
+      effect = GlassVisualEffect().apply {
+        tint = Color.Transparent
+        specularIntensity = 0f
+        ambientResponse = 1f
+        edgeSoftness = 8.dp
+      },
+      sample = Offset(2f, 60f),
+    )
+    assertDirectAlphaHalvesContribution(
+      effect = GlassVisualEffect().apply {
+        tint = Color.Transparent
+        specularIntensity = 0f
+        edgeSoftness = 0.dp
+        pressed { lightingIntensity(1f) }
+      },
+      sample = Offset(60f, 60f),
+      activateInteraction = true,
+    )
+  }
+
+  private fun FallbackGlassDelegate.prepare(context: FallbackRecordingContext) {
+    CanvasDrawScope().draw(
+      density = Density(1f),
+      layoutDirection = LayoutDirection.Ltr,
+      canvas = Canvas(ImageBitmap(1, 1)),
+      size = context.size,
+    ) {
+      with(this@prepare) { prepareDraw(context) }
+    }
+  }
+
+  private fun FallbackGlassDelegate.groupAlphaForTest(): RetainedGlassGroupAlphaLayer =
+    javaClass.getDeclaredField("groupAlpha").run {
+      isAccessible = true
+      get(this@groupAlphaForTest) as RetainedGlassGroupAlphaLayer
+    }
+
+  @Composable
+  private fun FallbackTestContent(fallbackVisualEffect: FallbackOnlyVisualEffect) {
+    Box(
+      Modifier
+        .size(120.dp)
+        .testTag(FALLBACK_TAG)
+        .hazeEffect { visualEffect = fallbackVisualEffect },
+    )
+  }
+}
+
+private const val FALLBACK_TAG = "fallback"
+
+private class FallbackOnlyVisualEffect(
+  private val glass: GlassVisualEffect,
+  private val fallback: FallbackGlassDelegate,
+) : VisualEffect {
+  private var prepareGroup = true
+
+  fun disableGroupPreparation() {
+    prepareGroup = false
+    fallback.onTrimMemory(checkNotNull(glass.attachedContextForTest), TrimMemoryLevel.UI_HIDDEN)
+  }
+
+  override fun androidx.compose.ui.graphics.drawscope.DrawScope.prepareDraw(context: VisualEffectContext) {
+    if (prepareGroup) with(fallback) { prepareDraw(context) }
+  }
+
+  override fun androidx.compose.ui.graphics.drawscope.DrawScope.draw(context: VisualEffectContext) {
+    with(fallback) { draw(context) }
+  }
+
+  override fun attach(context: VisualEffectContext) {
+    glass.attach(context)
+    fallback.attach()
+  }
+
+  override fun update(context: VisualEffectContext) {
+    glass.update(context)
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    fallback.detach()
+    glass.detach(context)
+  }
+}
+
+private class FallbackRecordingContext(
+  override val size: Size,
+) : VisualEffectContext {
+  override val layerSize: Size = size
+  val graphicsContext = FallbackTestGraphicsContext()
+  override val position: Offset = Offset.Zero
+  override val layerOffset: Offset = Offset.Zero
+  override val rootBounds: Rect = Rect.Zero
+  override val inputScale: HazeInputScale = HazeInputScale.None
+  override val windowId: Any? = null
+  override val areas: List<HazeArea> = emptyList()
+  override val state: HazeState? = null
+  override val coroutineScope: CoroutineScope = object : CoroutineScope {
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext
+  }
+
+  override fun positionOf(area: HazeArea): Offset = area.coordinates.localPosition
+  override fun boundsOf(area: HazeArea): Rect? = null
+  override fun requirePlatformContext(): PlatformContext = error("Unused in fallback tests")
+  override fun requireDensity(): Density = Density(1f)
+  override fun <T> currentValueOf(local: androidx.compose.runtime.CompositionLocal<T>): T {
+    @Suppress("UNCHECKED_CAST")
+    return LayoutDirection.Ltr as T
+  }
+  override fun requireGraphicsContext(): GraphicsContext = graphicsContext
+  override fun invalidateDraw() = Unit
+}
+
+private class FallbackTestGraphicsContext : GraphicsContext {
+  val createdLayers = mutableListOf<GraphicsLayer>()
+  val releasedLayers = mutableListOf<GraphicsLayer>()
+
+  override fun createGraphicsLayer(): GraphicsLayer =
+    (fallbackUnsafe.allocateInstance(GraphicsLayer::class.java) as GraphicsLayer).also {
+      createdLayers += it
+    }
+
+  override fun releaseGraphicsLayer(layer: GraphicsLayer) {
+    releasedLayers += layer
+  }
+}
+
+private val fallbackUnsafe: Unsafe = Unsafe::class.java.getDeclaredField("theUnsafe").run {
+  isAccessible = true
+  get(null) as Unsafe
+}

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntSize
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
@@ -430,6 +431,29 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   @Test
+  fun fractionalAlpha_inputScalingUsesOutputSizedGroupLayerAndPlan() = runComposeUiTest {
+    val effect = activeDetailEffect().apply { alpha = 0.5f }
+
+    setContent {
+      RuntimeGlassTestContent(
+        effect = effect,
+        tag = "glass",
+        inputScale = HazeInputScale.Fixed(0.5f),
+      )
+    }
+    waitForIdle()
+
+    val outputSize = checkNotNull(effect.attachedContextForTest).size.roundToIntSize()
+    val groupLayer = checkNotNull((effect.delegate as RuntimeShaderGlassDelegate).layers.groupAlpha.layer)
+    val groupPlan = checkNotNull(effect.preparedRender).plan.layers.single {
+      it.kind == GlassRetainedLayerKind.GroupComposite
+    }
+
+    assertThat(groupLayer.size).isEqualTo(outputSize)
+    assertThat(groupPlan.size).isEqualTo(outputSize)
+  }
+
+  @Test
   fun initialBlurWorkingSizeSetup_doesNotInvalidateDraw() = runComposeUiTest {
     val glassEffect = animatedStageEffect().apply { resetDirtyTracker() }
     val effect = InvalidationTrackingVisualEffect(glassEffect)
@@ -700,7 +724,11 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   @Composable
-  private fun RuntimeGlassTestContent(effect: GlassVisualEffect, tag: String) {
+  private fun RuntimeGlassTestContent(
+    effect: GlassVisualEffect,
+    tag: String,
+    inputScale: HazeInputScale = HazeInputScale.None,
+  ) {
     val hazeState = remember { HazeState() }
     Box(Modifier.size(120.dp)) {
       Box(Modifier.fillMaxSize().background(Color.Red).hazeSource(hazeState))
@@ -709,7 +737,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
           .fillMaxSize()
           .testTag(tag)
           .hazeEffect(hazeState) {
-            inputScale = HazeInputScale.None
+            this.inputScale = inputScale
             visualEffect = effect
           },
       )

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -54,6 +54,27 @@ import kotlin.test.assertSame
 class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
 
   @Test
+  fun alphaZero_clearsRetainedOutputUntilVisibleFrameRefreshesIt() = runComposeUiTest {
+    val effect = activeDetailEffect().apply { alpha = 0.5f }
+    setContent { RuntimeGlassTestContent(effect, tag = "glass") }
+    waitForIdle()
+
+    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val sourceRecordsBeforeZero = delegate.sourceRecordCount
+
+    effect.alpha = 0f
+    waitForIdle()
+
+    assertThat(delegate.canDrawRetainedOutput()).isFalse()
+
+    effect.alpha = 0.5f
+    waitForIdle()
+
+    assertThat(delegate.canDrawRetainedOutput()).isTrue()
+    assertThat(delegate.sourceRecordCount).isGreaterThan(sourceRecordsBeforeZero)
+  }
+
+  @Test
   fun nonFiniteCornerShape_runtimeUsesCanonicalSafeRadii() = runComposeUiTest {
     val effect = activeDetailEffect().apply {
       shape = invalidCornerShape(Float.NaN)

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
@@ -44,6 +44,51 @@ import sun.misc.Unsafe
 class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
+  fun fractionalAlpha_reusesGroupLayerAndZeroReleasesIt() {
+    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val delegate = RuntimeShaderGlassDelegate(effect)
+    val context = RecordingVisualEffectContext(
+      size = Size(100f, 100f),
+      layerSize = Size(100f, 100f),
+    )
+
+    delegate.prepareDrawForTest(context, effect)
+    val first = checkNotNull(delegate.layers.groupAlpha.layer)
+    delegate.prepareDrawForTest(context, effect)
+    assertSame(first, delegate.layers.groupAlpha.layer)
+
+    effect.alpha = 0f
+    delegate.prepareDrawForTest(context, effect)
+
+    assertThat(delegate.layers.groupAlpha.layer).isNull()
+    assertThat(first in context.graphicsContext.releasedLayers).isTrue()
+  }
+
+  @Test
+  fun retainedGroupAlphaLayer_fractionalFramesReuseAllocation() {
+    val owner = RetainedGlassGroupAlphaLayer()
+    val graphicsContext = TestGraphicsContext()
+
+    owner.prepare(required = true, graphicsContext)
+    val first = checkNotNull(owner.layer)
+    owner.prepare(required = true, graphicsContext)
+
+    assertSame(first, owner.layer)
+    assertThat(graphicsContext.events.filterIsInstance<LayerEvent.Create>().size).isEqualTo(1)
+  }
+
+  @Test
+  fun retainedGroupAlphaLayer_zeroOrOversizedPathOwnsNoAllocation() {
+    val owner = RetainedGlassGroupAlphaLayer()
+    val graphicsContext = TestGraphicsContext()
+
+    owner.prepare(required = false, graphicsContext)
+
+    assertThat(owner.layer).isNull()
+    assertThat(graphicsContext.events.filterIsInstance<LayerEvent.Create>()).isEqualTo(emptyList())
+  }
+
+  @Test
   fun prepareDraw_consumesTheSelectedPreparedRenderParamsInstance() {
     val effect = GlassVisualEffect().apply {
       optics = GlassOptics.Absolute(depth = 0f)
@@ -296,7 +341,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     delegate.seedRetainedOutputAvailable()
     val retainedLayers = delegate.layers.allLayers()
 
-    assertThat(retainedLayers.size).isEqualTo(11)
+    assertThat(retainedLayers.size).isEqualTo(12)
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
 
     delegate.onTrimMemory(context, TrimMemoryLevel.BACKGROUND)
@@ -324,7 +369,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     val retainedLayers = delegate.layers.allLayers()
     delegate.setGraphicsContextForTest(context.graphicsContext)
 
-    assertThat(retainedLayers.size).isEqualTo(11)
+    assertThat(retainedLayers.size).isEqualTo(12)
 
     delegate.onTrimMemory(context, TrimMemoryLevel.UI_HIDDEN)
 
@@ -352,7 +397,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     assertThat(delegate.layers.hasInteractionRefractionDetail).isTrue()
     assertThat(delegate.layers.hasInteractionLighting).isTrue()
     assertThat(delegate.layers.hasRim).isTrue()
-    assertThat(retainedLayers.size).isEqualTo(11)
+    assertThat(retainedLayers.size).isEqualTo(12)
 
     delegate.onTrimMemory(context, TrimMemoryLevel.MODERATE)
 
@@ -372,7 +417,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     delegate.seedRetainedOutputAvailable()
     val retainedLayers = delegate.layers.allLayers()
 
-    assertThat(retainedLayers.size).isEqualTo(11)
+    assertThat(retainedLayers.size).isEqualTo(12)
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
 
     delegate.onTrimMemory(context, TrimMemoryLevel.COMPLETE)
@@ -488,7 +533,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
       val delegate = RuntimeShaderGlassDelegate(effect)
       val retainedLayers = delegate.prepareDrawWithRetainedLayers(context, effect)
 
-      assertThat(retainedLayers.size).isEqualTo(11)
+      assertThat(retainedLayers.size).isEqualTo(12)
       assertThat(context.graphicsContext.releasedLayers)
         .containsExactly(*retainedLayers.toTypedArray())
       assertThat(delegate.layers.isEmpty).isTrue()
@@ -522,6 +567,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
 @OptIn(InternalComposeUiApi::class)
 private fun GlassLayers.populate(graphicsContext: GraphicsContext) {
+  groupAlpha.prepare(required = true, graphicsContext)
   source = graphicsContext.createGraphicsLayer()
   blurPrefiltered = graphicsContext.createGraphicsLayer()
   blurHorizontal = graphicsContext.createGraphicsLayer()
@@ -536,6 +582,7 @@ private fun GlassLayers.populate(graphicsContext: GraphicsContext) {
 }
 
 private fun GlassLayers.allLayers(): List<GraphicsLayer> = listOfNotNull(
+  groupAlpha.layer,
   source,
   blurPrefiltered,
   blurHorizontal,


### PR DESCRIPTION
## Summary

- include the final Glass group-alpha composition surface in the retained render budget
- retain and reuse a bounded group layer for fractional alpha, while releasing it for zero/opaque alpha and memory trimming
- avoid allocation at zero alpha and force the next visible frame to refresh retained output
- degrade oversized fallback composition predictably with direct alpha
- preserve output-space composition when `HazeInputScale` reduces shader working dimensions

## Root cause

Glass group-alpha composition previously allocated an output-sized temporary `GraphicsLayer` on every fractional-alpha draw, outside the retained-layer budget. Moving that composition to a retained layer also required keeping the final group in output space rather than the input-scaled shader working space.

## Validation

- `./gradlew --no-scan --rerun-tasks :haze-glass:spotlessCheck :haze-glass:jvmTest :haze-glass:testAndroidHostTest`
- focused red/green coverage for fractional alpha with `HazeInputScale.Fixed(0.5f)`
- branch review swarm and behavior-preserving simplification passes
- `git diff --check`

Fixes #1062