### PR TITLE
Invalidate drawing when replacing visual effects

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -221,10 +221,24 @@ public class HazeEffectNode(
         pointerInputDelegate?.cancel(oldEffect as? InteractiveVisualEffect)
         if (isAttached) {
           attachVisualEffect(value)
+          try {
+            clearRetainedOutput()
+          } catch (throwable: Throwable) {
+            runCatching { detachVisualEffect(value) }
+              .exceptionOrNull()
+              ?.let(throwable::addSuppressed)
+            throw throwable
+          }
           runCatching { detachVisualEffect(oldEffect) }
+        } else {
+          clearRetainedOutput()
         }
         field = value
+        dirtyTracker += DirtyFields.VisualEffectLayerBounds
         syncPointerInputDelegate()
+        if (isAttached) {
+          invalidateVisualEffectDraw()
+        }
       }
     }
 

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -26,6 +26,7 @@ import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
@@ -264,6 +265,81 @@ class VisualEffectLifecycleTest : ContextTest() {
     assertFailure {
       HazeEffectNode().attachVisualEffect(sharedEffect)
     }.isInstanceOf<IllegalStateException>()
+  }
+
+  @Test
+  fun visualEffect_ownedReplacementFailureKeepsOldEffectAttached() = runComposeUiTest {
+    val oldEffect = RecordingVisualEffect()
+    val ownedEffect = RecordingVisualEffect()
+    var effectNode: HazeEffectNode? = null
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(100.dp)
+          .hazeEffect {
+            effectNode = this as HazeEffectNode
+            visualEffect = oldEffect
+          },
+      )
+    }
+    waitForIdle()
+
+    val owner = HazeEffectNode()
+    owner.attachVisualEffect(ownedEffect)
+    try {
+      assertFailure {
+        runOnIdle {
+          checkNotNull(effectNode).visualEffect = ownedEffect
+        }
+      }.isInstanceOf<IllegalStateException>()
+
+      assertThat(checkNotNull(effectNode).visualEffect).isSameInstanceAs(oldEffect)
+      assertThat(oldEffect.detachCalls).isEqualTo(0)
+      assertThat(ownedEffect.attachCalls).isEqualTo(1)
+    } finally {
+      owner.detachVisualEffect(ownedEffect)
+    }
+  }
+
+  @Test
+  fun visualEffect_retainedOutputClearFailureRollsBackReplacementOwnership() = runComposeUiTest {
+    val oldEffect = ThrowingClearVisualEffect()
+    val replacement = RecordingVisualEffect()
+    var effectNode: HazeEffectNode? = null
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(100.dp)
+          .hazeEffect {
+            effectNode = this as HazeEffectNode
+            visualEffect = oldEffect
+          },
+      )
+    }
+    waitForIdle()
+
+    val clearCallsBeforeReplacement = oldEffect.clearCalls
+    oldEffect.throwOnClear = true
+    assertFailure {
+      runOnIdle {
+        checkNotNull(effectNode).visualEffect = replacement
+      }
+    }.isInstanceOf<IllegalStateException>()
+    oldEffect.throwOnClear = false
+
+    assertThat(checkNotNull(effectNode).visualEffect).isSameInstanceAs(oldEffect)
+    assertThat(oldEffect.detachCalls).isEqualTo(0)
+    assertThat(oldEffect.clearCalls).isEqualTo(clearCallsBeforeReplacement + 1)
+    assertThat(replacement.attachCalls).isEqualTo(1)
+    assertThat(replacement.detachCalls).isEqualTo(1)
+
+    val nextOwner = HazeEffectNode()
+    nextOwner.attachVisualEffect(replacement)
+    nextOwner.detachVisualEffect(replacement)
+    assertThat(replacement.attachCalls).isEqualTo(2)
+    assertThat(replacement.detachCalls).isEqualTo(2)
   }
 
   @Test
@@ -622,4 +698,25 @@ internal class RetainedOutputRecordingVisualEffect : VisualEffect, RetainedOutpu
       retainedOutputAvailable = true
     }
   }
+}
+
+internal class ThrowingClearVisualEffect : VisualEffect, RetainedOutputVisualEffect {
+  var detachCalls = 0
+  var clearCalls = 0
+  var throwOnClear = false
+
+  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean = false
+
+  override fun clearRetainedOutput() {
+    clearCalls++
+    if (throwOnClear) {
+      error("clear failed")
+    }
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    detachCalls++
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) = Unit
 }

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/VisualEffectReplacementDrawTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/VisualEffectReplacementDrawTest.kt
@@ -1,0 +1,101 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.test.ContextTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class)
+class VisualEffectReplacementDrawTest : ContextTest() {
+
+  @Test
+  fun replacementDrawsNewEffectOnNextFrame() = runComposeUiTest {
+    val effect1 = RetainedOutputRecordingVisualEffect()
+    val effect2 = ReplacementBoundsVisualEffect()
+    val effect = mutableStateOf<VisualEffect>(effect1)
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(100.dp)
+          .hazeEffect {
+            visualEffect = effect.value
+          },
+      )
+    }
+
+    waitForIdle()
+    val effect1DrawCalls = effect1.drawCalls
+    val effect1ClearCalls = effect1.clearCalls
+
+    effect.value = effect2
+    waitForIdle()
+
+    assertThat(effect1.drawCalls).isEqualTo(effect1DrawCalls)
+    assertThat(effect1.clearCalls).isGreaterThan(effect1ClearCalls)
+    assertThat(effect2.calculateLayerBoundsCalls).isGreaterThan(0)
+    assertThat(effect2.drawCalls).isGreaterThan(0)
+  }
+
+  @Test
+  fun replacementWithEmptyRemovesOldEffectOnNextFrame() = runComposeUiTest {
+    val recordingEffect = RetainedOutputRecordingVisualEffect()
+    val effect = mutableStateOf<VisualEffect>(recordingEffect)
+    var contentDrawCalls = 0
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(100.dp)
+          .drawWithContent {
+            contentDrawCalls++
+            drawContent()
+          }
+          .hazeEffect {
+            visualEffect = effect.value
+          },
+      )
+    }
+
+    waitForIdle()
+    val recordingEffectDrawCalls = recordingEffect.drawCalls
+    val initialClearCalls = recordingEffect.clearCalls
+    val initialContentDrawCalls = contentDrawCalls
+
+    effect.value = VisualEffect.Empty
+    waitForIdle()
+
+    assertThat(recordingEffect.drawCalls).isEqualTo(recordingEffectDrawCalls)
+    assertThat(recordingEffect.clearCalls).isGreaterThan(initialClearCalls)
+    assertThat(contentDrawCalls).isGreaterThan(initialContentDrawCalls)
+  }
+}
+
+private class ReplacementBoundsVisualEffect : VisualEffect {
+  var calculateLayerBoundsCalls = 0
+  var drawCalls = 0
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
+    calculateLayerBoundsCalls++
+    return rect.inflate(8f)
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    drawCalls++
+  }
+}


### PR DESCRIPTION
## Summary

- clear retained output when replacing a visual effect
- invalidate layer bounds and drawing after a successful replacement
- preserve the existing effect when replacement attachment fails
- add draw and lifecycle regressions for effect-to-effect and effect-to-empty replacement

Fixes #1111

## Validation

- `./gradlew :haze:jvmTest :haze:testAndroidHostTest :haze:spotlessCheck --no-daemon`
- `git diff --check origin/main...HEAD`
- final standards and specification reviews on the exact head