### PR TITLE
Fix scaled Glass blur sigma

### DIFF
--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -630,6 +630,7 @@ internal fun buildGlassRenderParams(
 ): GlassRenderParams {
   val scaleFactor = coordinates.scaleFactor
   val resolvedOptics = style.resolvedOptics
+  val blurRadiusPx = resolvedOptics.blurRadiusPx.finiteOr(0f).coerceAtLeast(0f) * scaleFactor
   return GlassRenderParams(
     coordinates = coordinates,
     refractionStrength = resolvedOptics.refractionStrength.finiteOr(0f).coerceIn(0f, 1f),
@@ -638,8 +639,8 @@ internal fun buildGlassRenderParams(
     ambientResponse = style.ambientResponse,
     tint = style.tint,
     edgeSoftnessPx = style.edgeSoftnessPx * scaleFactor,
-    blurRadiusPx = resolvedOptics.blurRadiusPx.finiteOr(0f).coerceAtLeast(0f) * scaleFactor,
-    blurSigmaPx = resolvedOptics.blurSigmaPx.finiteOr(0f).coerceAtLeast(0f) * scaleFactor,
+    blurRadiusPx = blurRadiusPx,
+    blurSigmaPx = SemanticBlurKernel.radiusToSigma(blurRadiusPx),
     progressive = resolvedOptics.progressive,
     refractionHeightPx = resolvedOptics.refractionHeightPx.finiteOr(0f).coerceAtLeast(0f) * scaleFactor,
     chromaticAberrationStrength = style.chromaticAberrationStrength,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -804,6 +804,62 @@ class GlassRenderParamsTest {
   }
 
   @Test
+  fun renderParams_deriveBlurSigmaFromScaledRadius() {
+    val effect = GlassVisualEffect().apply {
+      optics = GlassOptics.Absolute(blurRadius = 20.dp)
+    }
+    val style = resolveGlassStyle(
+      effect = effect,
+      materialSizePx = Size(100f, 80f),
+      density = Density(1f),
+      layoutDirection = LayoutDirection.Ltr,
+    )
+
+    listOf(1f, 0.75f, 0.25f).forEach { scaleFactor ->
+      val params = buildGlassRenderParams(
+        style = style,
+        coordinates = resolveGlassCoordinates(
+          layerSize = Size(100f, 80f),
+          layerOffset = Offset.Zero,
+          materialSize = Size(100f, 80f),
+          scaleFactor = scaleFactor,
+        ),
+      )
+
+      assertThat(params.blurRadiusPx).isEqualTo(20f * scaleFactor)
+      assertThat(params.blurSigmaPx).isEqualTo(
+        SemanticBlurKernel.radiusToSigma(params.blurRadiusPx),
+      )
+    }
+  }
+
+  @Test
+  fun renderParams_zeroBlurHasZeroRadiusAndSigma() {
+    val effect = GlassVisualEffect().apply {
+      optics = GlassOptics.Absolute(blurRadius = 0.dp)
+    }
+    val style = resolveGlassStyle(
+      effect = effect,
+      materialSizePx = Size(100f, 80f),
+      density = Density(1f),
+      layoutDirection = LayoutDirection.Ltr,
+    )
+
+    val params = buildGlassRenderParams(
+      style = style,
+      coordinates = resolveGlassCoordinates(
+        layerSize = Size(100f, 80f),
+        layerOffset = Offset.Zero,
+        materialSize = Size(100f, 80f),
+        scaleFactor = 0.25f,
+      ),
+    )
+
+    assertThat(params.blurRadiusPx).isEqualTo(0f)
+    assertThat(params.blurSigmaPx).isEqualTo(0f)
+  }
+
+  @Test
   fun roundedSampleSize_matchesRetainedLayerDimensions() {
     val coordinates = resolveGlassCoordinates(
       layerSize = Size(140.8f, 100.8f),


### PR DESCRIPTION
## Summary

- derive Glass blur sigma from the finalized scaled blur radius
- preserve the existing semantic blur-plan and input-scale policy
- cover identity, intermediate, automatic-minimum, and zero-blur cases

## Verification

- `./gradlew :haze-glass:spotlessApply :haze-glass:jvmTest --console=plain`
- `./gradlew :haze-glass:spotlessCheck`
- `./gradlew :haze-glass:allTests`
- `git diff --check origin/main...HEAD`
- `/code-review origin/main` — Standards: no findings; Spec: no findings
- `/review-and-simplify-changes` — no remaining findings
- `/ponytail-review` — lean, no findings

## Risk

Low. The change is internal to render-parameter construction and does not alter public APIs,
automatic input-scale thresholds, or blur-plan policy.

Fixes #1098
