### PR TITLE
Avoid redundant Glass source snapshot work

### DIFF
--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStageInvalidation.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStageInvalidation.kt
@@ -233,61 +233,63 @@ internal fun VisualEffectContext.resolveGlassSourceState(
   previousSnapshot: GlassSourceSnapshot? = null,
 ): GlassSourceState {
   val effectPosition = position
-  val sourceAreas = areas.map { area -> area.toGlassSourceArea(this, effectPosition) }
-  if (previousSnapshot?.matches(captureScale, layerSize, layerOffset, sourceAreas) == true) {
-    return GlassSourceState(hasDrawableSource = true, snapshot = previousSnapshot)
+  var drawableAreas: MutableList<GlassSourceArea>? = null
+  val reusableSnapshot = previousSnapshot?.takeIf {
+    it.captureScale == captureScale &&
+      it.layerSize == layerSize &&
+      it.layerOffset == layerOffset
   }
-  return resolveGlassSourceState(
-    captureScale = captureScale,
-    layerSize = layerSize,
-    layerOffset = layerOffset,
-    areas = sourceAreas,
-  )
-}
-
-@OptIn(InternalHazeApi::class)
-private fun GlassSourceSnapshot.matches(
-  captureScale: Float,
-  context: VisualEffectContext,
-): Boolean {
-  if (
-    this.captureScale != captureScale ||
-    layerSize != context.layerSize ||
-    layerOffset != context.layerOffset
-  ) {
-    return false
-  }
-  val effectPosition = context.position
   var drawableIndex = 0
-  for (area in context.areas) {
+  for (area in areas) {
+    if (!(area.size.width > 0f && area.size.height > 0f)) continue
     val layer = area.contentLayer?.takeUnless { it.isReleased || !it.isDrawable } ?: continue
-    val previous = areas.getOrNull(drawableIndex++) ?: return false
-    val contentVersion = context.contentVersionOf(area) ?: return false
-    if (
-      previous.areaIdentity !== area ||
-      previous.contentLayerIdentity !== layer ||
-      previous.contentVersion != contentVersion ||
-      previous.position != context.glassSourcePositionOf(area, effectPosition) ||
-      previous.size != area.size
-    ) {
-      return false
+    val contentVersion = contentVersionOf(area)
+      ?: return GlassSourceState(hasDrawableSource = true, snapshot = null)
+    val position = glassSourcePositionOf(area, effectPosition)
+    val previous = if (drawableAreas == null) {
+      reusableSnapshot?.areas?.getOrNull(drawableIndex)
+    } else {
+      null
     }
+    if (
+      previous != null &&
+      previous.areaIdentity === area &&
+      previous.contentLayerIdentity === layer &&
+      previous.contentVersion == contentVersion &&
+      previous.position == position &&
+      previous.size == area.size
+    ) {
+      drawableIndex++
+      continue
+    }
+    if (drawableAreas == null) {
+      drawableAreas = mutableListOf()
+      if (reusableSnapshot != null) {
+        drawableAreas.addAll(reusableSnapshot.areas.subList(0, drawableIndex))
+      }
+    }
+    drawableAreas += GlassSourceArea(
+      areaIdentity = area,
+      contentLayerIdentity = layer,
+      contentVersion = contentVersion,
+      position = position,
+      size = area.size,
+    )
+    drawableIndex++
   }
-  return drawableIndex == areas.size
-}
-
-@OptIn(InternalHazeApi::class)
-private fun HazeArea.toGlassSourceArea(
-  context: VisualEffectContext,
-  effectPosition: Offset,
-): GlassSourceArea {
-  val layer = contentLayer?.takeUnless { it.isReleased || !it.isDrawable }
-  return GlassSourceArea(
-    areaIdentity = this,
-    contentLayerIdentity = layer,
-    contentVersion = context.contentVersionOf(this),
-    position = context.glassSourcePositionOf(this, effectPosition),
-    size = size,
+  if (drawableIndex == 0) {
+    return GlassSourceState(hasDrawableSource = false, snapshot = null)
+  }
+  if (drawableAreas == null) {
+    val snapshot = checkNotNull(reusableSnapshot)
+    if (drawableIndex == snapshot.areas.size) {
+      return GlassSourceState(hasDrawableSource = true, snapshot = snapshot)
+    }
+    drawableAreas = snapshot.areas.subList(0, drawableIndex).toMutableList()
+  }
+  return GlassSourceState(
+    hasDrawableSource = true,
+    snapshot = GlassSourceSnapshot(captureScale, layerSize, layerOffset, drawableAreas),
   )
 }
 

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.roundToIntSize
 import assertk.assertThat
@@ -41,9 +42,11 @@ import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
+import dev.chrisbanes.haze.HazeArea
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.RetainedOutputVisualEffect
 import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.VisualEffect
@@ -448,6 +451,123 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       .isGreaterThan(interactionCompositeRecordsBeforeMutation)
     assertThat(checkNotNull(delegate.lastSuccessfulSourceSnapshot))
       .isNotEqualTo(acceptedSnapshotBeforeMutation)
+  }
+
+  @Test
+  fun unchangedSourceSnapshot_matchesContextBeforeMaterializingAreas() = runComposeUiTest {
+    val effect = activeDetailEffect()
+    setContent { RuntimeGlassTestContent(effect, tag = "glass") }
+    waitForIdle()
+
+    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val previousSnapshot = checkNotNull(delegate.lastSuccessfulSourceSnapshot)
+    val context = checkNotNull(effect.attachedContextForTest)
+    val trackedAreas = SizeReadTrackingList(context.areas)
+    val trackingContext = object : VisualEffectContext by context {
+      override val areas = trackedAreas
+    }
+
+    val sourceState = trackingContext.resolveGlassSourceState(
+      captureScale = previousSnapshot.captureScale,
+      previousSnapshot = previousSnapshot,
+    )
+
+    assertThat(sourceState.snapshot).isSameInstanceAs(previousSnapshot)
+    assertThat(trackedAreas.sizeReadCount).isEqualTo(0)
+  }
+
+  @Test
+  @OptIn(InternalHazeApi::class)
+  fun changedSourceSnapshot_materializesReplacementInOneContextPass() = runComposeUiTest {
+    val effect = activeDetailEffect()
+    setContent { RuntimeGlassTestContent(effect, tag = "glass") }
+    waitForIdle()
+
+    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val previousSnapshot = checkNotNull(delegate.lastSuccessfulSourceSnapshot)
+    val context = checkNotNull(effect.attachedContextForTest)
+    val changedArea = context.areas.first()
+    val trackedAreas = SizeReadTrackingList(context.areas)
+    val trackingContext = object : VisualEffectContext by context {
+      override val areas = trackedAreas
+
+      override fun contentVersionOf(area: HazeArea): Long? {
+        val version = context.contentVersionOf(area)
+        return if (area === changedArea) version?.plus(1) else version
+      }
+    }
+
+    val sourceState = trackingContext.resolveGlassSourceState(
+      captureScale = previousSnapshot.captureScale,
+      previousSnapshot = previousSnapshot,
+    )
+
+    assertThat(sourceState.snapshot).isNotSameInstanceAs(previousSnapshot)
+    assertThat(trackedAreas.sizeReadCount).isEqualTo(0)
+    assertThat(trackedAreas.iteratorCount).isEqualTo(1)
+  }
+
+  @Test
+  @OptIn(InternalHazeApi::class)
+  fun zeroSizedSource_withRetainedLayerIsNotDrawable() = runComposeUiTest {
+    val hazeState = HazeState()
+    val sourceSize = mutableStateOf(120.dp)
+    val effect = activeDetailEffect()
+    setContent {
+      Box(Modifier.size(120.dp)) {
+        Box(
+          Modifier
+            .size(sourceSize.value)
+            .background(Color.Red)
+            .hazeSource(hazeState),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(hazeState) {
+              inputScale = HazeInputScale.None
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    val context = checkNotNull(effect.attachedContextForTest)
+    val area = context.areas.single()
+    val graphicsContext = context.requireGraphicsContext()
+
+    sourceSize.value = 0.dp
+    waitForIdle()
+
+    assertThat(area.size).isEqualTo(Size.Zero)
+    val contentLayerSetter = area.javaClass.declaredMethods
+      .single { it.name.startsWith("setContentLayer") }
+    val retainedLayer = graphicsContext.createGraphicsLayer().apply {
+      record(
+        density = context.requireDensity(),
+        layoutDirection = LayoutDirection.Ltr,
+        size = Size(120f, 120f).roundToIntSize(),
+      ) {}
+    }
+    try {
+      contentLayerSetter.invoke(area, retainedLayer)
+      assertThat(area.contentLayer).isSameInstanceAs(retainedLayer)
+      assertThat(retainedLayer.size.width).isGreaterThan(0)
+      assertThat(context.resolveGlassSourceState(captureScale = 1f).hasDrawableSource).isFalse()
+
+      val sizeSetter = area.javaClass.declaredMethods
+        .single { it.name.startsWith("setSize") }
+      val unspecifiedSize = Size::class.java.declaredMethods
+        .single { it.name == "unbox-impl" }
+        .invoke(Size.Unspecified)
+      sizeSetter.invoke(area, unspecifiedSize)
+      assertThat(area.size).isEqualTo(Size.Unspecified)
+      assertThat(context.resolveGlassSourceState(captureScale = 1f).hasDrawableSource).isFalse()
+    } finally {
+      contentLayerSetter.invoke(area, null)
+      graphicsContext.releaseGraphicsLayer(retainedLayer)
+    }
   }
 
   @Test
@@ -917,6 +1037,26 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
 
     override fun clearRetainedOutput() {
       delegate.clearRetainedOutput()
+    }
+  }
+
+  private class SizeReadTrackingList<T>(
+    private val delegate: List<T>,
+  ) : List<T> by delegate {
+    var sizeReadCount: Int = 0
+      private set
+    var iteratorCount: Int = 0
+      private set
+
+    override val size: Int
+      get() {
+        sizeReadCount++
+        return delegate.size
+      }
+
+    override fun iterator(): Iterator<T> {
+      iteratorCount++
+      return delegate.iterator()
     }
   }
 


### PR DESCRIPTION
## Summary

- reuse an unchanged Glass source snapshot before materializing replacement areas
- build changed snapshots in one `context.areas` traversal, retaining the already-verified prefix
- preserve non-drawable zero, negative, and unspecified source geometry
- cover unchanged reuse, semantic mutation, one-pass replacement, and retained-layer geometry regressions

Fixes #1115

## Validation

- `./gradlew :haze-glass:jvmTest :haze-glass:testAndroidHostTest :haze-glass:spotlessCheck --no-daemon --console=plain`
- `git diff --check origin/main...HEAD`
- exact-head standards review: clean
- exact-head spec review: clean
- review-and-simplify-changes: clean
- ponytail-review: Lean already. Ship.

## Pixel 6 Macrobenchmark

Physical Pixel 6, fixed-performance mode, 8 measured iterations per scenario. Both runs produced AndroidX benchmark JSON and 24 Perfetto traces.

| Scenario | Median metric | Before | After |
| --- | --- | ---: | ---: |
| `sourceUpdate9` | Glass draw count | 2448 | 2448 |
|  | heap max (KB) | 18497 | 18147 |
|  | GPU max (KB) | 95374 | 95438 |
|  | RSS anon max (KB) | 77174 | 76594 |
| `sourceUpdate` | Glass draw count | 272 | 272 |
|  | heap max (KB) | 16743 | 15595 |
|  | GPU max (KB) | 93904 | 105140 |
|  | RSS anon max (KB) | 65504 | 65824 |
| `retainedReuse` | Glass draw count | 272 | 272 |

Build scans: [baseline](https://gradle.com/s/lsxykuwsrwxei), [measured implementation head `5301ec74`](https://gradle.com/s/367x434d44sp6). The later review fix only restores filtering for non-positive/unspecified source geometry, which is outside the measured positive-size scenarios; current head `8ecd7275` passed the full validation above.