### PR TITLE
Fix Glass interaction stage caching

### DIFF
--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.test.AndroidComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
@@ -328,6 +329,35 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     }
 
   @Test
+  fun stableInteractionFrames_retainExistingStageRenderEffects() =
+    runAndroidComposeUiTest<ComponentActivity> {
+      val effect = interactiveEffect()
+      setContent { RuntimeGlassTestContent(effect) }
+      waitForIdle()
+      drawFrame()
+
+      effect.setPressedForTest(Offset(20f, 20f))
+      waitForIdle()
+      drawFrame()
+
+      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val opticalEffect = checkNotNull(delegate.layers.interactionOptical?.renderEffect)
+      val detailEffect = checkNotNull(delegate.layers.interactionRefractionDetail?.renderEffect)
+      val detailCoverageEffect = checkNotNull(
+        delegate.layers.interactionRefractionDetailCoverage?.renderEffect,
+      )
+      val lightingEffect = checkNotNull(delegate.layers.interactionLighting?.renderEffect)
+
+      drawFrame()
+
+      assertThat(delegate.layers.interactionOptical?.renderEffect).isSameInstanceAs(opticalEffect)
+      assertThat(delegate.layers.interactionRefractionDetail?.renderEffect).isSameInstanceAs(detailEffect)
+      assertThat(delegate.layers.interactionRefractionDetailCoverage?.renderEffect)
+        .isSameInstanceAs(detailCoverageEffect)
+      assertThat(delegate.layers.interactionLighting?.renderEffect).isSameInstanceAs(lightingEffect)
+    }
+
+  @Test
   fun largePanel_interactionPatchRetainsBaseLayersAcrossFrames() =
     runAndroidComposeUiTest<ComponentActivity> {
       val effect = largePanelInteractiveEffect()
@@ -429,6 +459,25 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       assertThat(delegate.layers.interactionOptical?.isReleased != false).isTrue()
       assertThat(delegate.layers.interactionRefractionDetail?.isReleased != false).isTrue()
       assertThat(delegate.layers.interactionLighting?.isReleased != false).isTrue()
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionOpticalLayer")).isNull()
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionDetailLayer")).isNull()
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionDetailCoverageLayer")).isNull()
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionCompositeLayer")).isNull()
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionLightingLayer")).isNull()
+
+      effect.setPressedForTest(positions.first())
+      drawInteractionFrame()
+
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionOpticalLayer"))
+        .isSameInstanceAs(delegate.layers.interactionOptical)
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionDetailLayer"))
+        .isSameInstanceAs(delegate.layers.interactionRefractionDetail)
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionDetailCoverageLayer"))
+        .isSameInstanceAs(delegate.layers.interactionRefractionDetailCoverage)
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionCompositeLayer"))
+        .isSameInstanceAs(delegate.layers.interactionRefractionComposite)
+      assertThat(delegate.recordedInteractionLayer("recordedInteractionLightingLayer"))
+        .isSameInstanceAs(delegate.layers.interactionLighting)
       assertThat(delegate.canDrawRetainedOutput()).isTrue()
       mainClock.autoAdvance = true
     }
@@ -737,9 +786,15 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     drawFrame()
   }
 
-  private fun RuntimeShaderGlassDelegate.interactionShaderHandle(fieldName: String): Any {
+  private fun RuntimeShaderGlassDelegate.interactionShaderHandle(fieldName: String): Any =
+    checkNotNull(interactionField(fieldName))
+
+  private fun RuntimeShaderGlassDelegate.interactionField(fieldName: String): Any? {
     val field = RuntimeShaderGlassDelegate::class.java.getDeclaredField(fieldName)
     field.isAccessible = true
-    return checkNotNull(field.get(this))
+    return field.get(this)
   }
+
+  private fun RuntimeShaderGlassDelegate.recordedInteractionLayer(fieldName: String): GraphicsLayer? =
+    interactionField(fieldName) as? GraphicsLayer
 }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.drawscope.scale
@@ -64,6 +65,22 @@ internal class RuntimeShaderGlassDelegate(
   private var interactionDetailEffect: MutableRuntimeShaderRenderEffect? = null
   private var interactionDetailCoverageEffect: MutableRuntimeShaderRenderEffect? = null
   private var interactionLightingEffect: MutableRuntimeShaderRenderEffect? = null
+  private var interactionOpticalEffectKey: GlassOpticalEffectKey? = null
+  private var interactionOpticalEffectUniforms: GlassInteractionUniforms? = null
+  private var interactionOpticalComposeEffect: RenderEffect? = null
+  private var interactionOpticalEffectLayer: GraphicsLayer? = null
+  private var interactionDetailEffectKey: GlassRefractionDetailEffectKey? = null
+  private var interactionDetailEffectUniforms: GlassInteractionUniforms? = null
+  private var interactionDetailComposeEffect: RenderEffect? = null
+  private var interactionDetailEffectLayer: GraphicsLayer? = null
+  private var interactionDetailCoverageEffectKey: GlassRefractionDetailEffectKey? = null
+  private var interactionDetailCoverageEffectUniforms: GlassInteractionUniforms? = null
+  private var interactionDetailCoverageComposeEffect: RenderEffect? = null
+  private var interactionDetailCoverageEffectLayer: GraphicsLayer? = null
+  private var interactionLightingEffectKey: GlassInteractionLightingKey? = null
+  private var interactionLightingEffectUniforms: GlassInteractionUniforms? = null
+  private var interactionLightingComposeEffect: RenderEffect? = null
+  private var interactionLightingEffectLayer: GraphicsLayer? = null
   private var recordedInteractionOpticalLayer: GraphicsLayer? = null
   private var recordedInteractionOpticalInput: GraphicsLayer? = null
   private var recordedInteractionOpticalKey: GlassOpticalEffectKey? = null
@@ -276,13 +293,16 @@ internal class RuntimeShaderGlassDelegate(
     if (!opticsRequired) {
       releaseLayer(layers.interactionOptical, graphicsContext)
       layers.interactionOptical = null
+      clearInteractionOpticalLayerMetadata()
     }
     if (!detailRequired) {
       layers.releaseInteractionRefractionDetail(graphicsContext)
+      clearInteractionRefractionLayerMetadata()
     }
     if (!lightingRequired) {
       releaseLayer(layers.interactionLighting, graphicsContext)
       layers.interactionLighting = null
+      clearInteractionLightingLayerMetadata()
     }
   }
 
@@ -669,9 +689,31 @@ internal class RuntimeShaderGlassDelegate(
   }
 
   private fun clearInteractionLayerMetadata() {
+    clearInteractionOpticalLayerMetadata()
+    clearInteractionRefractionLayerMetadata()
+    clearInteractionLightingLayerMetadata()
+    interactionOpticalEffectKey = null
+    interactionOpticalEffectUniforms = null
+    interactionOpticalComposeEffect = null
+    interactionDetailEffectKey = null
+    interactionDetailEffectUniforms = null
+    interactionDetailComposeEffect = null
+    interactionDetailCoverageEffectKey = null
+    interactionDetailCoverageEffectUniforms = null
+    interactionDetailCoverageComposeEffect = null
+    interactionLightingEffectKey = null
+    interactionLightingEffectUniforms = null
+    interactionLightingComposeEffect = null
+  }
+
+  private fun clearInteractionOpticalLayerMetadata() {
     recordedInteractionOpticalLayer = null
     recordedInteractionOpticalInput = null
     recordedInteractionOpticalKey = null
+    interactionOpticalEffectLayer = null
+  }
+
+  private fun clearInteractionRefractionLayerMetadata() {
     recordedInteractionDetailLayer = null
     recordedInteractionDetailInput = null
     recordedInteractionDetailKey = null
@@ -683,8 +725,14 @@ internal class RuntimeShaderGlassDelegate(
     recordedInteractionCompositeDetail = null
     recordedInteractionCompositeCoverage = null
     recordedInteractionCompositeSize = null
+    interactionDetailEffectLayer = null
+    interactionDetailCoverageEffectLayer = null
+  }
+
+  private fun clearInteractionLightingLayerMetadata() {
     recordedInteractionLightingLayer = null
     recordedInteractionLightingSize = null
+    interactionLightingEffectLayer = null
   }
 
   private fun clearSharedBlurSliceMetadata() {
@@ -1198,7 +1246,7 @@ internal class RuntimeShaderGlassDelegate(
     input.alpha = 1f
     input.blendMode = BlendMode.SrcOver
     layer.alpha = 1f
-    layer.renderEffect = updateInteractionOpticalEffect(localKey, patch.uniforms).asComposeRenderEffect()
+    updateInteractionOpticalEffect(layer, localKey, patch.uniforms)
     if (
       layer !== recordedInteractionOpticalLayer ||
       input !== recordedInteractionOpticalInput ||
@@ -1230,7 +1278,7 @@ internal class RuntimeShaderGlassDelegate(
         materialOrigin = patch.coordinates.materialOrigin,
         materialSize = patch.coordinates.materialSize,
       )
-      layer.renderEffect = updateInteractionDetailEffect(localKey, patch.uniforms).asComposeRenderEffect()
+      updateInteractionDetailEffect(layer, localKey, patch.uniforms)
       if (
         layer !== recordedInteractionDetailLayer ||
         input !== recordedInteractionDetailInput ||
@@ -1262,10 +1310,11 @@ internal class RuntimeShaderGlassDelegate(
         materialOrigin = patch.coordinates.materialOrigin,
         materialSize = patch.coordinates.materialSize,
       )
-      layer.renderEffect = updateInteractionDetailCoverageEffect(
+      updateInteractionDetailCoverageEffect(
+        layer,
         localKey,
         patch.uniforms,
-      ).asComposeRenderEffect()
+      )
       if (
         layer !== recordedInteractionDetailCoverageLayer ||
         input !== recordedInteractionDetailCoverageInput ||
@@ -1322,7 +1371,7 @@ internal class RuntimeShaderGlassDelegate(
   ): GraphicsLayer? = layers.interactionLighting?.takeUnless { it.isReleased }?.also { layer ->
     layer.alpha = 1f
     layer.blendMode = BlendMode.SrcOver
-    layer.renderEffect = updateInteractionLightingEffect(key, patch.uniforms).asComposeRenderEffect()
+    updateInteractionLightingEffect(layer, key, patch.uniforms)
     if (
       layer !== recordedInteractionLightingLayer ||
       patch.bounds.size != recordedInteractionLightingSize
@@ -1337,9 +1386,12 @@ internal class RuntimeShaderGlassDelegate(
   }
 
   private fun updateInteractionOpticalEffect(
+    layer: GraphicsLayer,
     key: GlassOpticalEffectKey,
     uniforms: GlassInteractionUniforms,
-  ): PlatformRenderEffect {
+  ) {
+    val needsUpdate = key != interactionOpticalEffectKey ||
+      uniforms != interactionOpticalEffectUniforms || interactionOpticalComposeEffect == null
     if (interactionOpticalEffect == null) {
       interactionOpticalEffect = traceCreateRenderEffect {
         createMutableRuntimeShaderRenderEffect(
@@ -1349,16 +1401,27 @@ internal class RuntimeShaderGlassDelegate(
         )
       }
     }
-    return checkNotNull(interactionOpticalEffect).updateUniforms {
-      setOpticalUniforms(key)
-      setInteractionOpticalUniforms(uniforms)
+    if (needsUpdate) {
+      interactionOpticalComposeEffect = checkNotNull(interactionOpticalEffect).updateUniforms {
+        setOpticalUniforms(key)
+        setInteractionOpticalUniforms(uniforms)
+      }.asComposeRenderEffect()
+      interactionOpticalEffectKey = key
+      interactionOpticalEffectUniforms = uniforms
+    }
+    if (needsUpdate || layer !== interactionOpticalEffectLayer) {
+      layer.renderEffect = checkNotNull(interactionOpticalComposeEffect)
+      interactionOpticalEffectLayer = layer
     }
   }
 
   private fun updateInteractionDetailEffect(
+    layer: GraphicsLayer,
     key: GlassRefractionDetailEffectKey,
     uniforms: GlassInteractionUniforms,
-  ): PlatformRenderEffect {
+  ) {
+    val needsUpdate = key != interactionDetailEffectKey ||
+      uniforms != interactionDetailEffectUniforms || interactionDetailComposeEffect == null
     if (interactionDetailEffect == null) {
       interactionDetailEffect = traceCreateRenderEffect {
         createMutableRuntimeShaderRenderEffect(
@@ -1368,16 +1431,28 @@ internal class RuntimeShaderGlassDelegate(
         )
       }
     }
-    return checkNotNull(interactionDetailEffect).updateUniforms {
-      setRefractionDetailUniforms(key)
-      setInteractionDetailUniforms(uniforms)
+    if (needsUpdate) {
+      interactionDetailComposeEffect = checkNotNull(interactionDetailEffect).updateUniforms {
+        setRefractionDetailUniforms(key)
+        setInteractionDetailUniforms(uniforms)
+      }.asComposeRenderEffect()
+      interactionDetailEffectKey = key
+      interactionDetailEffectUniforms = uniforms
+    }
+    if (needsUpdate || layer !== interactionDetailEffectLayer) {
+      layer.renderEffect = checkNotNull(interactionDetailComposeEffect)
+      interactionDetailEffectLayer = layer
     }
   }
 
   private fun updateInteractionDetailCoverageEffect(
+    layer: GraphicsLayer,
     key: GlassRefractionDetailEffectKey,
     uniforms: GlassInteractionUniforms,
-  ): PlatformRenderEffect {
+  ) {
+    val needsUpdate = key != interactionDetailCoverageEffectKey ||
+      uniforms != interactionDetailCoverageEffectUniforms ||
+      interactionDetailCoverageComposeEffect == null
     if (interactionDetailCoverageEffect == null) {
       interactionDetailCoverageEffect = createMutableRuntimeShaderRenderEffect(
         effect = GLASS_INTERACTION_REFRACTION_DETAIL_COVERAGE_EFFECT,
@@ -1385,16 +1460,28 @@ internal class RuntimeShaderGlassDelegate(
         inputs = arrayOf(null),
       )
     }
-    return checkNotNull(interactionDetailCoverageEffect).updateUniforms {
-      setRefractionDetailUniforms(key)
-      setInteractionDetailUniforms(uniforms)
+    if (needsUpdate) {
+      interactionDetailCoverageComposeEffect = checkNotNull(interactionDetailCoverageEffect)
+        .updateUniforms {
+          setRefractionDetailUniforms(key)
+          setInteractionDetailUniforms(uniforms)
+        }.asComposeRenderEffect()
+      interactionDetailCoverageEffectKey = key
+      interactionDetailCoverageEffectUniforms = uniforms
+    }
+    if (needsUpdate || layer !== interactionDetailCoverageEffectLayer) {
+      layer.renderEffect = checkNotNull(interactionDetailCoverageComposeEffect)
+      interactionDetailCoverageEffectLayer = layer
     }
   }
 
   private fun updateInteractionLightingEffect(
+    layer: GraphicsLayer,
     key: GlassInteractionLightingKey,
     uniforms: GlassInteractionUniforms,
-  ): PlatformRenderEffect {
+  ) {
+    val needsUpdate = key != interactionLightingEffectKey ||
+      uniforms != interactionLightingEffectUniforms || interactionLightingComposeEffect == null
     if (interactionLightingEffect == null) {
       interactionLightingEffect = traceCreateRenderEffect {
         createMutableRuntimeShaderRenderEffect(
@@ -1404,8 +1491,16 @@ internal class RuntimeShaderGlassDelegate(
         )
       }
     }
-    return checkNotNull(interactionLightingEffect).updateUniforms {
-      setInteractionLightingUniforms(key, uniforms)
+    if (needsUpdate) {
+      interactionLightingComposeEffect = checkNotNull(interactionLightingEffect).updateUniforms {
+        setInteractionLightingUniforms(key, uniforms)
+      }.asComposeRenderEffect()
+      interactionLightingEffectKey = key
+      interactionLightingEffectUniforms = uniforms
+    }
+    if (needsUpdate || layer !== interactionLightingEffectLayer) {
+      layer.renderEffect = checkNotNull(interactionLightingComposeEffect)
+      interactionLightingEffectLayer = layer
     }
   }
 


### PR DESCRIPTION
## Summary

- invalidate per-stage recording metadata whenever obsolete interaction layers are released
- retain interaction shader uniforms, wrapped render effects, and assignments across unchanged frames
- cover stable effects and release-to-reactivation for optical, refraction-detail, coverage/composite, and lighting stages

## Rationale

Layer recording metadata must follow layer lifetime rather than allocator identity. Stable interaction frames should also avoid uniform uploads, RenderEffect wrapping, and layer effect reassignment when neither the stage key nor interaction uniforms changed.

## Verification

- ./gradlew :haze-glass:jvmTest :haze-glass:testAndroidHostTest :haze-glass:spotlessCheck
- git diff --check origin/main...HEAD
- review-and-simplify-changes: clean on final HEAD
- ponytail-review: Lean already. Ship.
- Standards and Spec code review dispositioned with no remaining actionable findings

## Residual risk

Effect-update suppression is covered through retained RenderEffect identity rather than direct instrumentation of platform uniform calls. Release/reactivation coverage validates metadata invalidation because current Compose backends do not recycle GraphicsLayer identity.

Fixes #1067