### PR TITLE
Document intentional Glass constraints

### DIFF
--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
@@ -21,6 +21,8 @@ public sealed interface GlassOptics {
    * The built-in Haze glass material.
    *
    * Its optical response adapts to the material's size, aspect ratio, and roundness.
+   * Its adaptive blur scaling is applied after the [Absolute] blur-radius cap, so its effective
+   * blur radius can exceed that cap.
    */
   public data object Adaptive : GlassOptics
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -97,8 +97,12 @@ private val IdleInteractionState = GlassInteractionRenderState(Offset.Zero)
 private val IdleInteractionSignals = GlassInteractionSignals()
 
 /**
- * A [VisualEffect] implementation that renders a translucent refractive glass material.
- * refraction, depth layering, specular highlights, and soft tinted glass.
+ * A [VisualEffect] implementation that renders a translucent refractive glass material with
+ * refraction, depth layering, specular highlights, and a soft tint.
+ *
+ * Use one instance per `hazeEffect` node. A Glass effect retains node-specific layers and
+ * interaction state, so sharing an instance between nodes is unsupported. Use the
+ * `GlassVisualEffect(other)` copy constructor to duplicate configuration for another node.
  */
 @ExperimentalHazeApi
 @Stable

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeEffectScope.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeEffectScope.kt
@@ -8,6 +8,12 @@ import dev.chrisbanes.haze.HazeEffectScope
 
 /**
  * Configures a [GlassVisualEffect] for this effect scope.
+ *
+ * The outermost call for an effect owns its interaction-slot transaction. If its [block] throws,
+ * interaction-slot mutations, such as [GlassVisualEffect.hovered], are rolled back. Nested calls
+ * share that transaction, so catching a nested call's exception does not create a savepoint or
+ * roll back its mutations. Direct property writes, such as [GlassVisualEffect.tint] or
+ * [GlassVisualEffect.optics], remain applied even when the owning transaction rolls back.
  */
 @ExperimentalHazeApi
 public inline fun HazeEffectScope.glassEffect(

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -651,6 +651,9 @@ internal class RuntimeShaderGlassDelegate(
       val params = preparedParams ?: return
       requireDrawableMaterialSize(params.coordinates.materialSize, ::clearRetainedOutput) ?: return
       if (!retainedOutputAvailable) return
+      // Rim and interaction lighting must draw above this node's content. With group alpha, their
+      // independent alpha is an approximation of full-group composition and can slightly
+      // double-lighten where they overlap the glass.
       preparedInteractionUniforms?.takeIf { it.hasLighting }?.let {
         val patch = preparedInteractionPatch ?: return@let
         layers.interactionLighting?.takeUnless { layer -> layer.isReleased }?.let { layer ->


### PR DESCRIPTION
Closes #1072

## Summary
- document the intentional group-alpha approximation for foreground rim and interaction lighting
- clarify that the outermost `glassEffect {}` call owns interaction-slot rollback, nested calls
  share the transaction without savepoints, and direct property writes are not rolled back
- document one `GlassVisualEffect` instance per node and explicitly point to `GlassVisualEffect(other)` for copied configuration
- distinguish `Adaptive` blur scaling from the `Absolute` blur-radius cap
- repair the malformed `GlassVisualEffect` class summary

## Validation
- `:haze-glass:spotlessCheck`
- `:haze-glass:dokkaGenerate`
- `git diff --check`
- fresh Standards, Spec, simplification, and ponytail reviews clean on `ae9b2de6`

Dokka reports only the repository's existing unresolved `GlassStyle.*` link warnings.
