### PR TITLE
Preserve equal-z source order on updates

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -115,7 +115,7 @@ public class HazeArea internal constructor() {
   public var zIndex: Float by mutableFloatStateOf(0f)
     internal set
 
-  public var key: Any? = null
+  public var key: Any? by mutableStateOf(null)
     internal set
 
   public var windowId: Any? = null

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -123,6 +123,7 @@ public class HazeEffectNode(
 
   private val areaOffsets = MutableObjectLongMap<HazeArea>()
   private val areaZIndexes = MutableObjectLongMap<HazeArea>()
+  private val areaKeys = mutableMapOf<HazeArea, Any?>()
 
   private var _size: Size = Size.Unspecified
     set(value) {
@@ -324,6 +325,7 @@ public class HazeEffectNode(
     resetPendingInvalidations()
     _areas = emptyList()
     areaZIndexes.clear()
+    areaKeys.clear()
     contentDrawArea.releaseLayer()
     clearRetainedOutput()
     pointerInputDelegate?.let { delegate ->
@@ -521,7 +523,11 @@ public class HazeEffectNode(
       // We copy toList() because stateAreas is a SnapshotStateList reference
       // and would otherwise mutate lastSeenStateAreas in place.
       val currentStateAreas = stateAreas.toList()
-      if (currentStateAreas != lastSeenStateAreas || haveAreaZIndexesChanged(currentStateAreas)) {
+      if (
+        currentStateAreas != lastSeenStateAreas ||
+        haveAreaZIndexesChanged(currentStateAreas) ||
+        haveAreaKeysChanged(currentStateAreas)
+      ) {
         lastSeenStateAreas = currentStateAreas
         dirtyTracker += DirtyFields.Areas
       }
@@ -562,9 +568,11 @@ public class HazeEffectNode(
           clearRetainedOutput()
         }
         updateAreaZIndexes(currentStateAreas)
+        updateAreaKeys(currentStateAreas)
       }
     } else {
       areaZIndexes.clear()
+      areaKeys.clear()
       // Foreground (content) blur: always update contentDrawArea since its size,
       // position, and windowId may change every frame with no dirty flag.
       contentDrawArea.size = size
@@ -740,6 +748,20 @@ public class HazeEffectNode(
     areaZIndexes.clear()
     stateAreas.forEach { area ->
       areaZIndexes[area] = area.zIndex.toRawBits().toLong()
+    }
+  }
+
+  private fun haveAreaKeysChanged(stateAreas: List<HazeArea>): Boolean {
+    if (areaKeys.size != stateAreas.size) return true
+    return stateAreas.any { area ->
+      !areaKeys.containsKey(area) || areaKeys[area] != area.key
+    }
+  }
+
+  private fun updateAreaKeys(stateAreas: List<HazeArea>) {
+    areaKeys.clear()
+    stateAreas.forEach { area ->
+      areaKeys[area] = area.key
     }
   }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -71,6 +71,7 @@ public class HazeSourceNode(
 
   public var state: HazeState = state
     set(value) {
+      if (value === field) return
       val attachedToState = area in field.areas
       if (attachedToState) {
         // Detach ourselves from the old HazeState

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceNodeTest.kt
@@ -3,18 +3,29 @@
 
 package dev.chrisbanes.haze
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
@@ -24,6 +35,114 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
 class HazeSourceNodeTest : ContextTest() {
+
+  @Test
+  fun sourceElementUpdateWithUnchangedValuesPreservesEqualZOrder() = runComposeUiTest {
+    val state = HazeState()
+    val firstNode = HazeSourceNode(state, key = "first")
+    val secondNode = HazeSourceNode(state, key = "second")
+    val effect = SourceLayerVisualEffect()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testHazeSourceNode(firstNode)
+            .background(Color.Red),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testHazeSourceNode(secondNode)
+            .background(Color.Blue),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("effect")
+            .hazeEffect(state) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    assertThat(state.areas.map(HazeArea::key)).containsExactly("first", "second")
+    assertThat(effect.areaKeys).containsExactly("first", "second")
+    val initialPixel = onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50]
+    assertThat(initialPixel).isEqualTo(Color.Blue)
+
+    runOnIdle {
+      HazeSourceElement(state = state, zIndex = 0f, key = "first").update(firstNode)
+    }
+    waitForIdle()
+
+    assertThat(state.areas.map(HazeArea::key)).containsExactly("first", "second")
+    assertThat(effect.areaKeys).containsExactly("first", "second")
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(initialPixel)
+  }
+
+  @Test
+  fun stateChangeMovesAttachedSourceWithoutDuplicates() = runComposeUiTest {
+    val firstState = HazeState()
+    val secondState = HazeState()
+    val node = HazeSourceNode(firstState)
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .testHazeSourceNode(node),
+      )
+    }
+    waitForIdle()
+
+    runOnIdle {
+      node.state = secondState
+    }
+
+    assertThat(firstState.areas).isEmpty()
+    assertThat(secondState.areas).containsExactly(node.area)
+  }
+
+  @Test
+  fun keyChangeWithUnchangedStateRefreshesAreaFilter() = runComposeUiTest {
+    val state = HazeState()
+    val node = HazeSourceNode(state, key = "hidden")
+    val effect = SourceLayerVisualEffect()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testHazeSourceNode(node)
+            .background(Color.Red),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(state) {
+              canDrawArea = { area -> area.key != "hidden" }
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    assertThat(effect.areaKeys).isEmpty()
+
+    runOnIdle {
+      HazeSourceElement(state = state, zIndex = 0f, key = "visible").update(node)
+    }
+    waitForIdle()
+
+    assertThat(effect.areaKeys).containsExactly("visible")
+  }
 
   @Test
   fun onResetReleasesLayerAndClearsWindowId() = runComposeUiTest {
@@ -79,6 +198,17 @@ class HazeSourceNodeTest : ContextTest() {
     assertThat(node.area.contentLayer).isNotNull()
     assertThat(node.area.contentLayer).isNotEqualTo(initialLayer)
     assertThat(node.area.contentVersion).isNotEqualTo(initialContentVersion)
+  }
+}
+
+private class SourceLayerVisualEffect : VisualEffect {
+  var areaKeys: List<Any?> = emptyList()
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    areaKeys = context.areas.map(HazeArea::key)
+    context.areas.forEach { area ->
+      area.contentLayer?.let { drawLayer(it) }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- skip `HazeSourceNode.state` migration when the state instance is unchanged
- preserve insertion order for equal-z sources during modifier updates
- add a rendered overlap regression covering list order, effect order, and pixels
- verify real state migration still leaves exactly one membership in the destination state

Fixes #1113

## Validation

- red/green `HazeSourceNodeTest.sourceElementUpdateWithUnchangedValuesPreservesEqualZOrder`
- `./gradlew :haze:jvmTest :haze:testAndroidHostTest :haze:spotlessCheck --no-daemon`
- existing `hazeEffect_zIndexChangeRebuildsAreaOrder` coverage
- `git diff --check origin/main...HEAD`
- final standards and specification reviews on exact `HEAD`