### PR TITLE
Configure GitHub Project execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,8 @@ Use the default canonical triage labels. See `docs/agents/triage-labels.md`.
 
 Use a single-context layout with a root `CONTEXT.md` and `docs/adr/`. See
 `docs/agents/domain.md`.
+
+### GitHub Project execution
+
+The repository Project binding and execution policy are defined in
+`docs/agents/run-github-project.md`.

--- a/docs/agents/run-github-project.md
+++ b/docs/agents/run-github-project.md
@@ -1,0 +1,48 @@
+# Run GitHub Project
+
+## Repository
+
+- Host: `github.com`
+- Repository: `chrisbanes/haze`
+- Default branch: `main`
+- Base branch: `main`
+
+## Project
+
+- Owner: `chrisbanes`
+- Number: `7`
+- URL: `https://github.com/users/chrisbanes/projects/7`
+- Node ID: `PVT_kwHOAAN4ns4Beqrm`
+- Filter: `none`
+- Execution approver logins: `chrisbanes`
+
+## Status
+
+- Field name: `Status`
+- Field ID: `PVTSSF_lAHOAAN4ns4BeqrmzhZDK4M`
+- Planning name: `Planning`
+- Planning option ID: `61e4505c`
+- Ready to implement name: `Ready to implement`
+- Ready to implement option ID: `28bbf99e`
+- In progress name: `In progress`
+- In progress option ID: `47fc9ee4`
+- Done name: `Done`
+- Done option ID: `98236657`
+
+## Priority
+
+- Field name: `Priority`
+- Field ID: `PVTSSF_lAHOAAN4ns4BeqrmzhZDLC4`
+- Options in descending order:
+  1. `P0`: `79628723`
+  2. `P1`: `0a877460`
+  3. `P2`: `da944a9c`
+
+## Merge Policy
+
+- Method: `squash`
+- Issue closure: `closing-keyword`
+- Required reviews: `none`
+- Required checks: `build_docs`, `emulator_tests`, `linux_build`, `mac_build`, `Greptile Review`, `Screenshot tests (android)`, `Screenshot tests (jvm)`
+- Done automation: `set-status`
+- Automation description: Enabled `Item closed` and `Pull request merged` workflows set Status to `Done`; `Auto-close issue` is enabled; Done items are not automatically archived.


### PR DESCRIPTION
## Summary

- add the verified Haze GitHub Project binding for `run-github-project`
- reference the binding from the trusted repository instructions
- record the live Status, Priority, merge, check, closure, and Done-automation contracts

## Why

The Project runner requires a committed, trusted binding before it can claim or implement queued issues. This bootstraps that configuration after the human-managed Planning/Ready-to-implement schema cutover.

## Impact

Documentation and agent configuration only; no library or runtime behavior changes.

## Validation

- verified Project #7 field and option names against their live IDs
- verified `main` as both the default and configured base branch
- verified branch-protection checks and absence of required reviews
- verified zero In-progress items and migration of all legacy Ready items to Planning
- `git diff --check`
- `review-and-simplify-changes`: no actionable findings
- `ponytail-review`: Lean already. Ship.