### PR TITLE
Optimize blur RenderEffect reuse and post-processing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ All Kotlin sources use the default JetBrains style (four-space indentation, trai
 helpful). Spotless with ktlint enforces formatting; run `./gradlew spotlessApply` before committing.
 Keep public packages under `dev.chrisbanes.haze.*` and follow PascalCase for composables, camelCase
 for parameters, and `*Defaults` naming for reusable configuration containers.
+For internal or private value types, prefer `@Poko` over `data class`. Configure modules that use
+the project annotation with `pokoAnnotation.set("dev/chrisbanes/haze/Poko")`; reserve `data class`
+for types that intentionally require generated `copy` or component functions.
 
 ## Testing Guidelines
 

--- a/haze-blur/build.gradle.kts
+++ b/haze-blur/build.gradle.kts
@@ -120,3 +120,7 @@ kotlin {
 tasks.withType<org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest> {
   enabled = false
 }
+
+poko {
+  pokoAnnotation.set("dev/chrisbanes/haze/Poko")
+}

--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.android.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.android.kt
@@ -14,9 +14,13 @@ import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.graphics.Matrix
 import android.graphics.RenderEffect as AndroidRenderEffect
+import android.graphics.RuntimeShader
 import android.graphics.Shader.TileMode.REPEAT
+import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.toArgb
 import dev.chrisbanes.haze.HazeBlendMode
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.PlatformContext
@@ -26,6 +30,65 @@ import dev.chrisbanes.haze.createShaderRenderEffect
 import kotlin.math.abs
 
 private var noiseTexture: Bitmap? = null
+
+private const val COMBINED_NOISE_TINT_SKSL = """
+  uniform shader content;
+  uniform shader noise;
+  uniform float noiseAlpha;
+  layout(color) uniform half4 tintColor;
+
+  half guardedDivide(half numerator, half denominator) {
+    return denominator == 0.0 ? 0.0 : numerator / denominator;
+  }
+
+  half softLightComponent(half2 source, half2 destination) {
+    if (2.0 * source.x <= source.y) {
+      return guardedDivide(
+        destination.x * destination.x * (source.y - 2.0 * source.x),
+        destination.y
+      ) + (1.0 - destination.y) * source.x
+        + destination.x * (-source.y + 2.0 * source.x + 1.0);
+    } else if (4.0 * destination.x <= destination.y) {
+      half destinationSquared = destination.x * destination.x;
+      half destinationCubed = destinationSquared * destination.x;
+      half destinationAlphaSquared = destination.y * destination.y;
+      half destinationAlphaCubed = destinationAlphaSquared * destination.y;
+      return guardedDivide(
+        destinationAlphaSquared
+          * (source.x - destination.x * (3.0 * source.y - 6.0 * source.x - 1.0))
+          + 12.0 * destination.y * destinationSquared * (source.y - 2.0 * source.x)
+          - 16.0 * destinationCubed * (source.y - 2.0 * source.x)
+          - destinationAlphaCubed * source.x,
+        destinationAlphaSquared
+      );
+    } else {
+      return destination.x * (source.y - 2.0 * source.x + 1.0)
+        + source.x
+        - sqrt(destination.y * destination.x) * (source.y - 2.0 * source.x)
+        - destination.y * source.x;
+    }
+  }
+
+  half4 softLight(half4 source, half4 destination) {
+    if (destination.a == 0.0) {
+      return source;
+    }
+    return half4(
+      softLightComponent(source.ra, destination.ra),
+      softLightComponent(source.ga, destination.ga),
+      softLightComponent(source.ba, destination.ba),
+      source.a + (1.0 - source.a) * destination.a
+    );
+  }
+
+  half4 main(float2 coord) {
+    half4 blurred = content.eval(coord);
+    half4 noiseColor = noise.eval(coord) * noiseAlpha;
+    half4 withNoise = softLight(noiseColor, blurred);
+    half4 tint = tintColor.rgb1 * tintColor.a;
+    return tint + withNoise * (1.0 - tintColor.a);
+  }
+"""
 
 internal fun Context.getNoiseTexture(): Bitmap {
   val cached = noiseTexture
@@ -38,6 +101,39 @@ internal fun Context.getNoiseTexture(): Bitmap {
   }
 }
 
+private fun Context.createNoiseShader(scale: Float): BitmapShader {
+  val normalizedScale = if (scale > 0f) scale else 1f
+  return BitmapShader(getNoiseTexture(), REPEAT, REPEAT).apply {
+    if (abs(normalizedScale - 1f) >= 0.001f) {
+      setLocalMatrix(
+        Matrix().apply {
+          val reciprocal = 1f / normalizedScale
+          setScale(reciprocal, reciprocal)
+        },
+      )
+    }
+  }
+}
+
+@RequiresApi(31)
+internal actual fun createCombinedNoiseTintRenderEffectOrNull(
+  context: PlatformContext,
+  input: PlatformRenderEffect,
+  noiseFactor: Float,
+  tintColor: Color,
+  scale: Float,
+): PlatformRenderEffect? {
+  if (Build.VERSION.SDK_INT < 33) return null
+
+  val shader = RuntimeShader(COMBINED_NOISE_TINT_SKSL).apply {
+    setInputShader("noise", context.createNoiseShader(scale))
+    setFloatUniform("noiseAlpha", noiseFactor.coerceIn(0f, 1f))
+    setColorUniform("tintColor", tintColor.toArgb())
+  }
+  val postProcess = AndroidRenderEffect.createRuntimeShaderEffect(shader, "content")
+  return AndroidRenderEffect.createChainEffect(postProcess, input)
+}
+
 @RequiresApi(31)
 internal actual fun createNoiseEffect(
   context: PlatformContext,
@@ -46,19 +142,8 @@ internal actual fun createNoiseEffect(
   scale: Float,
 ): PlatformRenderEffect {
   // Apply scaling through the shader matrix so we can reuse the decoded bitmap.
-  val normalizedScale = if (scale > 0f) scale else 1f
-  val noiseShader = BitmapShader(context.getNoiseTexture(), REPEAT, REPEAT).apply {
-    if (abs(normalizedScale - 1f) >= 0.001f) {
-      val matrix = Matrix().apply {
-        val reciprocal = 1f / normalizedScale
-        setScale(reciprocal, reciprocal)
-      }
-      setLocalMatrix(matrix)
-    }
-  }
-
   val noiseAlpha = noiseFactor.coerceIn(0f, 1f)
-  val baseNoiseEffect = AndroidRenderEffect.createShaderEffect(noiseShader)
+  val baseNoiseEffect = AndroidRenderEffect.createShaderEffect(context.createNoiseShader(scale))
   val noiseEffect = if (noiseAlpha < 1f) {
     val matrix = ColorMatrix().apply { setScale(1f, 1f, 1f, noiseAlpha) }
     AndroidRenderEffect.createColorFilterEffect(ColorMatrixColorFilter(matrix), baseNoiseEffect)

--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegate.android.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegate.android.kt
@@ -67,8 +67,7 @@ private fun RenderEffectBlurVisualEffectDelegate.drawLinearGradientProgressiveEf
 ) = with(drawScope) {
   val colorEffects = blurVisualEffect.colorEffects
   val noiseFactor = blurVisualEffect.noiseFactor
-  val blurRadius = blurVisualEffect.blurRadius.takeOrElse { 0.dp } *
-    blurVisualEffect.resolveInputScaleFactor(context.inputScale)
+  val blurRadius = blurVisualEffect.blurRadius.takeOrElse { 0.dp }
 
   drawProgressiveWithMultipleLayers(progressive) { mask, intensity ->
     context.withGraphicsLayer { layer ->

--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
@@ -167,7 +167,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
 
         // Draw the noise on top...
         val noiseFactor = blurVisualEffect.noiseFactor
-        if (noiseFactor > 0f) {
+        if (noiseFactor.hasVisibleNoise()) {
           translate(offset = -offset) {
             PaintPool.usePaint { paint ->
               paint.isAntiAlias = true

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.kt
@@ -68,27 +68,62 @@ internal fun createRenderEffect(
     ) ?: createOffsetRenderEffect(0f, 0f)
   }
 
-  val blurWithNoise = if (params.noiseFactor.hasVisibleNoise()) {
-    blur.blendForeground(
-      foreground = createNoiseEffect(
-        context = context,
-        noiseFactor = params.noiseFactor,
-        mask = progressiveShader,
-        scale = params.scale,
-      ),
-      blendMode = HazeBlendMode.Softlight,
+  val combinedNoiseTintEffect = params.combinedNoiseTintColor()?.let { tintColor ->
+    createCombinedNoiseTintRenderEffectOrNull(
+      context = context,
+      input = blur,
+      noiseFactor = params.noiseFactor,
+      tintColor = tintColor,
+      scale = params.scale,
     )
-  } else {
-    blur
   }
 
-  return blurWithNoise
-    .withTints(params.colorEffects, size, offset, params.colorEffectsAlphaModulate, progressiveShader)
+  val styled = combinedNoiseTintEffect ?: run {
+    val blurWithNoise = if (params.noiseFactor.hasVisibleNoise()) {
+      blur.blendForeground(
+        foreground = createNoiseEffect(
+          context = context,
+          noiseFactor = params.noiseFactor,
+          mask = progressiveShader,
+          scale = params.scale,
+        ),
+        blendMode = HazeBlendMode.Softlight,
+      )
+    } else {
+      blur
+    }
+
+    blurWithNoise.withTints(
+      params.colorEffects,
+      size,
+      offset,
+      params.colorEffectsAlphaModulate,
+      progressiveShader,
+    )
+  }
+
+  return styled
     .withMask(params.mask, size, offset)
     .asComposeRenderEffect()
 }
 
 internal fun Float.hasVisibleNoise(): Boolean = this > 0f
+
+private fun RenderEffectParams.combinedNoiseTintColor(): Color? {
+  if (!noiseFactor.hasVisibleNoise() || progressive != null || mask != null) return null
+  val tint = colorEffects.singleOrNull() as? HazeColorEffect.TintColor ?: return null
+  if (tint.blendMode != BlendMode.SrcOver) return null
+
+  return tint.resolveColor(colorEffectsAlphaModulate)
+}
+
+internal expect fun createCombinedNoiseTintRenderEffectOrNull(
+  context: PlatformContext,
+  input: PlatformRenderEffect,
+  noiseFactor: Float,
+  tintColor: Color,
+  scale: Float,
+): PlatformRenderEffect?
 
 /**
  * Creates the platform-specific noise effect.
@@ -175,12 +210,7 @@ private fun PlatformRenderEffect.withColorTint(
   alphaModulate: Float,
   mask: Shader?,
 ): PlatformRenderEffect {
-  val tintColor = when {
-    alphaModulate < 1f -> effect.color.copy(alpha = effect.color.alpha * alphaModulate)
-    else -> effect.color
-  }
-
-  if (tintColor.alpha < 0.005f) return this
+  val tintColor = effect.resolveColor(alphaModulate) ?: return this
 
   val colorEffect = createBlendColorFilter(tintColor.toArgb(), effect.blendMode.toHazeBlendMode())
 
@@ -205,6 +235,14 @@ private fun PlatformRenderEffect.withColorTint(
   } else {
     effectWithMask
   }
+}
+
+private fun HazeColorEffect.TintColor.resolveColor(alphaModulate: Float): Color? {
+  val resolved = when {
+    alphaModulate < 1f -> color.copy(alpha = color.alpha * alphaModulate)
+    else -> color
+  }
+  return resolved.takeIf { it.alpha >= 0.005f }
 }
 
 /**

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.kt
@@ -47,7 +47,7 @@ internal fun createRenderEffect(
   val size = ceil(params.contentSize * params.scale)
   val offset = (params.contentOffset * params.scale).round()
 
-  val blurRadiusPx = with(density) { blurRadius.toPx() }
+  val blurRadiusPx = params.resolveBlurRadiusPx(density)
   val progressiveShader = params.progressive?.asBrush()?.toShader(size)
 
   val blur = if (progressiveShader != null && isRuntimeShaderRenderEffectSupported()) {
@@ -68,14 +68,27 @@ internal fun createRenderEffect(
     ) ?: createOffsetRenderEffect(0f, 0f)
   }
 
-  val noise = createNoiseEffect(context, params.noiseFactor, progressiveShader, params.scale)
+  val blurWithNoise = if (params.noiseFactor.hasVisibleNoise()) {
+    blur.blendForeground(
+      foreground = createNoiseEffect(
+        context = context,
+        noiseFactor = params.noiseFactor,
+        mask = progressiveShader,
+        scale = params.scale,
+      ),
+      blendMode = HazeBlendMode.Softlight,
+    )
+  } else {
+    blur
+  }
 
-  return blur
-    .blendForeground(foreground = noise, blendMode = HazeBlendMode.Softlight)
+  return blurWithNoise
     .withTints(params.colorEffects, size, offset, params.colorEffectsAlphaModulate, progressiveShader)
     .withMask(params.mask, size, offset)
     .asComposeRenderEffect()
 }
+
+internal fun Float.hasVisibleNoise(): Boolean = this > 0f
 
 /**
  * Creates the platform-specific noise effect.

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.takeOrElse
@@ -62,7 +63,7 @@ internal fun BlurVisualEffect.getOrCreateRenderEffect(
 }
 
 private val renderEffectCache = lazy(mode = LazyThreadSafetyMode.NONE) {
-  LruCache<RenderEffectParams, RenderEffect>(maxSize = 50)
+  LruCache<RenderEffectCacheKey, RenderEffect>(maxSize = 50)
 }
 
 internal fun clearRenderEffectCache() {
@@ -89,21 +90,63 @@ internal class RenderEffectParams(
   val blurTileMode: TileMode,
 )
 
+internal data class RenderEffectCacheKey(
+  val blurRadiusPx: Float,
+  val noiseFactor: Float,
+  val scale: Float,
+  val contentSize: Size,
+  val contentOffset: Offset,
+  val colorEffects: List<HazeColorEffect>,
+  val colorEffectsAlphaModulate: Float,
+  val mask: Brush?,
+  val progressive: HazeProgressive?,
+  val blurTileMode: TileMode,
+)
+
+internal fun RenderEffectParams.resolveBlurRadiusPx(density: Density): Float =
+  with(density) { (blurRadius * scale).toPx() }
+
+internal fun RenderEffectParams.renderEffectCacheKey(density: Density): RenderEffectCacheKey {
+  val hasBrushTint = colorEffects.any { it is HazeColorEffect.TintBrush }
+  val hasOffsetColorEffect = colorEffects.any {
+    it is HazeColorEffect.TintBrush || it is HazeColorEffect.ColorFilter
+  }
+  val usesContentSize = progressive != null || mask != null || hasBrushTint
+  val usesContentOffset = progressive != null || mask != null || hasOffsetColorEffect
+
+  return RenderEffectCacheKey(
+    blurRadiusPx = resolveBlurRadiusPx(density),
+    noiseFactor = if (noiseFactor.hasVisibleNoise()) noiseFactor else 0f,
+    scale = scale,
+    contentSize = if (usesContentSize) contentSize else Size.Zero,
+    contentOffset = if (usesContentOffset) contentOffset else Offset.Zero,
+    colorEffects = colorEffects,
+    colorEffectsAlphaModulate = colorEffectsAlphaModulate,
+    mask = mask,
+    progressive = progressive,
+    blurTileMode = blurTileMode,
+  )
+}
+
 @OptIn(ExperimentalHazeApi::class)
 private fun getOrCreateRenderEffect(context: VisualEffectContext, params: RenderEffectParams): RenderEffect? {
   HazeLogger.d(BlurVisualEffect.TAG) { "getOrCreateRenderEffect: $params" }
-  val cached = renderEffectCache.value[params]
+  val density = context.requireDensity()
+  val cacheKey = params.renderEffectCacheKey(density)
+  val cached = renderEffectCache.value[cacheKey]
   if (cached != null) {
     HazeLogger.d(BlurVisualEffect.TAG) { "getOrCreateRenderEffect. Returning cached: $params" }
     return cached
   }
 
   HazeLogger.d(BlurVisualEffect.TAG) { "getOrCreateRenderEffect. Creating: $params" }
-  return createRenderEffect(
-    context = context.requirePlatformContext(),
-    density = context.requireDensity(),
-    params = params,
-  ).also { effect ->
-    renderEffectCache.value.put(params, effect)
+  return trace("HazeBlur-createRenderEffect") {
+    createRenderEffect(
+      context = context.requirePlatformContext(),
+      density = density,
+      params = params,
+    )
+  }.also { effect ->
+    renderEffectCache.value.put(cacheKey, effect)
   }
 }

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
@@ -90,7 +90,8 @@ internal class RenderEffectParams(
   val blurTileMode: TileMode,
 )
 
-internal data class RenderEffectCacheKey(
+@Poko
+internal class RenderEffectCacheKey(
   val blurRadiusPx: Float,
   val noiseFactor: Float,
   val scale: Float,

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtilsTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtilsTest.kt
@@ -4,9 +4,20 @@
 package dev.chrisbanes.haze.blur
 
 import androidx.collection.LruCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isTrue
+import dev.chrisbanes.haze.HazeProgressive
 import kotlin.test.Test
 
 class BlurVisualEffectUtilsTest {
@@ -40,4 +51,133 @@ class BlurVisualEffectUtilsTest {
     assertThat(cleared).isTrue()
     assertThat(lazyCache.value[1] == null).isTrue()
   }
+
+  @Test
+  fun renderEffectCacheKey_solidColorGraphIgnoresGeometry() {
+    val colorEffects = listOf(HazeColorEffect.tint(Color.Red))
+    val params = renderEffectParams(colorEffects = colorEffects)
+
+    assertThat(params.renderEffectCacheKey(Density(2f))).isEqualTo(
+      renderEffectParams(
+        colorEffects = colorEffects,
+        contentSize = Size(800f, 600f),
+        contentOffset = Offset(24f, 12f),
+      ).renderEffectCacheKey(Density(2f)),
+    )
+  }
+
+  @Test
+  fun renderEffectCacheKey_brushTintTracksSizeAndOffset() {
+    val colorEffects = listOf(
+      HazeColorEffect.tint(Brush.verticalGradient(listOf(Color.Red, Color.Blue))),
+    )
+    val params = renderEffectParams(colorEffects = colorEffects)
+    val key = params.renderEffectCacheKey(Density(2f))
+
+    assertThat(key).isNotEqualTo(
+      renderEffectParams(
+        colorEffects = colorEffects,
+        contentSize = Size(800f, 600f),
+      ).renderEffectCacheKey(Density(2f)),
+    )
+    assertThat(key).isNotEqualTo(
+      renderEffectParams(
+        colorEffects = colorEffects,
+        contentOffset = Offset(24f, 12f),
+      ).renderEffectCacheKey(Density(2f)),
+    )
+  }
+
+  @Test
+  fun renderEffectCacheKey_colorFilterTracksOffsetButNotSize() {
+    val colorEffects = listOf(
+      HazeColorEffect.colorFilter(ColorFilter.tint(Color.Red)),
+    )
+    val params = renderEffectParams(colorEffects = colorEffects)
+    val key = params.renderEffectCacheKey(Density(2f))
+
+    assertThat(key).isEqualTo(
+      renderEffectParams(
+        colorEffects = colorEffects,
+        contentSize = Size(800f, 600f),
+      ).renderEffectCacheKey(Density(2f)),
+    )
+    assertThat(key).isNotEqualTo(
+      renderEffectParams(
+        colorEffects = colorEffects,
+        contentOffset = Offset(24f, 12f),
+      ).renderEffectCacheKey(Density(2f)),
+    )
+  }
+
+  @Test
+  fun renderEffectCacheKey_maskAndProgressiveTrackGeometry() {
+    val mask = Brush.verticalGradient(listOf(Color.Black, Color.Transparent))
+    val progressive = HazeProgressive.verticalGradient(startIntensity = 1f, endIntensity = 0f)
+    val masked = renderEffectParams(mask = mask)
+    val progressiveParams = renderEffectParams(progressive = progressive)
+
+    assertThat(masked.renderEffectCacheKey(Density(2f))).isNotEqualTo(
+      renderEffectParams(
+        contentSize = Size(800f, 600f),
+        contentOffset = Offset(24f, 12f),
+        mask = mask,
+      ).renderEffectCacheKey(Density(2f)),
+    )
+    assertThat(progressiveParams.renderEffectCacheKey(Density(2f))).isNotEqualTo(
+      renderEffectParams(
+        contentSize = Size(800f, 600f),
+        contentOffset = Offset(24f, 12f),
+        progressive = progressive,
+      ).renderEffectCacheKey(Density(2f)),
+    )
+  }
+
+  @Test
+  fun renderEffectCacheKey_tracksDensity() {
+    val params = renderEffectParams()
+
+    assertThat(params.renderEffectCacheKey(Density(1f)))
+      .isNotEqualTo(params.renderEffectCacheKey(Density(2f)))
+  }
+
+  @Test
+  fun renderEffectCacheKey_canonicalizesDisabledNoise() {
+    val density = Density(2f)
+    val key = renderEffectParams(noiseFactor = 0f).renderEffectCacheKey(density)
+
+    assertThat(key)
+      .isEqualTo(renderEffectParams(noiseFactor = -1f).renderEffectCacheKey(density))
+    assertThat(key)
+      .isEqualTo(renderEffectParams(noiseFactor = Float.NaN).renderEffectCacheKey(density))
+    assertThat(key)
+      .isNotEqualTo(renderEffectParams(noiseFactor = 0.15f).renderEffectCacheKey(density))
+  }
+
+  @Test
+  fun hasVisibleNoise_onlyForPositiveFactors() {
+    assertThat((-1f).hasVisibleNoise()).isFalse()
+    assertThat(0f.hasVisibleNoise()).isFalse()
+    assertThat(Float.NaN.hasVisibleNoise()).isFalse()
+    assertThat(0.15f.hasVisibleNoise()).isTrue()
+  }
+
+  private fun renderEffectParams(
+    colorEffects: List<HazeColorEffect> = listOf(HazeColorEffect.tint(Color.Red)),
+    noiseFactor: Float = 0.15f,
+    contentSize: Size = Size(640f, 480f),
+    contentOffset: Offset = Offset(8f, 4f),
+    mask: Brush? = null,
+    progressive: HazeProgressive? = null,
+  ) = RenderEffectParams(
+    blurRadius = 20.dp,
+    noiseFactor = noiseFactor,
+    scale = 1f,
+    contentSize = contentSize,
+    contentOffset = contentOffset,
+    colorEffects = colorEffects,
+    mask = mask,
+    progressive = progressive,
+    blurTileMode = TileMode.Clamp,
+  )
 }

--- a/haze-blur/src/skikoMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.skiko.kt
+++ b/haze-blur/src/skikoMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.skiko.kt
@@ -5,6 +5,7 @@
 
 package dev.chrisbanes.haze.blur
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shader
 import dev.chrisbanes.haze.HazeBlendMode
 import dev.chrisbanes.haze.InternalHazeApi
@@ -25,6 +26,14 @@ private val NOISE_SHADER by lazy(LazyThreadSafetyMode.NONE) {
     seed = 2.0f,
   )
 }
+
+internal actual fun createCombinedNoiseTintRenderEffectOrNull(
+  context: PlatformContext,
+  input: PlatformRenderEffect,
+  noiseFactor: Float,
+  tintColor: Color,
+  scale: Float,
+): PlatformRenderEffect? = null
 
 internal actual fun createNoiseEffect(
   context: PlatformContext,

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/BlurInputScaleAndroidScreenshotTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/BlurInputScaleAndroidScreenshotTest.kt
@@ -1,0 +1,103 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isLessThanOrEqualTo
+import dev.chrisbanes.haze.blur.BlurVisualEffect
+import dev.chrisbanes.haze.test.ScreenshotTest
+import dev.chrisbanes.haze.test.ScreenshotTheme
+import dev.chrisbanes.haze.test.runScreenshotTest
+import kotlin.math.abs
+import kotlin.test.Test
+import org.robolectric.annotation.Config
+
+@Config(sdk = [32])
+class BlurInputScaleAndroidScreenshotTest : ScreenshotTest() {
+
+  @Test
+  fun progressiveBlur_preservesScreenSpaceRadiusAcrossInputScales() = runScreenshotTest {
+    val effect = BlurVisualEffect().apply {
+      blurRadius = 48.dp
+      noiseFactor = 0f
+      progressive = HazeProgressive.verticalGradient()
+    }
+    var inputScale by mutableStateOf<HazeInputScale>(HazeInputScale.None)
+
+    setContent {
+      ScreenshotTheme {
+        val hazeState = rememberHazeState()
+        Box(Modifier.fillMaxSize()) {
+          Row(
+            Modifier
+              .fillMaxSize()
+              .hazeSource(hazeState),
+          ) {
+            Box(
+              Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .background(Color.Black),
+            )
+            Box(
+              Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .background(Color.White),
+            )
+          }
+          Box(
+            Modifier
+              .fillMaxSize()
+              .hazeEffect(hazeState) {
+                this.inputScale = inputScale
+                visualEffect = effect
+              },
+          )
+        }
+      }
+    }
+
+    val unscaled = captureRootPixels().snapshot()
+    inputScale = HazeInputScale.Fixed(0.5f)
+    waitForIdle()
+    val scaled = captureRootPixels().snapshot()
+
+    val scanY = unscaled.height * 3 / 4
+    val unscaledWidth = unscaled.horizontalTransitionWidth(scanY)
+    val scaledWidth = scaled.horizontalTransitionWidth(scanY)
+
+    assertThat(abs(unscaledWidth - scaledWidth)).isLessThanOrEqualTo(4)
+  }
+}
+
+private fun PixelSnapshot.horizontalTransitionWidth(y: Int): Int {
+  val luminance = (0 until width).map { x -> this[x, y].luminance() }
+  val minimum = luminance.min()
+  val maximum = luminance.max()
+  val range = maximum - minimum
+  assertThat(range, "transition luminance range").isGreaterThan(0.5f)
+
+  val low = minimum + range * 0.1f
+  val high = minimum + range * 0.9f
+  val lowIndex = luminance.indexOfFirst { it >= low }
+  val highIndex = luminance.indexOfFirst { it >= high }
+  assertThat(lowIndex, "low transition threshold index").isGreaterThanOrEqualTo(0)
+  assertThat(highIndex, "high transition threshold index").isGreaterThanOrEqualTo(lowIndex)
+  return highIndex - lowIndex
+}

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 private const val DEFAULT_ITERATIONS = 16
+private const val HYPOTHESIS_ITERATIONS = 5
 private const val APP_PACKAGE = "dev.chrisbanes.haze.sample.android"
 
 @RunWith(AndroidJUnit4::class)
@@ -46,6 +47,23 @@ class BenchmarkTest {
       setupBlock = {
         startActivityAndWait()
         device.setBlurEnabled(true)
+        device.navigateToScaffold()
+      },
+    ) {
+      device.repeatedScrolls("lazy_grid")
+    }
+  }
+
+  @Test
+  fun scaffoldBlurDisabled() {
+    benchmarkRule.measureRepeated(
+      packageName = APP_PACKAGE,
+      metrics = listOf(FrameTimingMetric()),
+      startupMode = StartupMode.WARM,
+      iterations = HYPOTHESIS_ITERATIONS,
+      setupBlock = {
+        startActivityAndWait()
+        device.setBlurEnabled(false)
         device.navigateToScaffold()
       },
     ) {


### PR DESCRIPTION
## Summary

- normalize blur `RenderEffect` cache keys so geometry changes only recreate effects when they affect rendering
- use `@Poko` for the new internal value types and document that convention for future internal/private classes
- fuse Android 33+ noise and a single `SrcOver` tint into one runtime-shader post-process, retaining the existing graph as the fallback for unsupported or more complex effects
- add cache-key regression coverage and a disabled-Haze benchmark variant

## Why

The blur cache key included values that did not always affect the generated effect, causing unnecessary effect recreation. On Android 33+, visible noise and a common single-color tint were also represented as separate rendering nodes after the platform blur. The combined runtime shader preserves the platform blur while reducing the post-processing work.

## Benchmarks

Pixel 6, Android API 37, `BenchmarkTest#scaffold`, 16 measured iterations per variant:

| CPU frame duration | Fused | Adjacent baseline | Difference |
| --- | ---: | ---: | ---: |
| P50 | 7.259 ms | 7.6 ms | -4.5% |
| P90 | 9.818 ms | 10.1 ms | -2.8% |
| P95 | 10.636 ms | 10.9 ms | -2.4% |
| P99 | 12.726 ms | 12.4 ms | +2.6% |

Median-trace rendering work:

- Ganesh OpsTasks: 1,481 → 1,274 (-14.0%)
- RenderThread `flush commands` CPU: 273.347 ms → 247.487 ms (-9.5%)
- RenderThread `QueueSubmit` CPU: 175.999 ms → 154.297 ms (-12.3%)
- `QueueSubmit` count: unchanged at 198

The central percentiles and trace-level work improve consistently; the isolated P99 difference is within observed tail variability. Adaptive input scaling is tracked separately in #1083.

## Validation

- `./gradlew :haze-blur:spotlessApply :haze-blur:check :haze-screenshot-tests:testAndroidHostTest`
- `./gradlew :haze-blur:check` after rebasing onto current `origin/main`
- two 16-iteration Pixel 6 Macrobenchmark runs
- final review-and-simplify and over-engineering review passes
- `git diff --check origin/main...HEAD`