### PR TITLE
Fix drawContentBehind default in documentation

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -87,7 +87,7 @@ Options:
 
 #### drawContentBehind
 
-When `true`, the original source content is drawn before the effect is applied. When `false`, only the effect is drawn. Defaults to `true`.
+When `true`, the original source content is drawn before the effect is applied. When `false`, only the effect is drawn. Defaults to `false`.
 
 #### canDrawArea
 


### PR DESCRIPTION
## Summary

- Correct the documented default value of `drawContentBehind` from `true` to `false`.

## Why

`HazeEffectScope` and `HazeEffectNode` initialize `drawContentBehind` to `false`. Aligning the core concepts documentation with the implementation avoids misleading users configuring foreground effects.

## Validation

- `git diff --check`
- `python -m markdown docs/core-concepts.md`
