### PR TITLE
Preserve translucent Glass detail alpha

### DIFF
--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassLayers.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassLayers.kt
@@ -21,6 +21,8 @@ internal class GlassLayers {
   var depthMixed: GraphicsLayer? = null
   var optical: GraphicsLayer? = null
   var refractionDetail: GraphicsLayer? = null
+  var refractionDetailCoverage: GraphicsLayer? = null
+  var refractionComposite: GraphicsLayer? = null
   var interactionOptical: GraphicsLayer? = null
   var interactionRefractionDetail: GraphicsLayer? = null
   var interactionLighting: GraphicsLayer? = null
@@ -35,6 +37,8 @@ internal class GlassLayers {
   val hasDepthMixed: Boolean get() = depthMixed?.isReleased == false
   val hasOptical: Boolean get() = optical?.isReleased == false
   val hasRefractionDetail: Boolean get() = refractionDetail?.isReleased == false
+  val hasRefractionDetailCoverage: Boolean get() = refractionDetailCoverage?.isReleased == false
+  val hasRefractionComposite: Boolean get() = refractionComposite?.isReleased == false
   val hasInteractionOptical: Boolean get() = interactionOptical?.isReleased == false
   val hasInteractionRefractionDetail: Boolean
     get() = interactionRefractionDetail?.isReleased == false
@@ -44,6 +48,7 @@ internal class GlassLayers {
   val isEmpty: Boolean
     get() = groupAlpha.layer == null && source == null && blurPrefiltered == null && blurHorizontal == null && blurred == null &&
       depthMixed == null && optical == null && refractionDetail == null &&
+      refractionDetailCoverage == null && refractionComposite == null &&
       interactionOptical == null && interactionRefractionDetail == null &&
       interactionLighting == null && rim == null
 
@@ -79,6 +84,14 @@ internal class GlassLayers {
 
   fun ensureRefractionDetail(graphicsContext: GraphicsContext): GraphicsLayer =
     ensureLayer(refractionDetail, graphicsContext).also { refractionDetail = it }
+
+  fun ensureRefractionDetailCoverage(graphicsContext: GraphicsContext): GraphicsLayer =
+    ensureLayer(refractionDetailCoverage, graphicsContext).also {
+      refractionDetailCoverage = it
+    }
+
+  fun ensureRefractionComposite(graphicsContext: GraphicsContext): GraphicsLayer =
+    ensureLayer(refractionComposite, graphicsContext).also { refractionComposite = it }
 
   fun prepareRefractionDetail(
     required: Boolean,
@@ -138,6 +151,10 @@ internal class GlassLayers {
   fun releaseRefractionDetail(graphicsContext: GraphicsContext?) {
     releaseLayer(refractionDetail, graphicsContext)
     refractionDetail = null
+    releaseLayer(refractionDetailCoverage, graphicsContext)
+    refractionDetailCoverage = null
+    releaseLayer(refractionComposite, graphicsContext)
+    refractionComposite = null
   }
 
   fun release(graphicsContext: GraphicsContext?) {
@@ -150,6 +167,8 @@ internal class GlassLayers {
       depthMixed,
       optical,
       refractionDetail,
+      refractionDetailCoverage,
+      refractionComposite,
       interactionOptical,
       interactionRefractionDetail,
       interactionLighting,
@@ -164,6 +183,8 @@ internal class GlassLayers {
     depthMixed = null
     optical = null
     refractionDetail = null
+    refractionDetailCoverage = null
+    refractionComposite = null
     interactionOptical = null
     interactionRefractionDetail = null
     interactionLighting = null

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
@@ -18,6 +18,8 @@ internal enum class GlassRetainedLayerKind {
   DepthMixed,
   Optical,
   RefractionDetail,
+  RefractionDetailCoverage,
+  RefractionComposite,
   Rim,
   InteractionOptical,
   InteractionDetail,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -758,6 +758,8 @@ private fun buildGlassRetainedLayerPlan(
     add(GlassRetainedLayer(GlassRetainedLayerKind.Optical, sampleSize))
     if (refractionDetailActive) {
       add(GlassRetainedLayer(GlassRetainedLayerKind.RefractionDetail, sampleSize))
+      add(GlassRetainedLayer(GlassRetainedLayerKind.RefractionDetailCoverage, sampleSize))
+      add(GlassRetainedLayer(GlassRetainedLayerKind.RefractionComposite, sampleSize))
     }
     if (rimActive) add(GlassRetainedLayer(GlassRetainedLayerKind.Rim, sampleSize))
     if (interactionOpticsActive) {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassShaders.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassShaders.kt
@@ -277,7 +277,10 @@ internal object GlassShaders {
     }
   """
 
-  fun buildRefractionDetail(interactive: Boolean = false): String = """
+  fun buildRefractionDetail(
+    interactive: Boolean = false,
+    coverageOnly: Boolean = false,
+  ): String = """
     uniform shader content;
     uniform float2 sampleSize;
     uniform float2 materialOrigin;
@@ -351,6 +354,7 @@ internal object GlassShaders {
       float detailAlpha = sourceShapeMask * innerEnvelope * outerEnvelope * detailIntensity * detailVisibility;
       if (detailAlpha <= 0.0) return vec4(0.0);
 
+      ${if (coverageOnly) "return vec4(vec3(detailAlpha), detailAlpha);" else ""}
       vec4 sharpSample = content.eval(refractCoord);
       vec4 detailColor = sharpSample * detailAlpha;
       return detailColor.a > 0.0 ? detailColor : vec4(0.0);

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.layer.CompositingStrategy
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.unit.IntSize
@@ -51,6 +52,8 @@ internal class RuntimeShaderGlassDelegate(
   internal var refractionDetailShader: MutableRuntimeShaderRenderEffect? = null
     private set
   private var refractionDetailEffect: PlatformRenderEffect? = null
+  private var refractionDetailCoverageShader: MutableRuntimeShaderRenderEffect? = null
+  private var refractionDetailCoverageEffect: PlatformRenderEffect? = null
   private var rimKey: GlassRimEffectKey? = null
   internal var rimShader: MutableRuntimeShaderRenderEffect? = null
     private set
@@ -191,6 +194,8 @@ internal class RuntimeShaderGlassDelegate(
     layers.ensureOptical(currentGraphicsContext)
     if (refractionDetailRequired) {
       layers.ensureRefractionDetail(currentGraphicsContext)
+      layers.ensureRefractionDetailCoverage(currentGraphicsContext)
+      layers.ensureRefractionComposite(currentGraphicsContext)
     }
     if (rimRequired) {
       layers.ensureRim(currentGraphicsContext)
@@ -300,6 +305,35 @@ internal class RuntimeShaderGlassDelegate(
           ::clearRetainedOutput,
         ) ?: return
       }
+      val refractionDetailCoverage = effects.refractionDetail?.let {
+        requireRetainedStage(
+          if (invalidation.detail) {
+            recordRefractionDetailCoverage(source, params, it)
+          } else {
+            layers.refractionDetailCoverage?.takeUnless { layer -> layer.isReleased }
+          },
+          ::clearRetainedOutput,
+        ) ?: return
+      }
+      val completedOptical = if (
+        refractionDetail != null && refractionDetailCoverage != null
+      ) {
+        requireRetainedStage(
+          if (invalidation.optical || invalidation.detail) {
+            recordRefractionComposite(
+              optical = optical,
+              detail = refractionDetail,
+              coverage = refractionDetailCoverage,
+              params = params,
+            )
+          } else {
+            layers.refractionComposite?.takeUnless { layer -> layer.isReleased }
+          },
+          ::clearRetainedOutput,
+        ) ?: return
+      } else {
+        optical
+      }
       requireRetainedStage(
         if (invalidation.rim) recordRimIfNeeded(params, effects) else retainedRim(effects),
         ::clearRetainedOutput,
@@ -345,8 +379,7 @@ internal class RuntimeShaderGlassDelegate(
       }
       if (render.alpha >= 1f) {
         drawCompletedOutput(
-          optical = optical,
-          refractionDetail = refractionDetail,
+          optical = completedOptical,
           interactionOptical = interactionOptical,
           interactionRefractionDetail = interactionRefractionDetail,
           interactionPatch = interactionPatch,
@@ -368,8 +401,7 @@ internal class RuntimeShaderGlassDelegate(
           size = groupCompositeSize,
         ) {
           drawCompletedOutput(
-            optical = optical,
-            refractionDetail = refractionDetail,
+            optical = completedOptical,
             interactionOptical = interactionOptical,
             interactionRefractionDetail = interactionRefractionDetail,
             interactionPatch = interactionPatch,
@@ -424,7 +456,7 @@ internal class RuntimeShaderGlassDelegate(
     val interactionLightingRequired = interactionPatchAvailable && interactionUniforms?.hasLighting == true
     return retainedOutputAvailable && layers.hasOptical &&
       (!requiresGlassGroupAlpha(preparedRender?.alpha ?: 1f) || layers.groupAlpha.isAvailable) &&
-      (!detailRequired || layers.hasRefractionDetail) &&
+      (!detailRequired || layers.hasRefractionComposite) &&
       (!interactionOpticsRequired || layers.hasInteractionOptical) &&
       (!interactionDetailRequired || layers.hasInteractionRefractionDetail) &&
       (!interactionLightingRequired || layers.hasInteractionLighting)
@@ -480,6 +512,8 @@ internal class RuntimeShaderGlassDelegate(
     refractionDetailKey = null
     refractionDetailShader = null
     refractionDetailEffect = null
+    refractionDetailCoverageShader = null
+    refractionDetailCoverageEffect = null
     rimKey = null
     rimShader = null
     rimEffect = null
@@ -537,7 +571,9 @@ internal class RuntimeShaderGlassDelegate(
         (!blur.key.plan.requiresPrefilter || layers.hasBlurPrefiltered),
       depth = !shouldDepthMix(params, effects) || layers.hasDepthMixed,
       optical = layers.hasOptical,
-      detail = effects.refractionDetail == null || layers.hasRefractionDetail,
+      detail = effects.refractionDetail == null ||
+        layers.hasRefractionDetail && layers.hasRefractionDetailCoverage &&
+        layers.hasRefractionComposite,
       rim = effects.rim == null || layers.hasRim,
     )
   }
@@ -670,6 +706,45 @@ internal class RuntimeShaderGlassDelegate(
     }
     detailRecordCount++
   }
+
+  private fun DrawScope.recordRefractionDetailCoverage(
+    source: GraphicsLayer,
+    params: GlassRenderParams,
+    detail: GlassRefractionDetailRenderEffect,
+  ): GraphicsLayer? = layers.refractionDetailCoverage
+    ?.takeUnless { it.isReleased }
+    ?.also { layer ->
+      source.alpha = 1f
+      source.blendMode = BlendMode.SrcOver
+      layer.alpha = 1f
+      layer.blendMode = BlendMode.SrcOver
+      layer.renderEffect = detail.coverageEffect.asComposeRenderEffect()
+      layer.record(params.coordinates.sampleSize.roundToIntSize()) {
+        drawLayer(source)
+      }
+    }
+
+  private fun DrawScope.recordRefractionComposite(
+    optical: GraphicsLayer,
+    detail: GraphicsLayer,
+    coverage: GraphicsLayer,
+    params: GlassRenderParams,
+  ): GraphicsLayer? = layers.refractionComposite
+    ?.takeUnless { it.isReleased }
+    ?.also { layer ->
+      layer.alpha = 1f
+      layer.blendMode = BlendMode.SrcOver
+      layer.compositingStrategy = CompositingStrategy.Offscreen
+      layer.renderEffect = null
+      layer.record(params.coordinates.sampleSize.roundToIntSize()) {
+        optical.blendMode = BlendMode.SrcOver
+        drawLayer(optical)
+        coverage.blendMode = BlendMode.DstOut
+        drawLayer(coverage)
+        detail.blendMode = BlendMode.Plus
+        drawLayer(detail)
+      }
+    }
 
   private fun DrawScope.recordRimIfNeeded(
     params: GlassRenderParams,
@@ -832,7 +907,6 @@ internal class RuntimeShaderGlassDelegate(
 
   private fun DrawScope.drawCompletedOutput(
     optical: GraphicsLayer,
-    refractionDetail: GraphicsLayer?,
     interactionOptical: GraphicsLayer?,
     interactionRefractionDetail: GraphicsLayer?,
     interactionPatch: GlassInteractionPatch?,
@@ -840,9 +914,6 @@ internal class RuntimeShaderGlassDelegate(
     params: GlassRenderParams,
   ) {
     drawCompletedLayer(optical, context, params, alpha = 1f)
-    if (refractionDetail != null) {
-      drawCompletedLayer(refractionDetail, context, params, alpha = 1f)
-    }
     if (interactionOptical != null && interactionPatch != null) {
       drawCompletedPatch(
         layer = interactionOptical,
@@ -925,12 +996,20 @@ internal class RuntimeShaderGlassDelegate(
     val nextRefractionDetailKey = render.refractionDetailKey
     if (
       nextRefractionDetailKey != refractionDetailKey ||
-      nextRefractionDetailKey != null && refractionDetailEffect == null
+      nextRefractionDetailKey != null &&
+      (refractionDetailEffect == null || refractionDetailCoverageEffect == null)
     ) {
       refractionDetailEffect = nextRefractionDetailKey?.let { key ->
         val shader = refractionDetailShader ?: createRefractionDetailRenderEffect().also {
           refractionDetailShader = it
         }
+        shader.updateUniforms { setRefractionDetailUniforms(key) }
+      }
+      refractionDetailCoverageEffect = nextRefractionDetailKey?.let { key ->
+        val shader = refractionDetailCoverageShader
+          ?: createSharedRefractionDetailCoverageRenderEffect().also {
+            refractionDetailCoverageShader = it
+          }
         shader.updateUniforms { setRefractionDetailUniforms(key) }
       }
       refractionDetailKey = nextRefractionDetailKey
@@ -947,7 +1026,11 @@ internal class RuntimeShaderGlassDelegate(
       blur = blurEffects,
       optical = checkNotNull(opticalEffect),
       refractionDetail = nextRefractionDetailKey?.let { key ->
-        GlassRefractionDetailRenderEffect(key, checkNotNull(refractionDetailEffect))
+        GlassRefractionDetailRenderEffect(
+          key = key,
+          effect = checkNotNull(refractionDetailEffect),
+          coverageEffect = checkNotNull(refractionDetailCoverageEffect),
+        )
       },
       rim = rimEffect,
     )
@@ -1039,6 +1122,7 @@ internal data class GlassRenderEffects(
 internal data class GlassRefractionDetailRenderEffect(
   val key: GlassRefractionDetailEffectKey,
   val effect: PlatformRenderEffect,
+  val coverageEffect: PlatformRenderEffect,
 )
 
 @OptIn(InternalHazeApi::class)
@@ -1100,6 +1184,13 @@ internal fun createSharedRefractionDetailRenderEffect(): MutableRuntimeShaderRen
     inputs = arrayOf(null),
   )
 
+internal fun createSharedRefractionDetailCoverageRenderEffect(): MutableRuntimeShaderRenderEffect =
+  createMutableRuntimeShaderRenderEffect(
+    effect = GLASS_REFRACTION_DETAIL_COVERAGE_EFFECT,
+    shaderNames = arrayOf("content"),
+    inputs = arrayOf(null),
+  )
+
 internal fun createSharedGlassRimRenderEffect(): MutableRuntimeShaderRenderEffect =
   createMutableRuntimeShaderRenderEffect(
     effect = GLASS_RIM_EFFECT,
@@ -1153,6 +1244,9 @@ private val GLASS_INTERACTION_OPTICAL_EFFECT by lazy(LazyThreadSafetyMode.NONE) 
 }
 private val GLASS_REFRACTION_DETAIL_EFFECT by lazy(LazyThreadSafetyMode.NONE) {
   createRuntimeEffect(GlassShaders.buildRefractionDetail())
+}
+private val GLASS_REFRACTION_DETAIL_COVERAGE_EFFECT by lazy(LazyThreadSafetyMode.NONE) {
+  createRuntimeEffect(GlassShaders.buildRefractionDetail(coverageOnly = true))
 }
 private val GLASS_INTERACTION_REFRACTION_DETAIL_EFFECT by lazy(LazyThreadSafetyMode.NONE) {
   createRuntimeEffect(GlassShaders.buildRefractionDetail(interactive = true))

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -367,6 +367,8 @@ class GlassRenderParamsTest {
       GlassRetainedLayerKind.Source,
       GlassRetainedLayerKind.Optical,
       GlassRetainedLayerKind.RefractionDetail,
+      GlassRetainedLayerKind.RefractionDetailCoverage,
+      GlassRetainedLayerKind.RefractionComposite,
       GlassRetainedLayerKind.Rim,
       GlassRetainedLayerKind.InteractionOptical,
       GlassRetainedLayerKind.InteractionDetail,

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
@@ -319,16 +319,20 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
   }
 
   @Test
-  fun releaseRefractionDetail_releasesOnlyDetailLayer() {
+  fun releaseRefractionDetail_releasesDetailCompositeGraph() {
     val layers = GlassLayers()
     val graphicsContext = TestGraphicsContext()
     layers.populate(graphicsContext)
     val detail = checkNotNull(layers.refractionDetail)
+    val coverage = checkNotNull(layers.refractionDetailCoverage)
+    val composite = checkNotNull(layers.refractionComposite)
 
     layers.releaseRefractionDetail(graphicsContext)
 
-    assertThat(graphicsContext.releasedLayers).containsExactly(detail)
+    assertThat(graphicsContext.releasedLayers).containsExactly(detail, coverage, composite)
     assertThat(layers.hasRefractionDetail).isFalse()
+    assertThat(layers.hasRefractionDetailCoverage).isFalse()
+    assertThat(layers.hasRefractionComposite).isFalse()
     assertThat(layers.hasOptical).isTrue()
   }
 
@@ -341,7 +345,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     delegate.seedRetainedOutputAvailable()
     val retainedLayers = delegate.layers.allLayers()
 
-    assertThat(retainedLayers.size).isEqualTo(12)
+    assertThat(retainedLayers.size).isEqualTo(14)
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
 
     delegate.onTrimMemory(context, TrimMemoryLevel.BACKGROUND)
@@ -353,6 +357,8 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     assertThat(delegate.layers.hasDepthMixed).isTrue()
     assertThat(delegate.layers.hasOptical).isTrue()
     assertThat(delegate.layers.hasRefractionDetail).isTrue()
+    assertThat(delegate.layers.hasRefractionDetailCoverage).isTrue()
+    assertThat(delegate.layers.hasRefractionComposite).isTrue()
     assertThat(delegate.layers.hasInteractionOptical).isTrue()
     assertThat(delegate.layers.hasInteractionRefractionDetail).isTrue()
     assertThat(delegate.layers.hasInteractionLighting).isTrue()
@@ -369,7 +375,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     val retainedLayers = delegate.layers.allLayers()
     delegate.setGraphicsContextForTest(context.graphicsContext)
 
-    assertThat(retainedLayers.size).isEqualTo(12)
+    assertThat(retainedLayers.size).isEqualTo(14)
 
     delegate.onTrimMemory(context, TrimMemoryLevel.UI_HIDDEN)
 
@@ -397,7 +403,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     assertThat(delegate.layers.hasInteractionRefractionDetail).isTrue()
     assertThat(delegate.layers.hasInteractionLighting).isTrue()
     assertThat(delegate.layers.hasRim).isTrue()
-    assertThat(retainedLayers.size).isEqualTo(12)
+    assertThat(retainedLayers.size).isEqualTo(14)
 
     delegate.onTrimMemory(context, TrimMemoryLevel.MODERATE)
 
@@ -417,7 +423,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     delegate.seedRetainedOutputAvailable()
     val retainedLayers = delegate.layers.allLayers()
 
-    assertThat(retainedLayers.size).isEqualTo(12)
+    assertThat(retainedLayers.size).isEqualTo(14)
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
 
     delegate.onTrimMemory(context, TrimMemoryLevel.COMPLETE)
@@ -533,7 +539,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
       val delegate = RuntimeShaderGlassDelegate(effect)
       val retainedLayers = delegate.prepareDrawWithRetainedLayers(context, effect)
 
-      assertThat(retainedLayers.size).isEqualTo(12)
+      assertThat(retainedLayers.size).isEqualTo(14)
       assertThat(context.graphicsContext.releasedLayers)
         .containsExactly(*retainedLayers.toTypedArray())
       assertThat(delegate.layers.isEmpty).isTrue()
@@ -575,6 +581,8 @@ private fun GlassLayers.populate(graphicsContext: GraphicsContext) {
   depthMixed = graphicsContext.createGraphicsLayer()
   optical = graphicsContext.createGraphicsLayer()
   refractionDetail = graphicsContext.createGraphicsLayer()
+  refractionDetailCoverage = graphicsContext.createGraphicsLayer()
+  refractionComposite = graphicsContext.createGraphicsLayer()
   interactionOptical = graphicsContext.createGraphicsLayer()
   interactionRefractionDetail = graphicsContext.createGraphicsLayer()
   interactionLighting = graphicsContext.createGraphicsLayer()
@@ -590,6 +598,8 @@ private fun GlassLayers.allLayers(): List<GraphicsLayer> = listOfNotNull(
   depthMixed,
   optical,
   refractionDetail,
+  refractionDetailCoverage,
+  refractionComposite,
   interactionOptical,
   interactionRefractionDetail,
   interactionLighting,

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInvariantSample.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInvariantSample.kt
@@ -1140,10 +1140,14 @@ internal fun ScreenshotUiTest.assertGlassTranslucentSourceInvariant() {
   val shape = RoundedCornerShape(28.dp)
   val effect = GlassVisualEffect().apply {
     tint = Color.Transparent
-    optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
+    optics = GlassOptics.Absolute(
+      depth = 0f,
+      blurRadius = 0.dp,
+    )
+    chromaticAberrationStrength = 0f
     specularIntensity = 0f
     ambientResponse = 0f
-    edgeSoftness = 8.dp
+    edgeSoftness = 0.dp
     this.shape = shape
   }
   var showSource by mutableStateOf(true)
@@ -1167,6 +1171,29 @@ internal fun ScreenshotUiTest.assertGlassTranslucentSourceInvariant() {
     x = (geometry.surfaceBounds.left + geometry.surfaceBounds.right) / 2,
     y = (geometry.surfaceBounds.top + geometry.surfaceBounds.bottom) / 2,
   )
+  val detailBandColors = (
+    geometry.surfaceBounds.left + 2..<geometry.surfaceBounds.right - 2
+    ).map { x -> live[x, geometry.centerY] }
+  val expectedAlpha = 0.5f
+  val expectedRed = InvariantSourceColor.red * expectedAlpha
+  val expectedGreen = InvariantSourceColor.green * expectedAlpha
+  val expectedBlue = InvariantSourceColor.blue * expectedAlpha
+  val maximumDetailBandAlphaError = detailBandColors.maxOf { color ->
+    abs(color.alpha - expectedAlpha)
+  }
+  val maximumDetailBandPremultipliedRgbError = detailBandColors.maxOf { color ->
+    maxOf(
+      abs(color.red - expectedRed),
+      abs(color.green - expectedGreen),
+      abs(color.blue - expectedBlue),
+    )
+  }
+  val maximumAdjacentAlphaDelta = detailBandColors
+    .zipWithNext { first, second -> abs(first.alpha - second.alpha) }
+    .max()
+  assertThat(maximumDetailBandAlphaError).isLessThanOrEqualTo(2f / 255f)
+  assertThat(maximumDetailBandPremultipliedRgbError).isLessThanOrEqualTo(2f / 255f)
+  assertThat(maximumAdjacentAlphaDelta).isLessThanOrEqualTo(1.001f / 255f)
   assertThat(kotlin.math.abs(live[center.x, center.y].alpha - 0.5f))
     .isLessThanOrEqualTo(1f / 255f)
   assertThat(kotlin.math.abs(live[center.x, center.y].red - InvariantSourceColor.red * 0.5f))


### PR DESCRIPTION
Fixes #1059

## Rationale

Refraction detail previously source-overed a second premultiplied source sample onto the completed optical output, increasing translucent alpha coverage.

This change composites the base refraction detail at native sample size before the existing scale/offset draw:

- record the detail coverage;
- remove the corresponding optical contribution with `DstOut`;
- add the premultiplied sharp detail with `Plus`.

For opaque sources this is algebraically identical to the established interpolation, while translucent premultiplied RGBA and alpha continuity are preserved.

The retained-layer budget and lifecycle handling now account for the coverage and composite stages.

## Verification

- `./gradlew :haze-glass:jvmTest :haze-glass:testAndroidHostTest :haze-screenshot-tests:jvmTest :haze-screenshot-tests:testAndroidHostTest spotlessCheck`
- `git diff --check`
- New Desktop and Android-host active-detail matte-recovery coverage
- Existing opaque and interaction screenshot baselines unchanged
- Internal code review: 0 Standards findings, 0 Spec findings

## Residual risk

Active base refraction detail retains two additional sample-sized layers. The render budget, trimming lifecycle, and retained-output availability checks cover these stages, and the applicable JVM, Android-host, and screenshot suites pass.