### PR TITLE
Clear stale layers for zero-sized sources

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.toIntSize
 import androidx.compose.ui.unit.toSize
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 import kotlinx.coroutines.DisposableHandle
 
 /**
@@ -769,9 +770,9 @@ public class HazeEffectNode(
 
   private fun hasDrawableSourceLayers(): Boolean {
     return areas.any { area ->
-      area.contentLayer
-        ?.takeUnless { it.isReleased }
-        ?.takeUnless { it.size.width <= 0 || it.size.height <= 0 } != null
+      area.size.isSpecified &&
+        area.size.minDimension.roundToInt() >= 1 &&
+        area.contentLayer?.isReleased == false
     }
   }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -223,6 +223,9 @@ public class HazeSourceNode(
         HazeLogger.d(TAG) { "Drawn layer to canvas: $contentLayer" }
       } else {
         HazeLogger.d(TAG) { "Not using graphics layer, so drawing content direct to canvas" }
+        // A previously recorded layer must not remain available to effects after this source
+        // becomes too small to capture. Effects may retain their own output separately.
+        area.releaseLayer()
         // If we're not using graphics layers, just call drawContent and return early
         drawContentSafely()
       }

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
@@ -5,6 +5,9 @@ package dev.chrisbanes.haze
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
@@ -13,6 +16,7 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
@@ -42,6 +46,38 @@ class HazeSourceNodeTest : ContextTest() {
 
     assertThat(node.area.contentLayer).isEqualTo(null)
     assertThat(node.area.windowId).isEqualTo(null)
+  }
+
+  @Test
+  fun sourceSize_zeroSizedReleasesLayerAndRecordsFreshCaptureWhenRestored() = runComposeUiTest {
+    val state = HazeState()
+    val node = HazeSourceNode(state)
+    var sourceSize by mutableStateOf(100.dp)
+
+    setContent {
+      Box(
+        Modifier
+          .size(sourceSize)
+          .testHazeSourceNode(node),
+      )
+    }
+
+    waitForIdle()
+    val initialLayer = node.area.contentLayer
+    val initialContentVersion = node.area.contentVersion
+    assertThat(initialLayer).isNotNull()
+
+    sourceSize = 0.1.dp
+    waitForIdle()
+
+    assertThat(node.area.contentLayer).isEqualTo(null)
+
+    sourceSize = 100.dp
+    waitForIdle()
+
+    assertThat(node.area.contentLayer).isNotNull()
+    assertThat(node.area.contentLayer).isNotEqualTo(initialLayer)
+    assertThat(node.area.contentVersion).isNotEqualTo(initialContentVersion)
   }
 }
 

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/VisualEffectRetainedOutputTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/VisualEffectRetainedOutputTest.kt
@@ -6,7 +6,9 @@ package dev.chrisbanes.haze
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -143,6 +145,71 @@ class VisualEffectRetainedOutputTest : ContextTest() {
     assertThat(effect.clearCalls).isGreaterThan(0)
     assertThat(effect.drawCalls).isEqualTo(beforeRemovalDraws)
     assertThat(effect.retainedOutputAvailable).isEqualTo(false)
+  }
+
+  @Test
+  fun visualEffect_zeroSizedSourceClearsRetainedOutputWhenDisabled() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    var sourceSize by mutableStateOf(100.dp)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.size(sourceSize).hazeSource(hazeState))
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+              retainOutputWhenSourceUnavailable = false
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.retainedOutputAvailable).isEqualTo(true)
+    val beforeCollapseDraws = effect.drawCalls
+    val beforeCollapseClears = effect.clearCalls
+
+    sourceSize = 0.1.dp
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isGreaterThan(beforeCollapseClears)
+    assertThat(effect.drawCalls).isEqualTo(beforeCollapseDraws)
+    assertThat(effect.retainedOutputAvailable).isEqualTo(false)
+  }
+
+  @Test
+  fun visualEffect_zeroSizedSourceRetainsOutputWhenEnabled() = runComposeUiTest {
+    val hazeState = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    var sourceSize by mutableStateOf(100.dp)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.size(sourceSize).hazeSource(hazeState))
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(hazeState) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+
+    waitForIdle()
+    assertThat(effect.retainedOutputAvailable).isEqualTo(true)
+    val beforeCollapseDraws = effect.drawCalls
+    val beforeCollapseClears = effect.clearCalls
+
+    sourceSize = 0.1.dp
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isEqualTo(beforeCollapseClears)
+    assertThat(effect.drawCalls).isGreaterThan(beforeCollapseDraws)
+    assertThat(effect.retainedOutputAvailable).isEqualTo(true)
   }
 
   @Test


### PR DESCRIPTION
Fixes #1109

## Summary
- release a source area's cached graphics layer when it becomes non-capturable or measures to zero pixels
- exclude zero-sized areas from drawable retained-source selection
- cover zero-size collapse and restoration with source-node and retained-output regression tests

## Validation
- `./gradlew :haze:jvmTest --tests 'dev.chrisbanes.haze.HazeSourceNodeTest' --tests 'dev.chrisbanes.haze.VisualEffectRetainedOutputTest'`
- `./gradlew :haze-glass:jvmTest --tests 'dev.chrisbanes.haze.glass.GlassVisualEffectLifecycleTest.clipping_stateBackedCornerSizeInvalidatesDecisionBeforePreparation'`
- `./gradlew spotlessCheck`
- `git diff --check origin/main...HEAD`
- `./gradlew check` ran 980 tasks; all branch-relevant checks passed. The two local macOS Product screenshot mismatches reproduce unchanged on clean `origin/main` (Linux-authored desktop baselines), and the one unrelated Glass lifecycle failure passed immediately in isolation.