### PR TITLE
Use AssertK for test assertions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,12 @@ for parameters, and `*Defaults` naming for reusable configuration containers.
 ## Testing Guidelines
 
 Unit and snapshot tests sit alongside sources (for example, `haze/src/commonTest/kotlin`). Compose
-UI tests leverage `assertk`, `kotlin.test`, and Roborazzi-based screenshot assertions. Prefer
-descriptive method-level names such as `functionName_emitsExpectedBlur`. Run `./gradlew check`
-locally before opening a PR. Regenerate library snapshots with
+UI tests use Compose semantics and Roborazzi screenshot assertions where appropriate. Use AssertK
+for every author-written value, type, collection, boolean, and exception assertion; do not use
+assertion functions from `kotlin.test`, JUnit, or Truth. Semantic custom assertion helpers are
+allowed when implemented with AssertK. Prefer descriptive method-level names such as
+`functionName_emitsExpectedBlur`. Run `./gradlew check` locally before opening a PR. Regenerate
+library snapshots with
 `./gradlew :haze-screenshot-tests:recordRoborazzi`; regenerate Glass Gallery snapshots with
 `./gradlew :sample:screenshot-tests:recordRoborazzi` when intentional UI changes occur.
 

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isLessThan
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
@@ -154,8 +155,8 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
         assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
           .isEqualTo(plannedKinds)
         listOf(interactionOptical, interactionDetail, interactionLighting).forEach { layer ->
-          assertThat(layer.size.width < source.size.width).isTrue()
-          assertThat(layer.size.height < source.size.height).isTrue()
+          assertThat(layer.size.width).isLessThan(source.size.width)
+          assertThat(layer.size.height).isLessThan(source.size.height)
         }
       }
 
@@ -184,8 +185,8 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
         assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
           .isEqualTo(plannedKinds)
         listOf(interactionOptical, interactionDetail, interactionLighting).forEach { layer ->
-          assertThat(layer.size.width < source.size.width).isTrue()
-          assertThat(layer.size.height < source.size.height).isTrue()
+          assertThat(layer.size.width).isLessThan(source.size.width)
+          assertThat(layer.size.height).isLessThan(source.size.height)
         }
       }
       repeat(12) {

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -19,15 +19,17 @@ import androidx.compose.ui.test.AndroidComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotSameInstanceAs
+import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotSame
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
@@ -56,8 +58,8 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      assertSame(opticalShader, delegate.opticalShader)
-      assertNotSame(opticalEffect, delegate.opticalEffect)
+      assertThat(delegate.opticalShader).isSameInstanceAs(opticalShader)
+      assertThat(delegate.opticalEffect).isNotSameInstanceAs(opticalEffect)
 
       val rimShader = delegate.rimShader
       val rimEffect = delegate.rimEffect
@@ -65,8 +67,8 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      assertSame(rimShader, delegate.rimShader)
-      assertNotSame(rimEffect, delegate.rimEffect)
+      assertThat(delegate.rimShader).isSameInstanceAs(rimShader)
+      assertThat(delegate.rimEffect).isNotSameInstanceAs(rimEffect)
     }
 
   @Test
@@ -94,9 +96,12 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      assertSame(opticalEffect, delegate.interactionShaderHandle("interactionOpticalEffect"))
-      assertSame(detailEffect, delegate.interactionShaderHandle("interactionDetailEffect"))
-      assertSame(lightingEffect, delegate.interactionShaderHandle("interactionLightingEffect"))
+      assertThat(delegate.interactionShaderHandle("interactionOpticalEffect"))
+        .isSameInstanceAs(opticalEffect)
+      assertThat(delegate.interactionShaderHandle("interactionDetailEffect"))
+        .isSameInstanceAs(detailEffect)
+      assertThat(delegate.interactionShaderHandle("interactionLightingEffect"))
+        .isSameInstanceAs(lightingEffect)
     }
 
   @Test
@@ -130,24 +135,27 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
         effect.setPressedForTest(position)
         drawInteractionFrame()
 
-        assertSame(delegate, effect.delegate)
-        assertSame(source, delegate.layers.source)
-        assertSame(optical, delegate.layers.optical)
-        assertSame(detail, delegate.layers.refractionDetail)
-        assertSame(interactionOptical, delegate.layers.interactionOptical)
-        assertSame(interactionDetail, delegate.layers.interactionRefractionDetail)
-        assertSame(interactionLighting, delegate.layers.interactionLighting)
-        assertSame(interactionOpticalShader, delegate.interactionShaderHandle("interactionOpticalEffect"))
-        assertSame(interactionDetailShader, delegate.interactionShaderHandle("interactionDetailEffect"))
-        assertSame(interactionLightingShader, delegate.interactionShaderHandle("interactionLightingEffect"))
-        assertEquals(
-          scaleFactor,
+        assertThat(effect.delegate).isSameInstanceAs(delegate)
+        assertThat(delegate.layers.source).isSameInstanceAs(source)
+        assertThat(delegate.layers.optical).isSameInstanceAs(optical)
+        assertThat(delegate.layers.refractionDetail).isSameInstanceAs(detail)
+        assertThat(delegate.layers.interactionOptical).isSameInstanceAs(interactionOptical)
+        assertThat(delegate.layers.interactionRefractionDetail).isSameInstanceAs(interactionDetail)
+        assertThat(delegate.layers.interactionLighting).isSameInstanceAs(interactionLighting)
+        assertThat(delegate.interactionShaderHandle("interactionOpticalEffect"))
+          .isSameInstanceAs(interactionOpticalShader)
+        assertThat(delegate.interactionShaderHandle("interactionDetailEffect"))
+          .isSameInstanceAs(interactionDetailShader)
+        assertThat(delegate.interactionShaderHandle("interactionLightingEffect"))
+          .isSameInstanceAs(interactionLightingShader)
+        assertThat(
           (effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor,
-        )
-        assertEquals(plannedKinds, checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
+        ).isEqualTo(scaleFactor)
+        assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
+          .isEqualTo(plannedKinds)
         listOf(interactionOptical, interactionDetail, interactionLighting).forEach { layer ->
-          assertTrue(layer.size.width < source.size.width)
-          assertTrue(layer.size.height < source.size.height)
+          assertThat(layer.size.width < source.size.width).isTrue()
+          assertThat(layer.size.height < source.size.height).isTrue()
         }
       }
 
@@ -155,47 +163,50 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       repeat(3) {
         drawInteractionFrame()
 
-        assertTrue(effect.currentInteractionState.hasLighting)
-        assertTrue(effect.currentInteractionState.hasOptics)
-        assertSame(delegate, effect.delegate)
-        assertSame(source, delegate.layers.source)
-        assertSame(optical, delegate.layers.optical)
-        assertSame(detail, delegate.layers.refractionDetail)
-        assertSame(interactionOptical, delegate.layers.interactionOptical)
-        assertSame(interactionDetail, delegate.layers.interactionRefractionDetail)
-        assertSame(interactionLighting, delegate.layers.interactionLighting)
-        assertSame(interactionOpticalShader, delegate.interactionShaderHandle("interactionOpticalEffect"))
-        assertSame(interactionDetailShader, delegate.interactionShaderHandle("interactionDetailEffect"))
-        assertSame(interactionLightingShader, delegate.interactionShaderHandle("interactionLightingEffect"))
-        assertEquals(
-          scaleFactor,
+        assertThat(effect.currentInteractionState.hasLighting).isTrue()
+        assertThat(effect.currentInteractionState.hasOptics).isTrue()
+        assertThat(effect.delegate).isSameInstanceAs(delegate)
+        assertThat(delegate.layers.source).isSameInstanceAs(source)
+        assertThat(delegate.layers.optical).isSameInstanceAs(optical)
+        assertThat(delegate.layers.refractionDetail).isSameInstanceAs(detail)
+        assertThat(delegate.layers.interactionOptical).isSameInstanceAs(interactionOptical)
+        assertThat(delegate.layers.interactionRefractionDetail).isSameInstanceAs(interactionDetail)
+        assertThat(delegate.layers.interactionLighting).isSameInstanceAs(interactionLighting)
+        assertThat(delegate.interactionShaderHandle("interactionOpticalEffect"))
+          .isSameInstanceAs(interactionOpticalShader)
+        assertThat(delegate.interactionShaderHandle("interactionDetailEffect"))
+          .isSameInstanceAs(interactionDetailShader)
+        assertThat(delegate.interactionShaderHandle("interactionLightingEffect"))
+          .isSameInstanceAs(interactionLightingShader)
+        assertThat(
           (effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor,
-        )
-        assertEquals(plannedKinds, checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
+        ).isEqualTo(scaleFactor)
+        assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
+          .isEqualTo(plannedKinds)
         listOf(interactionOptical, interactionDetail, interactionLighting).forEach { layer ->
-          assertTrue(layer.size.width < source.size.width)
-          assertTrue(layer.size.height < source.size.height)
+          assertThat(layer.size.width < source.size.width).isTrue()
+          assertThat(layer.size.height < source.size.height).isTrue()
         }
       }
       repeat(12) {
         drawInteractionFrame()
 
-        assertSame(delegate, effect.delegate)
-        assertSame(source, delegate.layers.source)
-        assertSame(optical, delegate.layers.optical)
-        assertSame(detail, delegate.layers.refractionDetail)
-        assertEquals(
-          scaleFactor,
+        assertThat(effect.delegate).isSameInstanceAs(delegate)
+        assertThat(delegate.layers.source).isSameInstanceAs(source)
+        assertThat(delegate.layers.optical).isSameInstanceAs(optical)
+        assertThat(delegate.layers.refractionDetail).isSameInstanceAs(detail)
+        assertThat(
           (effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor,
-        )
-        assertEquals(plannedKinds, checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
+        ).isEqualTo(scaleFactor)
+        assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
+          .isEqualTo(plannedKinds)
       }
-      assertTrue(!effect.currentInteractionState.hasLighting)
-      assertTrue(!effect.currentInteractionState.hasOptics)
-      assertTrue(delegate.layers.interactionOptical?.isReleased != false)
-      assertTrue(delegate.layers.interactionRefractionDetail?.isReleased != false)
-      assertTrue(delegate.layers.interactionLighting?.isReleased != false)
-      assertTrue(delegate.canDrawRetainedOutput())
+      assertThat(effect.currentInteractionState.hasLighting).isFalse()
+      assertThat(effect.currentInteractionState.hasOptics).isFalse()
+      assertThat(delegate.layers.interactionOptical?.isReleased != false).isTrue()
+      assertThat(delegate.layers.interactionRefractionDetail?.isReleased != false).isTrue()
+      assertThat(delegate.layers.interactionLighting?.isReleased != false).isTrue()
+      assertThat(delegate.canDrawRetainedOutput()).isTrue()
       mainClock.autoAdvance = true
     }
 
@@ -224,14 +235,14 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      assertSame(horizontalShader, delegate.blurHorizontalShader)
-      assertSame(verticalShader, delegate.blurVerticalShader)
-      assertSame(prefilterShader, delegate.blurPrefilterShader)
-      assertSame(detailShader, delegate.refractionDetailShader)
-      assertNotSame(horizontalEffect, delegate.layers.blurHorizontal?.renderEffect)
-      assertNotSame(verticalEffect, delegate.layers.blurred?.renderEffect)
-      assertNotSame(prefilterEffect, delegate.layers.blurPrefiltered?.renderEffect)
-      assertNotSame(detailEffect, delegate.layers.refractionDetail?.renderEffect)
+      assertThat(delegate.blurHorizontalShader).isSameInstanceAs(horizontalShader)
+      assertThat(delegate.blurVerticalShader).isSameInstanceAs(verticalShader)
+      assertThat(delegate.blurPrefilterShader).isSameInstanceAs(prefilterShader)
+      assertThat(delegate.refractionDetailShader).isSameInstanceAs(detailShader)
+      assertThat(delegate.layers.blurHorizontal?.renderEffect).isNotSameInstanceAs(horizontalEffect)
+      assertThat(delegate.layers.blurred?.renderEffect).isNotSameInstanceAs(verticalEffect)
+      assertThat(delegate.layers.blurPrefiltered?.renderEffect).isNotSameInstanceAs(prefilterEffect)
+      assertThat(delegate.layers.refractionDetail?.renderEffect).isNotSameInstanceAs(detailEffect)
     }
 
   @Test
@@ -263,10 +274,10 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      assertSame(horizontalShader, delegate.progressiveBlurHorizontalShader)
-      assertSame(verticalShader, delegate.progressiveBlurVerticalShader)
-      assertNotSame(horizontalEffect, delegate.layers.blurHorizontal?.renderEffect)
-      assertNotSame(verticalEffect, delegate.layers.blurred?.renderEffect)
+      assertThat(delegate.progressiveBlurHorizontalShader).isSameInstanceAs(horizontalShader)
+      assertThat(delegate.progressiveBlurVerticalShader).isSameInstanceAs(verticalShader)
+      assertThat(delegate.layers.blurHorizontal?.renderEffect).isNotSameInstanceAs(horizontalEffect)
+      assertThat(delegate.layers.blurred?.renderEffect).isNotSameInstanceAs(verticalEffect)
     }
 
   private fun animatedStageEffect() = GlassVisualEffect().apply {

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/CornerRadiiTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/CornerRadiiTest.kt
@@ -8,10 +8,12 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 class CornerRadiiTest {
 
@@ -91,13 +93,12 @@ class CornerRadiiTest {
       bottomStart = 0.dp,
     )
 
-    val exception = assertFailsWith<IllegalArgumentException> {
+    assertFailure {
       shape.toCornerRadiiPx(Size(100f, 100f), Density(1f), LayoutDirection.Ltr)
-    }
-
-    assertThat(exception.message).isEqualTo(
-      "Corner size in Px can't be negative(topStart = -1.0, topEnd = 0.0, " +
-        "bottomEnd = 0.0, bottomStart = 0.0)!",
-    )
+    }.isInstanceOf<IllegalArgumentException>()
+      .hasMessage(
+        "Corner size in Px can't be negative(topStart = -1.0, topEnd = 0.0, " +
+          "bottomEnd = 0.0, bottomStart = 0.0)!",
+      )
   }
 }

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionDslTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionDslTest.kt
@@ -3,9 +3,11 @@
 
 package dev.chrisbanes.haze.glass
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.HazeArea
@@ -13,7 +15,6 @@ import dev.chrisbanes.haze.HazeEffectScope
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.VisualEffect
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 class GlassInteractionDslTest {
 
@@ -74,12 +75,12 @@ class GlassInteractionDslTest {
     val pressed = checkNotNull(effect.pressedSlot)
     effect.resetDirtyTracker()
 
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       scope.glassEffect {
         pressed { lightingIntensity(0.6f) }
         throw IllegalStateException("rollback")
       }
-    }
+    }.isInstanceOf<IllegalStateException>()
 
     assertThat(effect.hoveredSlot).isEqualTo(hovered)
     assertThat(effect.focusedSlot).isEqualTo(focused)
@@ -179,18 +180,18 @@ class GlassInteractionDslTest {
 
   @Test
   fun invalidValues_failDuringResponseCompilation() {
-    assertFailsWith<IllegalArgumentException> {
+    assertFailure {
       GlassVisualEffect().pressed { scale(Float.NaN) }
-    }
-    assertFailsWith<IllegalArgumentException> {
+    }.isInstanceOf<IllegalArgumentException>()
+    assertFailure {
       GlassVisualEffect().pressed { lightingIntensity(1.1f) }
-    }
-    assertFailsWith<IllegalArgumentException> {
+    }.isInstanceOf<IllegalArgumentException>()
+    assertFailure {
       GlassVisualEffect().pressed { refractionMultiplier(2.1f) }
-    }
-    assertFailsWith<IllegalArgumentException> {
+    }.isInstanceOf<IllegalArgumentException>()
+    assertFailure {
       GlassVisualEffect().pressed { whitePointDelta(-1.1f) }
-    }
+    }.isInstanceOf<IllegalArgumentException>()
   }
 
   private fun configureAndReturn(scope: TestHazeEffectScope): String {

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassOpticsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassOpticsTest.kt
@@ -5,10 +5,11 @@ package dev.chrisbanes.haze.glass
 
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 class GlassOpticsTest {
 
@@ -31,7 +32,7 @@ class GlassOpticsTest {
       { GlassOptics.Absolute(blurRadius = Dp.Unspecified) },
       { GlassOptics.Absolute(blurRadius = (-1).dp) },
     ).forEach { create ->
-      assertFailsWith<IllegalArgumentException> { create() }
+      assertFailure { create() }.isInstanceOf<IllegalArgumentException>()
     }
   }
 }

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudgetTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudgetTest.kt
@@ -8,11 +8,11 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isLessThanOrEqualTo
 import assertk.assertions.isTrue
 import kotlin.math.roundToInt
 import kotlin.test.Test
-import kotlin.test.assertIs
 
 class GlassRenderBudgetTest {
 
@@ -134,7 +134,7 @@ class GlassRenderBudgetTest {
   @Test
   fun overBudgetRequest_selectsLargestSafeScale() {
     val result = resolveGlassRenderBudget(1f) { squarePlan(it, 8192) }
-    val runtime = assertIs<GlassRenderBudgetDecision.Runtime>(result)
+    val runtime = result.assertRuntime()
 
     assertThat(runtime.scaleFactor).isGreaterThanOrEqualTo(0.5f)
     assertThat(runtime.scaleFactor).isLessThanOrEqualTo(4096.5f / 8192f)
@@ -150,9 +150,7 @@ class GlassRenderBudgetTest {
 
   @Test
   fun explicitlyRequestedSubFloorScale_isNeverIncreased() {
-    val result = assertIs<GlassRenderBudgetDecision.Runtime>(
-      resolveGlassRenderBudget(0.125f) { squarePlan(it, 8192) },
-    )
+    val result = resolveGlassRenderBudget(0.125f) { squarePlan(it, 8192) }.assertRuntime()
 
     assertThat(result.scaleFactor).isEqualTo(0.125f)
   }
@@ -162,7 +160,7 @@ class GlassRenderBudgetTest {
     val result = resolveGlassRenderBudget(1f) { scale ->
       blurThresholdPlan(scale = scale, sideAtFullScale = 7_370, blurRadiusAtFullScale = 85.49f)
     }
-    val runtime = assertIs<GlassRenderBudgetDecision.Runtime>(result)
+    val runtime = result.assertRuntime()
 
     assertThat(runtime.scaleFactor).isGreaterThanOrEqualTo(0.261f)
     assertThat(checkNotNull(runtime.plan.retainedPixelCountOrNull())).isLessThanOrEqualTo(
@@ -185,7 +183,7 @@ class GlassRenderBudgetTest {
         interactionLightingActive = false,
       )
     }
-    val runtime = assertIs<GlassRenderBudgetDecision.Runtime>(result)
+    val runtime = result.assertRuntime()
 
     assertThat(runtime.scaleFactor).isGreaterThanOrEqualTo(0.9993f)
     assertThat(runtime.scaleFactor).isLessThanOrEqualTo(0.9994f)
@@ -228,4 +226,9 @@ class GlassRenderBudgetTest {
       },
     )
   }
+}
+
+private fun GlassRenderBudgetDecision.assertRuntime(): GlassRenderBudgetDecision.Runtime {
+  assertThat(this).isInstanceOf<GlassRenderBudgetDecision.Runtime>()
+  return this as GlassRenderBudgetDecision.Runtime
 }

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -12,15 +12,17 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.roundToIntSize
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.containsExactly
+import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isLessThan
 import kotlin.math.abs
 import kotlin.math.sqrt
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 class GlassRenderParamsTest {
 
@@ -277,16 +279,15 @@ class GlassRenderParamsTest {
       )
     }
 
-    val exception = assertFailsWith<IllegalArgumentException> {
+    assertFailure {
       resolveGlassStyle(
         effect = effect,
         materialSizePx = Size(100f, 80f),
         density = Density(1f),
         layoutDirection = LayoutDirection.Ltr,
       )
-    }
-
-    assertThat(exception.message).isEqualTo("custom corner conversion failed")
+    }.isInstanceOf<IllegalArgumentException>()
+      .hasMessage("custom corner conversion failed")
   }
 
   @Test

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStageInvalidationTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStageInvalidationTest.kt
@@ -10,9 +10,9 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import kotlin.test.Test
-import kotlin.test.assertSame
 
 class GlassStageInvalidationTest {
 
@@ -367,7 +367,7 @@ class GlassStageInvalidationTest {
       previousSnapshot = first,
     ).snapshot
 
-    assertSame(first, second)
+    assertThat(second).isSameInstanceAs(first)
   }
 
   @Test

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
@@ -20,7 +20,9 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeArea
 import dev.chrisbanes.haze.HazeInputScale
@@ -30,8 +32,6 @@ import dev.chrisbanes.haze.PlatformContext
 import dev.chrisbanes.haze.VisualEffectContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
-import kotlin.test.assertNotSame
-import kotlin.test.assertSame
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -224,10 +224,10 @@ class GlassVisualEffectLifecycleTest {
     ) as GlassRenderBudgetDecision.Runtime
     val secondPrepared = checkNotNull(effect.preparedRender)
 
-    assertSame(first, second)
-    assertSame(firstPrepared, secondPrepared)
-    assertSame(firstPrepared.blurKey?.plan, secondPrepared.blurKey?.plan)
-    assertSame(second.plan, secondPrepared.plan)
+    assertThat(second).isSameInstanceAs(first)
+    assertThat(secondPrepared).isSameInstanceAs(firstPrepared)
+    assertThat(secondPrepared.blurKey?.plan).isSameInstanceAs(firstPrepared.blurKey?.plan)
+    assertThat(secondPrepared.plan).isSameInstanceAs(second.plan)
   }
 
   @Test
@@ -242,17 +242,17 @@ class GlassVisualEffectLifecycleTest {
     effect.prepareRenderBudget(context, runtimeShaderSupported = true)
     val second = checkNotNull(effect.preparedRender)
 
-    assertNotSame(first, second)
-    assertSame(first.params, second.params)
-    assertSame(first.blurKey, second.blurKey)
-    assertSame(first.opticalKey, second.opticalKey)
-    assertSame(first.refractionDetailKey, second.refractionDetailKey)
-    assertSame(first.rimKey, second.rimKey)
+    assertThat(second).isNotSameInstanceAs(first)
+    assertThat(second.params).isSameInstanceAs(first.params)
+    assertThat(second.blurKey).isSameInstanceAs(first.blurKey)
+    assertThat(second.opticalKey).isSameInstanceAs(first.opticalKey)
+    assertThat(second.refractionDetailKey).isSameInstanceAs(first.refractionDetailKey)
+    assertThat(second.rimKey).isSameInstanceAs(first.rimKey)
     assertThat(first.plan.layers.any { it.kind == GlassRetainedLayerKind.GroupComposite })
       .isEqualTo(false)
     assertThat(second.plan.layers.any { it.kind == GlassRetainedLayerKind.GroupComposite })
       .isEqualTo(true)
-    assertNotSame(first.plan, second.plan)
+    assertThat(second.plan).isNotSameInstanceAs(first.plan)
   }
 
   @Test
@@ -273,12 +273,12 @@ class GlassVisualEffectLifecycleTest {
     effect.prepareRenderBudget(context, runtimeShaderSupported = true)
     val second = checkNotNull(effect.preparedRender)
 
-    assertNotSame(first.plan, second.plan)
-    assertSame(first.params, second.params)
-    assertSame(first.blurKey, second.blurKey)
-    assertSame(first.opticalKey, second.opticalKey)
-    assertSame(first.refractionDetailKey, second.refractionDetailKey)
-    assertSame(first.rimKey, second.rimKey)
+    assertThat(second.plan).isNotSameInstanceAs(first.plan)
+    assertThat(second.params).isSameInstanceAs(first.params)
+    assertThat(second.blurKey).isSameInstanceAs(first.blurKey)
+    assertThat(second.opticalKey).isSameInstanceAs(first.opticalKey)
+    assertThat(second.refractionDetailKey).isSameInstanceAs(first.refractionDetailKey)
+    assertThat(second.rimKey).isSameInstanceAs(first.rimKey)
   }
 
   @Test
@@ -313,12 +313,12 @@ class GlassVisualEffectLifecycleTest {
     effect.prepareRenderBudget(context, runtimeShaderSupported = true)
     val second = checkNotNull(effect.preparedRender)
 
-    assertNotSame(first.params, second.params)
-    assertSame(first.blurKey, second.blurKey)
-    assertSame(first.opticalKey, second.opticalKey)
-    assertSame(first.refractionDetailKey, second.refractionDetailKey)
-    assertNotSame(first.rimKey, second.rimKey)
-    assertSame(first.plan, second.plan)
+    assertThat(second.params).isNotSameInstanceAs(first.params)
+    assertThat(second.blurKey).isSameInstanceAs(first.blurKey)
+    assertThat(second.opticalKey).isSameInstanceAs(first.opticalKey)
+    assertThat(second.refractionDetailKey).isSameInstanceAs(first.refractionDetailKey)
+    assertThat(second.rimKey).isNotSameInstanceAs(first.rimKey)
+    assertThat(second.plan).isSameInstanceAs(first.plan)
   }
 
   @Test
@@ -333,13 +333,13 @@ class GlassVisualEffectLifecycleTest {
     effect.prepareRenderBudget(context, runtimeShaderSupported = true)
     val second = checkNotNull(effect.preparedRender)
 
-    assertNotSame(first.interactionUniforms, second.interactionUniforms)
-    assertSame(first.params, second.params)
-    assertSame(first.blurKey, second.blurKey)
-    assertSame(first.opticalKey, second.opticalKey)
-    assertSame(first.refractionDetailKey, second.refractionDetailKey)
-    assertSame(first.rimKey, second.rimKey)
-    assertNotSame(first.plan, second.plan)
+    assertThat(second.interactionUniforms).isNotSameInstanceAs(first.interactionUniforms)
+    assertThat(second.params).isSameInstanceAs(first.params)
+    assertThat(second.blurKey).isSameInstanceAs(first.blurKey)
+    assertThat(second.opticalKey).isSameInstanceAs(first.opticalKey)
+    assertThat(second.refractionDetailKey).isSameInstanceAs(first.refractionDetailKey)
+    assertThat(second.rimKey).isSameInstanceAs(first.rimKey)
+    assertThat(second.plan).isNotSameInstanceAs(first.plan)
   }
 
   @Test

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
@@ -29,7 +29,12 @@ import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotNull
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.HazeArea
 import dev.chrisbanes.haze.HazeInputScale
@@ -43,11 +48,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.abs
 import kotlin.test.Test
-import kotlin.test.assertNotNull
-import kotlin.test.assertNotSame
-import kotlin.test.assertNull
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import sun.misc.Unsafe
 
@@ -64,7 +64,7 @@ class FallbackGlassDelegateTest {
     val first = checkNotNull(delegate.groupAlphaForTest().layer)
     delegate.prepare(context)
 
-    assertSame(first, delegate.groupAlphaForTest().layer)
+    assertThat(delegate.groupAlphaForTest().layer).isSameInstanceAs(first)
     assertThat(context.graphicsContext.createdLayers).isEqualTo(listOf(first))
   }
 
@@ -147,8 +147,8 @@ class FallbackGlassDelegateTest {
       ]
 
       assertThat(fallback.groupAlphaForTest().isAvailable).isFalse()
-      assertTrue(opaque.alpha > 0.01f)
-      assertTrue(abs(direct.alpha - opaque.alpha / 2f) < 0.03f)
+      assertThat(opaque.alpha).isGreaterThan(0.01f)
+      assertThat(abs(direct.alpha - opaque.alpha / 2f)).isLessThan(0.03f)
     }
 
     assertDirectAlphaHalvesContribution(
@@ -215,7 +215,7 @@ class FallbackGlassDelegateTest {
       with(fallback) { drawForeground(context) }
     }
 
-    assertTrue(image.toPixelMap()[60, 60].red > 0.01f)
+    assertThat(image.toPixelMap()[60, 60].red).isGreaterThan(0.01f)
   }
 
   @Test
@@ -235,47 +235,47 @@ class FallbackGlassDelegateTest {
     delegate.prepare(context)
     val stable = delegate.preparedResourcesForTest()
 
-    assertSame(first.prepared, stable.prepared)
-    assertSame(first.style, stable.style)
-    assertSame(first.shapePath, stable.shapePath)
-    assertSame(first.highlightBrush, stable.highlightBrush)
-    assertSame(first.edgeBrush, stable.edgeBrush)
-    assertSame(first.edgeStroke, stable.edgeStroke)
+    assertThat(stable.prepared).isSameInstanceAs(first.prepared)
+    assertThat(stable.style).isSameInstanceAs(first.style)
+    assertThat(stable.shapePath).isSameInstanceAs(first.shapePath)
+    assertThat(stable.highlightBrush).isSameInstanceAs(first.highlightBrush)
+    assertThat(stable.edgeBrush).isSameInstanceAs(first.edgeBrush)
+    assertThat(stable.edgeStroke).isSameInstanceAs(first.edgeStroke)
 
     effect.lightPosition = Offset(24f, 36f)
     delegate.prepare(context)
     val movedLight = delegate.preparedResourcesForTest()
 
-    assertNotSame(stable.prepared, movedLight.prepared)
-    assertNotSame(stable.highlightBrush, movedLight.highlightBrush)
-    assertSame(stable.shapePath, movedLight.shapePath)
-    assertSame(stable.edgeBrush, movedLight.edgeBrush)
-    assertSame(stable.edgeStroke, movedLight.edgeStroke)
+    assertThat(movedLight.prepared).isNotSameInstanceAs(stable.prepared)
+    assertThat(movedLight.highlightBrush).isNotSameInstanceAs(stable.highlightBrush)
+    assertThat(movedLight.shapePath).isSameInstanceAs(stable.shapePath)
+    assertThat(movedLight.edgeBrush).isSameInstanceAs(stable.edgeBrush)
+    assertThat(movedLight.edgeStroke).isSameInstanceAs(stable.edgeStroke)
 
     effect.ambientResponse = 0.5f
     delegate.prepare(context)
     val changedEdge = delegate.preparedResourcesForTest()
 
-    assertSame(movedLight.highlightBrush, changedEdge.highlightBrush)
-    assertNotSame(movedLight.edgeBrush, changedEdge.edgeBrush)
-    assertSame(movedLight.edgeStroke, changedEdge.edgeStroke)
-    assertSame(movedLight.shapePath, changedEdge.shapePath)
+    assertThat(changedEdge.highlightBrush).isSameInstanceAs(movedLight.highlightBrush)
+    assertThat(changedEdge.edgeBrush).isNotSameInstanceAs(movedLight.edgeBrush)
+    assertThat(changedEdge.edgeStroke).isSameInstanceAs(movedLight.edgeStroke)
+    assertThat(changedEdge.shapePath).isSameInstanceAs(movedLight.shapePath)
 
     effect.edgeSoftness = 0.dp
     delegate.prepare(context)
     val noEdge = delegate.preparedResourcesForTest()
 
-    assertNull(noEdge.edgeBrush)
-    assertNull(noEdge.edgeDirectBrush)
-    assertNull(noEdge.edgeStroke)
+    assertThat(noEdge.edgeBrush).isNull()
+    assertThat(noEdge.edgeDirectBrush).isNull()
+    assertThat(noEdge.edgeStroke).isNull()
 
     effect.edgeSoftness = 8.dp
     delegate.prepare(context)
     val restoredEdge = delegate.preparedResourcesForTest()
 
-    assertNotNull(restoredEdge.edgeBrush)
-    assertNotNull(restoredEdge.edgeDirectBrush)
-    assertNotNull(restoredEdge.edgeStroke)
+    assertThat(restoredEdge.edgeBrush).isNotNull()
+    assertThat(restoredEdge.edgeDirectBrush).isNotNull()
+    assertThat(restoredEdge.edgeStroke).isNotNull()
   }
 
   private fun FallbackGlassDelegate.prepare(context: FallbackRecordingContext) {

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -37,7 +37,9 @@ import assertk.assertions.isGreaterThan
 import assertk.assertions.isLessThan
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeProgressive
@@ -50,8 +52,6 @@ import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
-import kotlin.test.assertNotSame
-import kotlin.test.assertSame
 
 @OptIn(ExperimentalTestApi::class)
 class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
@@ -190,7 +190,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     mainClock.advanceTimeBy(500)
     waitForIdle()
 
-    assertSame(opticalEffect, delegate.opticalEffect)
+    assertThat(delegate.opticalEffect).isSameInstanceAs(opticalEffect)
     assertThat(delegate.layers.hasInteractionOptical).isTrue()
     assertThat(delegate.layers.hasInteractionRefractionDetail).isTrue()
     assertThat(delegate.layers.hasInteractionRefractionDetailCoverage).isTrue()
@@ -229,10 +229,10 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       mainClock.advanceTimeByFrame()
       mainClock.advanceTimeByFrame()
 
-      assertSame(delegate, effect.delegate)
-      assertSame(source, delegate.layers.source)
-      assertSame(optical, delegate.layers.optical)
-      assertSame(detail, delegate.layers.refractionDetail)
+      assertThat(effect.delegate).isSameInstanceAs(delegate)
+      assertThat(delegate.layers.source).isSameInstanceAs(source)
+      assertThat(delegate.layers.optical).isSameInstanceAs(optical)
+      assertThat(delegate.layers.refractionDetail).isSameInstanceAs(detail)
       assertThat((effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor)
         .isEqualTo(decision.scaleFactor)
       assertThat(checkNotNull(delegate.layers.interactionOptical).size.width).isLessThan(source.size.width)
@@ -243,10 +243,10 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     effect.setPressedForTest(positions.last(), pressed = false)
     repeat(12) {
       mainClock.advanceTimeByFrame()
-      assertSame(delegate, effect.delegate)
-      assertSame(source, delegate.layers.source)
-      assertSame(optical, delegate.layers.optical)
-      assertSame(detail, delegate.layers.refractionDetail)
+      assertThat(effect.delegate).isSameInstanceAs(delegate)
+      assertThat(delegate.layers.source).isSameInstanceAs(source)
+      assertThat(delegate.layers.optical).isSameInstanceAs(optical)
+      assertThat(delegate.layers.refractionDetail).isSameInstanceAs(detail)
       assertThat((effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor)
         .isEqualTo(decision.scaleFactor)
       assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind }).isEqualTo(plannedKinds)
@@ -324,9 +324,12 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       effect.optics = (effect.optics as GlassOptics.Absolute).copy(refractionScale = 18f)
       waitForIdle()
 
-      assertSame(opticalEffect, delegate.interactionShaderHandle("interactionOpticalEffect"))
-      assertSame(detailEffect, delegate.interactionShaderHandle("interactionDetailEffect"))
-      assertSame(lightingEffect, delegate.interactionShaderHandle("interactionLightingEffect"))
+      assertThat(delegate.interactionShaderHandle("interactionOpticalEffect"))
+        .isSameInstanceAs(opticalEffect)
+      assertThat(delegate.interactionShaderHandle("interactionDetailEffect"))
+        .isSameInstanceAs(detailEffect)
+      assertThat(delegate.interactionShaderHandle("interactionLightingEffect"))
+        .isSameInstanceAs(lightingEffect)
 
       effect.onTrimMemory(checkNotNull(effect.attachedContextForTest), TrimMemoryLevel.UI_HIDDEN)
       assertThat(delegate.interactionShaderHandleOrNull("interactionOpticalEffect")).isNull()
@@ -416,9 +419,9 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     showSource.value = false
     waitForIdle()
 
-    assertSame(detailLayer, delegate.layers.refractionDetail)
-    assertSame(delegate, effect.delegate)
-    assertSame(sourceSnapshot, delegate.lastSuccessfulSourceSnapshot)
+    assertThat(delegate.layers.refractionDetail).isSameInstanceAs(detailLayer)
+    assertThat(effect.delegate).isSameInstanceAs(delegate)
+    assertThat(delegate.lastSuccessfulSourceSnapshot).isSameInstanceAs(sourceSnapshot)
     assertThat(delegate.lastSuccessfulStageInputs?.detail).isNotNull().isEqualTo(detailKey)
     assertThat(delegate.layers.hasRefractionDetail).isTrue()
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
@@ -619,7 +622,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     effect.ambientResponse = 0.6f
     waitForIdle()
 
-    assertSame(opticalShader, delegate.opticalShader)
+    assertThat(delegate.opticalShader).isSameInstanceAs(opticalShader)
     assertThat(delegate.opticalRecordCount).isEqualTo(beforeAlpha.optical + 1)
     assertThat(delegate.blurRecordCount).isEqualTo(beforeAlpha.blur)
     assertThat(delegate.depthRecordCount).isEqualTo(beforeAlpha.depth)
@@ -629,7 +632,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     effect.lightPosition = Offset(10f, 20f)
     waitForIdle()
 
-    assertSame(rimShader, delegate.rimShader)
+    assertThat(delegate.rimShader).isSameInstanceAs(rimShader)
     assertThat(delegate.rimRecordCount).isEqualTo(beforeRim + 1)
   }
 
@@ -655,14 +658,14 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     )
     waitForIdle()
 
-    assertSame(horizontalShader, delegate.blurHorizontalShader)
-    assertSame(verticalShader, delegate.blurVerticalShader)
-    assertSame(prefilterShader, delegate.blurPrefilterShader)
-    assertSame(detailShader, delegate.refractionDetailShader)
-    assertNotSame(horizontalEffect, delegate.layers.blurHorizontal?.renderEffect)
-    assertNotSame(verticalEffect, delegate.layers.blurred?.renderEffect)
-    assertNotSame(prefilterEffect, delegate.layers.blurPrefiltered?.renderEffect)
-    assertNotSame(detailEffect, delegate.layers.refractionDetail?.renderEffect)
+    assertThat(delegate.blurHorizontalShader).isSameInstanceAs(horizontalShader)
+    assertThat(delegate.blurVerticalShader).isSameInstanceAs(verticalShader)
+    assertThat(delegate.blurPrefilterShader).isSameInstanceAs(prefilterShader)
+    assertThat(delegate.refractionDetailShader).isSameInstanceAs(detailShader)
+    assertThat(delegate.layers.blurHorizontal?.renderEffect).isNotSameInstanceAs(horizontalEffect)
+    assertThat(delegate.layers.blurred?.renderEffect).isNotSameInstanceAs(verticalEffect)
+    assertThat(delegate.layers.blurPrefiltered?.renderEffect).isNotSameInstanceAs(prefilterEffect)
+    assertThat(delegate.layers.refractionDetail?.renderEffect).isNotSameInstanceAs(detailEffect)
   }
 
   @Test
@@ -691,10 +694,10 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     )
     waitForIdle()
 
-    assertSame(horizontalShader, delegate.progressiveBlurHorizontalShader)
-    assertSame(verticalShader, delegate.progressiveBlurVerticalShader)
-    assertNotSame(horizontalEffect, delegate.layers.blurHorizontal?.renderEffect)
-    assertNotSame(verticalEffect, delegate.layers.blurred?.renderEffect)
+    assertThat(delegate.progressiveBlurHorizontalShader).isSameInstanceAs(horizontalShader)
+    assertThat(delegate.progressiveBlurVerticalShader).isSameInstanceAs(verticalShader)
+    assertThat(delegate.layers.blurHorizontal?.renderEffect).isNotSameInstanceAs(horizontalEffect)
+    assertThat(delegate.layers.blurred?.renderEffect).isNotSameInstanceAs(verticalEffect)
   }
 
   private fun activeDetailEffect() = GlassVisualEffect().apply {

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
@@ -25,6 +25,7 @@ import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isGreaterThanOrEqualTo
 import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeArea
@@ -36,7 +37,6 @@ import dev.chrisbanes.haze.VisualEffectContext
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
-import kotlin.test.assertSame
 import kotlinx.coroutines.CoroutineScope
 import sun.misc.Unsafe
 
@@ -55,7 +55,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     delegate.prepareDrawForTest(context, effect)
     val first = checkNotNull(delegate.layers.groupAlpha.layer)
     delegate.prepareDrawForTest(context, effect)
-    assertSame(first, delegate.layers.groupAlpha.layer)
+    assertThat(delegate.layers.groupAlpha.layer).isSameInstanceAs(first)
 
     effect.alpha = 0f
     delegate.prepareDrawForTest(context, effect)
@@ -73,7 +73,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     val first = checkNotNull(owner.layer)
     owner.prepare(required = true, graphicsContext)
 
-    assertSame(first, owner.layer)
+    assertThat(owner.layer).isSameInstanceAs(first)
     assertThat(graphicsContext.events.filterIsInstance<LayerEvent.Create>().size).isEqualTo(1)
   }
 
@@ -105,7 +105,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
       with(delegate) { prepareDraw(context) }
     }
 
-    assertSame(prepared.params, delegate.preparedParamsForTest())
+    assertThat(delegate.preparedParamsForTest()).isSameInstanceAs(prepared.params)
   }
 
   @Test
@@ -192,8 +192,8 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     }
     assertThat(lastObsoleteRelease).isGreaterThanOrEqualTo(0)
     assertThat(firstCreate).isGreaterThan(lastObsoleteRelease)
-    assertSame(retainedSource, delegate.layers.source)
-    assertSame(retainedOptical, delegate.layers.optical)
+    assertThat(delegate.layers.source).isSameInstanceAs(retainedSource)
+    assertThat(delegate.layers.optical).isSameInstanceAs(retainedOptical)
   }
 
   @Test

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassImageMetricsTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassImageMetricsTest.kt
@@ -7,11 +7,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
+import assertk.assertFailure
 import assertk.assertThat
-import assertk.assertions.contains
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.messageContains
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 class GlassImageMetricsTest {
 
@@ -154,54 +155,48 @@ class GlassImageMetricsTest {
     assertThat(
       signedHorizontalCorrelationDisplacementPx(reference, shifted, y = 0, range = 8..55, maxShiftPx = 6),
     ).isEqualTo(3f)
-    assertFailsWith<AssertionError> {
+    assertFailure {
       assertContentAlignedAcrossInputScales(reference, shifted, y = 0, range = 8..55)
-    }
+    }.isInstanceOf<AssertionError>()
     assertContentAlignedAcrossInputScales(reference, reference, y = 0, range = 8..55)
   }
 
   @Test
   fun pixelSnapshot_rejectsMismatchedStorage() {
-    val failure = assertFailsWith<IllegalArgumentException> {
+    assertFailure {
       PixelSnapshot(width = 2, height = 2, colors = listOf(Color.Black))
-    }
-
-    assertThat(failure.message.orEmpty()).contains("4 colors")
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("4 colors")
   }
 
   @Test
   fun comparisons_rejectEmptySnapshots() {
     val empty = PixelSnapshot(width = 0, height = 0, colors = emptyList())
 
-    assertThat(
-      assertFailsWith<IllegalArgumentException> { empty.changedPixelRatio(empty) }
-        .message.orEmpty(),
-    ).contains("non-empty")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> { empty.meanAbsoluteDifference(empty) }
-        .message.orEmpty(),
-    ).contains("non-empty")
+    assertFailure { empty.changedPixelRatio(empty) }
+      .isInstanceOf<IllegalArgumentException>()
+      .messageContains("non-empty")
+    assertFailure { empty.meanAbsoluteDifference(empty) }
+      .isInstanceOf<IllegalArgumentException>()
+      .messageContains("non-empty")
   }
 
   @Test
   fun scanlineDerivative_rejectsInvalidCoordinatesAndShortRanges() {
     val snapshot = snapshot(width = 3, height = 2)
 
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.scanlineDerivative(y = 2, xRange = 0..2)
-      }.message.orEmpty(),
-    ).contains("y")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.scanlineDerivative(y = 0, xRange = 1..1)
-      }.message.orEmpty(),
-    ).contains("at least 2")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.scanlineDerivative(y = 0, xRange = 1..3)
-      }.message.orEmpty(),
-    ).contains("xRange")
+    assertFailure {
+      snapshot.scanlineDerivative(y = 2, xRange = 0..2)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("y")
+    assertFailure {
+      snapshot.scanlineDerivative(y = 0, xRange = 1..1)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("at least 2")
+    assertFailure {
+      snapshot.scanlineDerivative(y = 0, xRange = 1..3)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("xRange")
   }
 
   @Test
@@ -237,21 +232,18 @@ class GlassImageMetricsTest {
   fun verticalScanlineDerivative_rejectsInvalidCoordinatesAndShortRanges() {
     val snapshot = snapshot(width = 2, height = 3)
 
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.verticalScanlineDerivative(x = 2, yRange = 0..2)
-      }.message.orEmpty(),
-    ).contains("x")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.verticalScanlineDerivative(x = 0, yRange = 1..1)
-      }.message.orEmpty(),
-    ).contains("at least 2")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.verticalScanlineDerivative(x = 0, yRange = 1..3)
-      }.message.orEmpty(),
-    ).contains("yRange")
+    assertFailure {
+      snapshot.verticalScanlineDerivative(x = 2, yRange = 0..2)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("x")
+    assertFailure {
+      snapshot.verticalScanlineDerivative(x = 0, yRange = 1..1)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("at least 2")
+    assertFailure {
+      snapshot.verticalScanlineDerivative(x = 0, yRange = 1..3)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("yRange")
   }
 
   @Test
@@ -300,41 +292,37 @@ class GlassImageMetricsTest {
   fun highFrequencyEnergy_rejectsSmallAndOutOfBoundsRegions() {
     val snapshot = snapshot(width = 3, height = 3)
 
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.highFrequencyEnergy(IntRect(0, 0, 1, 2))
-      }.message.orEmpty(),
-    ).contains("at least 2x2")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.highFrequencyEnergy(IntRect(0, 0, 4, 3))
-      }.message.orEmpty(),
-    ).contains("bounds")
+    assertFailure {
+      snapshot.highFrequencyEnergy(IntRect(0, 0, 1, 2))
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("at least 2x2")
+    assertFailure {
+      snapshot.highFrequencyEnergy(IntRect(0, 0, 4, 3))
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("bounds")
   }
 
   @Test
   fun crop_rejectsEmptyAndOutOfBoundsRegions() {
     val snapshot = snapshot(width = 3, height = 3)
 
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.crop(IntRect(1, 1, 1, 2))
-      }.message.orEmpty(),
-    ).contains("non-empty")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        snapshot.crop(IntRect(-1, 0, 2, 2))
-      }.message.orEmpty(),
-    ).contains("bounds")
+    assertFailure {
+      snapshot.crop(IntRect(1, 1, 1, 2))
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("non-empty")
+    assertFailure {
+      snapshot.crop(IntRect(-1, 0, 2, 2))
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("bounds")
   }
 
   @Test
   fun transparentPoints_requireTransparentAlphaAndRgb() {
     val opaque = PixelSnapshot(width = 1, height = 1, colors = listOf(Color.Black))
 
-    assertFailsWith<AssertionError> {
+    assertFailure {
       opaque.assertTransparentAt(listOf(IntOffset.Zero))
-    }
+    }.isInstanceOf<AssertionError>()
 
     PixelSnapshot(width = 1, height = 1, colors = listOf(Color.Transparent))
       .assertTransparentAt(listOf(IntOffset.Zero))
@@ -372,21 +360,18 @@ class GlassImageMetricsTest {
       listOf(Color(red = 0.5f, green = 0.6f, blue = 0.5f)),
     )
 
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        recoverPremultipliedSnapshot(opaqueBlack, translucentWhite)
-      }.message.orEmpty(),
-    ).contains("opaque")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        recoverPremultipliedSnapshot(brighterBlack, darkerWhite)
-      }.message.orEmpty(),
-    ).contains("darker")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        recoverPremultipliedSnapshot(opaqueBlack, inconsistentWhite)
-      }.message.orEmpty(),
-    ).contains("agree")
+    assertFailure {
+      recoverPremultipliedSnapshot(opaqueBlack, translucentWhite)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("opaque")
+    assertFailure {
+      recoverPremultipliedSnapshot(brighterBlack, darkerWhite)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("darker")
+    assertFailure {
+      recoverPremultipliedSnapshot(opaqueBlack, inconsistentWhite)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("agree")
   }
 
   @Test
@@ -396,23 +381,21 @@ class GlassImageMetricsTest {
     val depth100 = PixelSnapshot(1, 1, listOf(Color.Gray))
 
     assertDepthProgression(depth0, depth50, depth100)
-    assertFailsWith<AssertionError> {
+    assertFailure {
       assertDepthProgression(depth0, depth0, depth100)
-    }
+    }.isInstanceOf<AssertionError>()
   }
 
   @Test
   fun boundaryContinuity_rejectsEmptyDerivativeAndInvalidIndex() {
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        assertBoundaryContinuous(emptyList(), boundaryIndex = 0)
-      }.message.orEmpty(),
-    ).contains("non-empty")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        assertBoundaryContinuous(listOf(0f), boundaryIndex = 1)
-      }.message.orEmpty(),
-    ).contains("Boundary range")
+    assertFailure {
+      assertBoundaryContinuous(emptyList(), boundaryIndex = 0)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("non-empty")
+    assertFailure {
+      assertBoundaryContinuous(listOf(0f), boundaryIndex = 1)
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("Boundary range")
   }
 
   @Test
@@ -421,12 +404,12 @@ class GlassImageMetricsTest {
       if (index in 7..9) 0.25f else 0.01f
     }
 
-    assertFailsWith<AssertionError> {
+    assertFailure {
       assertBoundaryCurvatureContinuous(
         derivative = derivative,
         boundaryIndex = 8,
       )
-    }
+    }.isInstanceOf<AssertionError>()
   }
 
   @Test
@@ -477,21 +460,18 @@ class GlassImageMetricsTest {
     val onePixel = snapshot(width = 1, height = 1)
     val twoPixels = snapshot(width = 2, height = 1)
 
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        assertOutsideMatchesBackground(onePixel, onePixel, emptyList())
-      }.message.orEmpty(),
-    ).contains("non-empty")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        assertOutsideMatchesBackground(onePixel, twoPixels, listOf(IntOffset.Zero))
-      }.message.orEmpty(),
-    ).contains("dimensions")
-    assertThat(
-      assertFailsWith<IllegalArgumentException> {
-        assertOutsideMatchesBackground(onePixel, onePixel, listOf(IntOffset(1, 0)))
-      }.message.orEmpty(),
-    ).contains("within")
+    assertFailure {
+      assertOutsideMatchesBackground(onePixel, onePixel, emptyList())
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("non-empty")
+    assertFailure {
+      assertOutsideMatchesBackground(onePixel, twoPixels, listOf(IntOffset.Zero))
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("dimensions")
+    assertFailure {
+      assertOutsideMatchesBackground(onePixel, onePixel, listOf(IntOffset(1, 0)))
+    }.isInstanceOf<IllegalArgumentException>()
+      .messageContains("within")
   }
 }
 

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
@@ -26,6 +26,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThanOrEqualTo
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
 import dev.chrisbanes.haze.glass.GlassLighting
 import dev.chrisbanes.haze.glass.GlassOptics
@@ -38,7 +41,6 @@ import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertTrue
 
 class GlassScreenshotTest : ScreenshotTest() {
 
@@ -135,10 +137,10 @@ class GlassScreenshotTest : ScreenshotTest() {
     val lowAlphaPixels = captureRootPixels().snapshot()
     captureRoot("15")
 
-    assertTrue(
-      initialPixels.changedPixelRatio(lowAlphaPixels) > 0.01f,
-      "Expected changing alpha to affect more than 1% of pixels",
-    )
+    assertThat(
+      initialPixels.changedPixelRatio(lowAlphaPixels),
+      "changing alpha affected pixel ratio",
+    ).isGreaterThan(0.01f)
   }
 
   @Test
@@ -251,19 +253,19 @@ class GlassScreenshotTest : ScreenshotTest() {
     waitForIdle()
     val densityOnePixels = captureRootPixels().snapshot()
 
-    assertTrue(
-      zeroBlurPixels.changedPixelRatio(densityOnePixels) > 0.01f,
-      "Expected capped blur to materially change the rendered pixels",
-    )
+    assertThat(
+      zeroBlurPixels.changedPixelRatio(densityOnePixels),
+      "capped blur changed pixel ratio",
+    ).isGreaterThan(0.01f)
 
     density = Density(3f)
     waitForIdle()
     val densityThreePixels = captureRootPixels().snapshot()
 
-    assertTrue(
-      densityOnePixels.changedPixelRatio(densityThreePixels) <= 0.001f,
-      "Expected above-cap blur to stay visually stable across densities",
-    )
+    assertThat(
+      densityOnePixels.changedPixelRatio(densityThreePixels),
+      "above-cap blur changed pixel ratio across densities",
+    ).isLessThanOrEqualTo(0.001f)
   }
 
   @Test

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
@@ -25,10 +25,12 @@ import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
+import assertk.assertions.containsAtLeast
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
-import assertk.assertions.isTrue
 import dev.chrisbanes.haze.blur.BlurVisualEffect
 import dev.chrisbanes.haze.blur.HazeBlurDefaults
 import dev.chrisbanes.haze.blur.HazeBlurStyle
@@ -768,11 +770,13 @@ class HazeScreenshotTest : ScreenshotTest() {
     requestedPage = 2
     waitForIdle()
     assertThat(initialPagerState.currentPage).isEqualTo(2)
-    assertThat(composedEffects.keys.containsAll((0..2).toList())).isTrue()
-    assertThat(composedEffects.all { (page, effect) -> effect === threePageEffects[page] }).isTrue()
-    assertThat(
-      composedEffects[0] !== composedEffects[1] && composedEffects[1] !== composedEffects[2],
-    ).isTrue()
+    assertThat(composedEffects.keys).containsAtLeast(0, 1, 2)
+    (0..2).forEach { page ->
+      assertThat(composedEffects[page], "effect for page $page")
+        .isSameInstanceAs(threePageEffects[page])
+    }
+    assertThat(composedEffects[0]).isNotSameInstanceAs(composedEffects[1])
+    assertThat(composedEffects[1]).isNotSameInstanceAs(composedEffects[2])
 
     threePageEffects[0].blurRadius = 16.dp
     assertThat(threePageEffects[1].blurRadius).isEqualTo(8.dp)
@@ -780,7 +784,7 @@ class HazeScreenshotTest : ScreenshotTest() {
     pageCount = 2
     waitForIdle()
     assertThat(pagerState).isSameInstanceAs(initialPagerState)
-    assertThat(initialPagerState.currentPage < pageCount).isTrue()
+    assertThat(initialPagerState.currentPage).isLessThan(pageCount)
 
     pageCount = 3
     requestedPage = 0

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
@@ -24,6 +24,11 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.blur.BlurVisualEffect
 import dev.chrisbanes.haze.blur.HazeBlurDefaults
 import dev.chrisbanes.haze.blur.HazeBlurStyle
@@ -35,8 +40,6 @@ import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class HazeScreenshotTest : ScreenshotTest() {
 
@@ -120,10 +123,8 @@ class HazeScreenshotTest : ScreenshotTest() {
 
     if (supportsRuntimeBlur) {
       val blurChangedPixelRatio = defaultPixels.changedPixelRatio(disabledPixels)
-      assertTrue(
-        blurChangedPixelRatio > 0.01f,
-        "Expected disabling blur to affect more than 1% of pixels, got $blurChangedPixelRatio",
-      )
+      assertThat(blurChangedPixelRatio, "disabling blur changed pixel ratio")
+        .isGreaterThan(0.01f)
     }
   }
 
@@ -229,18 +230,18 @@ class HazeScreenshotTest : ScreenshotTest() {
     captureRoot("70")
     val alpha70Pixels = captureRootPixels().snapshot()
 
-    assertTrue(
-      initialPixels.changedPixelRatio(alpha20Pixels) > 0.01f,
-      "Expected changing alpha from the initial value to 0.2 to affect more than 1% of pixels",
-    )
-    assertTrue(
-      alpha20Pixels.changedPixelRatio(alpha70Pixels) > 0.01f,
-      "Expected changing alpha from 0.2 to 0.7 to affect more than 1% of pixels",
-    )
-    assertTrue(
-      initialPixels.changedPixelRatio(alpha70Pixels) > 0.01f,
-      "Expected changing alpha from the initial value to 0.7 to affect more than 1% of pixels",
-    )
+    assertThat(
+      initialPixels.changedPixelRatio(alpha20Pixels),
+      "initial-to-0.2 alpha changed pixel ratio",
+    ).isGreaterThan(0.01f)
+    assertThat(
+      alpha20Pixels.changedPixelRatio(alpha70Pixels),
+      "0.2-to-0.7 alpha changed pixel ratio",
+    ).isGreaterThan(0.01f)
+    assertThat(
+      initialPixels.changedPixelRatio(alpha70Pixels),
+      "initial-to-0.7 alpha changed pixel ratio",
+    ).isGreaterThan(0.01f)
   }
 
   @Test
@@ -388,18 +389,18 @@ class HazeScreenshotTest : ScreenshotTest() {
     captureRoot("red")
     val redPixels = captureRootPixels().snapshot()
 
-    assertTrue(
-      magentaPixels.changedPixelRatio(yellowPixels) > 0.01f,
-      "Expected changing child tint from magenta to yellow to affect more than 1% of pixels",
-    )
-    assertTrue(
-      yellowPixels.changedPixelRatio(redPixels) > 0.01f,
-      "Expected changing child tint from yellow to red to affect more than 1% of pixels",
-    )
-    assertTrue(
-      magentaPixels.changedPixelRatio(redPixels) > 0.01f,
-      "Expected changing child tint from magenta to red to affect more than 1% of pixels",
-    )
+    assertThat(
+      magentaPixels.changedPixelRatio(yellowPixels),
+      "magenta-to-yellow tint changed pixel ratio",
+    ).isGreaterThan(0.01f)
+    assertThat(
+      yellowPixels.changedPixelRatio(redPixels),
+      "yellow-to-red tint changed pixel ratio",
+    ).isGreaterThan(0.01f)
+    assertThat(
+      magentaPixels.changedPixelRatio(redPixels),
+      "magenta-to-red tint changed pixel ratio",
+    ).isGreaterThan(0.01f)
   }
 
   @Test
@@ -762,30 +763,30 @@ class HazeScreenshotTest : ScreenshotTest() {
     val initialPagerState = requireNotNull(pagerState)
     recompositionToken++
     waitForIdle()
-    assertTrue(pagerState === initialPagerState)
+    assertThat(pagerState).isSameInstanceAs(initialPagerState)
 
     requestedPage = 2
     waitForIdle()
-    assertEquals(2, initialPagerState.currentPage)
-    assertTrue(composedEffects.keys.containsAll((0..2).toList()))
-    assertTrue(composedEffects.all { (page, effect) -> effect === threePageEffects[page] })
-    assertTrue(
+    assertThat(initialPagerState.currentPage).isEqualTo(2)
+    assertThat(composedEffects.keys.containsAll((0..2).toList())).isTrue()
+    assertThat(composedEffects.all { (page, effect) -> effect === threePageEffects[page] }).isTrue()
+    assertThat(
       composedEffects[0] !== composedEffects[1] && composedEffects[1] !== composedEffects[2],
-    )
+    ).isTrue()
 
     threePageEffects[0].blurRadius = 16.dp
-    assertEquals(8.dp, threePageEffects[1].blurRadius)
+    assertThat(threePageEffects[1].blurRadius).isEqualTo(8.dp)
 
     pageCount = 2
     waitForIdle()
-    assertTrue(pagerState === initialPagerState)
-    assertTrue(initialPagerState.currentPage < pageCount)
+    assertThat(pagerState).isSameInstanceAs(initialPagerState)
+    assertThat(initialPagerState.currentPage < pageCount).isTrue()
 
     pageCount = 3
     requestedPage = 0
     waitForIdle()
-    assertTrue(pagerState === initialPagerState)
-    assertTrue(composedEffects[0] === threePageEffects[0])
+    assertThat(pagerState).isSameInstanceAs(initialPagerState)
+    assertThat(composedEffects[0]).isSameInstanceAs(threePageEffects[0])
   }
 
   @Test

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectNodeConstructorTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectNodeConstructorTest.kt
@@ -4,10 +4,11 @@
 package dev.chrisbanes.haze
 
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 @OptIn(ExperimentalHazeApi::class)
 class HazeEffectNodeConstructorTest {
@@ -69,9 +70,9 @@ class HazeEffectNodeConstructorTest {
     val node2 = HazeEffectNode()
     val effect = ThrowOnFirstAttachVisualEffect()
 
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       node1.attachVisualEffect(effect)
-    }
+    }.isInstanceOf<IllegalStateException>()
 
     // Should succeed after failure on another node if attach bookkeeping is rolled back
     node2.attachVisualEffect(effect)
@@ -101,9 +102,9 @@ class HazeEffectNodeConstructorTest {
     node.attachVisualEffect(effect)
 
     // detachVisualEffect still throws, but the registry cleanup runs in the finally block.
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       node.detachVisualEffect(effect)
-    }
+    }.isInstanceOf<IllegalStateException>()
 
     // After detach (which threw), the effect should no longer be owned,
     // so attaching it to a different node should succeed.

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -19,15 +19,16 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 @OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class, InternalHazeApi::class)
 class VisualEffectLifecycleTest : ContextTest() {
@@ -260,9 +261,9 @@ class VisualEffectLifecycleTest : ContextTest() {
     assertThat(sharedEffect.attachCalls).isEqualTo(1)
 
     // Attempting to attach the same instance to a second active node must fail
-    assertFailsWith<IllegalStateException> {
+    assertFailure {
       HazeEffectNode().attachVisualEffect(sharedEffect)
-    }
+    }.isInstanceOf<IllegalStateException>()
   }
 
   @Test

--- a/haze/src/iosTest/kotlin/dev/chrisbanes/haze/TrimMemoryCallbackTest.ios.kt
+++ b/haze/src/iosTest/kotlin/dev/chrisbanes/haze/TrimMemoryCallbackTest.ios.kt
@@ -3,9 +3,10 @@
 
 package dev.chrisbanes.haze
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSThread
 import platform.UIKit.UIApplicationDidReceiveMemoryWarningNotification
@@ -13,7 +14,7 @@ import platform.UIKit.UIApplicationDidReceiveMemoryWarningNotification
 class TrimMemoryCallbackTest {
   @Test
   fun memoryWarning_deliversCompleteUntilDisposed() {
-    assertTrue(NSThread.isMainThread)
+    assertThat(NSThread.isMainThread).isTrue()
     val received = mutableListOf<TrimMemoryLevel>()
     val handle = registerTrimMemoryCallback(
       context = PlatformContext.INSTANCE,
@@ -24,13 +25,13 @@ class TrimMemoryCallbackTest {
       UIApplicationDidReceiveMemoryWarningNotification,
       null,
     )
-    assertEquals(listOf(TrimMemoryLevel.COMPLETE), received)
+    assertThat(received).isEqualTo(listOf(TrimMemoryLevel.COMPLETE))
 
     handle.dispose()
     NSNotificationCenter.defaultCenter.postNotificationName(
       UIApplicationDidReceiveMemoryWarningNotification,
       null,
     )
-    assertEquals(listOf(TrimMemoryLevel.COMPLETE), received)
+    assertThat(received).isEqualTo(listOf(TrimMemoryLevel.COMPLETE))
   }
 }

--- a/internal/screenshot-test/build.gradle.kts
+++ b/internal/screenshot-test/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
     jvmTest {
       dependencies {
         implementation(kotlin("test"))
+        implementation(libs.assertk)
       }
     }
   }

--- a/internal/screenshot-test/src/jvmTest/kotlin/dev/chrisbanes/haze/test/HazeRoborazziDefaultsTest.kt
+++ b/internal/screenshot-test/src/jvmTest/kotlin/dev/chrisbanes/haze/test/HazeRoborazziDefaultsTest.kt
@@ -3,11 +3,12 @@
 
 package dev.chrisbanes.haze.test
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import com.dropbox.differ.ImageComparator.ComparisonResult
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class HazeRoborazziDefaultsTest {
 
@@ -25,8 +26,8 @@ class HazeRoborazziDefaultsTest {
       ),
     )
 
-    assertTrue(result)
-    assertEquals(emptyList(), messages)
+    assertThat(result).isTrue()
+    assertThat(messages).isEqualTo(emptyList())
   }
 
   @Test
@@ -43,13 +44,12 @@ class HazeRoborazziDefaultsTest {
       ),
     )
 
-    assertFalse(result)
-    assertEquals(
+    assertThat(result).isFalse()
+    assertThat(messages).isEqualTo(
       listOf(
         "Roborazzi image diff: 0.81% unmatched " +
           "(81/10000 pixels, threshold 0.80%, maxDistance 0.02, hShift 2, vShift 2)",
       ),
-      messages,
     )
   }
 
@@ -59,8 +59,8 @@ class HazeRoborazziDefaultsTest {
       unmatchedPixelThreshold = 0.014f,
     )
 
-    assertEquals(0.7, options.recordOptions.resizeScale)
-    assertTrue(
+    assertThat(options.recordOptions.resizeScale).isEqualTo(0.7)
+    assertThat(
       options.compareOptions.resultValidator(
         ComparisonResult(
           pixelDifferences = 13_100,
@@ -69,6 +69,6 @@ class HazeRoborazziDefaultsTest {
           height = 1_000,
         ),
       ),
-    )
+    ).isTrue()
   }
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
@@ -5,40 +5,46 @@
 
 package dev.chrisbanes.haze.sample
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isLessThan
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassVisualEffect
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 class GlassGalleryModelsTest {
   @Test
   fun adaptivePreset_usesBuiltInAdaptiveOptics() {
-    assertEquals(GlassOptics.Adaptive, glassLabPresetStyle(GlassLabPresetId.Adaptive).optics)
+    assertThat(glassLabPresetStyle(GlassLabPresetId.Adaptive).optics)
+      .isEqualTo(GlassOptics.Adaptive)
   }
 
   @Test
   fun literalPresets_haveDistinctCompleteOptics() {
-    val clear = assertIs<GlassOptics.Absolute>(glassLabPresetStyle(GlassLabPresetId.Clear).optics)
-    val frosted = assertIs<GlassOptics.Absolute>(glassLabPresetStyle(GlassLabPresetId.Frosted).optics)
-    val deep = assertIs<GlassOptics.Absolute>(glassLabPresetStyle(GlassLabPresetId.Deep).optics)
-    val prism = assertIs<GlassOptics.Absolute>(glassLabPresetStyle(GlassLabPresetId.Prism).optics)
+    val clear = absoluteOpticsFor(GlassLabPresetId.Clear)
+    val frosted = absoluteOpticsFor(GlassLabPresetId.Frosted)
+    val deep = absoluteOpticsFor(GlassLabPresetId.Deep)
+    val prism = absoluteOpticsFor(GlassLabPresetId.Prism)
 
-    assertTrue(clear.blurRadius < frosted.blurRadius)
-    assertTrue(clear.depth < deep.depth)
-    assertNotEquals(deep, prism)
-    assertEquals(
-      ChromaticAberrationMode.Full,
+    assertThat(clear.blurRadius).isLessThan(frosted.blurRadius)
+    assertThat(clear.depth).isLessThan(deep.depth)
+    assertThat(prism).isNotEqualTo(deep)
+    assertThat(
       glassLabPresetStyle(GlassLabPresetId.Prism).rendering.chromaticAberrationMode,
+    ).isEqualTo(
+      ChromaticAberrationMode.Full,
     )
-    assertEquals(
-      0.22f,
+    assertThat(
       glassLabPresetStyle(GlassLabPresetId.Prism).rendering.chromaticAberrationStrength,
+    ).isEqualTo(
+      0.22f,
     )
   }
 
@@ -48,29 +54,29 @@ class GlassGalleryModelsTest {
       style.copy(optics = GlassOptics.Absolute(refractionStrength = 0.6f))
     }
 
-    assertEquals(GlassLabPresetId.Custom, edited.preset)
-    assertIs<GlassOptics.Absolute>(edited.style.optics)
+    assertThat(edited.preset).isEqualTo(GlassLabPresetId.Custom)
+    assertThat(edited.style.optics).isNotNull().isInstanceOf<GlassOptics.Absolute>()
   }
 
   @Test
   fun interactionModes_configureExpectedPointerSlots() {
     val off = GlassVisualEffect()
     GlassLabInteractionMode.Off.applyTo(off)
-    assertFalse(off.observesPointerEvents)
+    assertThat(off.observesPointerEvents).isFalse()
 
     val pressed = GlassVisualEffect()
     GlassLabInteractionMode.Pressed.applyTo(pressed)
-    assertTrue(pressed.observesPointerEvents)
+    assertThat(pressed.observesPointerEvents).isTrue()
     pressed.clearPressed()
-    assertFalse(pressed.observesPointerEvents)
+    assertThat(pressed.observesPointerEvents).isFalse()
 
     val all = GlassVisualEffect()
     GlassLabInteractionMode.All.applyTo(all)
-    assertTrue(all.observesPointerEvents)
+    assertThat(all.observesPointerEvents).isTrue()
     all.clearPressed()
-    assertTrue(all.observesPointerEvents)
+    assertThat(all.observesPointerEvents).isTrue()
     all.clearHovered()
-    assertFalse(all.observesPointerEvents)
+    assertThat(all.observesPointerEvents).isFalse()
   }
 
   @Test
@@ -83,6 +89,12 @@ class GlassGalleryModelsTest {
       style = glassLabPresetStyle(GlassLabPresetId.Prism),
     )
 
-    assertEquals(GlassLabState(), changed.reset())
+    assertThat(changed.reset()).isEqualTo(GlassLabState())
   }
+}
+
+private fun absoluteOpticsFor(id: GlassLabPresetId): GlassOptics.Absolute {
+  val optics = glassLabPresetStyle(id).optics
+  assertThat(optics).isNotNull().isInstanceOf<GlassOptics.Absolute>()
+  return optics as GlassOptics.Absolute
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisualsTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisualsTest.kt
@@ -12,11 +12,12 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.v2.runComposeUiTest
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.rememberHazeState
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class GlassGalleryVisualsTest : ContextTest() {
@@ -57,8 +58,8 @@ class GlassGalleryVisualsTest : ContextTest() {
     onNodeWithContentDescription("Enter recording mode")
       .performSemanticsAction(SemanticsActions.OnClick) { action -> action() }
 
-    assertEquals(1, playPauseCount)
-    assertEquals(1, resetCount)
-    assertTrue(recordingMode)
+    assertThat(playPauseCount).isEqualTo(1)
+    assertThat(resetCount).isEqualTo(1)
+    assertThat(recordingMode).isTrue()
   }
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassLabSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassLabSampleTest.kt
@@ -23,11 +23,13 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
 class GlassLabSampleTest : ContextTest() {
@@ -75,20 +77,20 @@ class GlassLabSampleTest : ContextTest() {
           action(textLayouts)
         }
       val textLayout = textLayouts.single()
-      assertEquals(1, textLayout.lineCount, optionName)
-      assertTrue(
+      assertThat(textLayout.lineCount, optionName).isEqualTo(1)
+      assertThat(
         textLayout.multiParagraph.intrinsics.maxIntrinsicWidth <= textLayout.size.width + 1f,
         "$optionName: size=${textLayout.size}, intrinsicWidth=" +
           textLayout.multiParagraph.intrinsics.maxIntrinsicWidth,
-      )
+      ).isTrue()
     }
   }
 
   @Test
   fun narrowLabSizesSelectorsToWholeVisibleItems() {
-    assertEquals(288.dp, labSegmentedButtonWidth(288.dp, itemCount = 5))
-    assertEquals(174.dp, labSegmentedButtonWidth(348.dp, itemCount = 5))
-    assertEquals(160.dp, labSegmentedButtonWidth(800.dp, itemCount = 5))
+    assertThat(labSegmentedButtonWidth(288.dp, itemCount = 5)).isEqualTo(288.dp)
+    assertThat(labSegmentedButtonWidth(348.dp, itemCount = 5)).isEqualTo(174.dp)
+    assertThat(labSegmentedButtonWidth(800.dp, itemCount = 5)).isEqualTo(160.dp)
   }
 
   @Test
@@ -106,22 +108,22 @@ class GlassLabSampleTest : ContextTest() {
     onNode(hasText("Prism") and hasClickAction())
       .performScrollTo()
       .performSemanticsAction(SemanticsActions.OnClick) { action -> action() }
-    assertEquals(GlassLabPresetId.Prism, state.preset)
+    assertThat(state.preset).isEqualTo(GlassLabPresetId.Prism)
 
     onNode(hasText("Grid") and hasClickAction())
       .performScrollTo()
       .performSemanticsAction(SemanticsActions.OnClick) { action -> action() }
-    assertEquals(GlassGalleryBackdropId.Grid, state.backdrop)
+    assertThat(state.backdrop).isEqualTo(GlassGalleryBackdropId.Grid)
 
     onNode(hasText("Off") and hasClickAction())
       .performScrollTo()
       .performSemanticsAction(SemanticsActions.OnClick) { action -> action() }
-    assertEquals(GlassLabInteractionMode.Off, state.interaction)
+    assertThat(state.interaction).isEqualTo(GlassLabInteractionMode.Off)
 
     onNodeWithText("Advanced")
       .performScrollTo()
       .performSemanticsAction(SemanticsActions.OnClick) { action -> action() }
-    assertTrue(state.advancedExpanded)
+    assertThat(state.advancedExpanded).isTrue()
   }
 
   @Test
@@ -154,6 +156,6 @@ class GlassLabSampleTest : ContextTest() {
     }
 
     onNodeWithContentDescription("Glass specimen").performTouchInput { click() }
-    assertEquals(false, recordingModeChanged)
+    assertThat(recordingModeChanged).isFalse()
   }
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSampleTest.kt
@@ -6,14 +6,16 @@ package dev.chrisbanes.haze.sample
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.GlassTransformPivot
 import dev.chrisbanes.haze.glass.GlassTransformTarget
 import dev.chrisbanes.haze.glass.GlassVisualEffect
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalHazeApi::class)
 class GlassPlaygroundSampleTest : ContextTest() {
@@ -24,15 +26,15 @@ class GlassPlaygroundSampleTest : ContextTest() {
 
     effect.configurePlaygroundInteraction(source)
 
-    assertEquals(source, effect.interactionSource)
-    assertEquals(GlassTransformTarget.MaterialAndContent, effect.interactionTransformTarget)
-    assertEquals(GlassTransformPivot.Pointer, effect.interactionTransformPivot)
-    assertTrue(effect.observesPointerEvents)
+    assertThat(effect.interactionSource).isEqualTo(source)
+    assertThat(effect.interactionTransformTarget).isEqualTo(GlassTransformTarget.MaterialAndContent)
+    assertThat(effect.interactionTransformPivot).isEqualTo(GlassTransformPivot.Pointer)
+    assertThat(effect.observesPointerEvents).isTrue()
 
     effect.clearPressed()
-    assertTrue(effect.observesPointerEvents)
+    assertThat(effect.observesPointerEvents).isTrue()
     effect.clearHovered()
-    assertEquals(false, effect.observesPointerEvents)
+    assertThat(effect.observesPointerEvents).isFalse()
   }
 
   @Test
@@ -50,8 +52,8 @@ class GlassPlaygroundSampleTest : ContextTest() {
       dragOffset = Offset(-200f, 200f),
     )
 
-    assertEquals(Offset(140f, 150f), base)
-    assertEquals(Offset(-60f, 350f), dragged)
+    assertThat(base).isEqualTo(Offset(140f, 150f))
+    assertThat(dragged).isEqualTo(Offset(-60f, 350f))
   }
 
   @Test
@@ -64,6 +66,6 @@ class GlassPlaygroundSampleTest : ContextTest() {
       dragOffset = Offset(40f, -20f),
     )
 
-    assertEquals(Offset(310f, -130f), light)
+    assertThat(light).isEqualTo(Offset(310f, -130f))
   }
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
@@ -10,10 +10,11 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThanOrEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isLessThanOrEqualTo
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
-import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.GlassOptics
 import kotlin.test.Test
@@ -30,8 +31,10 @@ class GlassPlaygroundTimelineTest {
       val frame = glassPlaygroundFrame(progress)
       GlassPlaygroundSurfaceId.entries.forEach { id ->
         val position = frame.position(id)
-        assertThat(position.x in 0.1f..0.9f, "$id x at $progress").isTrue()
-        assertThat(position.y in 0.1f..0.9f, "$id y at $progress").isTrue()
+        assertThat(position.x, "$id x at $progress").isGreaterThanOrEqualTo(0.1f)
+        assertThat(position.x, "$id x at $progress").isLessThanOrEqualTo(0.9f)
+        assertThat(position.y, "$id y at $progress").isGreaterThanOrEqualTo(0.1f)
+        assertThat(position.y, "$id y at $progress").isLessThanOrEqualTo(0.9f)
       }
     }
   }
@@ -54,16 +57,14 @@ class GlassPlaygroundTimelineTest {
           surfaceSize = surfaceSize,
           dragOffset = Offset.Zero,
         )
-        assertThat(center.x - surfaceSize.width / 2f >= 0f, "$id left edge at $step").isTrue()
-        assertThat(
-          center.x + surfaceSize.width / 2f <= sceneSize.width,
-          "$id right edge at $step",
-        ).isTrue()
-        assertThat(center.y - surfaceSize.height / 2f >= 0f, "$id top edge at $step").isTrue()
-        assertThat(
-          center.y + surfaceSize.height / 2f <= sceneSize.height,
-          "$id bottom edge at $step",
-        ).isTrue()
+        assertThat(center.x - surfaceSize.width / 2f, "$id left edge at $step")
+          .isGreaterThanOrEqualTo(0f)
+        assertThat(center.x + surfaceSize.width / 2f, "$id right edge at $step")
+          .isLessThanOrEqualTo(sceneSize.width.toFloat())
+        assertThat(center.y - surfaceSize.height / 2f, "$id top edge at $step")
+          .isGreaterThanOrEqualTo(0f)
+        assertThat(center.y + surfaceSize.height / 2f, "$id bottom edge at $step")
+          .isLessThanOrEqualTo(sceneSize.height.toFloat())
       }
     }
   }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
@@ -8,16 +8,20 @@ package dev.chrisbanes.haze.sample
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.GlassOptics
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class GlassPlaygroundTimelineTest {
   @Test
   fun timeline_isSeamlessAtLoopBoundary() {
-    assertEquals(glassPlaygroundFrame(0f), glassPlaygroundFrame(1f))
+    assertThat(glassPlaygroundFrame(1f)).isEqualTo(glassPlaygroundFrame(0f))
   }
 
   @Test
@@ -26,8 +30,8 @@ class GlassPlaygroundTimelineTest {
       val frame = glassPlaygroundFrame(progress)
       GlassPlaygroundSurfaceId.entries.forEach { id ->
         val position = frame.position(id)
-        assertTrue(position.x in 0.1f..0.9f, "$id x out of bounds at $progress: $position")
-        assertTrue(position.y in 0.1f..0.9f, "$id y out of bounds at $progress: $position")
+        assertThat(position.x in 0.1f..0.9f, "$id x at $progress").isTrue()
+        assertThat(position.y in 0.1f..0.9f, "$id y at $progress").isTrue()
       }
     }
   }
@@ -50,10 +54,16 @@ class GlassPlaygroundTimelineTest {
           surfaceSize = surfaceSize,
           dragOffset = Offset.Zero,
         )
-        assertTrue(center.x - surfaceSize.width / 2f >= 0f, "$id crosses left edge at $step")
-        assertTrue(center.x + surfaceSize.width / 2f <= sceneSize.width, "$id crosses right edge at $step")
-        assertTrue(center.y - surfaceSize.height / 2f >= 0f, "$id crosses top edge at $step")
-        assertTrue(center.y + surfaceSize.height / 2f <= sceneSize.height, "$id crosses bottom edge at $step")
+        assertThat(center.x - surfaceSize.width / 2f >= 0f, "$id left edge at $step").isTrue()
+        assertThat(
+          center.x + surfaceSize.width / 2f <= sceneSize.width,
+          "$id right edge at $step",
+        ).isTrue()
+        assertThat(center.y - surfaceSize.height / 2f >= 0f, "$id top edge at $step").isTrue()
+        assertThat(
+          center.y + surfaceSize.height / 2f <= sceneSize.height,
+          "$id bottom edge at $step",
+        ).isTrue()
       }
     }
   }
@@ -62,16 +72,22 @@ class GlassPlaygroundTimelineTest {
   fun backdropAndLight_moveAcrossTheLoop() {
     val opening = glassPlaygroundFrame(0f)
     val quarter = glassPlaygroundFrame(0.25f)
-    assertTrue(opening.backdropOffset != quarter.backdropOffset)
-    assertTrue(opening.lightPosition != quarter.lightPosition)
+    assertThat(opening.backdropOffset).isNotEqualTo(quarter.backdropOffset)
+    assertThat(opening.lightPosition).isNotEqualTo(quarter.lightPosition)
   }
 
   @Test
   fun smallSurfacesUseAdaptiveAndFeatureSurfacesUseLiteralOptics() {
-    assertEquals(GlassOptics.Adaptive, glassPlaygroundStyle(GlassPlaygroundSurfaceId.Lens).optics)
-    assertEquals(GlassOptics.Adaptive, glassPlaygroundStyle(GlassPlaygroundSurfaceId.Pill).optics)
-    assertTrue(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Card).optics is GlassOptics.Absolute)
-    assertTrue(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Prism).optics is GlassOptics.Absolute)
+    assertThat(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Lens).optics)
+      .isEqualTo(GlassOptics.Adaptive)
+    assertThat(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Pill).optics)
+      .isEqualTo(GlassOptics.Adaptive)
+    assertThat(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Card).optics)
+      .isNotNull()
+      .isInstanceOf<GlassOptics.Absolute>()
+    assertThat(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Prism).optics)
+      .isNotNull()
+      .isInstanceOf<GlassOptics.Absolute>()
   }
 
   @Test
@@ -84,6 +100,6 @@ class GlassPlaygroundTimelineTest {
       cardPosition = Offset(0.6f, 0.6f),
       prismPosition = Offset(0.8f, 0.8f),
     )
-    assertEquals(Offset(0.8f, 0.8f), frame.position(GlassPlaygroundSurfaceId.Prism))
+    assertThat(frame.position(GlassPlaygroundSurfaceId.Prism)).isEqualTo(Offset(0.8f, 0.8f))
   }
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassProductSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassProductSampleTest.kt
@@ -18,18 +18,19 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.v2.runComposeUiTest
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
 class GlassProductSampleTest : ContextTest() {
   @Test
   fun productGlassStyle_alwaysUsesAdaptiveOptics() {
-    assertEquals(GlassOptics.Adaptive, productGlassStyle(isDark = false).optics)
-    assertEquals(GlassOptics.Adaptive, productGlassStyle(isDark = true).optics)
+    assertThat(productGlassStyle(isDark = false).optics).isEqualTo(GlassOptics.Adaptive)
+    assertThat(productGlassStyle(isDark = true).optics).isEqualTo(GlassOptics.Adaptive)
   }
 
   @Test

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
@@ -7,17 +7,19 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.v2.runComposeUiTest
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @OptIn(ExperimentalTestApi::class)
 class SamplesTest : ContextTest() {
   @Test
   fun commonSamples_containsOnlyThreeGlassGalleryDestinations() {
-    assertEquals(
-      listOf("Glass — Product", "Glass — Playground", "Glass — Lab"),
+    assertThat(
       CommonSamples.map(Sample::title).filter { "Glass" in it },
+    ).isEqualTo(
+      listOf("Glass — Product", "Glass — Playground", "Glass — Lab"),
     )
   }
 


### PR DESCRIPTION
## Summary

- migrate author-written test assertions across Haze, Glass, screenshot infrastructure, and samples to AssertK
- preserve framework-provided Compose UI and Roborazzi assertions
- add AssertK to the JVM screenshot-test source set
- document AssertK as the repository-wide assertion convention for agents

## Why

Using one fluent assertion library keeps test style and failure output consistent across the Kotlin Multiplatform test suites.

## Validation

- `./gradlew :haze:allTests :haze-glass:allTests :haze-screenshot-tests:test :internal:screenshot-test:jvmTest :sample:shared:allTests spotlessCheck`
- repository-wide scan confirmed no remaining `kotlin.test`, JUnit, or Truth assertion calls/imports
