### PR TITLE
Use semantic null assertion in source test

### DIFF
--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
@@ -18,6 +18,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
@@ -70,7 +71,7 @@ class HazeSourceNodeTest : ContextTest() {
     sourceSize = 0.1.dp
     waitForIdle()
 
-    assertThat(node.area.contentLayer).isEqualTo(null)
+    assertThat(node.area.contentLayer).isNull()
 
     sourceSize = 100.dp
     waitForIdle()


### PR DESCRIPTION
Follow-up to #1134 and its inline review at https://github.com/chrisbanes/haze/pull/1134#discussion_r3661491861.

Uses AssertK's semantic `isNull()` assertion in the newly added zero-size source regression test.

Validation:
- `./gradlew :haze:jvmTest --tests 'dev.chrisbanes.haze.HazeSourceNodeTest'`
- `./gradlew spotlessCheck`
- `git diff --check origin/main...HEAD`