### PR TITLE
Harden RuntimeShader retained-layer invariants

### DIFF
--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -263,7 +263,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     }
 
   @Test
-  fun liveUniformChanges_retainShadersAndReplaceOnlyAffectedRenderEffectWrappers() =
+  fun liveUniformChanges_retainShadersAndReplaceRetainedLayerRenderEffects() =
     runAndroidComposeUiTest<ComponentActivity> {
       val effect = animatedStageEffect()
       setContent { RuntimeGlassTestContent(effect) }
@@ -278,21 +278,25 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
 
       val opticalShader = delegate.opticalShader
       val opticalEffect = delegate.opticalEffect
+      val opticalLayerEffect = checkNotNull(delegate.layers.optical?.renderEffect)
       effect.ambientResponse = 0.6f
       waitForIdle()
       drawFrame()
 
       assertThat(delegate.opticalShader).isSameInstanceAs(opticalShader)
       assertThat(delegate.opticalEffect).isNotSameInstanceAs(opticalEffect)
+      assertThat(delegate.layers.optical?.renderEffect).isNotSameInstanceAs(opticalLayerEffect)
 
       val rimShader = delegate.rimShader
       val rimEffect = delegate.rimEffect
+      val rimLayerEffect = checkNotNull(delegate.layers.rim?.renderEffect)
       effect.lightPosition = Offset(10f, 20f)
       waitForIdle()
       drawFrame()
 
       assertThat(delegate.rimShader).isSameInstanceAs(rimShader)
       assertThat(delegate.rimEffect).isNotSameInstanceAs(rimEffect)
+      assertThat(delegate.layers.rim?.renderEffect).isNotSameInstanceAs(rimLayerEffect)
     }
 
   @Test

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -339,10 +339,10 @@ internal data class GlassBlurEffectKey(
 )
 
 internal fun GlassRenderParams.blurEffectKey(): GlassBlurEffectKey {
-  val sampleSize = coordinates.sampleSize
+  val sampleSize = coordinates.sampleSize.roundToIntSize()
   val plan = SemanticBlurPlan.createForSigma(
-    sampleWidth = sampleSize.width.toInt().coerceAtLeast(1),
-    sampleHeight = sampleSize.height.toInt().coerceAtLeast(1),
+    sampleWidth = sampleSize.width.coerceAtLeast(1),
+    sampleHeight = sampleSize.height.coerceAtLeast(1),
     effectiveRadiusPx = blurRadiusPx,
     sigmaPx = blurSigmaPx,
     allowMultiscale = progressive == null,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -1638,6 +1638,9 @@ internal class RuntimeShaderGlassDelegate(
   ): Boolean = params.depth > 0f && params.depth < 1f && shouldBlur(params, effects)
 
   private fun getRenderEffects(render: GlassPreparedRender): GlassRenderEffects {
+    // Android mutations update a shared, live RuntimeShader, whereas Skiko snapshots uniforms
+    // into each ImageFilter. Every effect mutated here must be reassigned before its retained
+    // layer is recorded; never update uniforms on a path that presents retained output as-is.
     val nextBlurKey = render.blurKey
     if (nextBlurKey != blurKey) {
       blurEffects = nextBlurKey?.let(::updateBlurRenderEffects)

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -762,6 +762,23 @@ class GlassRenderParamsTest {
   }
 
   @Test
+  fun blurEffectKey_roundsUnroundedSampleSizeLikeRetainedLayers() {
+    val params = testRenderParams(
+      coordinates = GlassCoordinates(
+        sampleSize = Size(140.8f, 100.8f),
+        materialOrigin = Offset.Zero,
+        materialSize = Size(100f, 80f),
+        scaleFactor = 0.75f,
+      ),
+      blurRadiusPx = 12f,
+    )
+
+    assertThat(params.blurEffectKey().plan.sampleSize).isEqualTo(
+      params.coordinates.sampleSize.roundToIntSize(),
+    )
+  }
+
+  @Test
   fun samplePadding_addsSerialStageSupport() {
     assertThat(
       calculateGlassSamplePaddingPx(

--- a/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/RuntimeShader.android.kt
+++ b/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/RuntimeShader.android.kt
@@ -66,6 +66,8 @@ private class AndroidMutableRuntimeShaderRenderEffect(
   override fun updateUniforms(
     uniforms: RuntimeShaderUniformProvider.() -> Unit,
   ): PlatformRenderEffect {
+    // RuntimeShader is live: every RenderEffect created from this shared shader observes these
+    // mutations. Callers retaining an earlier effect must replace or re-record that layer first.
     uniforms(provider)
     return createAndroidRuntimeShaderRenderEffect(shader, shaderNames, inputs)
   }

--- a/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/RenderEffect.skiko.kt
+++ b/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/RenderEffect.skiko.kt
@@ -169,6 +169,7 @@ private class SkikoMutableRuntimeShaderRenderEffect(
     uniforms: RuntimeShaderUniformProvider.() -> Unit,
   ): PlatformRenderEffect {
     uniforms(provider)
+    // ImageFilter snapshots the builder's current uniforms, unlike Android's live RuntimeShader.
     return ImageFilter.makeRuntimeShader(builder, shaderNames, inputs)
   }
 }


### PR DESCRIPTION
Closes #1071

## Summary
- document Android's live shared `RuntimeShader` mutation semantics and Skiko's `ImageFilter` snapshot semantics at their implementations
- state the retained-layer reassignment requirement at the Glass render-effect mutation boundary
- regression-test Android optical and rim retained-layer effect replacement while preserving shared shader handles
- make blur planning use the same `roundToIntSize()` contract as retained layer sizing

## Validation
- `:haze-utils:spotlessCheck`
- `:haze-glass:spotlessCheck`
- `:haze-glass:jvmTest --tests dev.chrisbanes.haze.glass.GlassRenderParamsTest`
- `:haze-glass:testAndroidHostTest --tests dev.chrisbanes.haze.glass.RuntimeShaderGlassDelegateAndroidHostTest`
- `git diff --check`
- fresh Standards, Spec, simplification, and ponytail reviews clean on `5e0909cb`
