### PR TITLE
Add Cupertino material branch tests

### DIFF
--- a/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterialsTest.kt
+++ b/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterialsTest.kt
@@ -3,9 +3,11 @@
 
 package dev.chrisbanes.haze.blur.materials
 
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import dev.chrisbanes.haze.blur.HazeColorEffect
 import kotlin.test.Test
 
 class CupertinoMaterialsTest {
@@ -23,5 +25,47 @@ class CupertinoMaterialsTest {
     )
 
     assertThat(style.backgroundColor).isEqualTo(containerColor)
+  }
+
+  @Test
+  fun cupertinoMaterialStyle_usesLightEffectsForLightContainer() {
+    val lightBackgroundColor = Color(0xFF111111)
+    val lightForegroundColor = Color(0xFF222222)
+
+    val style = cupertinoMaterialStyle(
+      containerColor = Color.White,
+      lightBackgroundColor = lightBackgroundColor,
+      lightForegroundColor = lightForegroundColor,
+      darkBackgroundColor = Color(0xFF333333),
+      darkForegroundColor = Color(0xFF444444),
+    )
+
+    assertThat(style.colorEffects).isEqualTo(
+      listOf(
+        HazeColorEffect.tint(lightBackgroundColor, BlendMode.ColorDodge),
+        HazeColorEffect.tint(lightForegroundColor),
+      ),
+    )
+  }
+
+  @Test
+  fun cupertinoMaterialStyle_usesDarkEffectsForDarkContainer() {
+    val darkBackgroundColor = Color(0xFF333333)
+    val darkForegroundColor = Color(0xFF444444)
+
+    val style = cupertinoMaterialStyle(
+      containerColor = Color.Black,
+      lightBackgroundColor = Color(0xFF111111),
+      lightForegroundColor = Color(0xFF222222),
+      darkBackgroundColor = darkBackgroundColor,
+      darkForegroundColor = darkForegroundColor,
+    )
+
+    assertThat(style.colorEffects).isEqualTo(
+      listOf(
+        HazeColorEffect.tint(darkBackgroundColor, BlendMode.Overlay),
+        HazeColorEffect.tint(darkForegroundColor),
+      ),
+    )
   }
 }


### PR DESCRIPTION
## Summary

- add coverage for automatic light and dark Cupertino material selection
- verify the selected tint colors, effect order, and blend modes

## Motivation

The existing Cupertino material test only verifies that the container color becomes the style background. These tests also protect the luminance-based branch that selects the light or dark effects and their corresponding blend modes.

## Affected module

- `haze-materials`

## Validation

- `./gradlew :haze-materials:jvmTest :haze-materials:spotlessCheck`
- `git diff --check origin/main...HEAD`