### PR TITLE
Guard inactive Glass lighting work

### DIFF
--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassShaders.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassShaders.kt
@@ -119,21 +119,27 @@ internal object GlassShaders {
       vec3 refractedStraightColor =
         sampleChroma(refractCoord, chromaOffset, refractedCenter);
 
-      vec2 gradient = surfaceGradient(localCoord);
-      vec3 shapeNormal = normalize(vec3(-gradient.x, -gradient.y, 1.0));
-      vec3 contentNormal = computeContentNormal(refractCoord, refractedCenter);
-      vec3 normal = normalize(mix(shapeNormal, contentNormal, contentNormalBlend));
-      float fresnel;
-      if (fresnelExponent == 0.0) {
-        fresnel = 1.0;
-      } else {
-        float fresnelBase =
-          1.0 - max(dot(normal, vec3(0.0, 0.0, 1.0)), 0.0);
-        fresnel = fresnelExponent == 3.0
-          ? fresnelBase * fresnelBase * fresnelBase
-          : pow(fresnelBase, fresnelExponent);
+      float ambient = 1.0;
+      if (ambientResponse > 0.0) {
+        float clampedAmbientResponse = clamp(ambientResponse, 0.0, 1.0);
+        if (fresnelExponent == 0.0) {
+          ambient = 1.0 + clampedAmbientResponse;
+        } else {
+          vec2 gradient = surfaceGradient(localCoord);
+          vec3 shapeNormal = normalize(vec3(-gradient.x, -gradient.y, 1.0));
+          vec3 normal = shapeNormal;
+          if (contentNormalBlend > 0.0) {
+            vec3 contentNormal = computeContentNormal(refractCoord, refractedCenter);
+            normal = normalize(mix(shapeNormal, contentNormal, contentNormalBlend));
+          }
+          float fresnelBase =
+            1.0 - max(dot(normal, vec3(0.0, 0.0, 1.0)), 0.0);
+          float fresnel = fresnelExponent == 3.0
+            ? fresnelBase * fresnelBase * fresnelBase
+            : pow(fresnelBase, fresnelExponent);
+          ambient = mix(1.0, 1.0 + fresnel, clampedAmbientResponse);
+        }
       }
-      float ambient = mix(1.0, 1.0 + fresnel, clamp(ambientResponse, 0.0, 1.0));
       vec3 gradedColor = applyColorGrading(
         refractedStraightColor,
         ${if (interactionOptics) "localizedWhitePoint" else "whitePoint"}

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -76,6 +76,7 @@ internal class RuntimeShaderGlassDelegate(
   private var interactionOpticalEffectUniforms: GlassInteractionUniforms? = null
   private var interactionOpticalPlatformEffect: PlatformRenderEffect? = null
   private var interactionOpticalComposeEffect: RenderEffect? = null
+  private var interactionOpticalEffectLayer: GraphicsLayer? = null
   private var interactionOutputEffect: MutableRuntimeShaderRenderEffect? = null
   private var interactionOutputInput: PlatformRenderEffect? = null
   private var interactionOutputUniforms: GlassInteractionUniforms? = null
@@ -765,6 +766,7 @@ internal class RuntimeShaderGlassDelegate(
     recordedInteractionOpticalLayer = null
     recordedInteractionOpticalInput = null
     recordedInteractionOpticalKey = null
+    interactionOpticalEffectLayer = null
   }
 
   private fun clearInteractionRefractionLayerMetadata() {
@@ -1288,7 +1290,10 @@ internal class RuntimeShaderGlassDelegate(
       interactionOpticalEffectKey = key
       interactionOpticalEffectUniforms = uniforms
     }
-    layer.renderEffect = checkNotNull(interactionOpticalComposeEffect)
+    if (needsUpdate || layer !== interactionOpticalEffectLayer) {
+      layer.renderEffect = checkNotNull(interactionOpticalComposeEffect)
+      interactionOpticalEffectLayer = layer
+    }
   }
 
   private fun updateInteractionDetailEffect(

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassShadersTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassShadersTest.kt
@@ -22,7 +22,7 @@ class GlassShadersTest {
     val shader = GlassShaders.buildFused()
 
     assertThat(shader).contains("if (fresnelExponent == 0.0)")
-    assertThat(shader).contains("fresnel = 1.0;")
+    assertThat(shader).contains("ambient = 1.0 + clampedAmbientResponse;")
   }
 
   @Test
@@ -221,6 +221,22 @@ class GlassShadersTest {
   @Test
   fun opticalShader_skipsInactiveLightingAndContentNormalWork() {
     val main = GlassShaders.buildOptical().substringAfter("vec4 main(vec2 coord)")
+
+    assertThat(main).contains("if (ambientResponse > 0.0) {")
+    assertThat(main).contains("if (contentNormalBlend > 0.0) {")
+    assertThat(main).contains("vec3 normal = shapeNormal;")
+    assertThat(main).contains(
+      "normal = normalize(mix(shapeNormal, contentNormal, contentNormalBlend));",
+    )
+    assertThat(main).contains("float ambient = 1.0;")
+    assertThat(main).contains(
+      "ambient = mix(1.0, 1.0 + fresnel, clampedAmbientResponse);",
+    )
+  }
+
+  @Test
+  fun fusedShader_skipsInactiveLightingAndContentNormalWork() {
+    val main = GlassShaders.buildFused().substringAfter("vec4 main(vec2 coord)")
 
     assertThat(main).contains("if (ambientResponse > 0.0) {")
     assertThat(main).contains("if (contentNormalBlend > 0.0) {")

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -199,6 +199,36 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   @Test
+  fun interactionOpticalEffect_reusesStableLayerEffectAndUpdatesNewTargets() = runComposeUiTest {
+    val effect = runtimeInteractiveEffect()
+    setContent { RuntimeGlassTestContent(effect, tag = "glass") }
+    waitForIdle()
+
+    effect.setPressedForTest(Offset(60f, 60f))
+    waitForIdle()
+
+    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val layer = checkNotNull(delegate.layers.interactionOptical)
+    val stableEffect = checkNotNull(layer.renderEffect)
+
+    effect.setPressedForTest(Offset(60f, 60f))
+    waitForIdle()
+
+    assertThat(layer.renderEffect).isSameInstanceAs(stableEffect)
+
+    effect.ambientResponse = 0.6f
+    waitForIdle()
+
+    assertThat(layer.renderEffect).isNotSameInstanceAs(stableEffect)
+
+    delegate.layers.interactionOptical = null
+    effect.ambientResponse = 0.5f
+    waitForIdle()
+
+    assertThat(checkNotNull(delegate.layers.interactionOptical).renderEffect).isNotNull()
+  }
+
+  @Test
   fun largePanel_interactionPatchRetainsBaseLayersAcrossFrames() = runComposeUiTest {
     val effect = activeDetailEffect().apply {
       pressed {


### PR DESCRIPTION
## Summary

- gate fused Glass gradient and normal work behind the established lighting conditions
- retain stable interaction-optical RenderEffect assignments until state or target changes
- add generated-shader and retained-layer regression coverage

## Verification

- `./gradlew :haze-glass:spotlessApply :haze-glass:jvmTest --console=plain` (343 tests)
- targeted `GlassShadersTest` and `RuntimeShaderGlassDelegateIntegrationTest`
- `git diff --check origin/main...HEAD`
- `/code-review origin/main` — Standards: no findings; Spec: no findings
- `/review-and-simplify-changes` — no remaining findings
- `/ponytail-review` — lean, no findings

## Risk

Low. The change mirrors existing non-fused and sibling retained-layer guards. Shader handles,
layer topology, public APIs, and lighting semantics remain unchanged.

Fixes #1099
