### PR TITLE
Fix Glass focus interaction position

### DIFF
--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteractionController.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteractionController.kt
@@ -431,11 +431,13 @@ internal class GlassInteractionController(
 
   private fun updatePositionForCurrentInputs(size: Size) {
     if (!size.isDrawable()) return
-    val target = rawPosition.takeIf { rawPressed }
-      ?: hoverPosition
-      ?: sourcePosition
-      ?: rawPosition
-      ?: size.center
+    val target = when {
+      rawPressed -> rawPosition ?: sourcePosition ?: size.center
+      sourcePresses.isNotEmpty() -> sourcePosition ?: rawPosition ?: size.center
+      rawHovered -> hoverPosition ?: size.center
+      sourceHovers.isNotEmpty() || sourceFocuses.isNotEmpty() -> size.center
+      else -> hoverPosition ?: rawPosition ?: size.center
+    }
     updatePosition(target.clampTo(size))
   }
 

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
@@ -346,6 +346,105 @@ class GlassInteractionControllerTest : ContextTest() {
   }
 
   @Test
+  fun hoverExit_retainsLatestHoverPositionAfterAnEarlierPress() = runComposeUiTest {
+    val effect = GlassVisualEffect().apply {
+      hovered()
+      pressed()
+      interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
+    }
+    setTaggedEffectContent(effect)
+
+    onNodeWithTag("glass").performTouchInput { click(Offset(10f, 20f)) }
+    onNodeWithTag("glass").performMouseInput {
+      enter(Offset(30f, 40f))
+      moveTo(Offset(70f, 60f))
+      exit()
+    }
+    waitForIdle()
+
+    assertThat(renderState(effect).position).isEqualTo(Offset(70f, 60f))
+  }
+
+  @Test
+  fun inactiveHoverPosition_doesNotOverrideSubsequentFocus() = runComposeUiTest {
+    val source = MutableInteractionSource()
+    val focus = FocusInteraction.Focus()
+    val effect = GlassVisualEffect().apply {
+      hovered()
+      focused()
+      interactionSource = source
+      interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
+    }
+    setTaggedEffectContent(effect)
+
+    onNodeWithTag("glass").performMouseInput {
+      enter(Offset(10f, 10f))
+      moveTo(Offset(20f, 30f))
+      exit()
+    }
+    waitForIdle()
+    assertThat(renderState(effect).position).isEqualTo(Offset(20f, 30f))
+
+    source.tryEmit(focus)
+    waitForIdle()
+
+    assertThat(renderState(effect).position).isEqualTo(Offset(50f, 50f))
+  }
+
+  @Test
+  fun activePointerInteractions_overrideFocusPosition() = runComposeUiTest {
+    val source = MutableInteractionSource()
+    val focus = FocusInteraction.Focus()
+    val press = PressInteraction.Press(Offset(20f, 10f))
+    val effect = GlassVisualEffect().apply {
+      hovered()
+      focused()
+      pressed()
+      interactionSource = source
+      interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
+    }
+    setTaggedEffectContent(effect)
+    source.tryEmit(focus)
+    waitForIdle()
+
+    onNodeWithTag("glass").performMouseInput { enter(Offset(30f, 40f)) }
+    waitForIdle()
+    assertThat(renderState(effect).position).isEqualTo(Offset(30f, 40f))
+
+    source.tryEmit(press)
+    waitForIdle()
+    assertThat(renderState(effect).position).isEqualTo(Offset(20f, 10f))
+
+    onNodeWithTag("glass").performTouchInput { down(Offset(15f, 25f)) }
+    waitForIdle()
+
+    assertThat(renderState(effect).position).isEqualTo(Offset(15f, 25f))
+  }
+
+  @Test
+  fun pointerCancellation_doesNotAllowRetainedHoverToOverrideLaterFocus() = runComposeUiTest {
+    val source = MutableInteractionSource()
+    val focus = FocusInteraction.Focus()
+    val effect = GlassVisualEffect().apply {
+      hovered()
+      focused()
+      interactionSource = source
+      interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
+    }
+    setTaggedEffectContent(effect)
+
+    onNodeWithTag("glass").performMouseInput { enter(Offset(20f, 30f)) }
+    interactive(effect).onCancelPointerInput(context(effect))
+    waitForIdle()
+    assertThat(renderState(effect).position).isEqualTo(Offset(20f, 30f))
+
+    source.tryEmit(focus)
+    waitForIdle()
+
+    assertThat(renderState(effect).position).isEqualTo(Offset(50f, 50f))
+  }
+
+  @Test
   fun rawAndSourceHover_releaseIndependently() = runComposeUiTest {
     val source = MutableInteractionSource()
     val sourceHover = HoverInteraction.Enter()


### PR DESCRIPTION
## Summary

- distinguish active pointer inputs from retained idle hover coordinates
- center focus-driven interactions when no source position is available
- preserve active press/hover precedence and last-position idle behavior
- cover hover-exit-focus, pointer precedence, and cancellation-focus transitions

## Verification

- `./gradlew :haze-glass:jvmTest --tests dev.chrisbanes.haze.glass.GlassInteractionControllerTest :haze-glass:spotlessCheck`
- `./gradlew :haze-glass:allTests :haze-glass:spotlessCheck`
- `git diff --check origin/main...HEAD`
- `/code-review origin/main` — Standards: no findings; Spec: no findings
- `/review-and-simplify-changes` — no findings
- `/ponytail-review` — lean, no findings

## Risk

Low. The change is internal to interaction-position selection and leaves animation specs,
response ownership, and retained idle-position behavior unchanged.

Fixes #1100
