### PR TITLE
Parallelize CI screenshot tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     runs-on: macos-26
-    needs: linux_build
     timeout-minutes: 30
 
     steps:
@@ -78,7 +77,11 @@ jobs:
             caches/build-cache-1
 
       - name: Assemble and check
-        run: ./gradlew check assembleDebug -Phaze.disableAppleTargets -Pandroidx.baselineprofile.skipgeneration
+        run: >
+          ./gradlew check assembleDebug
+          -x :haze-screenshot-tests:testAndroidHostTest
+          -Phaze.disableAppleTargets
+          -Pandroidx.baselineprofile.skipgeneration
         env:
           ORG_GRADLE_PROJECT_remoteBuildCacheUrl: ${{ secrets.GRADLE_REMOTE_CACHE_URL }}
           ORG_GRADLE_PROJECT_remoteBuildCacheUsername: ${{ secrets.GRADLE_REMOTE_CACHE_USERNAME }}
@@ -93,6 +96,47 @@ jobs:
           path: |
             **/build/reports/**
             **/build/outputs/roborazzi/**
+
+  screenshot_tests:
+    name: Screenshot tests (android)
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
+
+      - name: Run screenshot tests
+        run: >
+          ./gradlew :haze-screenshot-tests:testAndroidHostTest
+          -Phaze.disableAppleTargets
+          -Pandroidx.baselineprofile.skipgeneration
+        env:
+          ORG_GRADLE_PROJECT_remoteBuildCacheUrl: ${{ secrets.GRADLE_REMOTE_CACHE_URL }}
+          ORG_GRADLE_PROJECT_remoteBuildCacheUsername: ${{ secrets.GRADLE_REMOTE_CACHE_USERNAME }}
+          ORG_GRADLE_PROJECT_remoteBuildCachePassword: ${{ secrets.GRADLE_REMOTE_CACHE_PASSWORD }}
+          ORG_GRADLE_PROJECT_remoteBuildCachePush: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1') }}
+
+      - name: Upload reports + Roborazzi outputs
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: haze-screenshot-android-reports
+          path: |
+            haze-screenshot-tests/build/reports/**
+            haze-screenshot-tests/build/outputs/roborazzi/**
 
   emulator_tests:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
@@ -150,7 +194,11 @@ jobs:
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/v1'
 
     runs-on: macos-26
-    needs: [ mac_build, emulator_tests ]
+    needs:
+      - linux_build
+      - mac_build
+      - screenshot_tests
+      - emulator_tests
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary

- start the macOS build alongside Linux instead of waiting for `linux_build`
- keep JVM screenshots in `linux_build` and move only the Android-host screenshot suite into a parallel job
- keep sample screenshot coverage in `linux_build` and make deploy wait for all verification jobs

## Why

Recent PR runs spent roughly 20 minutes executing the library JVM and Android-host screenshot suites sequentially, followed by another 8–14 minutes for the gated macOS job. Runner queueing and emulator tests were not on the critical path.

The first CI run confirmed that Android screenshots and macOS are the slowest parallel legs. Keeping JVM screenshots in Linux avoids another runner and duplicated setup while preserving the shorter critical path and the existing memory isolation between JVM and Android-host screenshots.

## Validation

- `actionlint .github/workflows/build.yml`
- YAML workflow graph assertions
- `git diff --check`
- Gradle dry-run confirming `linux_build` includes library JVM screenshots and their Roborazzi finalizer, excludes only Android-host screenshots, and retains sample screenshot tests
- Gradle dry-run confirming the Android screenshot job includes its Roborazzi finalizer without pulling in JVM screenshots
- `review-and-simplify-changes` and `ponytail-review` pre-push reviews
