### PR TITLE
Optimize Glass optical shader lighting

### DIFF
--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassShaders.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassShaders.kt
@@ -371,15 +371,26 @@ internal object GlassShaders {
     "sampleChroma(refractCoord, chromaOffset, refractedCenterSample)"
   }};
 
-      vec2 gradient = surfaceGradient(localCoord);
-      vec3 shapeNormal = normalize(vec3(-gradient.x, -gradient.y, 1.0));
-      vec3 contentNormal = computeContentNormal(
-        ${if (tiled) "sampleCoord, tileOrigin, sampleSize" else "coord"}
-      );
-      vec3 normal = normalize(mix(shapeNormal, contentNormal, contentNormalBlend));
-      float fresnelBase = 1.0 - max(dot(normal, vec3(0.0, 0.0, 1.0)), 0.0);
-      float fresnel = fresnelExponent == 0.0 ? 1.0 : pow(fresnelBase, fresnelExponent);
-      float ambient = mix(1.0, 1.0 + fresnel, clamp(ambientResponse, 0.0, 1.0));
+      float ambient = 1.0;
+      if (ambientResponse > 0.0) {
+        float clampedAmbientResponse = clamp(ambientResponse, 0.0, 1.0);
+        if (fresnelExponent == 0.0) {
+          ambient = 1.0 + clampedAmbientResponse;
+        } else {
+          vec2 gradient = surfaceGradient(localCoord);
+          vec3 shapeNormal = normalize(vec3(-gradient.x, -gradient.y, 1.0));
+          vec3 normal = shapeNormal;
+          if (contentNormalBlend > 0.0) {
+            vec3 contentNormal = computeContentNormal(
+              ${if (tiled) "sampleCoord, tileOrigin, sampleSize" else "coord"}
+            );
+            normal = normalize(mix(shapeNormal, contentNormal, contentNormalBlend));
+          }
+          float fresnelBase = 1.0 - max(dot(normal, vec3(0.0, 0.0, 1.0)), 0.0);
+          float fresnel = pow(fresnelBase, fresnelExponent);
+          ambient = mix(1.0, 1.0 + fresnel, clampedAmbientResponse);
+        }
+      }
       vec3 opticalColor = refractedStraightColor;
       vec3 gradedColor = applyColorGrading(
         opticalColor,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassShadersTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassShadersTest.kt
@@ -189,6 +189,22 @@ class GlassShadersTest {
   }
 
   @Test
+  fun opticalShader_skipsInactiveLightingAndContentNormalWork() {
+    val main = GlassShaders.buildOptical().substringAfter("vec4 main(vec2 coord)")
+
+    assertThat(main).contains("if (ambientResponse > 0.0) {")
+    assertThat(main).contains("if (contentNormalBlend > 0.0) {")
+    assertThat(main).contains("vec3 normal = shapeNormal;")
+    assertThat(main).contains(
+      "normal = normalize(mix(shapeNormal, contentNormal, contentNormalBlend));",
+    )
+    assertThat(main).contains("float ambient = 1.0;")
+    assertThat(main).contains(
+      "ambient = mix(1.0, 1.0 + fresnel, clampedAmbientResponse);",
+    )
+  }
+
+  @Test
   fun opticalShader_unpremultipliesSamplesAndRepremultipliesWithRefractedCenterAlpha() {
     val shader = GlassShaders.buildOptical()
 
@@ -555,7 +571,8 @@ class GlassShadersTest {
     val optical = GlassShaders.buildOptical()
     val rim = GlassShaders.buildRim()
 
-    assertThat(optical).contains("fresnelExponent == 0.0 ? 1.0 : pow(")
+    assertThat(optical).contains("if (fresnelExponent == 0.0) {")
+    assertThat(optical).contains("ambient = 1.0 + clampedAmbientResponse;")
     assertThat(rim).contains("specularExponent == 0.0 ? 1.0 : pow(")
   }
 


### PR DESCRIPTION
## Summary

- skip optical lighting work when ambient response is inactive
- skip four-tap content-normal sampling when its blend is zero
- use a constant full-response fast path for zero Fresnel exponent
- add generated-shader contract coverage for each uniform guard

## Rationale

The affected uniforms are constant across a draw, so these branches avoid redundant per-pixel gradient, normal, sampling, dot-product, and pow work without fragment divergence or pixel changes.

## Verification

- ./gradlew :haze-glass:jvmTest :haze-glass:spotlessCheck :haze-screenshot-tests:test :haze-screenshot-tests:spotlessCheck
- screenshot suite passed repeatedly with no baseline changes
- git diff --check origin/main...HEAD
- review-and-simplify-changes: clean on final HEAD
- ponytail-review: Lean already. Ship.
- final Standards and Spec reviews: no findings

## Residual risk

Generated-shader tests verify the guard structure; complete Desktop and Android-host screenshot suites provide the pixel-identity evidence.

Fixes #1069