### PR TITLE
Fall back when runtime glass construction fails

### DIFF
--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -28,6 +28,7 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
@@ -35,6 +36,7 @@ import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
@@ -47,6 +49,31 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [35])
 class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
+
+  @Test
+  fun runtimeConstructionFailure_usesFallbackWithoutRetryingEveryFrame() =
+    runAndroidComposeUiTest<ComponentActivity> {
+      var creationAttempts = 0
+      val effect = retainedBlurEffect().apply {
+        runtimeEffectFactory = GlassRuntimeEffectFactory {
+          creationAttempts++
+          throw RuntimeShaderRenderEffectException(
+            IllegalArgumentException("broken Android runtime effect"),
+          )
+        }
+      }
+      setContent { RuntimeGlassTestContent(effect) }
+      waitForIdle()
+      drawFrame()
+
+      assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+      assertThat(creationAttempts).isEqualTo(1)
+
+      drawFrame()
+
+      assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+      assertThat(creationAttempts).isEqualTo(1)
+    }
 
   @Test
   fun singleStandardBlur_usesFusedBaseRenderer() =

--- a/haze-glass/src/androidMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectFactory.android.kt
+++ b/haze-glass/src/androidMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectFactory.android.kt
@@ -22,26 +22,28 @@ internal actual fun createGlassDepthInputRenderEffect(
   if (blur == null || depth <= 0.0001f) return null
   if (depth >= 0.9999f) return blur
 
-  fun scaledInput(scale: Float, input: RenderEffect? = null): RenderEffect {
-    val matrix = ColorMatrix().apply {
-      // Color filters operate on straight RGB and premultiply the result. Scaling both RGB and
-      // alpha would therefore apply the factor twice to premultiplied color. Scale alpha only to
-      // match Canvas layer alpha, which scales premultiplied RGBA once.
-      setScale(1f, 1f, 1f, scale)
+  return wrapGlassRuntimeEffectConstruction {
+    fun scaledInput(scale: Float, input: RenderEffect? = null): RenderEffect {
+      val matrix = ColorMatrix().apply {
+        // Color filters operate on straight RGB and premultiply the result. Scaling both RGB and
+        // alpha would therefore apply the factor twice to premultiplied color. Scale alpha only to
+        // match Canvas layer alpha, which scales premultiplied RGBA once.
+        setScale(1f, 1f, 1f, scale)
+      }
+      val filter = ColorMatrixColorFilter(matrix)
+      return if (input != null) {
+        RenderEffect.createColorFilterEffect(filter, input)
+      } else {
+        RenderEffect.createColorFilterEffect(filter)
+      }
     }
-    val filter = ColorMatrixColorFilter(matrix)
-    return if (input != null) {
-      RenderEffect.createColorFilterEffect(filter, input)
-    } else {
-      RenderEffect.createColorFilterEffect(filter)
-    }
-  }
 
-  return RenderEffect.createBlendModeEffect(
-    scaledInput(1f - depth),
-    scaledInput(depth, blur),
-    BlendMode.PLUS,
-  )
+    RenderEffect.createBlendModeEffect(
+      scaledInput(1f - depth),
+      scaledInput(depth, blur),
+      BlendMode.PLUS,
+    )
+  }
 }
 
 internal actual val supportsFusedGlassRenderEffect: Boolean = true

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -700,9 +700,6 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       } catch (failure: RuntimeShaderRenderEffectException) {
         if (selectedDelegate !is RuntimeShaderGlassDelegate) throw failure
         downgradeRuntimeDelegate(selectedDelegate, context, failure)
-        withMaterialTransform(context) {
-          with(delegate) { draw(context) }
-        }
       }
     } finally {
       resetDirtyTracker()

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -38,6 +38,7 @@ import dev.chrisbanes.haze.HazeLogger
 import dev.chrisbanes.haze.InteractiveVisualEffect
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.RetainedOutputVisualEffect
+import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
 import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.VisualEffect
 import dev.chrisbanes.haze.VisualEffectContext
@@ -176,6 +177,11 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
     get() = interactionController?.currentSignals ?: IdleInteractionSignals
 
   private var needsDelegateSelection: Boolean = true
+
+  internal var runtimeEffectFactory: GlassRuntimeEffectFactory = PlatformGlassRuntimeEffectFactory
+
+  internal var runtimeShaderIncompatible: Boolean = false
+    private set
 
   internal var preparedRenderBudget: GlassRenderBudgetDecision =
     GlassRenderBudgetDecision.Fallback(GlassRenderBudgetFallbackReason.InvalidGeometry)
@@ -572,6 +578,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       isAttached = false
       delegate.detach()
     }
+    runtimeShaderIncompatible = false
+    needsDelegateSelection = true
     preparedRender = null
     clearPreparedRenderCache()
   }
@@ -636,7 +644,13 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
         selectDelegateForDraw(context)
       }
       trace(GlassTraceSection.DelegatePrepare) {
-        with(delegate) { prepareDraw(context) }
+        val selectedDelegate = delegate
+        try {
+          with(selectedDelegate) { prepareDraw(context) }
+        } catch (failure: RuntimeShaderRenderEffectException) {
+          if (selectedDelegate !is RuntimeShaderGlassDelegate) throw failure
+          downgradeRuntimeDelegate(selectedDelegate, context, failure)
+        }
       }
       cachePreparedDrawInputs(context)
     }
@@ -678,12 +692,36 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
   override fun DrawScope.draw(context: VisualEffectContext) {
     try {
       selectDelegateForDraw(context)
-      withMaterialTransform(context) {
-        with(delegate) { draw(context) }
+      val selectedDelegate = delegate
+      try {
+        withMaterialTransform(context) {
+          with(selectedDelegate) { draw(context) }
+        }
+      } catch (failure: RuntimeShaderRenderEffectException) {
+        if (selectedDelegate !is RuntimeShaderGlassDelegate) throw failure
+        downgradeRuntimeDelegate(selectedDelegate, context, failure)
+        withMaterialTransform(context) {
+          with(delegate) { draw(context) }
+        }
       }
     } finally {
       resetDirtyTracker()
     }
+  }
+
+  private fun DrawScope.downgradeRuntimeDelegate(
+    runtimeDelegate: RuntimeShaderGlassDelegate,
+    context: VisualEffectContext,
+    failure: RuntimeShaderRenderEffectException,
+  ) {
+    runtimeDelegate.releaseAfterConstructionFailure()
+    runtimeShaderIncompatible = true
+    HazeLogger.d(TAG) {
+      "Runtime shader construction failed; using fallback until reattachment: $failure"
+    }
+    delegate = FallbackGlassDelegate(this@GlassVisualEffect)
+    with(delegate) { prepareDraw(context) }
+    context.invalidateDraw()
   }
 
   override fun DrawScope.drawForeground(context: VisualEffectContext) {
@@ -1761,9 +1799,11 @@ internal interface RetainedOutputDelegate {
 internal fun GlassVisualEffect.updateDelegate(): GlassVisualEffect.Delegate {
   val wantsRuntime =
     preparedRenderBudget is GlassRenderBudgetDecision.Runtime &&
-      preparedRender != null
+      preparedRender != null &&
+      !runtimeShaderIncompatible
   return when {
-    wantsRuntime && delegate !is RuntimeShaderGlassDelegate -> RuntimeShaderGlassDelegate(this)
+    wantsRuntime && delegate !is RuntimeShaderGlassDelegate ->
+      RuntimeShaderGlassDelegate(this, runtimeEffectFactory)
     !wantsRuntime && delegate !is FallbackGlassDelegate -> FallbackGlassDelegate(this)
     else -> delegate
   }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -22,6 +22,7 @@ import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.MutableRuntimeShaderRenderEffect
 import dev.chrisbanes.haze.PlatformRenderEffect
 import dev.chrisbanes.haze.Poko
+import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
 import dev.chrisbanes.haze.RuntimeShaderUniformProvider
 import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.VisualEffectContext
@@ -34,6 +35,7 @@ import dev.chrisbanes.haze.trace
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
 internal class RuntimeShaderGlassDelegate(
   private val effect: GlassVisualEffect,
+  private val runtimeEffectFactory: GlassRuntimeEffectFactory = PlatformGlassRuntimeEffectFactory,
 ) : GlassVisualEffect.Delegate, RetainedOutputDelegate {
   private var blurKey: GlassBlurEffectKey? = null
   private var blurEffects: GlassBlurRenderEffects? = null
@@ -797,6 +799,10 @@ internal class RuntimeShaderGlassDelegate(
     releaseRetainedResources(releaseShaderHandles = false)
   }
 
+  internal fun releaseAfterConstructionFailure() {
+    releaseRetainedResources(releaseShaderHandles = true)
+  }
+
   override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
     if (shouldReleaseRetainedGlass(level)) {
       releaseRetainedResources(graphicsContext ?: context.requireGraphicsContext())
@@ -1335,11 +1341,13 @@ internal class RuntimeShaderGlassDelegate(
       uniforms != interactionDetailCoverageEffectUniforms ||
       interactionDetailCoverageComposeEffect == null
     if (interactionDetailCoverageEffect == null) {
-      interactionDetailCoverageEffect = createMutableRuntimeShaderRenderEffect(
-        effect = GLASS_INTERACTION_REFRACTION_DETAIL_COVERAGE_EFFECT,
-        shaderNames = arrayOf("content"),
-        inputs = arrayOf(null),
-      )
+      interactionDetailCoverageEffect = traceCreateRenderEffect {
+        createMutableRuntimeShaderRenderEffect(
+          effect = GLASS_INTERACTION_REFRACTION_DETAIL_COVERAGE_EFFECT,
+          shaderNames = arrayOf("content"),
+          inputs = arrayOf(null),
+        )
+      }
     }
     if (needsUpdate) {
       interactionDetailCoverageComposeEffect = checkNotNull(interactionDetailCoverageEffect)
@@ -1384,11 +1392,13 @@ internal class RuntimeShaderGlassDelegate(
     featherWidth: Float,
   ) {
     if (interactionOutputEffect == null || input != interactionOutputInput) {
-      interactionOutputEffect = createMutableRuntimeShaderRenderEffect(
-        effect = GLASS_INTERACTION_OUTPUT_EFFECT,
-        shaderNames = arrayOf("content"),
-        inputs = arrayOf(input),
-      )
+      interactionOutputEffect = traceCreateRenderEffect {
+        createMutableRuntimeShaderRenderEffect(
+          effect = GLASS_INTERACTION_OUTPUT_EFFECT,
+          shaderNames = arrayOf("content"),
+          inputs = arrayOf(input),
+        )
+      }
       interactionOutputInput = input
       interactionOutputUniforms = null
       interactionOutputFeatherWidth = Float.NaN
@@ -1537,7 +1547,9 @@ internal class RuntimeShaderGlassDelegate(
       }
       refractionDetailCoverageEffect = nextRefractionDetailKey?.let { key ->
         val shader = refractionDetailCoverageShader
-          ?: createRetainedRefractionDetailCoverageRenderEffect().also {
+          ?: traceCreateRenderEffect {
+            createRetainedRefractionDetailCoverageRenderEffect()
+          }.also {
             refractionDetailCoverageShader = it
           }
         shader.updateUniforms { setRefractionDetailUniforms(key) }
@@ -1579,15 +1591,17 @@ internal class RuntimeShaderGlassDelegate(
           sharpDetail = key.detail != null,
         )
         if (fusedShader == null || fusedInputKey != nextInputKey) {
-          fusedShader = createFusedGlassRenderEffect(
-            input = createFusedDepthInputRenderEffect(
-              blur = key.blur,
-              depth = key.depth,
-              sampleSize = key.optical.coordinates.sampleSize,
-            ),
-            interactionOptics = nextInputKey.interactionOptics,
-            sharpDetail = nextInputKey.sharpDetail,
-          )
+          fusedShader = traceCreateRenderEffect {
+            createFusedGlassRenderEffect(
+              input = createFusedDepthInputRenderEffect(
+                blur = key.blur,
+                depth = key.depth,
+                sampleSize = key.optical.coordinates.sampleSize,
+              ),
+              interactionOptics = nextInputKey.interactionOptics,
+              sharpDetail = nextInputKey.sharpDetail,
+            )
+          }
           refractionDetailShader = null
           fusedInputKey = nextInputKey
         }
@@ -1610,11 +1624,13 @@ internal class RuntimeShaderGlassDelegate(
           setRefractionDetailUniforms(detailKey)
           key.interaction?.let(::setInteractionDetailUniforms)
         }
-        createBlendRenderEffect(
-          blendMode = BlendMode.Plus,
-          background = optical,
-          foreground = detail,
-        )
+        wrapGlassRuntimeEffectConstruction {
+          createBlendRenderEffect(
+            blendMode = BlendMode.Plus,
+            background = optical,
+            foreground = detail,
+          )
+        }
       }
       fusedEffectKey = nextFusedEffectKey
     }
@@ -1769,8 +1785,33 @@ internal class RuntimeShaderGlassDelegate(
     )
   }
 
-  private inline fun <T> traceCreateRenderEffect(block: () -> T): T =
-    trace(GlassTraceSection.CreateRenderEffect, block)
+  private fun traceCreateRenderEffect(
+    block: () -> MutableRuntimeShaderRenderEffect,
+  ): MutableRuntimeShaderRenderEffect =
+    trace(GlassTraceSection.CreateRenderEffect) {
+      runtimeEffectFactory.create(block)
+    }
+}
+
+@OptIn(InternalHazeApi::class)
+internal inline fun <T> wrapGlassRuntimeEffectConstruction(block: () -> T): T = try {
+  block()
+} catch (failure: RuntimeShaderRenderEffectException) {
+  throw failure
+} catch (failure: RuntimeException) {
+  throw RuntimeShaderRenderEffectException(failure)
+}
+
+internal fun interface GlassRuntimeEffectFactory {
+  fun create(
+    block: () -> MutableRuntimeShaderRenderEffect,
+  ): MutableRuntimeShaderRenderEffect
+}
+
+internal object PlatformGlassRuntimeEffectFactory : GlassRuntimeEffectFactory {
+  override fun create(
+    block: () -> MutableRuntimeShaderRenderEffect,
+  ): MutableRuntimeShaderRenderEffect = block()
 }
 
 internal data class GlassStageRecordCounts(

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -278,11 +278,72 @@ internal class RuntimeShaderGlassDelegate(
         graphicsContext = currentGraphicsContext,
       )
     }
+    prepareInteractionRenderEffects(
+      render = currentPreparedRender,
+      effects = currentRenderEffects,
+      patch = interactionPatch,
+      params = params,
+    )
     preparedRender = currentPreparedRender
     preparedParams = params
     preparedRenderEffects = currentRenderEffects
     preparedInteractionUniforms = interactionUniforms
     preparedInteractionPatch = interactionPatch
+  }
+
+  private fun prepareInteractionRenderEffects(
+    render: GlassPreparedRender,
+    effects: GlassRenderEffects,
+    patch: GlassInteractionPatch?,
+    params: GlassRenderParams,
+  ) {
+    if (patch == null) return
+    if (!supportsFusedGlassRenderEffect && render.interactionTopology.hasOptics) {
+      val opticalLayer = checkNotNull(layers.interactionOptical)
+      updateInteractionOpticalEffect(
+        opticalLayer,
+        render.opticalKey.copy(coordinates = patch.coordinates),
+        patch.uniforms,
+      )
+      val detail = effects.refractionDetail
+      val outputLayer = if (detail != null) {
+        val localDetailKey = detail.key.copy(
+          sampleSize = patch.coordinates.sampleSize,
+          materialOrigin = patch.coordinates.materialOrigin,
+          materialSize = patch.coordinates.materialSize,
+        )
+        updateInteractionDetailEffect(
+          checkNotNull(layers.interactionRefractionDetail),
+          localDetailKey,
+          patch.uniforms,
+        )
+        updateInteractionDetailCoverageEffect(
+          checkNotNull(layers.interactionRefractionDetailCoverage),
+          localDetailKey,
+          patch.uniforms,
+        )
+        checkNotNull(layers.interactionRefractionComposite)
+      } else {
+        opticalLayer
+      }
+      updateInteractionOutputEffect(
+        layer = outputLayer,
+        input = if (detail == null) checkNotNull(interactionOpticalPlatformEffect) else null,
+        patch = patch,
+        featherWidth = maxOf(params.sampleStepPx, 1f),
+      )
+    }
+    if (render.interactionTopology.hasLighting) {
+      updateInteractionLightingEffect(
+        layer = checkNotNull(layers.interactionLighting),
+        key = GlassInteractionLightingKey(
+          coordinates = patch.coordinates,
+          edgeSoftnessPx = params.edgeSoftnessPx,
+          cornerRadii = params.cornerRadii,
+        ),
+        uniforms = patch.uniforms,
+      )
+    }
   }
 
   private fun releaseObsoleteInteractionLayers(

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.captureToImage
@@ -403,32 +404,24 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     }
 
   @Test
-  fun interactionRuntimeConstructionFailure_drawsAndUpdatesFallback() = runComposeUiTest {
-    var failConstruction = false
+  fun runtimeConstructionFailure_preparesFallbackBeforeContentBehindDecision() = runComposeUiTest {
     var creationAttempts = 0
-    val effect = runtimeInteractiveEffect().apply {
-      runtimeEffectFactory = GlassRuntimeEffectFactory { create ->
+    val effect = activeDetailEffect().apply {
+      runtimeEffectFactory = GlassRuntimeEffectFactory {
         creationAttempts++
-        if (failConstruction) {
-          throw RuntimeShaderRenderEffectException(
-            IllegalArgumentException("broken interaction runtime effect"),
-          )
-        }
-        create()
+        throw RuntimeShaderRenderEffectException(
+          IllegalArgumentException("broken runtime effect"),
+        )
       }
     }
-    setContent { RuntimeGlassTestContent(effect, tag = "glass") }
-    waitForIdle()
-    val baseCreationAttempts = creationAttempts
-
-    failConstruction = true
-    effect.setPressedForTest(Offset(60f, 60f))
-    mainClock.advanceTimeBy(500)
+    setContent { RuntimeForegroundGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
     assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
-    assertThat(creationAttempts).isGreaterThan(baseCreationAttempts)
-    onNodeWithTag("glass").captureToImage()
+    assertThat(creationAttempts).isEqualTo(1)
+    val failureFrameCenter = onNodeWithTag("glass").captureToImage().toPixelMap()[60, 60]
+    assertThat(failureFrameCenter.alpha).isGreaterThan(0.9f)
+    assertThat(failureFrameCenter.red).isGreaterThan(0.9f)
     val attemptsAfterDowngrade = creationAttempts
 
     effect.tint = Color.Blue.copy(alpha = 0.5f)
@@ -437,6 +430,27 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
     assertThat(creationAttempts).isEqualTo(attemptsAfterDowngrade)
     onNodeWithTag("glass").captureToImage()
+  }
+
+  @Test
+  fun interactionRuntimeEffects_constructBeforeDraw() = runComposeUiTest {
+    var creationAttempts = 0
+    val effect = runtimeInteractiveEffect().apply {
+      runtimeEffectFactory = GlassRuntimeEffectFactory { create ->
+        creationAttempts++
+        create()
+      }
+    }
+    setContent { RuntimeGlassTestContent(effect, tag = "glass") }
+    waitForIdle()
+    val attemptsAfterPreparation = creationAttempts
+
+    effect.setPressedForTest(Offset(60f, 60f))
+    mainClock.advanceTimeBy(500)
+    waitForIdle()
+
+    assertThat(effect.delegate).isInstanceOf<RuntimeShaderGlassDelegate>()
+    assertThat(creationAttempts).isEqualTo(attemptsAfterPreparation)
   }
 
   @Test
@@ -973,10 +987,14 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   @Composable
-  private fun RuntimeForegroundGlassTestContent(effect: GlassVisualEffect) {
+  private fun RuntimeForegroundGlassTestContent(
+    effect: GlassVisualEffect,
+    tag: String? = null,
+  ) {
     Box(
       Modifier
         .size(120.dp)
+        .then(if (tag != null) Modifier.testTag(tag) else Modifier)
         .hazeEffect {
           inputScale = HazeInputScale.None
           visualEffect = effect

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -35,6 +35,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isLessThan
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
@@ -48,6 +49,7 @@ import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.RetainedOutputVisualEffect
+import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
 import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.VisualEffect
 import dev.chrisbanes.haze.VisualEffectContext
@@ -399,6 +401,43 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       assertThat(delegate.interactionShaderHandleOrNull("interactionDetailEffect")).isNull()
       assertThat(delegate.interactionShaderHandleOrNull("interactionLightingEffect")).isNull()
     }
+
+  @Test
+  fun interactionRuntimeConstructionFailure_drawsAndUpdatesFallback() = runComposeUiTest {
+    var failConstruction = false
+    var creationAttempts = 0
+    val effect = runtimeInteractiveEffect().apply {
+      runtimeEffectFactory = GlassRuntimeEffectFactory { create ->
+        creationAttempts++
+        if (failConstruction) {
+          throw RuntimeShaderRenderEffectException(
+            IllegalArgumentException("broken interaction runtime effect"),
+          )
+        }
+        create()
+      }
+    }
+    setContent { RuntimeGlassTestContent(effect, tag = "glass") }
+    waitForIdle()
+    val baseCreationAttempts = creationAttempts
+
+    failConstruction = true
+    effect.setPressedForTest(Offset(60f, 60f))
+    mainClock.advanceTimeBy(500)
+    waitForIdle()
+
+    assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(creationAttempts).isGreaterThan(baseCreationAttempts)
+    onNodeWithTag("glass").captureToImage()
+    val attemptsAfterDowngrade = creationAttempts
+
+    effect.tint = Color.Blue.copy(alpha = 0.5f)
+    waitForIdle()
+
+    assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(creationAttempts).isEqualTo(attemptsAfterDowngrade)
+    onNodeWithTag("glass").captureToImage()
+  }
 
   @Test
   fun heldInteraction_sourceContentChangeRecordsSource() = runComposeUiTest {

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
@@ -18,12 +18,14 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.roundToIntSize
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
@@ -32,8 +34,11 @@ import dev.chrisbanes.haze.HazeArea
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.PlatformContext
+import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
 import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.createMutableRuntimeShaderRenderEffect
+import dev.chrisbanes.haze.createRuntimeEffect
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
@@ -42,6 +47,32 @@ import sun.misc.Unsafe
 
 @OptIn(ExperimentalHazeApi::class, InternalComposeUiApi::class)
 class RuntimeShaderGlassDelegateTrimMemoryTest {
+
+  @Test
+  fun invalidSkikoSksl_isReportedAsRuntimeShaderConstructionFailure() {
+    assertFailure {
+      createRuntimeEffect("not valid SKSL")
+    }.isInstanceOf<RuntimeShaderRenderEffectException>()
+  }
+
+  @Test
+  fun runtimeShaderUniformFailure_isNotReportedAsConstructionFailure() {
+    val effect = createRuntimeEffect(
+      "half4 main(float2 coord) { return half4(1); }",
+    )
+    val mutableEffect = createMutableRuntimeShaderRenderEffect(
+      effect = effect,
+      shaderNames = arrayOf("content"),
+      inputs = arrayOf(null),
+    )
+    val unrelatedFailure = IllegalStateException("unrelated uniform failure")
+
+    assertFailure {
+      mutableEffect.updateUniforms {
+        throw unrelatedFailure
+      }
+    }.isSameInstanceAs(unrelatedFailure)
+  }
 
   @Test
   fun fractionalAlpha_reusesGroupLayerAndZeroReleasesIt() {
@@ -227,6 +258,82 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     assertThat(secondRuntime.layers.hasSource).isTrue()
     assertThat(secondRuntime.layers.hasOptical).isTrue()
     effect.detach(safeContext)
+  }
+
+  @Test
+  fun prepareDraw_runtimeConstructionFailureReleasesAndUsesFallbackUntilReattach() {
+    var creationAttempts = 0
+    val failingFactory = GlassRuntimeEffectFactory { create ->
+      creationAttempts++
+      if (creationAttempts % 2 == 0) {
+        throw RuntimeShaderRenderEffectException(IllegalArgumentException("broken runtime effect"))
+      }
+      create()
+    }
+    val effect = GlassVisualEffect().apply {
+      optics = GlassOptics.Absolute(
+        refractionStrength = 0.5f,
+        refractionScale = 20f,
+        depth = 0f,
+        blurRadius = 0.dp,
+      )
+      specularIntensity = 0f
+      runtimeEffectFactory = failingFactory
+    }
+    val context = RecordingVisualEffectContext(
+      size = Size(100f, 100f),
+      layerSize = Size(100f, 100f),
+    )
+    val runtimeDelegate = RuntimeShaderGlassDelegate(effect, failingFactory)
+    effect.delegate = runtimeDelegate
+    runtimeDelegate.layers.populate(context.graphicsContext)
+    val partialLayers = runtimeDelegate.layers.allLayers()
+    runtimeDelegate.setGraphicsContextForTest(context.graphicsContext)
+
+    effect.attach(context)
+    effect.prepareDrawForTest(context)
+
+    assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(context.graphicsContext.releasedLayers).containsExactly(*partialLayers.toTypedArray())
+    assertThat(runtimeDelegate.layers.isEmpty).isTrue()
+    assertThat(runtimeDelegate.opticalShader).isNull()
+    assertThat(runtimeDelegate.refractionDetailShader).isNull()
+    assertThat(creationAttempts).isEqualTo(2)
+    assertThat(context.invalidateDrawCalls).isEqualTo(1)
+
+    effect.prepareDrawForTest(context)
+
+    assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(creationAttempts).isEqualTo(2)
+
+    effect.detach(context)
+    effect.attach(context)
+    effect.prepareDrawForTest(context)
+
+    assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(creationAttempts).isEqualTo(4)
+    effect.detach(context)
+  }
+
+  @Test
+  fun prepareDraw_unrelatedRuntimeDelegateExceptionPropagates() {
+    val unrelatedFailure = IllegalStateException("unrelated")
+    val failingFactory = GlassRuntimeEffectFactory {
+      throw unrelatedFailure
+    }
+    val effect = GlassVisualEffect()
+    val context = RecordingVisualEffectContext(
+      size = Size(100f, 100f),
+      layerSize = Size(100f, 100f),
+    )
+    effect.delegate = RuntimeShaderGlassDelegate(effect, failingFactory)
+    effect.attach(context)
+
+    assertFailure {
+      effect.prepareDrawForTest(context)
+    }.isInstanceOf<IllegalStateException>()
+    assertThat(effect.delegate).isInstanceOf<RuntimeShaderGlassDelegate>()
+    effect.detach(context)
   }
 
   @Test

--- a/haze-utils/api/api.txt
+++ b/haze-utils/api/api.txt
@@ -81,6 +81,10 @@ package dev.chrisbanes.haze {
     method @dev.chrisbanes.haze.InternalHazeApi public static dev.chrisbanes.haze.PlatformRenderEffect then(dev.chrisbanes.haze.PlatformRenderEffect, dev.chrisbanes.haze.PlatformRenderEffect other);
   }
 
+  @dev.chrisbanes.haze.InternalHazeApi public final class RuntimeShaderRenderEffectException extends java.lang.RuntimeException {
+    ctor public RuntimeShaderRenderEffectException(Throwable cause);
+  }
+
   @dev.chrisbanes.haze.InternalHazeApi public interface RuntimeShaderUniformProvider {
     method public void setChildShader(String name, androidx.compose.ui.graphics.Shader shader);
     method public void setFloatUniform(String name, float value);

--- a/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/RuntimeShader.android.kt
+++ b/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/RuntimeShader.android.kt
@@ -36,7 +36,9 @@ public actual fun createRuntimeShaderRenderEffect(
   inputs: Array<PlatformRenderEffect?>,
   uniforms: RuntimeShaderUniformProvider.() -> Unit,
 ): PlatformRenderEffect {
-  val shader = RuntimeShader(effect.sksl)
+  val shader = wrapRuntimeShaderConstruction {
+    RuntimeShader(effect.sksl)
+  }
   val provider = AndroidRuntimeShaderUniformProvider(shader)
   uniforms(provider)
 
@@ -49,11 +51,13 @@ public actual fun createMutableRuntimeShaderRenderEffect(
   effect: PlatformRuntimeEffect,
   shaderNames: Array<String>,
   inputs: Array<PlatformRenderEffect?>,
-): MutableRuntimeShaderRenderEffect = AndroidMutableRuntimeShaderRenderEffect(
-  effect = effect,
-  shaderNames = shaderNames,
-  inputs = inputs,
-)
+): MutableRuntimeShaderRenderEffect = wrapRuntimeShaderConstruction {
+  AndroidMutableRuntimeShaderRenderEffect(
+    effect = effect,
+    shaderNames = shaderNames,
+    inputs = inputs,
+  )
+}
 
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 private class AndroidMutableRuntimeShaderRenderEffect(
@@ -94,13 +98,14 @@ private fun createAndroidRuntimeShaderRenderEffect(
     else -> shaderNames.first()
   }
 
-  // Chain any non-null input RenderEffects
-  val chainedInput = inputs.filterNotNull().reduceOrNull { acc, input ->
-    acc.then(input)
-  }
-
-  return RenderEffect.createRuntimeShaderEffect(shader, contentShaderName).let { content ->
-    chainedInput?.then(content) ?: content
+  return wrapRuntimeShaderConstruction {
+    // Chain any non-null input RenderEffects.
+    val chainedInput = inputs.filterNotNull().reduceOrNull { acc, input ->
+      acc.then(input)
+    }
+    RenderEffect.createRuntimeShaderEffect(shader, contentShaderName).let { content ->
+      chainedInput?.then(content) ?: content
+    }
   }
 }
 

--- a/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/RuntimeShader.kt
+++ b/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/RuntimeShader.kt
@@ -14,6 +14,26 @@ import androidx.compose.ui.graphics.Shader
 public expect class PlatformRuntimeEffect
 
 /**
+ * A platform runtime shader or its native render-effect graph could not be constructed.
+ *
+ * This exception is limited to native construction calls so callers can recover without hiding
+ * failures from uniform configuration or content drawing.
+ */
+@InternalHazeApi
+public class RuntimeShaderRenderEffectException(
+  cause: Throwable,
+) : RuntimeException("Unable to construct a runtime shader render effect", cause)
+
+@OptIn(InternalHazeApi::class)
+internal inline fun <T> wrapRuntimeShaderConstruction(block: () -> T): T = try {
+  block()
+} catch (failure: RuntimeShaderRenderEffectException) {
+  throw failure
+} catch (failure: RuntimeException) {
+  throw RuntimeShaderRenderEffectException(failure)
+}
+
+/**
  * Creates a [PlatformRuntimeEffect] from SKSL shader code.
  */
 @InternalHazeApi

--- a/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/RenderEffect.skiko.kt
+++ b/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/RenderEffect.skiko.kt
@@ -31,7 +31,9 @@ public actual typealias PlatformColorFilter = ColorFilter
 
 @InternalHazeApi
 public actual fun createRuntimeEffect(sksl: String): PlatformRuntimeEffect {
-  return RuntimeEffect.makeForShader(sksl)
+  return wrapRuntimeShaderConstruction {
+    RuntimeEffect.makeForShader(sksl)
+  }
 }
 
 @InternalHazeApi
@@ -137,14 +139,18 @@ public actual fun createRuntimeShaderRenderEffect(
   inputs: Array<PlatformRenderEffect?>,
   uniforms: RuntimeShaderUniformProvider.() -> Unit,
 ): PlatformRenderEffect {
-  val builder = RuntimeShaderBuilder(effect)
+  val builder = wrapRuntimeShaderConstruction {
+    RuntimeShaderBuilder(effect)
+  }
   SkikoRuntimeShaderUniformProvider(builder).also(uniforms)
 
-  return ImageFilter.makeRuntimeShader(
-    runtimeShaderBuilder = builder,
-    shaderNames = shaderNames,
-    inputs = inputs,
-  )
+  return wrapRuntimeShaderConstruction {
+    ImageFilter.makeRuntimeShader(
+      runtimeShaderBuilder = builder,
+      shaderNames = shaderNames,
+      inputs = inputs,
+    )
+  }
 }
 
 @InternalHazeApi
@@ -152,11 +158,13 @@ public actual fun createMutableRuntimeShaderRenderEffect(
   effect: PlatformRuntimeEffect,
   shaderNames: Array<String>,
   inputs: Array<PlatformRenderEffect?>,
-): MutableRuntimeShaderRenderEffect = SkikoMutableRuntimeShaderRenderEffect(
-  effect = effect,
-  shaderNames = shaderNames,
-  inputs = inputs,
-)
+): MutableRuntimeShaderRenderEffect = wrapRuntimeShaderConstruction {
+  SkikoMutableRuntimeShaderRenderEffect(
+    effect = effect,
+    shaderNames = shaderNames,
+    inputs = inputs,
+  )
+}
 
 private class SkikoMutableRuntimeShaderRenderEffect(
   private val effect: RuntimeEffect,
@@ -171,7 +179,9 @@ private class SkikoMutableRuntimeShaderRenderEffect(
   ): PlatformRenderEffect {
     uniforms(provider)
     // ImageFilter snapshots the builder's current uniforms, unlike Android's live RuntimeShader.
-    return ImageFilter.makeRuntimeShader(builder, shaderNames, inputs)
+    return wrapRuntimeShaderConstruction {
+      ImageFilter.makeRuntimeShader(builder, shaderNames, inputs)
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- classify native runtime shader and render-effect construction failures without hiding uniform or drawing exceptions
- release partially created runtime resources and downgrade the affected glass effect to the fallback renderer for the rest of its attachment
- retry runtime rendering after reattachment and keep fallback rendering invalidatable
- cover Skiko, Android host, interaction-time failure, cleanup, retry gating, and unrelated exception propagation

## Tests
- `./gradlew check --no-scan`
- `./gradlew :haze-glass:jvmTest --rerun-tasks --no-scan`
- `./gradlew :haze-glass:testAndroidHostTest --no-scan`

Fixes #1117