### PR TITLE
Make GlassVisualEffect shareable across nodes

### DIFF
--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectAndroidCapabilityTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectAndroidCapabilityTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import assertk.assertThat
 import assertk.assertions.isNotNull
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
@@ -33,7 +34,7 @@ class GlassVisualEffectAndroidCapabilityTest {
   @Test
   @Config(sdk = [32])
   fun unsupportedRuntimeShader_skipsExactRuntimePreparation() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = AndroidCapabilityContext()
 
     effect.prepareRenderBudget(
@@ -50,7 +51,7 @@ class GlassVisualEffectAndroidCapabilityTest {
   @Test
   @Config(sdk = [35])
   fun supportedRuntimeShader_buildsExactRuntimePreparation() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = AndroidCapabilityContext()
 
     effect.prepareRenderBudget(
@@ -61,6 +62,24 @@ class GlassVisualEffectAndroidCapabilityTest {
 
     assertThat(effect.preparedRender).isNotNull()
     assertThat(effect.delegate is RuntimeShaderGlassDelegate).isTrue()
+  }
+
+  @Test
+  @Config(sdk = [35])
+  fun runtimeEffectFactoryChange_replacesRuntimeDelegate() {
+    val effect = GlassRuntimeEffect()
+    val context = AndroidCapabilityContext()
+    effect.prepareRenderBudget(
+      context,
+      runtimeShaderSupported = isRuntimeShaderGlassSupported(),
+    )
+    effect.delegate = effect.updateDelegate()
+    val original = effect.delegate
+
+    effect.runtimeEffectFactory = GlassRuntimeEffectFactory { create -> create() }
+    effect.delegate = effect.updateDelegate()
+
+    assertThat(effect.delegate).isNotSameInstanceAs(original)
   }
 }
 

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -8,16 +8,20 @@ import android.graphics.Canvas
 import androidx.activity.ComponentActivity
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.test.AndroidComposeUiTest
@@ -291,9 +295,21 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
   @Test
   fun detachAndReattach_releasesLayersAndRetainsShaderHandles() =
     runAndroidComposeUiTest<ComponentActivity> {
-      val effect = animatedStageEffect()
+      val callerInteractionSource = MutableInteractionSource()
+      val callerShape = RoundedCornerShape(17.dp)
+      val callerPositionAnimationSpec = tween<Offset>(37)
+      val callerCompositionLocalStyle = GlassStyle(tint = Color.Red)
+      val effect = animatedStageEffect().apply {
+        interactionSource = callerInteractionSource
+        shape = callerShape
+        interactionPositionAnimationSpec = callerPositionAnimationSpec
+      }
       val attached = mutableStateOf(true)
-      setContent { RuntimeGlassTestContent(effect, attachEffect = attached.value) }
+      setContent {
+        CompositionLocalProvider(LocalGlassStyle provides callerCompositionLocalStyle) {
+          RuntimeGlassTestContent(effect, attachEffect = attached.value)
+        }
+      }
       waitForIdle()
       drawFrame()
       val initialRuntime = runtime(effect)
@@ -311,6 +327,16 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       assertThat(delegate.opticalShader).isNull()
       assertThat(delegate.refractionDetailShader).isSameInstanceAs(detailShader)
       assertThat(delegate.rimShader).isSameInstanceAs(rimShader)
+      assertThat(initialRuntime.interactionSource).isNull()
+      assertThat(initialRuntime.shape).isNotSameInstanceAs(callerShape)
+      assertThat(initialRuntime.interactionPositionAnimationSpec)
+        .isNotSameInstanceAs(callerPositionAnimationSpec)
+      assertThat(initialRuntime.compositionLocalStyle)
+        .isNotSameInstanceAs(callerCompositionLocalStyle)
+      assertThat(initialRuntime.runtimeEffectFactory)
+        .isSameInstanceAs(PlatformGlassRuntimeEffectFactory)
+      assertThat(delegate.runtimeEffectFactoryForTest)
+        .isSameInstanceAs(PlatformGlassRuntimeEffectFactory)
 
       attached.value = true
       waitForIdle()
@@ -325,6 +351,88 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       assertThat(reattachedDelegate.opticalShader).isNull()
       assertThat(reattachedDelegate.refractionDetailShader).isSameInstanceAs(detailShader)
       assertThat(reattachedDelegate.rimShader).isSameInstanceAs(rimShader)
+      assertThat(reattachedRuntime.interactionSource).isSameInstanceAs(callerInteractionSource)
+      assertThat(reattachedRuntime.shape).isSameInstanceAs(callerShape)
+      assertThat(reattachedRuntime.interactionPositionAnimationSpec)
+        .isSameInstanceAs(callerPositionAnimationSpec)
+      assertThat(reattachedRuntime.compositionLocalStyle)
+        .isSameInstanceAs(callerCompositionLocalStyle)
+      assertThat(reattachedDelegate.runtimeEffectFactoryForTest)
+        .isSameInstanceAs(PlatformGlassRuntimeEffectFactory)
+    }
+
+  @Test
+  fun progressiveConfiguration_detachReleasesOnlyConfigurationDerivedShaderHandles() =
+    runAndroidComposeUiTest<ComponentActivity> {
+      val callerBrush = Brush.linearGradient(listOf(Color.Transparent, Color.Black))
+      val effect = animatedStageEffect().apply {
+        optics = (optics as GlassOptics.Absolute).copy(
+          progressive = HazeProgressive.Brush(callerBrush),
+        )
+      }
+      val attached = mutableStateOf(true)
+      setContent { RuntimeGlassTestContent(effect, attachEffect = attached.value) }
+      waitForIdle()
+      drawFrame()
+
+      val initialDelegate =
+        checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
+      val fusedShader = checkNotNull(initialDelegate.fusedShader)
+      val detailShader = checkNotNull(initialDelegate.refractionDetailShader)
+      val rimShader = checkNotNull(initialDelegate.rimShader)
+
+      attached.value = false
+      waitForIdle()
+
+      assertThat(initialDelegate.fusedShader).isNull()
+      assertThat(initialDelegate.refractionDetailShader).isSameInstanceAs(detailShader)
+      assertThat(initialDelegate.rimShader).isSameInstanceAs(rimShader)
+
+      attached.value = true
+      waitForIdle()
+      drawFrame()
+
+      val reattachedDelegate =
+        checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
+      assertThat(reattachedDelegate).isSameInstanceAs(initialDelegate)
+      assertThat(reattachedDelegate.fusedShader).isNotSameInstanceAs(fusedShader)
+      assertThat(reattachedDelegate.refractionDetailShader).isNotSameInstanceAs(detailShader)
+      assertThat(reattachedDelegate.rimShader).isSameInstanceAs(rimShader)
+    }
+
+  @Test
+  fun runtimeEffectFactoryChangeWhileDetached_releasesRetainedShaderHandles() =
+    runAndroidComposeUiTest<ComponentActivity> {
+      val effect = animatedStageEffect().apply {
+        runtimeEffectFactory = GlassRuntimeEffectFactory { create -> create() }
+      }
+      val attached = mutableStateOf(true)
+      setContent { RuntimeGlassTestContent(effect, attachEffect = attached.value) }
+      waitForIdle()
+      drawFrame()
+
+      val initialDelegate =
+        checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
+      val initialFusedShader = checkNotNull(initialDelegate.fusedShader)
+
+      attached.value = false
+      waitForIdle()
+      assertThat(initialDelegate.fusedShader).isNull()
+      assertThat(initialDelegate.runtimeEffectFactoryForTest)
+        .isSameInstanceAs(PlatformGlassRuntimeEffectFactory)
+      val replacementFactory = GlassRuntimeEffectFactory { create -> create() }
+      effect.runtimeEffectFactory = replacementFactory
+      attached.value = true
+      waitForIdle()
+      drawFrame()
+
+      val reattachedDelegate =
+        checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
+      assertThat(reattachedDelegate).isNotSameInstanceAs(initialDelegate)
+      assertThat(initialDelegate.fusedShader).isNull()
+      assertThat(reattachedDelegate.fusedShader).isNotSameInstanceAs(initialFusedShader)
+      assertThat(reattachedDelegate.runtimeEffectFactoryForTest)
+        .isSameInstanceAs(replacementFactory)
     }
 
   @Test

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -34,8 +34,12 @@ import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeEffectNode
+import dev.chrisbanes.haze.HazeEffectScope
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
@@ -45,10 +49,30 @@ import kotlin.test.Test
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 
-@OptIn(ExperimentalTestApi::class)
+@OptIn(
+  ExperimentalTestApi::class,
+  ExperimentalHazeApi::class,
+  InternalHazeApi::class,
+)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [35])
 class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
+  private val attachedRuntimes = mutableMapOf<GlassVisualEffect, GlassRuntimeEffect>()
+
+  @Test
+  fun directConfigurationPath_materializesResourceOwningNodeRuntime() =
+    runAndroidComposeUiTest<ComponentActivity> {
+      val configuration = retainedBlurEffect()
+      setContent { RuntimeGlassTestContent(configuration) }
+      waitForIdle()
+      drawFrame()
+
+      val runtime = runtime(configuration)
+      val context = checkNotNull(runtime.attachedContextForTest)
+      assertThat(runtime.delegate).isInstanceOf<RuntimeShaderGlassDelegate>()
+      assertThat(runtime.delegate).isNotSameInstanceAs(configuration)
+      assertThat(configuration.canDrawRetainedOutput(context)).isFalse()
+    }
 
   @Test
   fun runtimeConstructionFailure_usesFallbackWithoutRetryingEveryFrame() =
@@ -66,12 +90,12 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+      assertThat(runtime(effect).delegate).isInstanceOf<FallbackGlassDelegate>()
       assertThat(creationAttempts).isEqualTo(1)
 
       drawFrame()
 
-      assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+      assertThat(runtime(effect).delegate).isInstanceOf<FallbackGlassDelegate>()
       assertThat(creationAttempts).isEqualTo(1)
     }
 
@@ -157,7 +181,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       drawFrame()
 
       val delegates = effects.map { effect ->
-        checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+        checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
       }
       delegates.forEach { delegate ->
         assertThat(delegate.fusedShader).isNotNull()
@@ -195,7 +219,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       drawFrame()
 
       val delegates = effects.map { effect ->
-        checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+        checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
       }
       delegates.forEach { delegate ->
         assertThat(delegate.fusedShader).isNotNull()
@@ -218,7 +242,8 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       }
       waitForIdle()
       drawFrame()
-      val firstDelegate = checkNotNull(effects.first().delegate as? RuntimeShaderGlassDelegate)
+      val firstDelegate =
+        checkNotNull(runtime(effects.first()).delegate as? RuntimeShaderGlassDelegate)
       val sourceLayer = checkNotNull(firstDelegate.layers.source)
       val fusedLayer = checkNotNull(firstDelegate.layers.optical)
       val dedicatedPixels = captureRegionPixels(
@@ -271,7 +296,8 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       setContent { RuntimeGlassTestContent(effect, attachEffect = attached.value) }
       waitForIdle()
       drawFrame()
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val initialRuntime = runtime(effect)
+      val delegate = checkNotNull(initialRuntime.delegate as? RuntimeShaderGlassDelegate)
       val fusedShader = checkNotNull(delegate.fusedShader)
       val detailShader = checkNotNull(delegate.refractionDetailShader)
       val rimShader = checkNotNull(delegate.rimShader)
@@ -290,10 +316,34 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      assertThat(delegate.fusedShader).isSameInstanceAs(fusedShader)
-      assertThat(delegate.opticalShader).isNull()
-      assertThat(delegate.refractionDetailShader).isSameInstanceAs(detailShader)
-      assertThat(delegate.rimShader).isSameInstanceAs(rimShader)
+      val reattachedRuntime = runtime(effect)
+      val reattachedDelegate =
+        checkNotNull(reattachedRuntime.delegate as? RuntimeShaderGlassDelegate)
+      assertThat(reattachedRuntime).isSameInstanceAs(initialRuntime)
+      assertThat(reattachedDelegate).isSameInstanceAs(delegate)
+      assertThat(reattachedDelegate.fusedShader).isSameInstanceAs(fusedShader)
+      assertThat(reattachedDelegate.opticalShader).isNull()
+      assertThat(reattachedDelegate.refractionDetailShader).isSameInstanceAs(detailShader)
+      assertThat(reattachedDelegate.rimShader).isSameInstanceAs(rimShader)
+    }
+
+  @Test
+  fun runtimeEffectFactoryChange_releasesReplacedDelegateShaderHandles() =
+    runAndroidComposeUiTest<ComponentActivity> {
+      val effect = retainedBlurEffect()
+      setContent { RuntimeGlassTestContent(effect) }
+      waitForIdle()
+      drawFrame()
+      val runtime = runtime(effect)
+      val originalDelegate = checkNotNull(runtime.delegate as? RuntimeShaderGlassDelegate)
+      assertThat(originalDelegate.fusedShader).isNotNull()
+
+      effect.runtimeEffectFactory = GlassRuntimeEffectFactory { create -> create() }
+      waitForIdle()
+      drawFrame()
+
+      assertThat(runtime.delegate).isNotSameInstanceAs(originalDelegate)
+      assertThat(originalDelegate.fusedShader).isNull()
     }
 
   @Test
@@ -303,10 +353,10 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       setContent { RuntimeGlassTestContent(effect) }
       waitForIdle()
       drawFrame()
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate) {
-        val context = effect.attachedContextForTest
-        "Expected runtime delegate; budget=${effect.preparedRenderBudget}, " +
-          "prepared=${effect.preparedRender}, runtimeSupported=${isRuntimeShaderGlassSupported()}, " +
+      val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate) {
+        val context = runtime(effect).attachedContextForTest
+        "Expected runtime delegate; budget=${runtime(effect).preparedRenderBudget}, " +
+          "prepared=${runtime(effect).preparedRender}, runtimeSupported=${isRuntimeShaderGlassSupported()}, " +
           "size=${context?.size}, layerSize=${context?.layerSize}, inputScale=${context?.inputScale}"
       }
 
@@ -341,14 +391,14 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
       val fusedShader = checkNotNull(delegate.fusedShader)
       val detailShader = checkNotNull(delegate.refractionDetailShader)
 
-      effect.setPressedForTest(Offset(20f, 20f))
+      runtime(effect).setPressedForTest(Offset(20f, 20f))
       waitForIdle()
       drawFrame()
-      effect.setPressedForTest(Offset(80f, 60f))
+      runtime(effect).setPressedForTest(Offset(80f, 60f))
       waitForIdle()
       drawFrame()
       effect.ambientResponse = 0.6f
@@ -369,11 +419,11 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      effect.setPressedForTest(Offset(60f, 60f))
+      runtime(effect).setPressedForTest(Offset(60f, 60f))
       waitForIdle()
       drawFrame()
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
-      assertThat(effect.currentInteractionState.hasLighting).isTrue()
+      val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
+      assertThat(runtime(effect).currentInteractionState.hasLighting).isTrue()
       assertThat(delegate.layers.interactionLighting).isNotNull()
       assertThat(delegate.layers.interactionLighting?.renderEffect).isNotNull()
     }
@@ -386,11 +436,11 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      effect.setPressedForTest(Offset(60f, 60f))
+      runtime(effect).setPressedForTest(Offset(60f, 60f))
       waitForIdle()
       drawFrame()
 
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
       assertThat(checkNotNull(delegate.layers.groupAlpha.layer).alpha).isEqualTo(0.5f)
       assertThat(checkNotNull(delegate.layers.interactionLighting).alpha).isEqualTo(0.5f)
     }
@@ -403,11 +453,11 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      effect.setPressedForTest(Offset(20f, 20f))
+      runtime(effect).setPressedForTest(Offset(20f, 20f))
       waitForIdle()
       drawFrame()
 
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
       val source = checkNotNull(delegate.layers.source)
       val optical = checkNotNull(delegate.layers.optical)
       val fusedShader = checkNotNull(delegate.fusedShader)
@@ -436,16 +486,16 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       drawFrame()
       mainClock.autoAdvance = false
 
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
       val source = checkNotNull(delegate.layers.source)
       val optical = checkNotNull(delegate.layers.optical)
       assertThat(delegate.fusedShader).isNotNull()
       assertThat(delegate.layers.refractionDetail).isNull()
-      val scaleFactor = (effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor
-      val plannedKinds = checkNotNull(effect.preparedRender).plan.layers.map { it.kind }
+      val scaleFactor = (runtime(effect).preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor
+      val plannedKinds = checkNotNull(runtime(effect).preparedRender).plan.layers.map { it.kind }
       val positions = listOf(Offset(200f, 150f), Offset(400f, 240f), Offset(600f, 360f))
 
-      effect.setPressedForTest(positions.first())
+      runtime(effect).setPressedForTest(positions.first())
       drawInteractionFrame()
 
       assertThat(delegate.layers.interactionOptical).isNull()
@@ -454,10 +504,10 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       val fusedShader = checkNotNull(delegate.fusedShader)
 
       positions.forEach { position ->
-        effect.setPressedForTest(position)
+        runtime(effect).setPressedForTest(position)
         drawInteractionFrame()
 
-        assertThat(effect.delegate).isSameInstanceAs(delegate)
+        assertThat(runtime(effect).delegate).isSameInstanceAs(delegate)
         assertThat(delegate.layers.source).isSameInstanceAs(source)
         assertThat(delegate.layers.optical).isSameInstanceAs(optical)
         assertThat(delegate.layers.refractionDetail).isNull()
@@ -466,19 +516,19 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
         assertThat(delegate.layers.interactionLighting).isNotNull()
         assertThat(delegate.fusedShader).isSameInstanceAs(fusedShader)
         assertThat(
-          (effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor,
+          (runtime(effect).preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor,
         ).isEqualTo(scaleFactor)
-        assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
+        assertThat(checkNotNull(runtime(effect).preparedRender).plan.layers.map { it.kind })
           .isEqualTo(plannedKinds)
       }
 
-      effect.setPressedForTest(positions.last(), pressed = false)
+      runtime(effect).setPressedForTest(positions.last(), pressed = false)
       repeat(3) {
         drawInteractionFrame()
 
-        assertThat(effect.currentInteractionState.hasLighting).isTrue()
-        assertThat(effect.currentInteractionState.hasOptics).isTrue()
-        assertThat(effect.delegate).isSameInstanceAs(delegate)
+        assertThat(runtime(effect).currentInteractionState.hasLighting).isTrue()
+        assertThat(runtime(effect).currentInteractionState.hasOptics).isTrue()
+        assertThat(runtime(effect).delegate).isSameInstanceAs(delegate)
         assertThat(delegate.layers.source).isSameInstanceAs(source)
         assertThat(delegate.layers.optical).isSameInstanceAs(optical)
         assertThat(delegate.layers.refractionDetail).isNull()
@@ -487,28 +537,28 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
         assertThat(delegate.layers.interactionLighting).isNotNull()
         assertThat(delegate.fusedShader).isSameInstanceAs(fusedShader)
         assertThat(
-          (effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor,
+          (runtime(effect).preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor,
         ).isEqualTo(scaleFactor)
-        assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
+        assertThat(checkNotNull(runtime(effect).preparedRender).plan.layers.map { it.kind })
           .isEqualTo(plannedKinds)
       }
       repeat(12) {
         drawInteractionFrame()
 
-        assertThat(effect.delegate).isSameInstanceAs(delegate)
+        assertThat(runtime(effect).delegate).isSameInstanceAs(delegate)
         assertThat(delegate.layers.source).isSameInstanceAs(source)
         assertThat(delegate.layers.optical).isSameInstanceAs(optical)
         assertThat(delegate.layers.refractionDetail).isNull()
         assertThat(delegate.layers.interactionOptical).isNull()
         assertThat(delegate.layers.interactionLighting).isNotNull()
         assertThat(
-          (effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor,
+          (runtime(effect).preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor,
         ).isEqualTo(scaleFactor)
-        assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind })
+        assertThat(checkNotNull(runtime(effect).preparedRender).plan.layers.map { it.kind })
           .isEqualTo(plannedKinds)
       }
-      assertThat(effect.currentInteractionState.hasLighting).isFalse()
-      assertThat(effect.currentInteractionState.hasOptics).isFalse()
+      assertThat(runtime(effect).currentInteractionState.hasLighting).isFalse()
+      assertThat(runtime(effect).currentInteractionState.hasOptics).isFalse()
       assertThat(delegate.layers.interactionOptical).isNull()
       assertThat(delegate.layers.interactionRefractionDetail).isNull()
       assertThat(delegate.layers.interactionLighting).isNotNull()
@@ -523,7 +573,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       setContent { RuntimeGlassTestContent(effect) }
       waitForIdle()
       drawFrame()
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
 
       val fusedShader = checkNotNull(delegate.fusedShader)
       val fusedEffect = checkNotNull(delegate.layers.optical?.renderEffect)
@@ -549,7 +599,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       setContent { RuntimeGlassTestContent(effect) }
       waitForIdle()
       drawFrame()
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
 
       val fusedShader = checkNotNull(delegate.fusedShader)
       effect.optics = (effect.optics as GlassOptics.Absolute).copy(blurRadius = 36.dp)
@@ -574,7 +624,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       setContent { RuntimeGlassTestContent(effect) }
       waitForIdle()
       drawFrame()
-      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
 
       val fusedShader = checkNotNull(delegate.fusedShader)
       val fusedEffect = checkNotNull(delegate.layers.optical?.renderEffect)
@@ -668,7 +718,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
           if (attachEffect) {
             Modifier.hazeEffect {
               inputScale = HazeInputScale.None
-              visualEffect = effect
+              trackRenderer(effect)
             }
           } else {
             Modifier
@@ -686,7 +736,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
         .size(width = 800.dp, height = 480.dp)
         .hazeEffect {
           inputScale = HazeInputScale.None
-          visualEffect = effect
+          trackRenderer(effect)
         },
     ) {
       Box(Modifier.fillMaxSize().background(Color.Red))
@@ -710,7 +760,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
               .size(120.dp)
               .hazeEffect(hazeState) {
                 inputScale = HazeInputScale.None
-                visualEffect = effect
+                trackRenderer(effect)
               },
           )
         }
@@ -739,7 +789,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
                   .size(100.dp)
                   .hazeEffect(hazeState) {
                     inputScale = HazeInputScale.None
-                    visualEffect = effect
+                    trackRenderer(effect)
                   },
               )
             }
@@ -778,7 +828,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
           .size(100.dp)
           .hazeEffect(hazeState) {
             inputScale = HazeInputScale.None
-            visualEffect = effects[0]
+            trackRenderer(effects[0])
           },
       )
       if (attachSecond) {
@@ -788,7 +838,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
             .size(100.dp)
             .hazeEffect(hazeState) {
               inputScale = HazeInputScale.None
-              visualEffect = effects[1]
+              trackRenderer(effects[1])
             },
         )
       }
@@ -799,6 +849,15 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     captureFrame().recycle()
   }
 
+  private fun HazeEffectScope.trackRenderer(effect: GlassVisualEffect) {
+    visualEffect = effect
+    attachedRuntimes[effect] =
+      ((this as HazeEffectNode).activeVisualEffect as GlassRenderer).runtimeForTest
+  }
+
+  private fun runtime(effect: GlassVisualEffect): GlassRuntimeEffect =
+    checkNotNull(attachedRuntimes[effect])
+
   private fun assertFusedRenderer(
     effect: GlassVisualEffect,
     assertions: (RuntimeShaderGlassDelegate) -> Unit,
@@ -807,7 +866,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     waitForIdle()
     drawFrame()
 
-    val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+    val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
     assertThat(delegate.fusedShader).isNotNull()
     assertThat(delegate.layers.source?.renderEffect).isNull()
     assertThat(delegate.layers.optical?.renderEffect).isNotNull()

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
@@ -23,8 +23,8 @@ import kotlin.math.max
 
 @OptIn(ExperimentalHazeApi::class)
 internal class FallbackGlassDelegate(
-  private val effect: GlassVisualEffect,
-) : GlassVisualEffect.Delegate {
+  private val effect: GlassRuntimeEffect,
+) : GlassRuntimeEffect.Delegate {
 
   private var preparedDraw: FallbackGlassPreparedDraw? = null
   private val groupAlpha = RetainedGlassGroupAlphaLayer()

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDirtyFields.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDirtyFields.kt
@@ -56,6 +56,8 @@ internal object GlassDirtyFields {
   const val LayerBoundsFlags: Int =
     Optics or ChromaticAberration or EdgeSoftness or Shape or InteractionLayerBounds
 
+  const val All: Int = InvalidateFlags or LayerBoundsFlags
+
   const val StyleResolutionFlags: Int = InvalidateFlags and Interaction.inv()
   const val ClipDecisionFlags: Int = Shape or EdgeSoftness
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDirtyFields.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDirtyFields.kt
@@ -29,6 +29,7 @@ internal object GlassDirtyFields {
   const val Style: Int = FresnelExponent shl 1
   const val InteractionLayerBounds: Int = Style shl 1
   const val Interaction: Int = InteractionLayerBounds shl 1
+  const val RuntimeEffectFactory: Int = Interaction shl 1
 
   const val InvalidateFlags: Int =
     Optics or
@@ -49,7 +50,8 @@ internal object GlassDirtyFields {
       SpecularExponent or
       FresnelExponent or
       Style or
-      Interaction
+      Interaction or
+      RuntimeEffectFactory
 
   const val LayerBoundsFlags: Int =
     Optics or ChromaticAberration or EdgeSoftness or Shape or InteractionLayerBounds
@@ -79,6 +81,7 @@ internal object GlassDirtyFields {
       if (Style in dirtyTracker) add("Style")
       if (InteractionLayerBounds in dirtyTracker) add("InteractionLayerBounds")
       if (Interaction in dirtyTracker) add("Interaction")
+      if (RuntimeEffectFactory in dirtyTracker) add("RuntimeEffectFactory")
     }
     return params.joinToString(separator = ", ", prefix = "[", postfix = "]")
   }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -3,16 +3,19 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.center
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.roundToIntSize
 import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.VisualEffectContext
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -560,8 +563,30 @@ internal data class ResolvedGlassStyle(
   val cornerRadii: CornerRadii,
 )
 
+@InternalHazeApi
+public interface GlassStyleConfiguration {
+  public var shape: RoundedCornerShape
+  public var optics: GlassOptics
+  public var specularIntensity: Float
+  public var ambientResponse: Float
+  public var tint: Color
+  public var edgeSoftness: Dp
+  public var lightPosition: Offset
+  public var chromaticAberrationStrength: Float
+  public var surfaceProfile: SurfaceProfile
+  public var chromaticAberrationMode: ChromaticAberrationMode
+  public var alpha: Float
+  public var contrast: Float
+  public var whitePoint: Float
+  public var chromaMultiplier: Float
+  public var contentNormalBlend: Float
+  public var specularExponent: Float
+  public var fresnelExponent: Float
+  public var style: GlassStyle
+}
+
 internal fun resolveGlassStyle(
-  effect: GlassVisualEffect,
+  effect: GlassStyleConfiguration,
   materialSizePx: Size,
   density: Density,
   layoutDirection: LayoutDirection,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderer.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderer.kt
@@ -1,0 +1,166 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.unit.Density
+import dev.chrisbanes.haze.InteractiveVisualEffect
+import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.RetainedOutputVisualEffect
+import dev.chrisbanes.haze.TrimMemoryLevel
+import dev.chrisbanes.haze.VisualEffect
+import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.VisualEffectTransform
+
+@OptIn(InternalHazeApi::class)
+internal class GlassRenderer(
+  configuration: GlassVisualEffect,
+) : VisualEffect, RetainedOutputVisualEffect, InteractiveVisualEffect {
+  private var configuration: GlassVisualEffect? = configuration
+  private val configurationKey = configuration.rendererCacheKey
+  internal val runtimeForTest = GlassRuntimeEffect(configuration)
+  private var observedConfigurationRevision = configuration.configurationRevision
+  private var observedConfigurationFieldVersions = configuration.configurationFieldVersions()
+
+  private fun synchronizeConfiguration() {
+    val configuration = checkNotNull(configuration) {
+      "A detached Glass renderer must be acquired before use."
+    }
+    val revision = configuration.configurationRevision
+    if (revision != observedConfigurationRevision) {
+      val fieldVersions = configuration.configurationFieldVersions()
+      var changedFields = 0
+      fieldVersions.indices.forEach { index ->
+        if (fieldVersions[index] != observedConfigurationFieldVersions[index]) {
+          changedFields = changedFields or (1 shl index)
+        }
+      }
+      runtimeForTest.synchronizeConfigurationFrom(configuration, changedFields)
+      observedConfigurationRevision = revision
+      observedConfigurationFieldVersions = fieldVersions
+    }
+  }
+
+  override val observesPointerEvents: Boolean
+    get() {
+      synchronizeConfiguration()
+      return runtimeForTest.observesPointerEvents
+    }
+
+  override fun attach(context: VisualEffectContext) {
+    synchronizeConfiguration()
+    runtimeForTest.attach(context)
+  }
+
+  override fun update(context: VisualEffectContext) {
+    synchronizeConfiguration()
+    runtimeForTest.update(context)
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    runtimeForTest.detach(context)
+    configuration = null
+    GlassRendererCache.recycle(configurationKey, this)
+  }
+
+  internal fun acquire(configuration: GlassVisualEffect) {
+    check(this.configuration == null) { "Glass renderer is already acquired." }
+    check(configuration.rendererCacheKey === configurationKey) {
+      "Glass renderer cache key does not match its configuration."
+    }
+    this.configuration = configuration
+  }
+
+  override fun DrawScope.prepareDraw(context: VisualEffectContext) {
+    synchronizeConfiguration()
+    with(runtimeForTest) { prepareDraw(context) }
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    synchronizeConfiguration()
+    with(runtimeForTest) { draw(context) }
+  }
+
+  override fun DrawScope.drawForeground(context: VisualEffectContext) {
+    synchronizeConfiguration()
+    with(runtimeForTest) { drawForeground(context) }
+  }
+
+  override fun onPointerEvent(event: PointerEvent, context: VisualEffectContext) {
+    synchronizeConfiguration()
+    runtimeForTest.onPointerEvent(event, context)
+  }
+
+  override fun onCancelPointerInput(context: VisualEffectContext) {
+    runtimeForTest.onCancelPointerInput(context)
+  }
+
+  override fun currentContentTransform(context: VisualEffectContext): VisualEffectTransform {
+    synchronizeConfiguration()
+    return runtimeForTest.currentContentTransform(context)
+  }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    runtimeForTest.onTrimMemory(context, level)
+  }
+
+  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean =
+    runtimeForTest.canDrawRetainedOutput(context)
+
+  override fun shouldDrawRetainedOutput(context: VisualEffectContext): Boolean =
+    runtimeForTest.shouldDrawRetainedOutput(context)
+
+  override fun clearRetainedOutput() {
+    runtimeForTest.clearRetainedOutput()
+  }
+
+  override fun shouldDrawContentBehind(context: VisualEffectContext): Boolean =
+    runtimeForTest.shouldDrawContentBehind(context)
+
+  override fun shouldClipToNodeBounds(): Boolean {
+    synchronizeConfiguration()
+    return runtimeForTest.shouldClipToNodeBounds()
+  }
+
+  override fun shouldPreferClipToAreaBounds(): Boolean =
+    runtimeForTest.shouldPreferClipToAreaBounds()
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
+    synchronizeConfiguration()
+    return runtimeForTest.calculateLayerBounds(rect, density)
+  }
+}
+
+/**
+ * Bounded handoff cache for preserving detached shader handles when Compose replaces a modifier
+ * node. Renderers release attached resources before entering the cache and do not retain their
+ * configuration while cached.
+ *
+ * The cache is main-thread confined by the modifier-node lifecycle. Bounding it prevents detached
+ * effects that are never reattached from accumulating indefinitely.
+ */
+internal object GlassRendererCache {
+  private const val MAX_ENTRIES = 8
+
+  private val entries = mutableListOf<Pair<Any, GlassRenderer>>()
+
+  fun acquire(configuration: GlassVisualEffect): GlassRenderer {
+    val index = entries.indexOfFirst { (key) -> key === configuration.rendererCacheKey }
+    return if (index >= 0) {
+      entries.removeAt(index).second.also { it.acquire(configuration) }
+    } else {
+      GlassRenderer(configuration)
+    }
+  }
+
+  fun recycle(key: Any, renderer: GlassRenderer) {
+    entries.removeAll { (_, cachedRenderer) -> cachedRenderer === renderer }
+    entries += key to renderer
+    if (entries.size > MAX_ENTRIES) {
+      entries.removeAt(0).second.runtimeForTest.release()
+    }
+  }
+}

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderer.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderer.kt
@@ -62,6 +62,7 @@ internal class GlassRenderer(
 
   override fun detach(context: VisualEffectContext) {
     runtimeForTest.detach(context)
+    runtimeForTest.clearConfigurationReferences()
     configuration = null
     GlassRendererCache.recycle(configurationKey, this)
   }
@@ -71,7 +72,15 @@ internal class GlassRenderer(
     check(configuration.rendererCacheKey === configurationKey) {
       "Glass renderer cache key does not match its configuration."
     }
+    val fieldVersions = configuration.configurationFieldVersions()
+    val runtimeEffectFactoryIndex = GlassDirtyFields.RuntimeEffectFactory.countTrailingZeroBits()
+    val runtimeEffectFactoryChanged =
+      fieldVersions[runtimeEffectFactoryIndex] !=
+        observedConfigurationFieldVersions[runtimeEffectFactoryIndex]
+    runtimeForTest.reseedConfiguration(configuration, runtimeEffectFactoryChanged)
     this.configuration = configuration
+    observedConfigurationRevision = configuration.configurationRevision
+    observedConfigurationFieldVersions = fieldVersions
   }
 
   override fun DrawScope.prepareDraw(context: VisualEffectContext) {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
@@ -1,0 +1,1043 @@
+// Copyright 2025, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass
+
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.SnapshotStateObserver
+import androidx.compose.ui.MotionDurationScale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.center
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntSize
+import dev.chrisbanes.haze.Bitmask
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeInputScale
+import dev.chrisbanes.haze.HazeLogger
+import dev.chrisbanes.haze.InteractiveVisualEffect
+import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.RetainedOutputVisualEffect
+import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
+import dev.chrisbanes.haze.TrimMemoryLevel
+import dev.chrisbanes.haze.VisualEffect
+import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.VisualEffectTransform
+import dev.chrisbanes.haze.trace
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+
+private class GlassPreparedRenderCacheKey(
+  val style: ResolvedGlassStyle,
+  val coordinates: GlassCoordinates,
+  val interaction: ResolvedGlassInteraction,
+  val interactionTopology: GlassInteractionTopology,
+)
+
+private class GlassRenderBudgetCacheKey(
+  val style: ResolvedGlassStyle,
+  val requestedScale: Float,
+  val layerSize: Size,
+  val materialSize: Size,
+  val interactionTopology: GlassInteractionTopology,
+  val interactionRadiusFraction: Float,
+)
+
+private class GlassPreparedDrawCacheKey(
+  val dirtyTrackerVersion: Int,
+  val size: Size,
+  val layerSize: Size,
+  val layerOffset: Offset,
+  val inputScale: HazeInputScale,
+  val density: Density,
+  val layoutDirection: LayoutDirection,
+  val style: ResolvedGlassStyle?,
+  val interactionState: GlassInteractionRenderState,
+  val interactionTopology: GlassInteractionTopology,
+)
+
+private fun ResolvedGlassStyle.hasSameRenderParams(other: ResolvedGlassStyle): Boolean =
+  resolvedOptics == other.resolvedOptics &&
+    specularIntensity == other.specularIntensity &&
+    ambientResponse == other.ambientResponse &&
+    tint == other.tint &&
+    edgeSoftnessPx == other.edgeSoftnessPx &&
+    lightPosition == other.lightPosition &&
+    chromaticAberrationStrength == other.chromaticAberrationStrength &&
+    surfaceProfile == other.surfaceProfile &&
+    chromaticAberrationMode == other.chromaticAberrationMode &&
+    contrast == other.contrast &&
+    whitePoint == other.whitePoint &&
+    chromaMultiplier == other.chromaMultiplier &&
+    contentNormalBlend == other.contentNormalBlend &&
+    specularExponent == other.specularExponent &&
+    fresnelExponent == other.fresnelExponent &&
+    cornerRadii == other.cornerRadii
+
+private fun ResolvedGlassStyle.hasSameBudgetParams(other: ResolvedGlassStyle): Boolean =
+  requiresGlassGroupAlpha(alpha) == requiresGlassGroupAlpha(other.alpha) &&
+    resolvedOptics.blurRadiusPx == other.resolvedOptics.blurRadiusPx &&
+    resolvedOptics.depth == other.resolvedOptics.depth &&
+    (resolvedOptics.progressive == null) == (other.resolvedOptics.progressive == null) &&
+    resolvedOptics.refractionStrength == other.resolvedOptics.refractionStrength &&
+    resolvedOptics.refractionScalePx == other.resolvedOptics.refractionScalePx &&
+    resolvedOptics.refractionHeightPx == other.resolvedOptics.refractionHeightPx &&
+    resolvedOptics.refractionDetailIntensity == other.resolvedOptics.refractionDetailIntensity &&
+    chromaticAberrationStrength == other.chromaticAberrationStrength &&
+    edgeSoftnessPx == other.edgeSoftnessPx &&
+    (specularIntensity > 0f) == (other.specularIntensity > 0f)
+
+private val IdleInteractionState = GlassInteractionRenderState(Offset.Zero)
+private val IdleInteractionSignals = GlassInteractionSignals()
+
+private class ResolvedGlassConfiguration(source: GlassVisualEffect) {
+  val value = GlassVisualEffect(source)
+}
+
+/**
+ * Node-owned runtime for rendering a translucent refractive glass material. Configuration is
+ * resolved through a resource-free [GlassVisualEffect] copy, while attachment state, delegates,
+ * caches, controllers, and platform resources remain local to this instance.
+ */
+@ExperimentalHazeApi
+@Stable
+@OptIn(InternalHazeApi::class)
+internal class GlassRuntimeEffect private constructor(
+  configuration: ResolvedGlassConfiguration,
+) :
+  VisualEffect,
+  RetainedOutputVisualEffect,
+  InteractiveVisualEffect,
+  GlassStyleConfiguration by configuration.value {
+
+  constructor(sourceConfiguration: GlassVisualEffect = GlassVisualEffect()) :
+    this(ResolvedGlassConfiguration(sourceConfiguration))
+
+  private val resolvedConfiguration = configuration.value
+
+  init {
+    resolvedConfiguration.trackConfigurationVersions = false
+    resolvedConfiguration.onConfigurationChanged = ::markDirty
+  }
+
+  internal fun synchronizeConfigurationFrom(other: GlassVisualEffect, changedFields: Int) {
+    resolvedConfiguration.synchronizeConfigurationFrom(other, changedFields)
+    markDirty(changedFields)
+  }
+
+  private var isAttached: Boolean = false
+
+  private var attachedContext: VisualEffectContext? = null
+
+  private var interactionController: GlassInteractionController? = null
+
+  internal val interactionControllerForTest: GlassInteractionController?
+    get() = interactionController
+
+  internal val attachedContextForTest: VisualEffectContext?
+    get() = attachedContext
+
+  internal val currentInteractionState: GlassInteractionRenderState
+    get() = interactionController?.renderState ?: IdleInteractionState
+
+  internal val currentInteractionSignals: GlassInteractionSignals
+    get() = interactionController?.currentSignals ?: IdleInteractionSignals
+
+  private var needsDelegateSelection: Boolean = true
+
+  internal var runtimeShaderIncompatible: Boolean = false
+    private set
+
+  internal var preparedRenderBudget: GlassRenderBudgetDecision =
+    GlassRenderBudgetDecision.Fallback(GlassRenderBudgetFallbackReason.InvalidGeometry)
+    private set
+
+  internal var preparedRender: GlassPreparedRender? = null
+    private set
+
+  private var preparedRenderCacheKey: GlassPreparedRenderCacheKey? = null
+  private var preparedRenderCache: GlassPreparedRender? = null
+
+  private var budgetCacheKey: GlassRenderBudgetCacheKey? = null
+  private var budgetCacheDecision: GlassRenderBudgetDecision? = null
+
+  private var preparedDrawCacheKey: GlassPreparedDrawCacheKey? = null
+
+  private var dirtyTrackerVersion: Int by mutableIntStateOf(0)
+  internal var dirtyTracker: Bitmask = Bitmask()
+    private set
+
+  private var resolvedStyleCache: ResolvedGlassStyle? = null
+  private var resolvedStyleCacheSize: Size = Size.Unspecified
+  private var resolvedStyleCacheDensity: Density? = null
+  private var resolvedStyleCacheLayoutDirection: LayoutDirection? = null
+
+  private var geometrySnapshotObserver: SnapshotStateObserver? = null
+  private var geometryObserverGeneration: Int = 0
+  private var geometryInvalidationJob: Job? = null
+  private val styleObservationScope = Any()
+  private val clipObservationScope = Any()
+  private val onObservedStyleChanged: (Any) -> Unit = {
+    scheduleObservedStyleInvalidation()
+  }
+
+  private var coordinatesCache: GlassCoordinates? = null
+  private var coordinatesCacheLayerSize: Size = Size.Unspecified
+  private var coordinatesCacheLayerOffset: Offset = Offset.Unspecified
+  private var coordinatesCacheMaterialSize: Size = Size.Unspecified
+  private var coordinatesCacheScaleFactor: Float = Float.NaN
+
+  private var interactionRenderStateCache: GlassInteractionRenderState? = null
+  private var interactionRadiusFractionCache: Float = Float.NaN
+  private var resolvedInteractionCache: ResolvedGlassInteraction? = null
+  private var idleInteractionRenderStateSize: Size = Size.Unspecified
+  private var idleInteractionRenderState: GlassInteractionRenderState = IdleInteractionState
+
+  private var shouldClipToNodeBoundsCacheValid: Boolean = false
+  private var shouldClipToNodeBoundsCache: Boolean = false
+
+  private val renderPreparation = GlassRenderPreparation(
+    decision = GlassRenderBudgetDecision.Fallback(
+      GlassRenderBudgetFallbackReason.InvalidGeometry,
+    ),
+    prepared = null,
+  )
+
+  internal val interactionSlots: GlassInteractionSlots
+    get() = resolvedConfiguration.resolvedInteractionSlots
+
+  private val interactionTopologySnapshot: GlassInteractionTopology
+    get() = resolvedConfiguration.resolvedInteractionTopology
+
+  override val observesPointerEvents: Boolean
+    get() = resolvedConfiguration.observesPointerEvents
+
+  public var interactionSource: InteractionSource?
+    get() = resolvedConfiguration.interactionSource
+    set(value) {
+      resolvedConfiguration.interactionSource = value
+    }
+
+  public var interactionLightRadiusFraction: Float
+    get() = resolvedConfiguration.interactionLightRadiusFraction
+    set(value) {
+      resolvedConfiguration.interactionLightRadiusFraction = value
+    }
+
+  public var interactionTransformTarget: GlassTransformTarget
+    get() = resolvedConfiguration.interactionTransformTarget
+    set(value) {
+      resolvedConfiguration.interactionTransformTarget = value
+    }
+
+  public var interactionTransformPivot: GlassTransformPivot
+    get() = resolvedConfiguration.interactionTransformPivot
+    set(value) {
+      resolvedConfiguration.interactionTransformPivot = value
+    }
+
+  public var interactionPositionAnimationSpec: FiniteAnimationSpec<Offset>
+    get() = resolvedConfiguration.interactionPositionAnimationSpec
+    set(value) {
+      resolvedConfiguration.interactionPositionAnimationSpec = value
+    }
+
+  public var interactionReducedMotionPolicy: GlassReducedMotionPolicy
+    get() = resolvedConfiguration.interactionReducedMotionPolicy
+    set(value) {
+      resolvedConfiguration.interactionReducedMotionPolicy = value
+    }
+
+  public fun hovered() = resolvedConfiguration.hovered()
+  public fun hovered(block: GlassInteractionScope.() -> Unit) = resolvedConfiguration.hovered(block)
+  public fun focused() = resolvedConfiguration.focused()
+  public fun focused(block: GlassInteractionScope.() -> Unit) = resolvedConfiguration.focused(block)
+  public fun pressed() = resolvedConfiguration.pressed()
+  public fun pressed(block: GlassInteractionScope.() -> Unit) = resolvedConfiguration.pressed(block)
+  public fun interactable() = resolvedConfiguration.interactable()
+  public fun clearHovered() = resolvedConfiguration.clearHovered()
+  public fun clearFocused() = resolvedConfiguration.clearFocused()
+  public fun clearPressed() = resolvedConfiguration.clearPressed()
+  public fun clearInteractions() = resolvedConfiguration.clearInteractions()
+
+  internal var delegate: Delegate = FallbackGlassDelegate(this)
+    set(value) {
+      if (value != field) {
+        HazeLogger.d(TAG) { "delegate changed. Current $field. New: $value" }
+        val old = field
+        field = value
+        if (isAttached) {
+          old.release()
+          value.attach()
+        }
+      }
+    }
+
+  override fun attach(context: VisualEffectContext) {
+    if (!isAttached) {
+      isAttached = true
+      attachedContext = context
+      val observerGeneration = ++geometryObserverGeneration
+      geometrySnapshotObserver = SnapshotStateObserver { command ->
+        context.coroutineScope.launch {
+          if (
+            isAttached &&
+            attachedContext === context &&
+            geometryObserverGeneration == observerGeneration
+          ) {
+            command()
+          }
+        }
+      }.also { it.start() }
+      resolvedStyleCache = null
+      shouldClipToNodeBoundsCacheValid = false
+      syncInteractionController(context)
+      delegate.attach()
+    }
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    if (isAttached) {
+      interactionController?.dispose()
+      interactionController = null
+      geometryObserverGeneration++
+      geometryInvalidationJob?.cancel()
+      geometryInvalidationJob = null
+      geometrySnapshotObserver?.stop()
+      geometrySnapshotObserver = null
+      attachedContext = null
+      isAttached = false
+      delegate.detach()
+    }
+    runtimeShaderIncompatible = false
+    needsDelegateSelection = true
+    preparedRender = null
+    clearPreparedRenderCache()
+  }
+
+  private fun scheduleObservedStyleInvalidation() {
+    if (geometryInvalidationJob?.isActive == true) return
+    val context = attachedContext ?: return
+    val observerGeneration = geometryObserverGeneration
+    geometryInvalidationJob = context.coroutineScope.launch {
+      yield()
+      if (
+        isAttached &&
+        attachedContext === context &&
+        geometryObserverGeneration == observerGeneration
+      ) {
+        resolvedStyleCache = null
+        shouldClipToNodeBoundsCacheValid = false
+        context.invalidateLayerBounds()
+        context.invalidateDraw()
+      }
+    }
+  }
+
+  override fun update(context: VisualEffectContext) {
+    dirtyTrackerVersion
+    compositionLocalStyle = context.currentValueOf(LocalGlassStyle)
+    syncInteractionController(context)
+
+    if (dirtyTracker.any(GlassDirtyFields.LayerBoundsFlags)) {
+      context.invalidateLayerBounds()
+    }
+    if (dirtyTracker.any(GlassDirtyFields.InvalidateFlags)) {
+      needsDelegateSelection = true
+      context.invalidateDraw()
+    }
+  }
+
+  override fun onPointerEvent(event: PointerEvent, context: VisualEffectContext) {
+    interactionController?.onPointerEvent(event, context.size)
+  }
+
+  override fun onCancelPointerInput(context: VisualEffectContext) {
+    interactionController?.cancelPointerInput(context.size)
+  }
+
+  internal fun setPressedForTest(position: Offset, pressed: Boolean = true) {
+    val context = attachedContext ?: return
+    interactionController?.setRawPressedForTest(pressed, position, context.size)
+  }
+
+  override fun DrawScope.prepareDraw(context: VisualEffectContext) {
+    trace(GlassTraceSection.Prepare) {
+      if (canReusePreparedDraw(context)) return@trace
+      val previousBudget = preparedRenderBudget
+      trace(GlassTraceSection.PrepareBudget) {
+        prepareRenderBudget(context, runtimeShaderSupported = isRuntimeShaderGlassSupported())
+      }
+      if (previousBudget::class != preparedRenderBudget::class) {
+        needsDelegateSelection = true
+      }
+      trace(GlassTraceSection.SelectDelegate) {
+        selectDelegateForDraw(context)
+      }
+      trace(GlassTraceSection.DelegatePrepare) {
+        val selectedDelegate = delegate
+        try {
+          with(selectedDelegate) { prepareDraw(context) }
+        } catch (failure: RuntimeShaderRenderEffectException) {
+          if (selectedDelegate !is RuntimeShaderGlassDelegate) throw failure
+          downgradeRuntimeDelegate(context, failure)
+        }
+      }
+      cachePreparedDrawInputs(context)
+    }
+  }
+
+  private fun canReusePreparedDraw(context: VisualEffectContext): Boolean {
+    val key = preparedDrawCacheKey ?: return false
+    val style = resolvedStyleCache ?: return false
+    val interactionState = interactionRenderState(context)
+    return preparedRender != null &&
+      (delegate as? RetainedOutputDelegate)?.canDrawRetainedOutput() == true &&
+      key.dirtyTrackerVersion == dirtyTrackerVersion &&
+      key.size == context.size &&
+      key.layerSize == context.layerSize &&
+      key.layerOffset == context.layerOffset &&
+      key.inputScale == context.inputScale &&
+      key.density == context.requireDensity() &&
+      key.layoutDirection == context.currentValueOf(LocalLayoutDirection) &&
+      key.style === style &&
+      key.interactionState === interactionState &&
+      key.interactionTopology === interactionTopologySnapshot
+  }
+
+  private fun cachePreparedDrawInputs(context: VisualEffectContext) {
+    preparedDrawCacheKey = GlassPreparedDrawCacheKey(
+      dirtyTrackerVersion = dirtyTrackerVersion,
+      size = context.size,
+      layerSize = context.layerSize,
+      layerOffset = context.layerOffset,
+      inputScale = context.inputScale,
+      density = context.requireDensity(),
+      layoutDirection = context.currentValueOf(LocalLayoutDirection),
+      style = resolvedStyleCache,
+      interactionState = interactionRenderState(context),
+      interactionTopology = interactionTopologySnapshot,
+    )
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    try {
+      selectDelegateForDraw(context)
+      val selectedDelegate = delegate
+      try {
+        withMaterialTransform(context) {
+          with(selectedDelegate) { draw(context) }
+        }
+      } catch (failure: RuntimeShaderRenderEffectException) {
+        if (selectedDelegate !is RuntimeShaderGlassDelegate) throw failure
+        downgradeRuntimeDelegate(context, failure)
+      }
+    } finally {
+      resetDirtyTracker()
+    }
+  }
+
+  private fun DrawScope.downgradeRuntimeDelegate(
+    context: VisualEffectContext,
+    failure: RuntimeShaderRenderEffectException,
+  ) {
+    runtimeShaderIncompatible = true
+    HazeLogger.d(TAG) {
+      "Runtime shader construction failed; using fallback until reattachment: $failure"
+    }
+    delegate = FallbackGlassDelegate(this@GlassRuntimeEffect)
+    with(delegate) { prepareDraw(context) }
+    context.invalidateDraw()
+  }
+
+  override fun DrawScope.drawForeground(context: VisualEffectContext) {
+    withMaterialTransform(context) {
+      with(delegate) { drawForeground(context) }
+    }
+  }
+
+  override fun currentContentTransform(context: VisualEffectContext): VisualEffectTransform {
+    return resolveTransform(context, GlassTransformTarget.MaterialAndContent)
+  }
+
+  internal fun currentMaterialTransform(context: VisualEffectContext): VisualEffectTransform {
+    return resolveTransform(context, GlassTransformTarget.MaterialOnly)
+  }
+
+  override fun shouldDrawContentBehind(context: VisualEffectContext): Boolean {
+    return delegate is FallbackGlassDelegate
+  }
+
+  internal fun controllerConfiguration(
+    systemMotionScale: Float,
+  ): GlassInteractionControllerConfiguration {
+    val (reduced, forceFull) = reducedMotion(
+      policy = interactionReducedMotionPolicy,
+      systemScale = systemMotionScale,
+    )
+    return GlassInteractionControllerConfiguration(
+      slots = interactionSlots,
+      positionAnimationSpec = interactionPositionAnimationSpec,
+      reducedMotion = reduced,
+      forceFullMotion = forceFull,
+    )
+  }
+
+  internal fun interactionRenderState(context: VisualEffectContext): GlassInteractionRenderState {
+    interactionController?.let { return it.renderState }
+    if (idleInteractionRenderStateSize != context.size) {
+      idleInteractionRenderStateSize = context.size
+      idleInteractionRenderState = GlassInteractionRenderState(position = context.size.center)
+    }
+    return idleInteractionRenderState
+  }
+
+  private fun resolveTransform(
+    context: VisualEffectContext,
+    target: GlassTransformTarget,
+  ): VisualEffectTransform {
+    if (interactionTransformTarget != target) return VisualEffectTransform.Identity
+    val state = currentInteractionState
+    val size = context.size
+    if (!state.hasTransform || !size.isDrawable()) return VisualEffectTransform.Identity
+    val pivot = when (interactionTransformPivot) {
+      GlassTransformPivot.Pointer -> state.position.clampTo(size)
+      GlassTransformPivot.Center -> size.center
+    }
+    return VisualEffectTransform(state.scaleX, state.scaleY, pivot)
+  }
+
+  private inline fun DrawScope.withMaterialTransform(
+    context: VisualEffectContext,
+    block: DrawScope.() -> Unit,
+  ) {
+    val transform = currentMaterialTransform(context)
+    if (transform == VisualEffectTransform.Identity) {
+      block()
+    } else {
+      scale(
+        scaleX = transform.scaleX,
+        scaleY = transform.scaleY,
+        pivot = transform.pivot,
+        block = block,
+      )
+    }
+  }
+
+  private fun syncInteractionController(context: VisualEffectContext) {
+    if (
+      interactionSlots.hovered == null &&
+      interactionSlots.focused == null &&
+      interactionSlots.pressed == null
+    ) {
+      val controller = interactionController ?: return
+      controller.dispose()
+      interactionController = null
+      context.invalidateDraw()
+      return
+    }
+    val controller = interactionController ?: GlassInteractionController(context).also {
+      interactionController = it
+    }
+    controller.updateConfiguration(controllerConfiguration(systemMotionScale(context)))
+    controller.updateInteractionSource(interactionSource, context.size)
+  }
+
+  private fun systemMotionScale(context: VisualEffectContext): Float {
+    return context.coroutineScope.coroutineContext[MotionDurationScale]?.scaleFactor ?: 1f
+  }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    delegate.onTrimMemory(context, level)
+  }
+
+  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean {
+    return (delegate as? RetainedOutputDelegate)?.canDrawRetainedOutput() == true
+  }
+
+  override fun shouldDrawRetainedOutput(context: VisualEffectContext): Boolean {
+    return (delegate as? RetainedOutputDelegate)?.shouldDrawRetainedOutput() == true
+  }
+
+  override fun clearRetainedOutput() {
+    (delegate as? RetainedOutputDelegate)?.clearRetainedOutput()
+  }
+
+  override fun shouldClipToNodeBounds(): Boolean {
+    if (!shouldClipToNodeBoundsCacheValid) {
+      val observer = geometrySnapshotObserver
+      if (observer != null) {
+        observer.observeReads(clipObservationScope, onObservedStyleChanged) {
+          shouldClipToNodeBoundsCache = edgeSoftness > 0.dp || !shape.hasZeroCornerRadii()
+        }
+      } else {
+        shouldClipToNodeBoundsCache = edgeSoftness > 0.dp || !shape.hasZeroCornerRadii()
+      }
+      shouldClipToNodeBoundsCacheValid = true
+    }
+    return shouldClipToNodeBoundsCache
+  }
+
+  internal fun resolveInputScaleFactor(scale: HazeInputScale): Float = when {
+    scale === HazeInputScale.Auto -> 0.75f
+    scale is HazeInputScale.Fixed -> scale.scale
+    else -> 1f
+  }
+
+  internal fun resolveGlassRenderBudget(context: VisualEffectContext): GlassRenderBudgetDecision {
+    return resolveGlassRenderPreparation(context, runtimeShaderSupported = true).decision
+  }
+
+  private fun resolvePreparedStyle(context: VisualEffectContext): ResolvedGlassStyle {
+    val density = context.requireDensity()
+    val layoutDirection = context.currentValueOf(LocalLayoutDirection)
+    resolvedStyleCache?.takeIf {
+      resolvedStyleCacheSize == context.size &&
+        resolvedStyleCacheDensity == density &&
+        resolvedStyleCacheLayoutDirection == layoutDirection
+    }?.let { return it }
+
+    val resolvedStyle = geometrySnapshotObserver?.let { observer ->
+      lateinit var observedStyle: ResolvedGlassStyle
+      observer.observeReads(styleObservationScope, onObservedStyleChanged) {
+        observedStyle = resolveGlassStyle(this, context.size, density, layoutDirection)
+      }
+      observedStyle
+    } ?: resolveGlassStyle(this, context.size, density, layoutDirection)
+
+    return resolvedStyle.also {
+      resolvedStyleCache = it
+      resolvedStyleCacheSize = context.size
+      resolvedStyleCacheDensity = density
+      resolvedStyleCacheLayoutDirection = layoutDirection
+    }
+  }
+
+  private fun resolvePreparedInteraction(
+    context: VisualEffectContext,
+  ): ResolvedGlassInteraction {
+    val state = interactionRenderState(context)
+    resolvedInteractionCache?.takeIf {
+      interactionRenderStateCache === state &&
+        interactionRadiusFractionCache == interactionLightRadiusFraction
+    }?.let { return it }
+
+    return resolveGlassInteraction(
+      state = state,
+      radiusFraction = interactionLightRadiusFraction,
+    ).also {
+      interactionRenderStateCache = state
+      interactionRadiusFractionCache = interactionLightRadiusFraction
+      resolvedInteractionCache = it
+    }
+  }
+
+  private fun resolvePreparedCoordinates(
+    layerSize: Size,
+    layerOffset: Offset,
+    materialSize: Size,
+    scaleFactor: Float,
+  ): GlassCoordinates {
+    coordinatesCache?.takeIf {
+      coordinatesCacheLayerSize == layerSize &&
+        coordinatesCacheLayerOffset == layerOffset &&
+        coordinatesCacheMaterialSize == materialSize &&
+        coordinatesCacheScaleFactor == scaleFactor
+    }?.let { return it }
+
+    return resolveGlassCoordinates(
+      layerSize = layerSize,
+      layerOffset = layerOffset,
+      materialSize = materialSize,
+      scaleFactor = scaleFactor,
+    ).withRoundedSampleSize().also {
+      coordinatesCache = it
+      coordinatesCacheLayerSize = layerSize
+      coordinatesCacheLayerOffset = layerOffset
+      coordinatesCacheMaterialSize = materialSize
+      coordinatesCacheScaleFactor = scaleFactor
+    }
+  }
+
+  private fun resolveGlassRenderPreparation(
+    context: VisualEffectContext,
+    runtimeShaderSupported: Boolean,
+  ): GlassRenderPreparation {
+    val requestedScale = resolveInputScaleFactor(context.inputScale)
+    if (
+      !requestedScale.isFinite() || requestedScale <= 0f ||
+      !context.size.isDrawable() || !context.layerSize.isDrawable()
+    ) {
+      clearPreparedRenderCache()
+      return updateRenderPreparation(
+        GlassRenderBudgetDecision.Fallback(GlassRenderBudgetFallbackReason.InvalidGeometry),
+        null,
+      )
+    }
+    val style = resolvePreparedStyle(context)
+    val interaction = resolvePreparedInteraction(context)
+    val interactionTopology = interactionTopologySnapshot
+    val optics = style.resolvedOptics
+    val budgetKey = budgetCacheKey
+    val decision = if (
+      budgetKey != null &&
+      budgetKey.style.hasSameBudgetParams(style) &&
+      budgetKey.requestedScale == requestedScale &&
+      budgetKey.layerSize == context.layerSize &&
+      budgetKey.materialSize == context.size &&
+      budgetKey.interactionTopology === interactionTopology &&
+      budgetKey.interactionRadiusFraction == interaction.radiusFraction
+    ) {
+      checkNotNull(budgetCacheDecision)
+    } else {
+      val allowMultiscaleBlur = optics.progressive == null
+      resolveGlassRenderBudget(requestedScale) { scaleFactor ->
+        val rawCoordinates = resolveGlassCoordinates(
+          layerSize = context.layerSize,
+          layerOffset = context.layerOffset,
+          materialSize = context.size,
+          scaleFactor = scaleFactor,
+        )
+        if (!rawCoordinates.materialSize.isDrawable() || !rawCoordinates.sampleSize.isDrawable()) {
+          return@resolveGlassRenderBudget GlassRetainedLayerPlan(emptyList())
+        }
+        val coordinates = rawCoordinates.withRoundedSampleSize()
+        if (!coordinates.materialSize.isDrawable() || !coordinates.sampleSize.isDrawable()) {
+          return@resolveGlassRenderBudget GlassRetainedLayerPlan(emptyList())
+        }
+        val outputSize = context.size.roundToIntSize()
+        val interactionPatchSize = calculateGlassInteractionPatchSize(
+          buildGlassRenderParams(style, coordinates),
+          radiusFraction = interaction.radiusFraction,
+          topology = interactionTopology,
+        )
+        val interactionLayersActive =
+          interactionPatchSize.width > 0 && interactionPatchSize.height > 0
+        buildGlassBudgetLayerPlan(
+          sampleSize = coordinates.sampleSize.roundToIntSize(),
+          groupCompositeSize = resolveGlassGroupCompositeSize(
+            outputSize = outputSize,
+            alpha = style.alpha,
+            interactionLayersActive = interactionLayersActive,
+            interactionTopology = interactionTopology,
+          ),
+          blurRadiusPx = optics.blurRadiusPx * scaleFactor,
+          depth = optics.depth,
+          allowMultiscaleBlur = allowMultiscaleBlur,
+          refractionDetailActive = isGlassRefractionDetailActive(
+            refractionStrength = optics.refractionStrength,
+            refractionScalePx = optics.refractionScalePx * scaleFactor,
+            refractionHeightPx = optics.refractionHeightPx * scaleFactor,
+            edgeSoftnessPx = style.edgeSoftnessPx * scaleFactor,
+            sampleStepPx = 2f * scaleFactor,
+            detailIntensity = optics.refractionDetailIntensity,
+          ),
+          rimActive = style.specularIntensity > 0f,
+          interactionPatchSize = interactionPatchSize,
+          interactionOpticsActive = interactionTopology.hasOptics,
+          interactionLightingActive = interactionTopology.hasLighting,
+        )
+      }.also { resolvedDecision ->
+        budgetCacheKey = GlassRenderBudgetCacheKey(
+          style = style,
+          requestedScale = requestedScale,
+          layerSize = context.layerSize,
+          materialSize = context.size,
+          interactionTopology = interactionTopology,
+          interactionRadiusFraction = interaction.radiusFraction,
+        )
+        budgetCacheDecision = resolvedDecision
+      }
+    }
+    if (decision !is GlassRenderBudgetDecision.Runtime) {
+      clearPreparedRenderCache()
+      return updateRenderPreparation(decision, null)
+    }
+    if (!runtimeShaderSupported) {
+      return updateRenderPreparation(decision, null)
+    }
+    val coordinates = resolvePreparedCoordinates(
+      layerSize = context.layerSize,
+      layerOffset = context.layerOffset,
+      materialSize = context.size,
+      scaleFactor = decision.scaleFactor,
+    )
+    val preparedCacheKey = preparedRenderCacheKey
+    if (
+      preparedCacheKey != null &&
+      style === preparedCacheKey.style &&
+      coordinates === preparedCacheKey.coordinates &&
+      interaction === preparedCacheKey.interaction &&
+      interactionTopology === preparedCacheKey.interactionTopology
+    ) {
+      return updateRenderPreparation(decision, checkNotNull(preparedRenderCache))
+    }
+    val previousStyle = preparedCacheKey?.style
+    val previousCoordinates = preparedCacheKey?.coordinates
+    val previousInteraction = preparedCacheKey?.interaction
+    val previousPrepared = preparedRenderCache
+    val params = if (
+      previousStyle != null && previousCoordinates != null && previousPrepared != null &&
+      coordinates === previousCoordinates &&
+      style.hasSameRenderParams(previousStyle)
+    ) {
+      previousPrepared.params
+    } else {
+      buildGlassRenderParams(style, coordinates)
+    }
+    val interactionUniforms = if (
+      previousCoordinates != null && previousInteraction != null && previousPrepared != null &&
+      coordinates === previousCoordinates &&
+      interaction === previousInteraction
+    ) {
+      previousPrepared.interactionUniforms
+    } else {
+      interaction.uniforms(coordinates)
+    }
+    val exactPrepared = buildGlassPreparedRender(
+      params = params,
+      interactionUniforms = interactionUniforms,
+      interactionTopology = interactionTopology,
+      interactionRadiusFraction = interaction.radiusFraction,
+      alpha = style.alpha,
+      outputSize = context.size.roundToIntSize(),
+      previous = previousPrepared,
+    )
+    if (!exactPrepared.plan.fitsGlassRenderBudget()) {
+      val fallback = GlassRenderBudgetDecision.Fallback(
+        GlassRenderBudgetFallbackReason.ExceedsLimits,
+      )
+      budgetCacheDecision = fallback
+      clearPreparedRenderCache()
+      return updateRenderPreparation(fallback, null)
+    }
+    val validatedDecision = if (decision.plan == exactPrepared.plan) {
+      decision
+    } else {
+      GlassRenderBudgetDecision.Runtime(decision.scaleFactor, exactPrepared.plan)
+        .also { budgetCacheDecision = it }
+    }
+    val prepared = if (exactPrepared.plan === validatedDecision.plan) {
+      exactPrepared
+    } else {
+      exactPrepared.copy(plan = validatedDecision.plan)
+    }
+    preparedRenderCacheKey = GlassPreparedRenderCacheKey(
+      style = style,
+      coordinates = coordinates,
+      interaction = interaction,
+      interactionTopology = interactionTopology,
+    )
+    preparedRenderCache = prepared
+    return updateRenderPreparation(validatedDecision, prepared)
+  }
+
+  private fun updateRenderPreparation(
+    decision: GlassRenderBudgetDecision,
+    prepared: GlassPreparedRender?,
+  ): GlassRenderPreparation {
+    renderPreparation.decision = decision
+    renderPreparation.prepared = prepared
+    return renderPreparation
+  }
+
+  private fun clearPreparedRenderCache() {
+    preparedRenderCacheKey = null
+    preparedRenderCache = null
+  }
+
+  internal fun prepareRenderBudget(
+    context: VisualEffectContext,
+    runtimeShaderSupported: Boolean,
+  ): GlassRenderBudgetDecision {
+    val previousBudget = preparedRenderBudget
+    val preparation = resolveGlassRenderPreparation(
+      context = context,
+      runtimeShaderSupported = runtimeShaderSupported,
+    )
+    preparedRenderBudget = preparation.decision
+    preparedRender = preparation.prepared
+    if (previousBudget != preparation.decision) {
+      when (val decision = preparation.decision) {
+        is GlassRenderBudgetDecision.Fallback -> HazeLogger.d(TAG) {
+          "Glass render budget selected fallback: ${decision.reason}"
+        }
+        is GlassRenderBudgetDecision.Runtime -> {
+          val requestedScale = resolveInputScaleFactor(context.inputScale)
+          if (decision.scaleFactor < requestedScale) {
+            HazeLogger.d(TAG) {
+              "Glass render budget reduced scale from $requestedScale to ${decision.scaleFactor}"
+            }
+          }
+        }
+      }
+    }
+    return preparation.decision
+  }
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
+    val resolvedStyle = resolveGlassStyle(
+      effect = this,
+      materialSizePx = rect.size,
+      density = density,
+      layoutDirection = LayoutDirection.Ltr,
+    )
+    val resolved = resolvedStyle.resolvedOptics
+    val paddingPx = calculateGlassSamplePaddingPx(
+      blurRadiusPx = if (resolved.depth <= 0f) 0f else resolved.blurRadiusPx,
+      refractionScale = resolved.refractionScalePx,
+      refractionStrength = (
+        resolved.refractionStrength * maximumInteractionRefractionMultiplier()
+        ).coerceIn(0f, 1f),
+      chromaticAberrationStrength = resolvedStyle.chromaticAberrationStrength,
+      edgeSoftnessPx = resolvedStyle.edgeSoftnessPx,
+      foregroundOutsetPx = 0f,
+    )
+    return rect.inflate(paddingPx)
+  }
+
+  override fun shouldPreferClipToAreaBounds(): Boolean = !shouldClipToNodeBounds()
+
+  private fun maximumInteractionRefractionMultiplier(): Float =
+    interactionTopologySnapshot.maxRefractionMultiplier
+
+  public fun clearOpticsOverride() = resolvedConfiguration.clearOpticsOverride()
+  public fun clearSurfaceProfileOverride() =
+    resolvedConfiguration.clearSurfaceProfileOverride()
+  public fun clearChromaticAberrationModeOverride() =
+    resolvedConfiguration.clearChromaticAberrationModeOverride()
+  public fun clearShapeOverride() = resolvedConfiguration.clearShapeOverride()
+
+  internal var compositionLocalStyle: GlassStyle
+    get() = resolvedConfiguration.compositionLocalStyle
+    set(value) {
+      resolvedConfiguration.compositionLocalStyle = value
+    }
+
+  internal var runtimeEffectFactory: GlassRuntimeEffectFactory
+    get() = resolvedConfiguration.runtimeEffectFactory
+    set(value) {
+      resolvedConfiguration.runtimeEffectFactory = value
+    }
+
+  internal interface Delegate {
+    fun attach() = Unit
+    fun DrawScope.prepareDraw(context: VisualEffectContext) = Unit
+    fun DrawScope.draw(context: VisualEffectContext)
+    fun DrawScope.drawForeground(context: VisualEffectContext) = Unit
+    fun detach() = Unit
+    fun release() = detach()
+    fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) = Unit
+  }
+
+  internal fun release() {
+    delegate.release()
+  }
+
+  internal fun resetDirtyTracker() {
+    dirtyTracker = Bitmask()
+  }
+
+  private fun markDirty(fields: Int) {
+    val updated = dirtyTracker + fields
+    if (updated != dirtyTracker) {
+      dirtyTracker = updated
+      dirtyTrackerVersion++
+    }
+    if (fields and GlassDirtyFields.StyleResolutionFlags != 0) {
+      resolvedStyleCache = null
+    }
+    if (fields and GlassDirtyFields.ClipDecisionFlags != 0) {
+      shouldClipToNodeBoundsCacheValid = false
+    }
+  }
+
+  private fun DrawScope.selectDelegateForDraw(context: VisualEffectContext) {
+    if (needsDelegateSelection) {
+      delegate = updateDelegate()
+      needsDelegateSelection = false
+    }
+  }
+
+  internal companion object {
+    const val TAG = "GlassVisualEffect"
+  }
+}
+
+private class GlassRenderPreparation(
+  var decision: GlassRenderBudgetDecision,
+  var prepared: GlassPreparedRender?,
+)
+
+internal interface RetainedOutputDelegate {
+  fun canDrawRetainedOutput(): Boolean
+
+  fun shouldDrawRetainedOutput(): Boolean = canDrawRetainedOutput()
+
+  fun clearRetainedOutput()
+}
+
+internal fun GlassRuntimeEffect.updateDelegate(): GlassRuntimeEffect.Delegate {
+  val wantsRuntime =
+    preparedRenderBudget is GlassRenderBudgetDecision.Runtime &&
+      preparedRender != null &&
+      !runtimeShaderIncompatible
+  return when {
+    wantsRuntime &&
+      (
+        delegate !is RuntimeShaderGlassDelegate ||
+          GlassDirtyFields.RuntimeEffectFactory in dirtyTracker
+        ) ->
+      RuntimeShaderGlassDelegate(this, runtimeEffectFactory)
+    !wantsRuntime && delegate !is FallbackGlassDelegate -> FallbackGlassDelegate(this)
+    else -> delegate
+  }
+}
+
+internal expect fun isRuntimeShaderGlassSupported(): Boolean
+
+internal fun RoundedCornerShape.hasZeroCornerRadii(): Boolean {
+  // Use unit values to check if all corner sizes resolve to zero.
+  val unitSize = androidx.compose.ui.geometry.Size(1f, 1f)
+  val unitDensity = androidx.compose.ui.unit.Density(1f)
+  return topStart.toPx(unitSize, unitDensity) == 0f &&
+    topEnd.toPx(unitSize, unitDensity) == 0f &&
+    bottomEnd.toPx(unitSize, unitDensity) == 0f &&
+    bottomStart.toPx(unitSize, unitDensity) == 0f
+}
+
+internal inline fun Float.takeOrElse(default: () -> Float): Float {
+  return if (this.isNaN()) default() else this
+}
+
+internal fun Float.hasSameOverrideValueAs(other: Float): Boolean =
+  this == other || isNaN() && other.isNaN()
+
+internal inline fun Float.hasSameNormalizedOverrideValueAs(
+  other: Float,
+  normalize: (Float) -> Float,
+): Boolean = hasSameOverrideValueAs(other) ||
+  isFinite() && other.isFinite() && normalize(this) == normalize(other)
+
+internal fun reducedMotion(
+  policy: GlassReducedMotionPolicy,
+  systemScale: Float,
+): Pair<Boolean, Boolean> = when (policy) {
+  GlassReducedMotionPolicy.System -> (systemScale == 0f) to false
+  GlassReducedMotionPolicy.Reduced -> true to false
+  GlassReducedMotionPolicy.Full -> false to true
+}

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
@@ -103,6 +103,7 @@ private fun ResolvedGlassStyle.hasSameBudgetParams(other: ResolvedGlassStyle): B
 
 private val IdleInteractionState = GlassInteractionRenderState(Offset.Zero)
 private val IdleInteractionSignals = GlassInteractionSignals()
+private val EmptyGlassConfiguration = GlassVisualEffect()
 
 private class ResolvedGlassConfiguration(source: GlassVisualEffect) {
   val value = GlassVisualEffect(source)
@@ -137,6 +138,62 @@ internal class GlassRuntimeEffect private constructor(
   internal fun synchronizeConfigurationFrom(other: GlassVisualEffect, changedFields: Int) {
     resolvedConfiguration.synchronizeConfigurationFrom(other, changedFields)
     markDirty(changedFields)
+  }
+
+  internal fun clearConfigurationReferences() {
+    val retainedRuntimeDelegate = delegate as? RuntimeShaderGlassDelegate
+    retainedRuntimeDelegate?.sanitizeConfigurationReferencesForCache(
+      releaseShaderHandles = runtimeEffectFactory !== PlatformGlassRuntimeEffectFactory,
+    )
+    replaceConfigurationFrom(EmptyGlassConfiguration)
+    retainedRuntimeDelegate?.updateRuntimeEffectFactory(
+      PlatformGlassRuntimeEffectFactory,
+    )
+    clearConfigurationCaches()
+    resetDirtyTracker()
+  }
+
+  internal fun reseedConfiguration(
+    other: GlassVisualEffect,
+    runtimeEffectFactoryChanged: Boolean,
+  ) {
+    replaceConfigurationFrom(other)
+    val retainedRuntimeDelegate = (delegate as? RuntimeShaderGlassDelegate)?.takeUnless {
+      runtimeEffectFactoryChanged
+    }
+    if (runtimeEffectFactoryChanged && delegate is RuntimeShaderGlassDelegate) {
+      delegate.release()
+      delegate = FallbackGlassDelegate(this)
+    }
+    retainedRuntimeDelegate?.updateRuntimeEffectFactory(runtimeEffectFactory)
+    resetDirtyTracker()
+    markDirty(
+      if (retainedRuntimeDelegate != null) {
+        GlassDirtyFields.All and GlassDirtyFields.RuntimeEffectFactory.inv()
+      } else {
+        GlassDirtyFields.All
+      },
+    )
+  }
+
+  private fun replaceConfigurationFrom(other: GlassVisualEffect) {
+    resolvedConfiguration.onConfigurationChanged = null
+    try {
+      resolvedConfiguration.copyConfigurationFrom(other)
+    } finally {
+      resolvedConfiguration.onConfigurationChanged = ::markDirty
+    }
+  }
+
+  private fun clearConfigurationCaches() {
+    preparedRender = null
+    renderPreparation.prepared = null
+    clearPreparedRenderCache()
+    budgetCacheKey = null
+    budgetCacheDecision = null
+    preparedDrawCacheKey = null
+    resolvedStyleCache = null
+    resolvedStyleCacheDensity = null
   }
 
   private var isAttached: Boolean = false
@@ -184,6 +241,10 @@ internal class GlassRuntimeEffect private constructor(
   private var resolvedStyleCache: ResolvedGlassStyle? = null
   private var resolvedStyleCacheSize: Size = Size.Unspecified
   private var resolvedStyleCacheDensity: Density? = null
+
+  internal val resolvedStyleCacheDensityForTest: Density?
+    get() = resolvedStyleCacheDensity
+
   private var resolvedStyleCacheLayoutDirection: LayoutDirection? = null
 
   private var geometrySnapshotObserver: SnapshotStateObserver? = null

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -12,24 +12,18 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.referentialEqualityPolicy
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateObserver
-import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.geometry.center
 import androidx.compose.ui.geometry.takeOrElse
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.input.pointer.PointerEvent
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.roundToIntSize
 import androidx.compose.ui.unit.takeOrElse
 import dev.chrisbanes.haze.Bitmask
 import dev.chrisbanes.haze.ExperimentalHazeApi
@@ -38,94 +32,32 @@ import dev.chrisbanes.haze.HazeLogger
 import dev.chrisbanes.haze.InteractiveVisualEffect
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.RetainedOutputVisualEffect
-import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
-import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.VisualEffect
 import dev.chrisbanes.haze.VisualEffectContext
-import dev.chrisbanes.haze.VisualEffectTransform
-import dev.chrisbanes.haze.trace
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.yield
-
-private class GlassPreparedRenderCacheKey(
-  val style: ResolvedGlassStyle,
-  val coordinates: GlassCoordinates,
-  val interaction: ResolvedGlassInteraction,
-  val interactionTopology: GlassInteractionTopology,
-)
-
-private class GlassRenderBudgetCacheKey(
-  val style: ResolvedGlassStyle,
-  val requestedScale: Float,
-  val layerSize: Size,
-  val materialSize: Size,
-  val interactionTopology: GlassInteractionTopology,
-  val interactionRadiusFraction: Float,
-)
-
-private class GlassPreparedDrawCacheKey(
-  val dirtyTrackerVersion: Int,
-  val size: Size,
-  val layerSize: Size,
-  val layerOffset: Offset,
-  val inputScale: HazeInputScale,
-  val density: Density,
-  val layoutDirection: LayoutDirection,
-  val style: ResolvedGlassStyle?,
-  val interactionState: GlassInteractionRenderState,
-  val interactionTopology: GlassInteractionTopology,
-)
-
-private fun ResolvedGlassStyle.hasSameRenderParams(other: ResolvedGlassStyle): Boolean =
-  resolvedOptics == other.resolvedOptics &&
-    specularIntensity == other.specularIntensity &&
-    ambientResponse == other.ambientResponse &&
-    tint == other.tint &&
-    edgeSoftnessPx == other.edgeSoftnessPx &&
-    lightPosition == other.lightPosition &&
-    chromaticAberrationStrength == other.chromaticAberrationStrength &&
-    surfaceProfile == other.surfaceProfile &&
-    chromaticAberrationMode == other.chromaticAberrationMode &&
-    contrast == other.contrast &&
-    whitePoint == other.whitePoint &&
-    chromaMultiplier == other.chromaMultiplier &&
-    contentNormalBlend == other.contentNormalBlend &&
-    specularExponent == other.specularExponent &&
-    fresnelExponent == other.fresnelExponent &&
-    cornerRadii == other.cornerRadii
-
-private fun ResolvedGlassStyle.hasSameBudgetParams(other: ResolvedGlassStyle): Boolean =
-  requiresGlassGroupAlpha(alpha) == requiresGlassGroupAlpha(other.alpha) &&
-    resolvedOptics.blurRadiusPx == other.resolvedOptics.blurRadiusPx &&
-    resolvedOptics.depth == other.resolvedOptics.depth &&
-    (resolvedOptics.progressive == null) == (other.resolvedOptics.progressive == null) &&
-    resolvedOptics.refractionStrength == other.resolvedOptics.refractionStrength &&
-    resolvedOptics.refractionScalePx == other.resolvedOptics.refractionScalePx &&
-    resolvedOptics.refractionHeightPx == other.resolvedOptics.refractionHeightPx &&
-    resolvedOptics.refractionDetailIntensity == other.resolvedOptics.refractionDetailIntensity &&
-    chromaticAberrationStrength == other.chromaticAberrationStrength &&
-    edgeSoftnessPx == other.edgeSoftnessPx &&
-    (specularIntensity > 0f) == (other.specularIntensity > 0f)
-
-private val IdleInteractionState = GlassInteractionRenderState(Offset.Zero)
-private val IdleInteractionSignals = GlassInteractionSignals()
+import dev.chrisbanes.haze.VisualEffectRendererFactory
 
 /**
- * A [VisualEffect] implementation that renders a translucent refractive glass material with
- * refraction, depth layering, specular highlights, and a soft tint.
+ * Shareable Glass compatibility configuration.
  *
- * Use one instance per `hazeEffect` node. A Glass effect retains node-specific layers and
- * interaction state, so sharing an instance between nodes is unsupported. Use the
- * `GlassVisualEffect(other)` copy constructor to duplicate configuration for another node.
+ * Each attached `hazeEffect` node materializes and owns an internal renderer. This object stores
+ * only caller configuration and may be reused by multiple nodes.
  */
 @ExperimentalHazeApi
 @Stable
 @OptIn(InternalHazeApi::class)
-public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, InteractiveVisualEffect {
-
+@Suppress("ktlint:standard:property-naming")
+public class GlassVisualEffect() :
+  VisualEffect,
+  InteractiveVisualEffect,
+  RetainedOutputVisualEffect,
+  VisualEffectRendererFactory,
+  GlassStyleConfiguration {
   /** Creates a new [GlassVisualEffect] copying all properties from [other]. */
   public constructor(other: GlassVisualEffect) : this() {
+    copyConfigurationFrom(other)
+  }
+
+  private fun copyConfigurationFrom(other: GlassVisualEffect) {
     _optics = other._optics
     _specularIntensity = other._specularIntensity
     _ambientResponse = other._ambientResponse
@@ -149,96 +81,149 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
     hoveredSlot = other.hoveredSlot
     focusedSlot = other.focusedSlot
     pressedSlot = other.pressedSlot
-    interactionSource = other.interactionSource
-    interactionLightRadiusFraction = other.interactionLightRadiusFraction
-    interactionTransformTarget = other.interactionTransformTarget
-    interactionTransformPivot = other.interactionTransformPivot
-    interactionPositionAnimationSpec = other.interactionPositionAnimationSpec
-    interactionReducedMotionPolicy = other.interactionReducedMotionPolicy
+    _interactionSource = other._interactionSource
+    _interactionLightRadiusFraction = other._interactionLightRadiusFraction
+    _interactionTransformTarget = other._interactionTransformTarget
+    _interactionTransformPivot = other._interactionTransformPivot
+    _interactionPositionAnimationSpec = other._interactionPositionAnimationSpec
+    _interactionReducedMotionPolicy = other._interactionReducedMotionPolicy
+    runtimeEffectFactory = other.runtimeEffectFactory
     refreshInteractionSnapshots()
   }
 
-  private var isAttached: Boolean = false
-
-  private var attachedContext: VisualEffectContext? = null
-
-  private var interactionController: GlassInteractionController? = null
-
-  internal val interactionControllerForTest: GlassInteractionController?
-    get() = interactionController
-
-  internal val attachedContextForTest: VisualEffectContext?
-    get() = attachedContext
-
-  internal val currentInteractionState: GlassInteractionRenderState
-    get() = interactionController?.renderState ?: IdleInteractionState
-
-  internal val currentInteractionSignals: GlassInteractionSignals
-    get() = interactionController?.currentSignals ?: IdleInteractionSignals
-
-  private var needsDelegateSelection: Boolean = true
-
-  internal var runtimeEffectFactory: GlassRuntimeEffectFactory = PlatformGlassRuntimeEffectFactory
-
-  internal var runtimeShaderIncompatible: Boolean = false
+  internal var configurationRevision: Int by mutableIntStateOf(0)
     private set
 
-  internal var preparedRenderBudget: GlassRenderBudgetDecision =
-    GlassRenderBudgetDecision.Fallback(GlassRenderBudgetFallbackReason.InvalidGeometry)
-    private set
+  private val configurationFieldVersions = IntArray(Int.SIZE_BITS)
+  internal var onConfigurationChanged: ((Int) -> Unit)? = null
+  internal var trackConfigurationVersions: Boolean = true
 
-  internal var preparedRender: GlassPreparedRender? = null
-    private set
+  internal fun configurationFieldVersions(): IntArray = configurationFieldVersions.copyOf()
 
-  private var preparedRenderCacheKey: GlassPreparedRenderCacheKey? = null
-  private var preparedRenderCache: GlassPreparedRender? = null
+  internal fun synchronizeConfigurationFrom(
+    other: GlassVisualEffect,
+    changedFields: Int,
+  ) {
+    val callback = onConfigurationChanged
+    onConfigurationChanged = null
+    try {
+      if (changedFields and GlassDirtyFields.Optics != 0) _optics = other._optics
+      if (changedFields and GlassDirtyFields.SpecularIntensity != 0) {
+        _specularIntensity = other._specularIntensity
+      }
+      if (changedFields and GlassDirtyFields.AmbientResponse != 0) {
+        _ambientResponse = other._ambientResponse
+      }
+      if (changedFields and GlassDirtyFields.Tint != 0) _tint = other._tint
+      if (changedFields and GlassDirtyFields.EdgeSoftness != 0) {
+        _edgeSoftness = other._edgeSoftness
+      }
+      if (changedFields and GlassDirtyFields.LightPosition != 0) {
+        _lightPosition = other._lightPosition
+      }
+      if (changedFields and GlassDirtyFields.ChromaticAberration != 0) {
+        _chromaticAberrationStrength = other._chromaticAberrationStrength
+      }
+      if (changedFields and GlassDirtyFields.SurfaceProfile != 0) {
+        _surfaceProfile = other._surfaceProfile
+      }
+      if (changedFields and GlassDirtyFields.ChromaticAberrationMode != 0) {
+        _chromaticAberrationMode = other._chromaticAberrationMode
+      }
+      if (changedFields and GlassDirtyFields.Shape != 0) _shape = other._shape
+      if (changedFields and GlassDirtyFields.Alpha != 0) _alpha = other._alpha
+      if (changedFields and GlassDirtyFields.Contrast != 0) _contrast = other._contrast
+      if (changedFields and GlassDirtyFields.WhitePoint != 0) _whitePoint = other._whitePoint
+      if (changedFields and GlassDirtyFields.ChromaMultiplier != 0) {
+        _chromaMultiplier = other._chromaMultiplier
+      }
+      if (changedFields and GlassDirtyFields.ContentNormalBlend != 0) {
+        _contentNormalBlend = other._contentNormalBlend
+      }
+      if (changedFields and GlassDirtyFields.SpecularExponent != 0) {
+        _specularExponent = other._specularExponent
+      }
+      if (changedFields and GlassDirtyFields.FresnelExponent != 0) {
+        _fresnelExponent = other._fresnelExponent
+      }
+      if (changedFields and GlassDirtyFields.Style != 0) style = other.style
+      if (changedFields and GlassDirtyFields.Interaction != 0) {
+        nextInteractionRevision = other.nextInteractionRevision
+        hoveredSlot = other.hoveredSlot
+        focusedSlot = other.focusedSlot
+        pressedSlot = other.pressedSlot
+        _interactionSource = other._interactionSource
+        _interactionLightRadiusFraction = other._interactionLightRadiusFraction
+        _interactionTransformTarget = other._interactionTransformTarget
+        _interactionTransformPivot = other._interactionTransformPivot
+        _interactionPositionAnimationSpec = other._interactionPositionAnimationSpec
+        _interactionReducedMotionPolicy = other._interactionReducedMotionPolicy
+        refreshInteractionSnapshots()
+      }
+      if (changedFields and GlassDirtyFields.RuntimeEffectFactory != 0) {
+        runtimeEffectFactory = other.runtimeEffectFactory
+      }
+    } finally {
+      onConfigurationChanged = callback
+    }
+  }
 
-  private var budgetCacheKey: GlassRenderBudgetCacheKey? = null
-  private var budgetCacheDecision: GlassRenderBudgetDecision? = null
-
-  private var preparedDrawCacheKey: GlassPreparedDrawCacheKey? = null
-
-  private var dirtyTrackerVersion: Int by mutableIntStateOf(0)
   internal var dirtyTracker: Bitmask = Bitmask()
     private set
 
-  private var resolvedStyleCache: ResolvedGlassStyle? = null
-  private var resolvedStyleCacheSize: Size = Size.Unspecified
-  private var resolvedStyleCacheDensity: Density? = null
-  private var resolvedStyleCacheLayoutDirection: LayoutDirection? = null
-
-  private var geometrySnapshotObserver: SnapshotStateObserver? = null
-  private var geometryObserverGeneration: Int = 0
-  private var geometryInvalidationJob: Job? = null
-  private val styleObservationScope = Any()
-  private val clipObservationScope = Any()
-  private val onObservedStyleChanged: (Any) -> Unit = {
-    scheduleObservedStyleInvalidation()
+  internal fun resetDirtyTracker() {
+    dirtyTracker = Bitmask()
   }
 
-  private var coordinatesCache: GlassCoordinates? = null
-  private var coordinatesCacheLayerSize: Size = Size.Unspecified
-  private var coordinatesCacheLayerOffset: Offset = Offset.Unspecified
-  private var coordinatesCacheMaterialSize: Size = Size.Unspecified
-  private var coordinatesCacheScaleFactor: Float = Float.NaN
+  internal var runtimeEffectFactory: GlassRuntimeEffectFactory = PlatformGlassRuntimeEffectFactory
+    set(value) {
+      if (field !== value) {
+        field = value
+        markDirty(GlassDirtyFields.RuntimeEffectFactory)
+      }
+    }
 
-  private var interactionRenderStateCache: GlassInteractionRenderState? = null
-  private var interactionRadiusFractionCache: Float = Float.NaN
-  private var resolvedInteractionCache: ResolvedGlassInteraction? = null
-  private var idleInteractionRenderStateSize: Size = Size.Unspecified
-  private var idleInteractionRenderState: GlassInteractionRenderState = IdleInteractionState
+  internal val rendererCacheKey: Any by lazy(LazyThreadSafetyMode.NONE) { Any() }
 
-  private var shouldClipToNodeBoundsCacheValid: Boolean = false
-  private var shouldClipToNodeBoundsCache: Boolean = false
+  override fun createRenderer(): VisualEffect = GlassRendererCache.acquire(this)
 
-  private val renderPreparation = GlassRenderPreparation(
-    decision = GlassRenderBudgetDecision.Fallback(
-      GlassRenderBudgetFallbackReason.InvalidGeometry,
-    ),
-    prepared = null,
-  )
+  override fun DrawScope.draw(context: VisualEffectContext): Unit = Unit
 
-  private var nextInteractionRevision: Long = 0L
+  override fun onPointerEvent(event: PointerEvent, context: VisualEffectContext): Unit = Unit
+
+  override fun onCancelPointerInput(context: VisualEffectContext): Unit = Unit
+
+  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean = false
+
+  override fun clearRetainedOutput(): Unit = Unit
+
+  override fun shouldClipToNodeBounds(): Boolean =
+    edgeSoftness > 0.dp || !shape.hasZeroCornerRadii()
+
+  override fun shouldPreferClipToAreaBounds(): Boolean = !shouldClipToNodeBounds()
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
+    val resolvedStyle = resolveGlassStyle(
+      effect = this,
+      materialSizePx = rect.size,
+      density = density,
+      layoutDirection = LayoutDirection.Ltr,
+    )
+    val resolved = resolvedStyle.resolvedOptics
+    val paddingPx = calculateGlassSamplePaddingPx(
+      blurRadiusPx = if (resolved.depth <= 0f) 0f else resolved.blurRadiusPx,
+      refractionScale = resolved.refractionScalePx,
+      refractionStrength = (
+        resolved.refractionStrength * maximumInteractionRefractionMultiplier()
+        ).coerceIn(0f, 1f),
+      chromaticAberrationStrength = resolvedStyle.chromaticAberrationStrength,
+      edgeSoftnessPx = resolvedStyle.edgeSoftnessPx,
+      foregroundOutsetPx = 0f,
+    )
+    return rect.inflate(paddingPx)
+  }
+
+  internal var nextInteractionRevision: Long = 0L
 
   internal var hoveredSlot: GlassInteractionSlot? by mutableStateOf(null)
     private set
@@ -250,11 +235,19 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
     private set
 
   private var interactionSlotsSnapshot: GlassInteractionSlots = GlassInteractionSlots()
-  private var interactionTopologySnapshot: GlassInteractionTopology =
-    interactionSlotsSnapshot.resolveInteractionTopology()
+  private var currentInteractionTopology = interactionSlotsSnapshot.resolveInteractionTopology()
 
-  internal val interactionSlots: GlassInteractionSlots
+  internal val resolvedInteractionSlots: GlassInteractionSlots
     get() = interactionSlotsSnapshot
+
+  internal val resolvedInteractionTopology: GlassInteractionTopology
+    get() = currentInteractionTopology
+
+  internal fun resolveInputScaleFactor(scale: HazeInputScale): Float = when {
+    scale === HazeInputScale.Auto -> 0.75f
+    scale is HazeInputScale.Fixed -> scale.scale
+    else -> 1f
+  }
 
   private class InteractionSlotTransaction(effect: GlassVisualEffect) {
     var hovered: GlassInteractionResponse? = effect.hoveredSlot?.response
@@ -267,7 +260,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
   override val observesPointerEvents: Boolean
     get() = hoveredSlot != null || pressedSlot != null
 
-  private var _interactionSource: InteractionSource? by mutableStateOf(
+  internal var _interactionSource: InteractionSource? by mutableStateOf(
     null,
     referentialEqualityPolicy(),
   )
@@ -282,7 +275,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       }
     }
 
-  private var _interactionLightRadiusFraction: Float by mutableStateOf(
+  internal var _interactionLightRadiusFraction: Float by mutableStateOf(
     GlassDefaults.interactionLightRadiusFraction,
   )
 
@@ -299,7 +292,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       }
     }
 
-  private var _interactionTransformTarget: GlassTransformTarget by mutableStateOf(
+  internal var _interactionTransformTarget: GlassTransformTarget by mutableStateOf(
     GlassTransformTarget.MaterialOnly,
   )
 
@@ -313,7 +306,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       }
     }
 
-  private var _interactionTransformPivot: GlassTransformPivot by mutableStateOf(
+  internal var _interactionTransformPivot: GlassTransformPivot by mutableStateOf(
     GlassTransformPivot.Pointer,
   )
 
@@ -327,7 +320,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       }
     }
 
-  private var _interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> by mutableStateOf(
+  internal var _interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> by mutableStateOf(
     GlassDefaults.positionAnimationSpec,
   )
 
@@ -341,7 +334,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       }
     }
 
-  private var _interactionReducedMotionPolicy: GlassReducedMotionPolicy by mutableStateOf(
+  internal var _interactionReducedMotionPolicy: GlassReducedMotionPolicy by mutableStateOf(
     GlassReducedMotionPolicy.System,
   )
 
@@ -471,9 +464,6 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
     ) {
       markDirty(GlassDirtyFields.InteractionLayerBounds)
     }
-    if (hoveredSlot == null && focusedSlot == null && pressedSlot == null) {
-      attachedContext?.let(::syncInteractionController)
-    }
   }
 
   private fun refreshInteractionSnapshots() {
@@ -484,7 +474,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
     )
     if (slots != interactionSlotsSnapshot) {
       interactionSlotsSnapshot = slots
-      interactionTopologySnapshot = slots.resolveInteractionTopology()
+      currentInteractionTopology = slots.resolveInteractionTopology()
     }
   }
 
@@ -529,646 +519,10 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
     }
   }
 
-  internal var delegate: Delegate = FallbackGlassDelegate(this)
-    set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "delegate changed. Current $field. New: $value" }
-        val old = field
-        field = value
-        if (isAttached) {
-          old.detach()
-          value.attach()
-        }
-      }
-    }
-
-  override fun attach(context: VisualEffectContext) {
-    if (!isAttached) {
-      isAttached = true
-      attachedContext = context
-      val observerGeneration = ++geometryObserverGeneration
-      geometrySnapshotObserver = SnapshotStateObserver { command ->
-        context.coroutineScope.launch {
-          if (
-            isAttached &&
-            attachedContext === context &&
-            geometryObserverGeneration == observerGeneration
-          ) {
-            command()
-          }
-        }
-      }.also { it.start() }
-      resolvedStyleCache = null
-      shouldClipToNodeBoundsCacheValid = false
-      syncInteractionController(context)
-      delegate.attach()
-    }
-  }
-
-  override fun detach(context: VisualEffectContext) {
-    if (isAttached) {
-      interactionController?.dispose()
-      interactionController = null
-      geometryObserverGeneration++
-      geometryInvalidationJob?.cancel()
-      geometryInvalidationJob = null
-      geometrySnapshotObserver?.stop()
-      geometrySnapshotObserver = null
-      attachedContext = null
-      isAttached = false
-      delegate.detach()
-    }
-    runtimeShaderIncompatible = false
-    needsDelegateSelection = true
-    preparedRender = null
-    clearPreparedRenderCache()
-  }
-
-  private fun scheduleObservedStyleInvalidation() {
-    if (geometryInvalidationJob?.isActive == true) return
-    val context = attachedContext ?: return
-    val observerGeneration = geometryObserverGeneration
-    geometryInvalidationJob = context.coroutineScope.launch {
-      yield()
-      if (
-        isAttached &&
-        attachedContext === context &&
-        geometryObserverGeneration == observerGeneration
-      ) {
-        resolvedStyleCache = null
-        shouldClipToNodeBoundsCacheValid = false
-        context.invalidateLayerBounds()
-        context.invalidateDraw()
-      }
-    }
-  }
-
-  override fun update(context: VisualEffectContext) {
-    dirtyTrackerVersion
-    compositionLocalStyle = context.currentValueOf(LocalGlassStyle)
-    syncInteractionController(context)
-
-    if (dirtyTracker.any(GlassDirtyFields.LayerBoundsFlags)) {
-      context.invalidateLayerBounds()
-    }
-    if (dirtyTracker.any(GlassDirtyFields.InvalidateFlags)) {
-      needsDelegateSelection = true
-      context.invalidateDraw()
-    }
-  }
-
-  override fun onPointerEvent(event: PointerEvent, context: VisualEffectContext) {
-    interactionController?.onPointerEvent(event, context.size)
-  }
-
-  override fun onCancelPointerInput(context: VisualEffectContext) {
-    interactionController?.cancelPointerInput(context.size)
-  }
-
-  internal fun setPressedForTest(position: Offset, pressed: Boolean = true) {
-    val context = attachedContext ?: return
-    interactionController?.setRawPressedForTest(pressed, position, context.size)
-  }
-
-  override fun DrawScope.prepareDraw(context: VisualEffectContext) {
-    trace(GlassTraceSection.Prepare) {
-      if (canReusePreparedDraw(context)) return@trace
-      val previousBudget = preparedRenderBudget
-      trace(GlassTraceSection.PrepareBudget) {
-        prepareRenderBudget(context, runtimeShaderSupported = isRuntimeShaderGlassSupported())
-      }
-      if (previousBudget::class != preparedRenderBudget::class) {
-        needsDelegateSelection = true
-      }
-      trace(GlassTraceSection.SelectDelegate) {
-        selectDelegateForDraw(context)
-      }
-      trace(GlassTraceSection.DelegatePrepare) {
-        val selectedDelegate = delegate
-        try {
-          with(selectedDelegate) { prepareDraw(context) }
-        } catch (failure: RuntimeShaderRenderEffectException) {
-          if (selectedDelegate !is RuntimeShaderGlassDelegate) throw failure
-          downgradeRuntimeDelegate(selectedDelegate, context, failure)
-        }
-      }
-      cachePreparedDrawInputs(context)
-    }
-  }
-
-  private fun canReusePreparedDraw(context: VisualEffectContext): Boolean {
-    val key = preparedDrawCacheKey ?: return false
-    val style = resolvedStyleCache ?: return false
-    val interactionState = interactionRenderState(context)
-    return preparedRender != null &&
-      (delegate as? RetainedOutputDelegate)?.canDrawRetainedOutput() == true &&
-      key.dirtyTrackerVersion == dirtyTrackerVersion &&
-      key.size == context.size &&
-      key.layerSize == context.layerSize &&
-      key.layerOffset == context.layerOffset &&
-      key.inputScale == context.inputScale &&
-      key.density == context.requireDensity() &&
-      key.layoutDirection == context.currentValueOf(LocalLayoutDirection) &&
-      key.style === style &&
-      key.interactionState === interactionState &&
-      key.interactionTopology === interactionTopologySnapshot
-  }
-
-  private fun cachePreparedDrawInputs(context: VisualEffectContext) {
-    preparedDrawCacheKey = GlassPreparedDrawCacheKey(
-      dirtyTrackerVersion = dirtyTrackerVersion,
-      size = context.size,
-      layerSize = context.layerSize,
-      layerOffset = context.layerOffset,
-      inputScale = context.inputScale,
-      density = context.requireDensity(),
-      layoutDirection = context.currentValueOf(LocalLayoutDirection),
-      style = resolvedStyleCache,
-      interactionState = interactionRenderState(context),
-      interactionTopology = interactionTopologySnapshot,
-    )
-  }
-
-  override fun DrawScope.draw(context: VisualEffectContext) {
-    try {
-      selectDelegateForDraw(context)
-      val selectedDelegate = delegate
-      try {
-        withMaterialTransform(context) {
-          with(selectedDelegate) { draw(context) }
-        }
-      } catch (failure: RuntimeShaderRenderEffectException) {
-        if (selectedDelegate !is RuntimeShaderGlassDelegate) throw failure
-        downgradeRuntimeDelegate(selectedDelegate, context, failure)
-      }
-    } finally {
-      resetDirtyTracker()
-    }
-  }
-
-  private fun DrawScope.downgradeRuntimeDelegate(
-    runtimeDelegate: RuntimeShaderGlassDelegate,
-    context: VisualEffectContext,
-    failure: RuntimeShaderRenderEffectException,
-  ) {
-    runtimeDelegate.releaseAfterConstructionFailure()
-    runtimeShaderIncompatible = true
-    HazeLogger.d(TAG) {
-      "Runtime shader construction failed; using fallback until reattachment: $failure"
-    }
-    delegate = FallbackGlassDelegate(this@GlassVisualEffect)
-    with(delegate) { prepareDraw(context) }
-    context.invalidateDraw()
-  }
-
-  override fun DrawScope.drawForeground(context: VisualEffectContext) {
-    withMaterialTransform(context) {
-      with(delegate) { drawForeground(context) }
-    }
-  }
-
-  override fun currentContentTransform(context: VisualEffectContext): VisualEffectTransform {
-    return resolveTransform(context, GlassTransformTarget.MaterialAndContent)
-  }
-
-  internal fun currentMaterialTransform(context: VisualEffectContext): VisualEffectTransform {
-    return resolveTransform(context, GlassTransformTarget.MaterialOnly)
-  }
-
-  override fun shouldDrawContentBehind(context: VisualEffectContext): Boolean {
-    return delegate is FallbackGlassDelegate
-  }
-
-  internal fun controllerConfiguration(
-    systemMotionScale: Float,
-  ): GlassInteractionControllerConfiguration {
-    val (reduced, forceFull) = reducedMotion(
-      policy = interactionReducedMotionPolicy,
-      systemScale = systemMotionScale,
-    )
-    return GlassInteractionControllerConfiguration(
-      slots = interactionSlots,
-      positionAnimationSpec = interactionPositionAnimationSpec,
-      reducedMotion = reduced,
-      forceFullMotion = forceFull,
-    )
-  }
-
-  internal fun interactionRenderState(context: VisualEffectContext): GlassInteractionRenderState {
-    interactionController?.let { return it.renderState }
-    if (idleInteractionRenderStateSize != context.size) {
-      idleInteractionRenderStateSize = context.size
-      idleInteractionRenderState = GlassInteractionRenderState(position = context.size.center)
-    }
-    return idleInteractionRenderState
-  }
-
-  private fun resolveTransform(
-    context: VisualEffectContext,
-    target: GlassTransformTarget,
-  ): VisualEffectTransform {
-    if (interactionTransformTarget != target) return VisualEffectTransform.Identity
-    val state = currentInteractionState
-    val size = context.size
-    if (!state.hasTransform || !size.isDrawable()) return VisualEffectTransform.Identity
-    val pivot = when (interactionTransformPivot) {
-      GlassTransformPivot.Pointer -> state.position.clampTo(size)
-      GlassTransformPivot.Center -> size.center
-    }
-    return VisualEffectTransform(state.scaleX, state.scaleY, pivot)
-  }
-
-  private inline fun DrawScope.withMaterialTransform(
-    context: VisualEffectContext,
-    block: DrawScope.() -> Unit,
-  ) {
-    val transform = currentMaterialTransform(context)
-    if (transform == VisualEffectTransform.Identity) {
-      block()
-    } else {
-      scale(
-        scaleX = transform.scaleX,
-        scaleY = transform.scaleY,
-        pivot = transform.pivot,
-        block = block,
-      )
-    }
-  }
-
-  private fun syncInteractionController(context: VisualEffectContext) {
-    if (hoveredSlot == null && focusedSlot == null && pressedSlot == null) {
-      val controller = interactionController ?: return
-      controller.dispose()
-      interactionController = null
-      context.invalidateDraw()
-      return
-    }
-    val controller = interactionController ?: GlassInteractionController(context).also {
-      interactionController = it
-    }
-    controller.updateConfiguration(controllerConfiguration(systemMotionScale(context)))
-    controller.updateInteractionSource(interactionSource, context.size)
-  }
-
-  private fun systemMotionScale(context: VisualEffectContext): Float {
-    return context.coroutineScope.coroutineContext[MotionDurationScale]?.scaleFactor ?: 1f
-  }
-
-  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
-    delegate.onTrimMemory(context, level)
-  }
-
-  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean {
-    return (delegate as? RetainedOutputDelegate)?.canDrawRetainedOutput() == true
-  }
-
-  override fun shouldDrawRetainedOutput(context: VisualEffectContext): Boolean {
-    return (delegate as? RetainedOutputDelegate)?.shouldDrawRetainedOutput() == true
-  }
-
-  override fun clearRetainedOutput() {
-    (delegate as? RetainedOutputDelegate)?.clearRetainedOutput()
-  }
-
-  override fun shouldClipToNodeBounds(): Boolean {
-    if (!shouldClipToNodeBoundsCacheValid) {
-      val observer = geometrySnapshotObserver
-      if (observer != null) {
-        observer.observeReads(clipObservationScope, onObservedStyleChanged) {
-          shouldClipToNodeBoundsCache = edgeSoftness > 0.dp || !shape.hasZeroCornerRadii()
-        }
-      } else {
-        shouldClipToNodeBoundsCache = edgeSoftness > 0.dp || !shape.hasZeroCornerRadii()
-      }
-      shouldClipToNodeBoundsCacheValid = true
-    }
-    return shouldClipToNodeBoundsCache
-  }
-
-  internal fun resolveInputScaleFactor(scale: HazeInputScale): Float = when {
-    scale === HazeInputScale.Auto -> 0.75f
-    scale is HazeInputScale.Fixed -> scale.scale
-    else -> 1f
-  }
-
-  internal fun resolveGlassRenderBudget(context: VisualEffectContext): GlassRenderBudgetDecision {
-    return resolveGlassRenderPreparation(context, runtimeShaderSupported = true).decision
-  }
-
-  private fun resolvePreparedStyle(context: VisualEffectContext): ResolvedGlassStyle {
-    val density = context.requireDensity()
-    val layoutDirection = context.currentValueOf(LocalLayoutDirection)
-    resolvedStyleCache?.takeIf {
-      resolvedStyleCacheSize == context.size &&
-        resolvedStyleCacheDensity == density &&
-        resolvedStyleCacheLayoutDirection == layoutDirection
-    }?.let { return it }
-
-    val resolvedStyle = geometrySnapshotObserver?.let { observer ->
-      lateinit var observedStyle: ResolvedGlassStyle
-      observer.observeReads(styleObservationScope, onObservedStyleChanged) {
-        observedStyle = resolveGlassStyle(this, context.size, density, layoutDirection)
-      }
-      observedStyle
-    } ?: resolveGlassStyle(this, context.size, density, layoutDirection)
-
-    return resolvedStyle.also {
-      resolvedStyleCache = it
-      resolvedStyleCacheSize = context.size
-      resolvedStyleCacheDensity = density
-      resolvedStyleCacheLayoutDirection = layoutDirection
-    }
-  }
-
-  private fun resolvePreparedInteraction(
-    context: VisualEffectContext,
-  ): ResolvedGlassInteraction {
-    val state = interactionRenderState(context)
-    resolvedInteractionCache?.takeIf {
-      interactionRenderStateCache === state &&
-        interactionRadiusFractionCache == interactionLightRadiusFraction
-    }?.let { return it }
-
-    return resolveGlassInteraction(
-      state = state,
-      radiusFraction = interactionLightRadiusFraction,
-    ).also {
-      interactionRenderStateCache = state
-      interactionRadiusFractionCache = interactionLightRadiusFraction
-      resolvedInteractionCache = it
-    }
-  }
-
-  private fun resolvePreparedCoordinates(
-    layerSize: Size,
-    layerOffset: Offset,
-    materialSize: Size,
-    scaleFactor: Float,
-  ): GlassCoordinates {
-    coordinatesCache?.takeIf {
-      coordinatesCacheLayerSize == layerSize &&
-        coordinatesCacheLayerOffset == layerOffset &&
-        coordinatesCacheMaterialSize == materialSize &&
-        coordinatesCacheScaleFactor == scaleFactor
-    }?.let { return it }
-
-    return resolveGlassCoordinates(
-      layerSize = layerSize,
-      layerOffset = layerOffset,
-      materialSize = materialSize,
-      scaleFactor = scaleFactor,
-    ).withRoundedSampleSize().also {
-      coordinatesCache = it
-      coordinatesCacheLayerSize = layerSize
-      coordinatesCacheLayerOffset = layerOffset
-      coordinatesCacheMaterialSize = materialSize
-      coordinatesCacheScaleFactor = scaleFactor
-    }
-  }
-
-  private fun resolveGlassRenderPreparation(
-    context: VisualEffectContext,
-    runtimeShaderSupported: Boolean,
-  ): GlassRenderPreparation {
-    val requestedScale = resolveInputScaleFactor(context.inputScale)
-    if (
-      !requestedScale.isFinite() || requestedScale <= 0f ||
-      !context.size.isDrawable() || !context.layerSize.isDrawable()
-    ) {
-      clearPreparedRenderCache()
-      return updateRenderPreparation(
-        GlassRenderBudgetDecision.Fallback(GlassRenderBudgetFallbackReason.InvalidGeometry),
-        null,
-      )
-    }
-    val style = resolvePreparedStyle(context)
-    val interaction = resolvePreparedInteraction(context)
-    val interactionTopology = interactionTopologySnapshot
-    val optics = style.resolvedOptics
-    val budgetKey = budgetCacheKey
-    val decision = if (
-      budgetKey != null &&
-      budgetKey.style.hasSameBudgetParams(style) &&
-      budgetKey.requestedScale == requestedScale &&
-      budgetKey.layerSize == context.layerSize &&
-      budgetKey.materialSize == context.size &&
-      budgetKey.interactionTopology === interactionTopology &&
-      budgetKey.interactionRadiusFraction == interaction.radiusFraction
-    ) {
-      checkNotNull(budgetCacheDecision)
-    } else {
-      val allowMultiscaleBlur = optics.progressive == null
-      resolveGlassRenderBudget(requestedScale) { scaleFactor ->
-        val rawCoordinates = resolveGlassCoordinates(
-          layerSize = context.layerSize,
-          layerOffset = context.layerOffset,
-          materialSize = context.size,
-          scaleFactor = scaleFactor,
-        )
-        if (!rawCoordinates.materialSize.isDrawable() || !rawCoordinates.sampleSize.isDrawable()) {
-          return@resolveGlassRenderBudget GlassRetainedLayerPlan(emptyList())
-        }
-        val coordinates = rawCoordinates.withRoundedSampleSize()
-        if (!coordinates.materialSize.isDrawable() || !coordinates.sampleSize.isDrawable()) {
-          return@resolveGlassRenderBudget GlassRetainedLayerPlan(emptyList())
-        }
-        val outputSize = context.size.roundToIntSize()
-        val interactionPatchSize = calculateGlassInteractionPatchSize(
-          buildGlassRenderParams(style, coordinates),
-          radiusFraction = interaction.radiusFraction,
-          topology = interactionTopology,
-        )
-        val interactionLayersActive =
-          interactionPatchSize.width > 0 && interactionPatchSize.height > 0
-        buildGlassBudgetLayerPlan(
-          sampleSize = coordinates.sampleSize.roundToIntSize(),
-          groupCompositeSize = resolveGlassGroupCompositeSize(
-            outputSize = outputSize,
-            alpha = style.alpha,
-            interactionLayersActive = interactionLayersActive,
-            interactionTopology = interactionTopology,
-          ),
-          blurRadiusPx = optics.blurRadiusPx * scaleFactor,
-          depth = optics.depth,
-          allowMultiscaleBlur = allowMultiscaleBlur,
-          refractionDetailActive = isGlassRefractionDetailActive(
-            refractionStrength = optics.refractionStrength,
-            refractionScalePx = optics.refractionScalePx * scaleFactor,
-            refractionHeightPx = optics.refractionHeightPx * scaleFactor,
-            edgeSoftnessPx = style.edgeSoftnessPx * scaleFactor,
-            sampleStepPx = 2f * scaleFactor,
-            detailIntensity = optics.refractionDetailIntensity,
-          ),
-          rimActive = style.specularIntensity > 0f,
-          interactionPatchSize = interactionPatchSize,
-          interactionOpticsActive = interactionTopology.hasOptics,
-          interactionLightingActive = interactionTopology.hasLighting,
-        )
-      }.also { resolvedDecision ->
-        budgetCacheKey = GlassRenderBudgetCacheKey(
-          style = style,
-          requestedScale = requestedScale,
-          layerSize = context.layerSize,
-          materialSize = context.size,
-          interactionTopology = interactionTopology,
-          interactionRadiusFraction = interaction.radiusFraction,
-        )
-        budgetCacheDecision = resolvedDecision
-      }
-    }
-    if (decision !is GlassRenderBudgetDecision.Runtime) {
-      clearPreparedRenderCache()
-      return updateRenderPreparation(decision, null)
-    }
-    if (!runtimeShaderSupported) {
-      return updateRenderPreparation(decision, null)
-    }
-    val coordinates = resolvePreparedCoordinates(
-      layerSize = context.layerSize,
-      layerOffset = context.layerOffset,
-      materialSize = context.size,
-      scaleFactor = decision.scaleFactor,
-    )
-    val preparedCacheKey = preparedRenderCacheKey
-    if (
-      preparedCacheKey != null &&
-      style === preparedCacheKey.style &&
-      coordinates === preparedCacheKey.coordinates &&
-      interaction === preparedCacheKey.interaction &&
-      interactionTopology === preparedCacheKey.interactionTopology
-    ) {
-      return updateRenderPreparation(decision, checkNotNull(preparedRenderCache))
-    }
-    val previousStyle = preparedCacheKey?.style
-    val previousCoordinates = preparedCacheKey?.coordinates
-    val previousInteraction = preparedCacheKey?.interaction
-    val previousPrepared = preparedRenderCache
-    val params = if (
-      previousStyle != null && previousCoordinates != null && previousPrepared != null &&
-      coordinates === previousCoordinates &&
-      style.hasSameRenderParams(previousStyle)
-    ) {
-      previousPrepared.params
-    } else {
-      buildGlassRenderParams(style, coordinates)
-    }
-    val interactionUniforms = if (
-      previousCoordinates != null && previousInteraction != null && previousPrepared != null &&
-      coordinates === previousCoordinates &&
-      interaction === previousInteraction
-    ) {
-      previousPrepared.interactionUniforms
-    } else {
-      interaction.uniforms(coordinates)
-    }
-    val exactPrepared = buildGlassPreparedRender(
-      params = params,
-      interactionUniforms = interactionUniforms,
-      interactionTopology = interactionTopology,
-      interactionRadiusFraction = interaction.radiusFraction,
-      alpha = style.alpha,
-      outputSize = context.size.roundToIntSize(),
-      previous = previousPrepared,
-    )
-    if (!exactPrepared.plan.fitsGlassRenderBudget()) {
-      val fallback = GlassRenderBudgetDecision.Fallback(
-        GlassRenderBudgetFallbackReason.ExceedsLimits,
-      )
-      budgetCacheDecision = fallback
-      clearPreparedRenderCache()
-      return updateRenderPreparation(fallback, null)
-    }
-    val validatedDecision = if (decision.plan == exactPrepared.plan) {
-      decision
-    } else {
-      GlassRenderBudgetDecision.Runtime(decision.scaleFactor, exactPrepared.plan)
-        .also { budgetCacheDecision = it }
-    }
-    val prepared = if (exactPrepared.plan === validatedDecision.plan) {
-      exactPrepared
-    } else {
-      exactPrepared.copy(plan = validatedDecision.plan)
-    }
-    preparedRenderCacheKey = GlassPreparedRenderCacheKey(
-      style = style,
-      coordinates = coordinates,
-      interaction = interaction,
-      interactionTopology = interactionTopology,
-    )
-    preparedRenderCache = prepared
-    return updateRenderPreparation(validatedDecision, prepared)
-  }
-
-  private fun updateRenderPreparation(
-    decision: GlassRenderBudgetDecision,
-    prepared: GlassPreparedRender?,
-  ): GlassRenderPreparation {
-    renderPreparation.decision = decision
-    renderPreparation.prepared = prepared
-    return renderPreparation
-  }
-
-  private fun clearPreparedRenderCache() {
-    preparedRenderCacheKey = null
-    preparedRenderCache = null
-  }
-
-  internal fun prepareRenderBudget(
-    context: VisualEffectContext,
-    runtimeShaderSupported: Boolean,
-  ): GlassRenderBudgetDecision {
-    val previousBudget = preparedRenderBudget
-    val preparation = resolveGlassRenderPreparation(
-      context = context,
-      runtimeShaderSupported = runtimeShaderSupported,
-    )
-    preparedRenderBudget = preparation.decision
-    preparedRender = preparation.prepared
-    if (previousBudget != preparation.decision) {
-      when (val decision = preparation.decision) {
-        is GlassRenderBudgetDecision.Fallback -> HazeLogger.d(TAG) {
-          "Glass render budget selected fallback: ${decision.reason}"
-        }
-        is GlassRenderBudgetDecision.Runtime -> {
-          val requestedScale = resolveInputScaleFactor(context.inputScale)
-          if (decision.scaleFactor < requestedScale) {
-            HazeLogger.d(TAG) {
-              "Glass render budget reduced scale from $requestedScale to ${decision.scaleFactor}"
-            }
-          }
-        }
-      }
-    }
-    return preparation.decision
-  }
-
-  override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
-    val resolvedStyle = resolveGlassStyle(
-      effect = this,
-      materialSizePx = rect.size,
-      density = density,
-      layoutDirection = LayoutDirection.Ltr,
-    )
-    val resolved = resolvedStyle.resolvedOptics
-    val paddingPx = calculateGlassSamplePaddingPx(
-      blurRadiusPx = if (resolved.depth <= 0f) 0f else resolved.blurRadiusPx,
-      refractionScale = resolved.refractionScalePx,
-      refractionStrength = (
-        resolved.refractionStrength * maximumInteractionRefractionMultiplier()
-        ).coerceIn(0f, 1f),
-      chromaticAberrationStrength = resolvedStyle.chromaticAberrationStrength,
-      edgeSoftnessPx = resolvedStyle.edgeSoftnessPx,
-      foregroundOutsetPx = 0f,
-    )
-    return rect.inflate(paddingPx)
-  }
-
-  override fun shouldPreferClipToAreaBounds(): Boolean = !shouldClipToNodeBounds()
-
   private fun maximumInteractionRefractionMultiplier(): Float =
-    interactionTopologySnapshot.maxRefractionMultiplier
+    currentInteractionTopology.maxRefractionMultiplier
 
-  private var _optics: GlassOptics? = null
+  internal var _optics: GlassOptics? = null
 
   /**
    * Complete optical configuration for this effect.
@@ -1176,7 +530,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    * A direct value takes precedence over [style], [LocalGlassStyle], and [GlassDefaults]. Call
    * [clearOpticsOverride] to restore the next complete inherited value.
    */
-  public var optics: GlassOptics
+  override var optics: GlassOptics
     get() = _optics ?: style.optics ?: compositionLocalStyle.optics ?: GlassDefaults.optics
     set(value) {
       if (value != _optics) {
@@ -1207,8 +561,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.specularIntensity] value set in [style], if specified.
    *  - [GlassStyle.specularIntensity] value set in the [LocalGlassStyle] composition local.
    */
-  private var _specularIntensity: Float = Float.NaN
-  public var specularIntensity: Float
+  internal var _specularIntensity: Float = Float.NaN
+  override var specularIntensity: Float
     get() = _specularIntensity
       .takeOrElse { styleLighting.specularIntensity }
       .takeOrElse { localLighting.specularIntensity }
@@ -1231,8 +585,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.ambientResponse] value set in [style], if specified.
    *  - [GlassStyle.ambientResponse] value set in the [LocalGlassStyle] composition local.
    */
-  private var _ambientResponse: Float = Float.NaN
-  public var ambientResponse: Float
+  internal var _ambientResponse: Float = Float.NaN
+  override var ambientResponse: Float
     get() = _ambientResponse
       .takeOrElse { styleLighting.ambientResponse }
       .takeOrElse { localLighting.ambientResponse }
@@ -1255,8 +609,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.tint] value set in [style], if specified.
    *  - [GlassStyle.tint] value set in the [LocalGlassStyle] composition local.
    */
-  private var _tint: Color = Color.Unspecified
-  public var tint: Color
+  internal var _tint: Color = Color.Unspecified
+  override var tint: Color
     get() = _tint
       .takeOrElse { style.tint }
       .takeOrElse { compositionLocalStyle.tint }
@@ -1278,8 +632,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.edgeSoftness] value set in [style], if specified.
    *  - [GlassStyle.edgeSoftness] value set in the [LocalGlassStyle] composition local.
    */
-  private var _edgeSoftness: Dp = Dp.Unspecified
-  public var edgeSoftness: Dp
+  internal var _edgeSoftness: Dp = Dp.Unspecified
+  override var edgeSoftness: Dp
     get() = _edgeSoftness
       .takeOrElse { styleRendering.edgeSoftness }
       .takeOrElse { localRendering.edgeSoftness }
@@ -1304,8 +658,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    * If no value is specified through any of the above, the delegate falls back to the
    * center of the layer at draw time.
    */
-  private var _lightPosition: Offset = Offset.Unspecified
-  public var lightPosition: Offset
+  internal var _lightPosition: Offset = Offset.Unspecified
+  override var lightPosition: Offset
     get() = _lightPosition
       .takeOrElse { styleLighting.lightPosition }
       .takeOrElse { localLighting.lightPosition }
@@ -1326,8 +680,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.chromaticAberrationStrength] value set in [style], if specified.
    *  - [GlassStyle.chromaticAberrationStrength] value set in the [LocalGlassStyle] composition local.
    */
-  private var _chromaticAberrationStrength: Float = Float.NaN
-  public var chromaticAberrationStrength: Float
+  internal var _chromaticAberrationStrength: Float = Float.NaN
+  override var chromaticAberrationStrength: Float
     get() = _chromaticAberrationStrength
       .takeOrElse { styleRendering.chromaticAberrationStrength }
       .takeOrElse { localRendering.chromaticAberrationStrength }
@@ -1352,9 +706,9 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.surfaceProfile] value set in [style], if specified.
    *  - [GlassStyle.surfaceProfile] value set in the [LocalGlassStyle] composition local.
    */
-  private var _surfaceProfile: SurfaceProfile? = null
+  internal var _surfaceProfile: SurfaceProfile? = null
 
-  public var surfaceProfile: SurfaceProfile
+  override var surfaceProfile: SurfaceProfile
     get() = _surfaceProfile ?: styleRendering.surfaceProfile ?: localRendering.surfaceProfile ?: GlassDefaults.surfaceProfile
     set(value) {
       if (value != _surfaceProfile) {
@@ -1385,9 +739,9 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.chromaticAberrationMode] value set in [style], if specified.
    *  - [GlassStyle.chromaticAberrationMode] value set in the [LocalGlassStyle] composition local.
    */
-  private var _chromaticAberrationMode: ChromaticAberrationMode? = null
+  internal var _chromaticAberrationMode: ChromaticAberrationMode? = null
 
-  public var chromaticAberrationMode: ChromaticAberrationMode
+  override var chromaticAberrationMode: ChromaticAberrationMode
     get() = _chromaticAberrationMode ?: styleRendering.chromaticAberrationMode ?: localRendering.chromaticAberrationMode ?: GlassDefaults.chromaticAberrationMode
     set(value) {
       if (value != _chromaticAberrationMode) {
@@ -1418,9 +772,9 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.shape] value set in [style], if specified.
    *  - [GlassStyle.shape] value set in the [LocalGlassStyle] composition local.
    */
-  private var _shape: RoundedCornerShape? = null
+  internal var _shape: RoundedCornerShape? = null
 
-  public var shape: RoundedCornerShape
+  override var shape: RoundedCornerShape
     get() = _shape ?: style.shape ?: compositionLocalStyle.shape ?: GlassDefaults.shape
     set(value) {
       if (value != _shape) {
@@ -1454,8 +808,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.alpha] value set in [style], if specified.
    *  - [GlassStyle.alpha] value set in the [LocalGlassStyle] composition local.
    */
-  private var _alpha: Float = Float.NaN
-  public var alpha: Float
+  internal var _alpha: Float = Float.NaN
+  override var alpha: Float
     get() = _alpha
       .takeOrElse { styleColor.alpha }
       .takeOrElse { localColor.alpha }
@@ -1478,8 +832,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.contrast] value set in [style], if specified.
    *  - [GlassStyle.contrast] value set in the [LocalGlassStyle] composition local.
    */
-  private var _contrast: Float = Float.NaN
-  public var contrast: Float
+  internal var _contrast: Float = Float.NaN
+  override var contrast: Float
     get() = _contrast
       .takeOrElse { styleColor.contrast }
       .takeOrElse { localColor.contrast }
@@ -1502,8 +856,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.whitePoint] value set in [style], if specified.
    *  - [GlassStyle.whitePoint] value set in the [LocalGlassStyle] composition local.
    */
-  private var _whitePoint: Float = Float.NaN
-  public var whitePoint: Float
+  internal var _whitePoint: Float = Float.NaN
+  override var whitePoint: Float
     get() = _whitePoint
       .takeOrElse { styleColor.whitePoint }
       .takeOrElse { localColor.whitePoint }
@@ -1526,8 +880,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.chromaMultiplier] value set in [style], if specified.
    *  - [GlassStyle.chromaMultiplier] value set in the [LocalGlassStyle] composition local.
    */
-  private var _chromaMultiplier: Float = Float.NaN
-  public var chromaMultiplier: Float
+  internal var _chromaMultiplier: Float = Float.NaN
+  override var chromaMultiplier: Float
     get() = _chromaMultiplier
       .takeOrElse { styleColor.chromaMultiplier }
       .takeOrElse { localColor.chromaMultiplier }
@@ -1550,8 +904,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.contentNormalBlend] value set in [style], if specified.
    *  - [GlassStyle.contentNormalBlend] value set in the [LocalGlassStyle] composition local.
    */
-  private var _contentNormalBlend: Float = Float.NaN
-  public var contentNormalBlend: Float
+  internal var _contentNormalBlend: Float = Float.NaN
+  override var contentNormalBlend: Float
     get() = _contentNormalBlend
       .takeOrElse { styleRendering.contentNormalBlend }
       .takeOrElse { localRendering.contentNormalBlend }
@@ -1574,8 +928,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.specularExponent] value set in [style], if specified.
    *  - [GlassStyle.specularExponent] value set in the [LocalGlassStyle] composition local.
    */
-  private var _specularExponent: Float = Float.NaN
-  public var specularExponent: Float
+  internal var _specularExponent: Float = Float.NaN
+  override var specularExponent: Float
     get() = _specularExponent
       .takeOrElse { styleLighting.specularExponent }
       .takeOrElse { localLighting.specularExponent }
@@ -1598,8 +952,8 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - [GlassStyle.fresnelExponent] value set in [style], if specified.
    *  - [GlassStyle.fresnelExponent] value set in the [LocalGlassStyle] composition local.
    */
-  private var _fresnelExponent: Float = Float.NaN
-  public var fresnelExponent: Float
+  internal var _fresnelExponent: Float = Float.NaN
+  override var fresnelExponent: Float
     get() = _fresnelExponent
       .takeOrElse { styleLighting.fresnelExponent }
       .takeOrElse { localLighting.fresnelExponent }
@@ -1623,7 +977,7 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
    *  - Value set here in [style], if specified.
    *  - Value set in the [LocalGlassStyle] composition local.
    */
-  public var style: GlassStyle = GlassStyle.Unspecified
+  override var style: GlassStyle = GlassStyle.Unspecified
     set(value) {
       if (field != value) {
         HazeLogger.d(TAG) { "style changed. Current: $field. New: $value" }
@@ -1649,38 +1003,18 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
       }
     }
 
-  internal interface Delegate {
-    fun attach() = Unit
-    fun DrawScope.prepareDraw(context: VisualEffectContext) = Unit
-    fun DrawScope.draw(context: VisualEffectContext)
-    fun DrawScope.drawForeground(context: VisualEffectContext) = Unit
-    fun detach() = Unit
-    fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) = Unit
-  }
-
-  internal fun resetDirtyTracker() {
-    dirtyTracker = Bitmask()
-  }
-
   private fun markDirty(fields: Int) {
-    val updated = dirtyTracker + fields
-    if (updated != dirtyTracker) {
-      dirtyTracker = updated
-      dirtyTrackerVersion++
+    if (trackConfigurationVersions) {
+      configurationRevision++
+      dirtyTracker += fields
+      configurationFieldVersions.indices.forEach { index ->
+        val field = 1 shl index
+        if (fields and field != 0) {
+          configurationFieldVersions[index]++
+        }
+      }
     }
-    if (fields and GlassDirtyFields.StyleResolutionFlags != 0) {
-      resolvedStyleCache = null
-    }
-    if (fields and GlassDirtyFields.ClipDecisionFlags != 0) {
-      shouldClipToNodeBoundsCacheValid = false
-    }
-  }
-
-  private fun DrawScope.selectDelegateForDraw(context: VisualEffectContext) {
-    if (needsDelegateSelection) {
-      delegate = updateDelegate()
-      needsDelegateSelection = false
-    }
+    onConfigurationChanged?.invoke(fields)
   }
 
   private fun onStyleChanged(old: GlassStyle, new: GlassStyle) {
@@ -1778,64 +1112,4 @@ public class GlassVisualEffect() : VisualEffect, RetainedOutputVisualEffect, Int
   internal companion object {
     const val TAG = "GlassVisualEffect"
   }
-}
-
-private class GlassRenderPreparation(
-  var decision: GlassRenderBudgetDecision,
-  var prepared: GlassPreparedRender?,
-)
-
-internal interface RetainedOutputDelegate {
-  fun canDrawRetainedOutput(): Boolean
-
-  fun shouldDrawRetainedOutput(): Boolean = canDrawRetainedOutput()
-
-  fun clearRetainedOutput()
-}
-
-internal fun GlassVisualEffect.updateDelegate(): GlassVisualEffect.Delegate {
-  val wantsRuntime =
-    preparedRenderBudget is GlassRenderBudgetDecision.Runtime &&
-      preparedRender != null &&
-      !runtimeShaderIncompatible
-  return when {
-    wantsRuntime && delegate !is RuntimeShaderGlassDelegate ->
-      RuntimeShaderGlassDelegate(this, runtimeEffectFactory)
-    !wantsRuntime && delegate !is FallbackGlassDelegate -> FallbackGlassDelegate(this)
-    else -> delegate
-  }
-}
-
-internal expect fun isRuntimeShaderGlassSupported(): Boolean
-
-private fun RoundedCornerShape.hasZeroCornerRadii(): Boolean {
-  // Use unit values to check if all corner sizes resolve to zero.
-  val unitSize = androidx.compose.ui.geometry.Size(1f, 1f)
-  val unitDensity = androidx.compose.ui.unit.Density(1f)
-  return topStart.toPx(unitSize, unitDensity) == 0f &&
-    topEnd.toPx(unitSize, unitDensity) == 0f &&
-    bottomEnd.toPx(unitSize, unitDensity) == 0f &&
-    bottomStart.toPx(unitSize, unitDensity) == 0f
-}
-
-private inline fun Float.takeOrElse(default: () -> Float): Float {
-  return if (this.isNaN()) default() else this
-}
-
-private fun Float.hasSameOverrideValueAs(other: Float): Boolean =
-  this == other || isNaN() && other.isNaN()
-
-private inline fun Float.hasSameNormalizedOverrideValueAs(
-  other: Float,
-  normalize: (Float) -> Float,
-): Boolean = hasSameOverrideValueAs(other) ||
-  isFinite() && other.isFinite() && normalize(this) == normalize(other)
-
-private fun reducedMotion(
-  policy: GlassReducedMotionPolicy,
-  systemScale: Float,
-): Pair<Boolean, Boolean> = when (policy) {
-  GlassReducedMotionPolicy.System -> (systemScale == 0f) to false
-  GlassReducedMotionPolicy.Reduced -> true to false
-  GlassReducedMotionPolicy.Full -> false to true
 }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -57,7 +57,7 @@ public class GlassVisualEffect() :
     copyConfigurationFrom(other)
   }
 
-  private fun copyConfigurationFrom(other: GlassVisualEffect) {
+  internal fun copyConfigurationFrom(other: GlassVisualEffect) {
     _optics = other._optics
     _specularIntensity = other._specularIntensity
     _ambientResponse = other._ambientResponse

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -35,8 +35,30 @@ import dev.chrisbanes.haze.trace
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
 internal class RuntimeShaderGlassDelegate(
   private val effect: GlassRuntimeEffect,
-  private val runtimeEffectFactory: GlassRuntimeEffectFactory = PlatformGlassRuntimeEffectFactory,
+  runtimeEffectFactory: GlassRuntimeEffectFactory = PlatformGlassRuntimeEffectFactory,
 ) : GlassRuntimeEffect.Delegate, RetainedOutputDelegate {
+  private var runtimeEffectFactory = runtimeEffectFactory
+
+  internal val runtimeEffectFactoryForTest: GlassRuntimeEffectFactory
+    get() = runtimeEffectFactory
+
+  internal fun updateRuntimeEffectFactory(value: GlassRuntimeEffectFactory) {
+    runtimeEffectFactory = value
+  }
+
+  internal fun sanitizeConfigurationReferencesForCache(releaseShaderHandles: Boolean) {
+    if (releaseShaderHandles) {
+      release()
+      return
+    }
+    progressiveBlurHorizontalShader = null
+    progressiveBlurVerticalShader = null
+    if (fusedInputKey?.blur?.progressive != null) {
+      fusedShader = null
+      fusedInputKey = null
+    }
+  }
+
   private var blurKey: GlassBlurEffectKey? = null
   private var blurEffects: GlassBlurRenderEffects? = null
   internal var blurHorizontalShader: MutableRuntimeShaderRenderEffect? = null

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -34,9 +34,9 @@ import dev.chrisbanes.haze.trace
 
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
 internal class RuntimeShaderGlassDelegate(
-  private val effect: GlassVisualEffect,
+  private val effect: GlassRuntimeEffect,
   private val runtimeEffectFactory: GlassRuntimeEffectFactory = PlatformGlassRuntimeEffectFactory,
-) : GlassVisualEffect.Delegate, RetainedOutputDelegate {
+) : GlassRuntimeEffect.Delegate, RetainedOutputDelegate {
   private var blurKey: GlassBlurEffectKey? = null
   private var blurEffects: GlassBlurRenderEffects? = null
   internal var blurHorizontalShader: MutableRuntimeShaderRenderEffect? = null
@@ -860,7 +860,7 @@ internal class RuntimeShaderGlassDelegate(
     releaseRetainedResources(releaseShaderHandles = false)
   }
 
-  internal fun releaseAfterConstructionFailure() {
+  override fun release() {
     releaseRetainedResources(releaseShaderHandles = true)
   }
 

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
@@ -38,7 +38,11 @@ import assertk.assertions.isGreaterThan
 import assertk.assertions.isLessThan
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeEffectNode
+import dev.chrisbanes.haze.HazeEffectScope
 import dev.chrisbanes.haze.InteractiveVisualEffect
+import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.VisualEffectTransform
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.test.ContextTest
@@ -46,8 +50,13 @@ import kotlin.test.Test
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 
-@OptIn(ExperimentalTestApi::class)
+@OptIn(
+  ExperimentalTestApi::class,
+  ExperimentalHazeApi::class,
+  InternalHazeApi::class,
+)
 class GlassInteractionControllerTest : ContextTest() {
+  private var attachedRuntime: GlassRuntimeEffect? = null
 
   @Test
   fun equivalentPresetInteractions_retainSlotsAndRevisions() {
@@ -111,7 +120,7 @@ class GlassInteractionControllerTest : ContextTest() {
       interactionPositionAnimationSpec = tween(1_000)
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
 
     mainClock.advanceTimeByFrame()
@@ -127,16 +136,16 @@ class GlassInteractionControllerTest : ContextTest() {
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
     }
     setContent {
-      Box(Modifier.size(100.dp, 80.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp, 80.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    effect.setPressedForTest(position = Offset(20f, 30f))
+    runtime(effect).setPressedForTest(position = Offset(20f, 30f))
     waitForIdle()
-    val context = checkNotNull(effect.attachedContextForTest)
+    val context = checkNotNull(runtime(effect).attachedContextForTest)
 
-    assertThat(effect.currentContentTransform(context))
+    assertThat(runtime(effect).currentContentTransform(context))
       .isEqualTo(VisualEffectTransform.Identity)
-    assertThat(effect.currentMaterialTransform(context))
+    assertThat(runtime(effect).currentMaterialTransform(context))
       .isEqualTo(VisualEffectTransform(0.9f, 0.8f, Offset(20f, 30f)))
   }
 
@@ -149,16 +158,16 @@ class GlassInteractionControllerTest : ContextTest() {
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
     }
     setContent {
-      Box(Modifier.size(100.dp, 80.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp, 80.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    effect.setPressedForTest(position = Offset(20f, 30f))
+    runtime(effect).setPressedForTest(position = Offset(20f, 30f))
     waitForIdle()
-    val context = checkNotNull(effect.attachedContextForTest)
+    val context = checkNotNull(runtime(effect).attachedContextForTest)
 
-    assertThat(effect.currentContentTransform(context))
+    assertThat(runtime(effect).currentContentTransform(context))
       .isEqualTo(VisualEffectTransform(0.9f, 0.9f, context.size.center))
-    assertThat(effect.currentMaterialTransform(context))
+    assertThat(runtime(effect).currentMaterialTransform(context))
       .isEqualTo(VisualEffectTransform.Identity)
   }
 
@@ -169,16 +178,16 @@ class GlassInteractionControllerTest : ContextTest() {
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
     }
     setContent {
-      Box(Modifier.size(0.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(0.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    effect.setPressedForTest(position = Offset.Zero)
+    runtime(effect).setPressedForTest(position = Offset.Zero)
     waitForIdle()
-    val context = checkNotNull(effect.attachedContextForTest)
+    val context = checkNotNull(runtime(effect).attachedContextForTest)
 
-    assertThat(effect.currentContentTransform(context))
+    assertThat(runtime(effect).currentContentTransform(context))
       .isEqualTo(VisualEffectTransform.Identity)
-    assertThat(effect.currentMaterialTransform(context))
+    assertThat(runtime(effect).currentMaterialTransform(context))
       .isEqualTo(VisualEffectTransform.Identity)
   }
 
@@ -228,20 +237,20 @@ class GlassInteractionControllerTest : ContextTest() {
         Modifier
           .size(size)
           .testTag("glass")
-          .hazeEffect { visualEffect = effect },
+          .hazeEffect { trackRenderer(effect) },
       )
     }
 
     onNodeWithTag("glass").performTouchInput { down(Offset(20f, 30f)) }
     waitForIdle()
-    assertThat(effect.currentInteractionSignals.rawPressed).isEqualTo(true)
+    assertThat(runtime(effect).currentInteractionSignals.rawPressed).isEqualTo(true)
 
     size = 0.dp
     waitForIdle()
     onNodeWithTag("glass").performTouchInput { up() }
     waitForIdle()
 
-    assertThat(effect.currentInteractionSignals.rawPressed).isEqualTo(false)
+    assertThat(runtime(effect).currentInteractionSignals.rawPressed).isEqualTo(false)
     assertThat(renderState(effect).lightingIntensity).isEqualTo(0f)
   }
 
@@ -250,7 +259,7 @@ class GlassInteractionControllerTest : ContextTest() {
     val effect = reducedPressEffect()
     setTaggedEffectContent(effect)
 
-    effect.setPressedForTest(position = Offset(120f, -10f), pressed = false)
+    runtime(effect).setPressedForTest(position = Offset(120f, -10f), pressed = false)
     waitForIdle()
     assertThat(renderState(effect).position).isEqualTo(Offset(100f, 0f))
   }
@@ -291,7 +300,7 @@ class GlassInteractionControllerTest : ContextTest() {
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
 
@@ -517,7 +526,7 @@ class GlassInteractionControllerTest : ContextTest() {
               }
             }
           }
-          .hazeEffect { visualEffect = effect },
+          .hazeEffect { trackRenderer(effect) },
       )
     }
     waitForIdle()
@@ -554,7 +563,7 @@ class GlassInteractionControllerTest : ContextTest() {
     val source = MutableInteractionSource()
     val effect = reducedPressEffect().apply { interactionSource = source }
     setContent {
-      Box(Modifier.size(0.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(0.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
 
@@ -667,7 +676,7 @@ class GlassInteractionControllerTest : ContextTest() {
     }
 
     val result = resolveGlassInteractionTargets(
-      slots = effect.interactionSlots,
+      slots = effect.runtimeSlots(),
       signals = GlassInteractionSignals(rawHovered = true, rawPressed = true),
     )
 
@@ -685,11 +694,11 @@ class GlassInteractionControllerTest : ContextTest() {
     }
 
     val pressedOnly = resolveGlassInteractionTargets(
-      effect.interactionSlots,
+      effect.runtimeSlots(),
       GlassInteractionSignals(rawPressed = true),
     )
     val pressedAndHovered = resolveGlassInteractionTargets(
-      effect.interactionSlots,
+      effect.runtimeSlots(),
       GlassInteractionSignals(rawHovered = true, rawPressed = true),
     )
 
@@ -707,13 +716,13 @@ class GlassInteractionControllerTest : ContextTest() {
       hovered { animate(hoverTo, hoverFrom) { scale(0.99f) } }
       pressed { animate(pressTo, pressFrom) { scale(0.96f) } }
     }
-    val idle = resolveGlassInteractionTargets(effect.interactionSlots, GlassInteractionSignals())
+    val idle = resolveGlassInteractionTargets(effect.runtimeSlots(), GlassInteractionSignals())
     val hover = resolveGlassInteractionTargets(
-      effect.interactionSlots,
+      effect.runtimeSlots(),
       GlassInteractionSignals(rawHovered = true),
     )
     val press = resolveGlassInteractionTargets(
-      effect.interactionSlots,
+      effect.runtimeSlots(),
       GlassInteractionSignals(rawHovered = true, rawPressed = true),
     )
 
@@ -722,7 +731,7 @@ class GlassInteractionControllerTest : ContextTest() {
         previous = idle.scaleX,
         next = hover.scaleX,
         previousSlots = GlassInteractionSlots(),
-        nextSlots = effect.interactionSlots,
+        nextSlots = effect.runtimeSlots(),
         previousSignals = GlassInteractionSignals(),
         nextSignals = GlassInteractionSignals(rawHovered = true),
       ),
@@ -731,8 +740,8 @@ class GlassInteractionControllerTest : ContextTest() {
       selectTransitionSpec(
         previous = hover.scaleX,
         next = press.scaleX,
-        previousSlots = effect.interactionSlots,
-        nextSlots = effect.interactionSlots,
+        previousSlots = effect.runtimeSlots(),
+        nextSlots = effect.runtimeSlots(),
         previousSignals = GlassInteractionSignals(rawHovered = true),
         nextSignals = GlassInteractionSignals(rawHovered = true, rawPressed = true),
       ),
@@ -741,8 +750,8 @@ class GlassInteractionControllerTest : ContextTest() {
       selectTransitionSpec(
         previous = press.scaleX,
         next = hover.scaleX,
-        previousSlots = effect.interactionSlots,
-        nextSlots = effect.interactionSlots,
+        previousSlots = effect.runtimeSlots(),
+        nextSlots = effect.runtimeSlots(),
         previousSignals = GlassInteractionSignals(rawHovered = true, rawPressed = true),
         nextSignals = GlassInteractionSignals(rawHovered = true),
       ),
@@ -760,12 +769,12 @@ class GlassInteractionControllerTest : ContextTest() {
       }
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val controller = checkNotNull(effect.interactionControllerForTest)
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
 
-    controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 1f))
+    controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 1f))
     controller.updateSignals(GlassInteractionSignals(rawPressed = true))
     mainClock.advanceTimeBy(50)
 
@@ -788,12 +797,12 @@ class GlassInteractionControllerTest : ContextTest() {
         interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
       }
       setContent {
-        Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+        Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
       }
       waitForIdle()
-      val controller = checkNotNull(effect.interactionControllerForTest)
+      val controller = checkNotNull(runtime(effect).interactionControllerForTest)
 
-      controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 1f))
+      controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 1f))
       controller.updateSignals(GlassInteractionSignals(rawPressed = true))
       waitForIdle()
 
@@ -815,10 +824,10 @@ class GlassInteractionControllerTest : ContextTest() {
       pressed { lightingIntensity(1f) }
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val controller = checkNotNull(effect.interactionControllerForTest)
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
     controller.updateSignals(GlassInteractionSignals(rawPressed = true))
     waitForIdle()
     assertThat(controller.renderState.lightingIntensity).isEqualTo(1f)
@@ -827,7 +836,7 @@ class GlassInteractionControllerTest : ContextTest() {
     effect.pressed {
       animate(tween(100), snap()) { lightingIntensity(0.2f) }
     }
-    controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 1f))
+    controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 1f))
     mainClock.advanceTimeBy(50)
 
     assertThat(controller.renderState.lightingIntensity).isGreaterThan(0.2f)
@@ -843,17 +852,17 @@ class GlassInteractionControllerTest : ContextTest() {
       }
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val controller = checkNotNull(effect.interactionControllerForTest)
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
     controller.updateSignals(GlassInteractionSignals(rawHovered = true, rawPressed = true))
     waitForIdle()
     assertThat(controller.renderState.lightingIntensity).isEqualTo(1f)
 
     mainClock.autoAdvance = false
     effect.clearPressed()
-    controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 1f))
+    controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 1f))
     mainClock.advanceTimeBy(50)
 
     assertThat(controller.renderState.lightingIntensity).isGreaterThan(0.2f)
@@ -866,10 +875,10 @@ class GlassInteractionControllerTest : ContextTest() {
       pressed { lightingIntensity(0.7f) }
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val controller = checkNotNull(effect.interactionControllerForTest)
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
 
     controller.updateSignals(GlassInteractionSignals(rawPressed = true))
     waitForIdle()
@@ -886,12 +895,12 @@ class GlassInteractionControllerTest : ContextTest() {
       }
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val controller = checkNotNull(effect.interactionControllerForTest)
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
 
-    controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 0f))
+    controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 0f))
     controller.updateSignals(GlassInteractionSignals(rawPressed = true))
     waitForIdle()
 
@@ -912,12 +921,12 @@ class GlassInteractionControllerTest : ContextTest() {
       }
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val controller = checkNotNull(effect.interactionControllerForTest)
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
 
-    controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 0f))
+    controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 0f))
     controller.updateSignals(GlassInteractionSignals(rawPressed = true))
     mainClock.advanceTimeBy(50)
 
@@ -936,11 +945,11 @@ class GlassInteractionControllerTest : ContextTest() {
       }
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val controller = checkNotNull(effect.interactionControllerForTest)
-    controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 1f))
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
+    controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 1f))
     controller.updateSignals(GlassInteractionSignals(rawPressed = true))
     controller.updatePosition(Offset(100f, 100f))
     mainClock.advanceTimeBy(100)
@@ -970,11 +979,11 @@ class GlassInteractionControllerTest : ContextTest() {
       }
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val controller = checkNotNull(effect.interactionControllerForTest)
-    controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 1f))
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
+    controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 1f))
     controller.updateSignals(GlassInteractionSignals(rawPressed = true))
     controller.updatePosition(Offset(100f, 100f))
     mainClock.advanceTimeBy(100)
@@ -999,12 +1008,12 @@ class GlassInteractionControllerTest : ContextTest() {
     runComposeUiTest {
       val effect = GlassVisualEffect().apply { pressed() }
       setContent {
-        Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+        Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
       }
       waitForIdle()
-      val context = checkNotNull(effect.attachedContextForTest)
+      val context = checkNotNull(runtime(effect).attachedContextForTest)
       val nodeMotionScale = context.coroutineScope.coroutineContext[MotionDurationScale]
-      val controller = checkNotNull(effect.interactionControllerForTest)
+      val controller = checkNotNull(runtime(effect).interactionControllerForTest)
 
       assertThat(nodeMotionScale).isNull()
       assertThat(controller.configurationForTest.reducedMotion).isEqualTo(false)
@@ -1026,21 +1035,21 @@ class GlassInteractionControllerTest : ContextTest() {
       }
     }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val controller = checkNotNull(effect.interactionControllerForTest)
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
     controller.updateSignals(GlassInteractionSignals(rawPressed = true))
     mainClock.advanceTimeBy(50)
     assertThat(controller.renderState.scaleX).isGreaterThan(0.9f)
 
     effect.interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
-    controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 1f))
+    controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 1f))
     mainClock.advanceTimeByFrame()
     assertThat(controller.renderState.scaleX).isEqualTo(1f)
 
     effect.interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
-    controller.updateConfiguration(effect.controllerConfiguration(systemMotionScale = 1f))
+    controller.updateConfiguration(effect.runtimeConfiguration(systemMotionScale = 1f))
     mainClock.advanceTimeByFrame()
     assertThat(controller.renderState.scaleX).isEqualTo(0.9f)
   }
@@ -1049,18 +1058,19 @@ class GlassInteractionControllerTest : ContextTest() {
   fun controller_clearingFinalSlotDisposesAndImmediatelyExposesIdentity() = runComposeUiTest {
     val effect = GlassVisualEffect().apply { pressed { scale(0.9f) } }
     setContent {
-      Box(Modifier.size(100.dp).hazeEffect { visualEffect = effect })
+      Box(Modifier.size(100.dp).hazeEffect { trackRenderer(effect) })
     }
     waitForIdle()
-    val context = checkNotNull(effect.attachedContextForTest)
-    val controller = checkNotNull(effect.interactionControllerForTest)
+    val context = checkNotNull(runtime(effect).attachedContextForTest)
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
     controller.updateSignals(GlassInteractionSignals(rawPressed = true))
     waitForIdle()
 
     effect.clearPressed()
+    waitForIdle()
 
-    assertThat(effect.interactionControllerForTest).isNull()
-    assertThat(effect.interactionRenderState(context)).isEqualTo(
+    assertThat(runtime(effect).interactionControllerForTest).isNull()
+    assertThat(runtime(effect).interactionRenderState(context)).isEqualTo(
       GlassInteractionRenderState(position = Offset(50f, 50f)),
     )
   }
@@ -1078,18 +1088,34 @@ class GlassInteractionControllerTest : ContextTest() {
         Modifier
           .size(100.dp)
           .testTag("glass")
-          .hazeEffect { visualEffect = effect },
+          .hazeEffect { trackRenderer(effect) },
       )
     }
   }
 
-  private fun interactive(effect: GlassVisualEffect): InteractiveVisualEffect =
-    effect
+  private fun HazeEffectScope.trackRenderer(effect: GlassVisualEffect) {
+    visualEffect = effect
+    attachedRuntime = ((this as HazeEffectNode).activeVisualEffect as GlassRenderer).runtimeForTest
+  }
 
-  private fun context(effect: GlassVisualEffect) = checkNotNull(effect.attachedContextForTest)
+  private fun runtime(effect: GlassVisualEffect): GlassRuntimeEffect = checkNotNull(attachedRuntime)
+
+  private fun interactive(effect: GlassVisualEffect): InteractiveVisualEffect =
+    runtime(effect)
+
+  private fun GlassVisualEffect.runtimeConfiguration(
+    systemMotionScale: Float,
+  ): GlassInteractionControllerConfiguration =
+    GlassRuntimeEffect(this).controllerConfiguration(systemMotionScale)
+
+  private fun GlassVisualEffect.runtimeSlots(): GlassInteractionSlots =
+    GlassRuntimeEffect(this).interactionSlots
+
+  private fun context(effect: GlassVisualEffect) =
+    checkNotNull(runtime(effect).attachedContextForTest)
 
   private fun renderState(effect: GlassVisualEffect): GlassInteractionRenderState =
-    effect.interactionRenderState(context(effect))
+    runtime(effect).interactionRenderState(context(effect))
 
   private fun testSlots(
     focused: GlassInteractionResponse? = null,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionDslTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionDslTest.kt
@@ -3,20 +3,102 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
+import assertk.assertions.isNotSameInstanceAs
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeArea
+import dev.chrisbanes.haze.HazeEffectNode
 import dev.chrisbanes.haze.HazeEffectScope
 import dev.chrisbanes.haze.HazeInputScale
+import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.VisualEffect
+import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
-class GlassInteractionDslTest {
+@OptIn(
+  ExperimentalTestApi::class,
+  ExperimentalHazeApi::class,
+  InternalHazeApi::class,
+)
+class GlassInteractionDslTest : ContextTest() {
+
+  @Test
+  fun glassEffect_reusesConfigurationWhileNodeKeepsRenderer() = runComposeUiTest {
+    val alpha = mutableStateOf(0.5f)
+    var initialConfiguration: GlassVisualEffect? = null
+    var currentConfiguration: GlassVisualEffect? = null
+    var initialRenderer: GlassRenderer? = null
+    var currentRenderer: GlassRenderer? = null
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(100.dp)
+          .hazeEffect {
+            glassEffect { this.alpha = alpha.value }
+            val node = this as HazeEffectNode
+            currentConfiguration = visualEffect as GlassVisualEffect
+            currentRenderer = node.activeVisualEffect as GlassRenderer
+            if (initialConfiguration == null) {
+              initialConfiguration = currentConfiguration
+              initialRenderer = currentRenderer
+            }
+          },
+      )
+    }
+    waitForIdle()
+
+    alpha.value = 0.6f
+    waitForIdle()
+
+    assertThat(currentConfiguration).isSameInstanceAs(initialConfiguration)
+    assertThat(currentRenderer).isSameInstanceAs(initialRenderer)
+    assertThat(checkNotNull(currentRenderer).runtimeForTest.alpha).isEqualTo(0.6f)
+  }
+
+  @Test
+  fun replacingConfiguredGlassEffect_replacesNodeRenderer() = runComposeUiTest {
+    val replacement = mutableStateOf<GlassVisualEffect?>(null)
+    var initialRenderer: GlassRenderer? = null
+    var currentRenderer: GlassRenderer? = null
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(100.dp)
+          .hazeEffect {
+            replacement.value?.let { visualEffect = it } ?: glassEffect()
+            currentRenderer = (this as HazeEffectNode).activeVisualEffect as GlassRenderer
+            if (initialRenderer == null) {
+              initialRenderer = currentRenderer
+            }
+          },
+      )
+    }
+    waitForIdle()
+
+    replacement.value = GlassVisualEffect().apply { alpha = 0.3f }
+    waitForIdle()
+
+    assertThat(currentRenderer).isNotSameInstanceAs(initialRenderer)
+    assertThat(checkNotNull(initialRenderer).runtimeForTest.attachedContextForTest).isEqualTo(null)
+    assertThat(checkNotNull(currentRenderer).runtimeForTest.alpha).isEqualTo(0.3f)
+  }
 
   @Test
   fun glassEffect_replayingInteractableWithCustomPress_retainsFinalSlotsAndConfiguration() {

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionIntegrationTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionIntegrationTest.kt
@@ -33,14 +33,23 @@ import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeEffectNode
+import dev.chrisbanes.haze.HazeEffectScope
 import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalTestApi::class)
+@OptIn(
+  ExperimentalTestApi::class,
+  ExperimentalHazeApi::class,
+  InternalHazeApi::class,
+)
 class GlassInteractionIntegrationTest : ContextTest() {
+  private val attachedRuntimes = mutableMapOf<GlassVisualEffect, GlassRuntimeEffect>()
 
   @Test
   fun interactiveGlass_doesNotBlockClick() = runComposeUiTest {
@@ -56,7 +65,7 @@ class GlassInteractionIntegrationTest : ContextTest() {
           Modifier
             .fillMaxSize()
             .testTag("glass")
-            .hazeEffect(hazeState) { visualEffect = effect }
+            .hazeEffect(hazeState) { trackRenderer(effect) }
             .clickable(interactionSource = source, indication = null, onClick = { clicks++ }),
         )
       }
@@ -80,7 +89,7 @@ class GlassInteractionIntegrationTest : ContextTest() {
           Modifier
             .fillMaxSize()
             .testTag("glass")
-            .hazeEffect(hazeState) { visualEffect = effect }
+            .hazeEffect(hazeState) { trackRenderer(effect) }
             .verticalScroll(scroll),
         ) { Spacer(Modifier.height(400.dp)) }
       }
@@ -94,7 +103,7 @@ class GlassInteractionIntegrationTest : ContextTest() {
     waitForIdle()
 
     assertThat(scroll.value).isGreaterThan(0)
-    assertThat(effect.currentInteractionSignals.rawPressed).isEqualTo(false)
+    assertThat(runtime(effect).currentInteractionSignals.rawPressed).isEqualTo(false)
   }
 
   @Test
@@ -105,7 +114,12 @@ class GlassInteractionIntegrationTest : ContextTest() {
     }
     setContent {
       GlassTestFixture { hazeState ->
-        Box(Modifier.fillMaxSize().testTag("glass").hazeEffect(hazeState) { visualEffect = effect })
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("glass")
+            .hazeEffect(hazeState) { trackRenderer(effect) },
+        )
       }
     }
 
@@ -114,13 +128,13 @@ class GlassInteractionIntegrationTest : ContextTest() {
       moveTo(Offset(70f, 60f))
     }
     waitForIdle()
-    assertThat(effect.currentInteractionState.position).isEqualTo(Offset(70f, 60f))
-    assertThat(effect.currentInteractionSignals.rawHovered).isEqualTo(true)
+    assertThat(runtime(effect).currentInteractionState.position).isEqualTo(Offset(70f, 60f))
+    assertThat(runtime(effect).currentInteractionSignals.rawHovered).isEqualTo(true)
 
     onNodeWithTag("glass").performMouseInput { exit() }
     waitForIdle()
 
-    assertThat(effect.currentInteractionSignals.rawHovered).isEqualTo(false)
+    assertThat(runtime(effect).currentInteractionSignals.rawHovered).isEqualTo(false)
   }
 
   @Test
@@ -130,7 +144,12 @@ class GlassInteractionIntegrationTest : ContextTest() {
     setContent {
       SideEffect { compositions++ }
       GlassTestFixture { hazeState ->
-        Box(Modifier.fillMaxSize().testTag("glass").hazeEffect(hazeState) { visualEffect = effect })
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("glass")
+            .hazeEffect(hazeState) { trackRenderer(effect) },
+        )
       }
     }
     waitForIdle()
@@ -159,7 +178,12 @@ class GlassInteractionIntegrationTest : ContextTest() {
     }
     setContent {
       GlassTestFixture { hazeState ->
-        Box(Modifier.fillMaxSize().testTag("glass").hazeEffect(hazeState) { visualEffect = effect })
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("glass")
+            .hazeEffect(hazeState) { trackRenderer(effect) },
+        )
       }
     }
     waitForIdle()
@@ -168,17 +192,26 @@ class GlassInteractionIntegrationTest : ContextTest() {
     source.tryEmit(press)
     waitForIdle()
 
-    assertThat(effect.currentInteractionState.position).isEqualTo(Offset(50f, 50f))
-    assertThat(effect.currentInteractionState.lightingIntensity).isEqualTo(1f)
+    assertThat(runtime(effect).currentInteractionState.position).isEqualTo(Offset(50f, 50f))
+    assertThat(runtime(effect).currentInteractionState.lightingIntensity).isEqualTo(1f)
 
     source.tryEmit(PressInteraction.Release(press))
     source.tryEmit(FocusInteraction.Unfocus(focus))
     waitForIdle()
 
-    assertThat(effect.currentInteractionState).isEqualTo(
+    assertThat(runtime(effect).currentInteractionState).isEqualTo(
       GlassInteractionRenderState(position = Offset(50f, 50f)),
     )
   }
+
+  private fun HazeEffectScope.trackRenderer(effect: GlassVisualEffect) {
+    visualEffect = effect
+    attachedRuntimes[effect] =
+      ((this as HazeEffectNode).activeVisualEffect as GlassRenderer).runtimeForTest
+  }
+
+  private fun runtime(effect: GlassVisualEffect): GlassRuntimeEffect =
+    checkNotNull(attachedRuntimes[effect])
 }
 
 @Composable

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -37,7 +37,7 @@ class GlassRenderParamsTest {
       }
     }
 
-    assertThat(effect.interactionSlots.resolveInteractionTopology()).isEqualTo(
+    assertThat(GlassRuntimeEffect(effect).interactionSlots.resolveInteractionTopology()).isEqualTo(
       GlassInteractionTopology(
         hasOptics = true,
         hasLighting = true,
@@ -56,7 +56,7 @@ class GlassRenderParamsTest {
       }
     }
 
-    assertThat(effect.interactionSlots.resolveInteractionTopology()).isEqualTo(
+    assertThat(GlassRuntimeEffect(effect).interactionSlots.resolveInteractionTopology()).isEqualTo(
       GlassInteractionTopology(false, false, 1f),
     )
   }

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -172,7 +172,7 @@ class GlassStyleTest {
 
   @Test
   fun retainedOutputAvailabilityReflectsDelegate() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val delegate = RetainedTrackingGlassDelegate()
     effect.delegate = delegate
 
@@ -227,7 +227,7 @@ private data object FakeGlassContext : VisualEffectContext {
 }
 
 private class RetainedTrackingGlassDelegate :
-  GlassVisualEffect.Delegate,
+  GlassRuntimeEffect.Delegate,
   RetainedOutputDelegate {
 
   var retainedOutputAvailable = false

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
@@ -37,7 +38,9 @@ import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.PlatformContext
+import dev.chrisbanes.haze.VisualEffect
 import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.VisualEffectRendererFactory
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
@@ -48,8 +51,128 @@ import kotlinx.coroutines.test.runTest
 class GlassVisualEffectLifecycleTest {
 
   @Test
+  fun sharedConfiguration_createsDistinctRenderersAndControllers() {
+    val configuration = GlassVisualEffect().apply { pressed() }
+    val configuredEffect: VisualEffect = configuration
+    val factory = configuredEffect as VisualEffectRendererFactory
+    val first = factory.createRenderer()
+    val second = factory.createRenderer()
+    val firstContext = TrackingVisualEffectContext()
+    val secondContext = TrackingVisualEffectContext()
+
+    first.attach(firstContext)
+    second.attach(secondContext)
+    first.update(firstContext)
+    second.update(secondContext)
+    val firstRenderer = first as GlassRenderer
+    val secondRenderer = second as GlassRenderer
+
+    assertThat(first).isNotSameInstanceAs(second)
+    assertThat(first).isNotSameInstanceAs(configuration)
+    assertThat(second).isNotSameInstanceAs(configuration)
+    assertThat(firstRenderer.runtimeForTest.delegate)
+      .isNotSameInstanceAs(secondRenderer.runtimeForTest.delegate)
+    assertThat(firstRenderer.runtimeForTest.interactionControllerForTest)
+      .isNotSameInstanceAs(secondRenderer.runtimeForTest.interactionControllerForTest)
+    assertThat(firstRenderer.runtimeForTest.attachedContextForTest).isSameInstanceAs(firstContext)
+    assertThat(secondRenderer.runtimeForTest.attachedContextForTest).isSameInstanceAs(secondContext)
+    first.detach(firstContext)
+    second.detach(secondContext)
+  }
+
+  @Test
+  fun configurationChange_invalidatesEveryRenderer() {
+    val configuration = GlassVisualEffect()
+    val factory = configuration as VisualEffectRendererFactory
+    val first = factory.createRenderer() as GlassRenderer
+    val second = factory.createRenderer() as GlassRenderer
+    val firstContext = TrackingVisualEffectContext()
+    val secondContext = TrackingVisualEffectContext()
+    first.attach(firstContext)
+    second.attach(secondContext)
+    first.update(firstContext)
+    second.update(secondContext)
+    first.runtimeForTest.resetDirtyTracker()
+    second.runtimeForTest.resetDirtyTracker()
+    firstContext.invalidateDrawCalls = 0
+    secondContext.invalidateDrawCalls = 0
+
+    configuration.alpha = 0.5f
+    first.update(firstContext)
+    second.update(secondContext)
+
+    assertThat(first.runtimeForTest.alpha).isEqualTo(0.5f)
+    assertThat(second.runtimeForTest.alpha).isEqualTo(0.5f)
+    assertThat(firstContext.invalidateDrawCalls).isEqualTo(1)
+    assertThat(secondContext.invalidateDrawCalls).isEqualTo(1)
+    first.detach(firstContext)
+    second.detach(secondContext)
+  }
+
+  @Test
+  fun runtimeEffectFactoryChange_synchronizesWithAttachedRenderer() {
+    val configuration = GlassVisualEffect()
+    val renderer = configuration.createRenderer() as GlassRenderer
+    val context = TrackingVisualEffectContext()
+    val replacement = GlassRuntimeEffectFactory { create -> create() }
+    renderer.attach(context)
+    renderer.update(context)
+
+    configuration.runtimeEffectFactory = replacement
+    renderer.update(context)
+
+    assertThat(renderer.runtimeForTest.runtimeEffectFactory).isSameInstanceAs(replacement)
+    renderer.detach(context)
+  }
+
+  @Test
+  fun rendererResourceRelease_isExactAndDoesNotAffectSibling() {
+    val configuration = GlassVisualEffect()
+    val first = configuration.createRenderer() as GlassRenderer
+    val second = configuration.createRenderer() as GlassRenderer
+    val firstDelegate = CountingGlassDelegate()
+    val secondDelegate = CountingGlassDelegate()
+    val firstContext = TrackingVisualEffectContext()
+    val secondContext = TrackingVisualEffectContext()
+    first.runtimeForTest.delegate = firstDelegate
+    second.runtimeForTest.delegate = secondDelegate
+    first.attach(firstContext)
+    second.attach(secondContext)
+
+    first.clearRetainedOutput()
+    first.detach(firstContext)
+
+    assertThat(firstDelegate.releaseCalls).isEqualTo(1)
+    assertThat(firstDelegate.detachCalls).isEqualTo(1)
+    assertThat(secondDelegate.releaseCalls).isEqualTo(0)
+    assertThat(secondDelegate.detachCalls).isEqualTo(0)
+
+    second.onTrimMemory(secondContext, dev.chrisbanes.haze.TrimMemoryLevel.UI_HIDDEN)
+    second.detach(secondContext)
+
+    assertThat(secondDelegate.releaseCalls).isEqualTo(1)
+    assertThat(secondDelegate.detachCalls).isEqualTo(1)
+  }
+
+  @Test
+  fun rendererCacheEviction_releasesRetainedShaderHandles() {
+    val delegates = List(9) {
+      val renderer = GlassVisualEffect().createRenderer() as GlassRenderer
+      val delegate = CountingGlassDelegate()
+      val context = TrackingVisualEffectContext()
+      renderer.runtimeForTest.delegate = delegate
+      renderer.attach(context)
+      renderer.detach(context)
+      delegate
+    }
+
+    assertThat(delegates.first().finalReleaseCalls).isEqualTo(1)
+    assertThat(delegates.last().finalReleaseCalls).isEqualTo(0)
+  }
+
+  @Test
   fun prepareBudget_fractionalAlphaIncludesMaterialSizedGroupComposite() {
-    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val effect = GlassRuntimeEffect().apply { alpha = 0.5f }
 
     val decision = effect.prepareRenderBudget(
       context = TrackingVisualEffectContext(effectSize = Size(100f, 80f), layerSize = Size(120f, 100f)),
@@ -63,7 +186,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_materialSizeChangeUpdatesGroupComposite() {
-    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val effect = GlassRuntimeEffect().apply { alpha = 0.5f }
     val layerSize = Size(160f, 140f)
 
     effect.prepareRenderBudget(
@@ -88,7 +211,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_interactionGroupCompositeContributesToScaleSelection() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(
         refractionStrength = 0f,
         refractionScale = 0f,
@@ -124,7 +247,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_safeGraphPreservesRequestedScale() {
-    val decision = GlassVisualEffect().resolveGlassRenderBudget(
+    val decision = GlassRuntimeEffect().resolveGlassRenderBudget(
       TrackingVisualEffectContext(effectSize = Size(100f, 100f), layerSize = Size(120f, 120f)),
     )
 
@@ -133,7 +256,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_maxRefractionUsesFallbackBeforeRuntimePreparation() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(
         refractionStrength = 1f,
         refractionScale = 16_384f,
@@ -152,7 +275,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_retainsSelectedRenderBundleWithoutInactiveBlurKey() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(depth = 0f, blurRadius = 38.5.dp)
     }
 
@@ -168,7 +291,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_runtimeUnavailableSkipsExactRenderBundle() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
 
     val decision = effect.prepareRenderBudget(
       TrackingVisualEffectContext(),
@@ -181,7 +304,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_scaleDependentDetailUsesExactSelectedPlan() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(
         refractionStrength = 1f,
         refractionScale = 0.18f,
@@ -213,7 +336,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_runtimeToFallbackClearsPreparedRenderBundle() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
 
     assertThat(
       effect.prepareRenderBudget(
@@ -234,7 +357,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun detach_clearsPreparedRenderBundle() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
 
     effect.prepareRenderBudget(context, runtimeShaderSupported = true)
@@ -247,7 +370,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_unchangedBudgetInputsReuseDecisionAndSelectedPlan() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
 
     val first = effect.prepareRenderBudget(
@@ -269,7 +392,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_chromaticAberrationChangeInvalidatesBudgetDecision() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
 
     val first = effect.prepareRenderBudget(
@@ -288,7 +411,7 @@ class GlassVisualEffectLifecycleTest {
   @Test
   fun stablePreparationAndClipping_doNotResolveCornerGeometryAgain() {
     val corner = CountingCornerSize(12f)
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       shape = RoundedCornerShape(corner)
     }
     val context = TrackingVisualEffectContext()
@@ -312,7 +435,7 @@ class GlassVisualEffectLifecycleTest {
   @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
   fun prepareBudget_stateBackedCornerSizeInvalidatesResolvedStyle() = runTest {
     val cornerPx = mutableFloatStateOf(4f)
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       shape = RoundedCornerShape(StateBackedCornerSize { cornerPx.floatValue })
     }
     val context = TrackingVisualEffectContext(
@@ -339,7 +462,7 @@ class GlassVisualEffectLifecycleTest {
   @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
   fun stateBackedCornerInvalidation_doesNotCrossAttachments() = runTest {
     val cornerPx = mutableFloatStateOf(0f)
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       shape = RoundedCornerShape(StateBackedCornerSize { cornerPx.floatValue })
     }
     val firstContext = TrackingVisualEffectContext(
@@ -368,7 +491,7 @@ class GlassVisualEffectLifecycleTest {
   @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
   fun clipping_stateBackedCornerSizeInvalidatesDecisionBeforePreparation() = runTest {
     val cornerPx = mutableFloatStateOf(0f)
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       edgeSoftness = 0.dp
       shape = RoundedCornerShape(StateBackedCornerSize { cornerPx.floatValue })
     }
@@ -391,7 +514,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_alphaOnlyChangeReusesUnderlyingPreparedData() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
 
     effect.prepareRenderBudget(context, runtimeShaderSupported = true)
@@ -416,7 +539,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_interactionRadiusChangeRebuildsPlanButReusesBaseEffectKeys() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       pressed {
         lightingIntensity(1f)
         refractionMultiplier(1.1f)
@@ -442,7 +565,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_zeroInteractionRadiusMatchesNoInteractionResponses() {
-    val configured = GlassVisualEffect().apply {
+    val configured = GlassRuntimeEffect().apply {
       pressed {
         lightingIntensity(1f)
         refractionMultiplier(1.1f)
@@ -454,7 +577,7 @@ class GlassVisualEffectLifecycleTest {
     configured.prepareRenderBudget(context, runtimeShaderSupported = true)
     val configuredPlan = checkNotNull(configured.preparedRender).plan
 
-    val baseline = GlassVisualEffect()
+    val baseline = GlassRuntimeEffect()
     baseline.prepareRenderBudget(context, runtimeShaderSupported = true)
 
     assertThat(configuredPlan).isEqualTo(checkNotNull(baseline.preparedRender).plan)
@@ -462,7 +585,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_lightingOnlyChangeReusesUnchangedPreparedData() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
 
     effect.prepareRenderBudget(context, runtimeShaderSupported = true)
@@ -482,7 +605,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_interactionOnlyChangeReusesBasePreparedData() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
 
     effect.prepareRenderBudget(context, runtimeShaderSupported = true)
@@ -503,7 +626,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun prepareBudget_configuredInteractionTopologyIsStableAcrossAnimatedValues() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       pressed {
         lightingIntensity(1f)
         refractionMultiplier(1.2f)
@@ -532,7 +655,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun update_readsInjectedMotionScaleAndFullOverridesIt() {
-    val effect = GlassVisualEffect().apply { pressed() }
+    val effect = GlassRuntimeEffect().apply { pressed() }
     val context = TrackingVisualEffectContext(
       motionScale = 0f,
       effectSize = Size.Zero,
@@ -555,7 +678,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun attachAndUpdate_withoutInteractionsDoesNotAllocateController() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
 
     effect.attach(context)
@@ -567,7 +690,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun detach_disposesInteractionController() {
-    val effect = GlassVisualEffect().apply { pressed() }
+    val effect = GlassRuntimeEffect().apply { pressed() }
     val context = TrackingVisualEffectContext()
 
     effect.attach(context)
@@ -582,7 +705,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun update_directShapeChangeInvalidatesLayerBounds() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
 
     effect.update(context)
@@ -596,7 +719,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun resettingConsumedDirtyFlags_doesNotNotifyObserver_butNextChangeDoes() {
-    val effect = GlassVisualEffect().apply { resetDirtyTracker() }
+    val effect = GlassRuntimeEffect().apply { resetDirtyTracker() }
     val context = TrackingVisualEffectContext()
     val observer = SnapshotStateObserver { command -> command() }
     var observerNotifications = 0
@@ -636,7 +759,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun markingAlreadyDirtyField_doesNotNotifyObserverAgain() {
-    val effect = GlassVisualEffect().apply { resetDirtyTracker() }
+    val effect = GlassRuntimeEffect().apply { resetDirtyTracker() }
     val context = TrackingVisualEffectContext()
     val observer = SnapshotStateObserver { command -> command() }
     var observerNotifications = 0
@@ -667,7 +790,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun update_adaptiveToAbsoluteInvalidatesDrawAndLayerBounds() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
 
     effect.optics = GlassOptics.Absolute(refractionStrength = 0.4f)
@@ -679,7 +802,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun update_replacingAbsoluteInvalidatesDrawAndLayerBounds() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(refractionStrength = 0.4f)
       resetDirtyTracker()
     }
@@ -694,14 +817,14 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun update_interactionRenderingConfigurationChangesInvalidateDraw() {
-    val changes = listOf<(GlassVisualEffect) -> Unit>(
+    val changes = listOf<(GlassRuntimeEffect) -> Unit>(
       { it.interactionLightRadiusFraction = 1.2f },
       { it.interactionTransformTarget = GlassTransformTarget.MaterialAndContent },
       { it.interactionTransformPivot = GlassTransformPivot.Center },
     )
 
     changes.forEach { change ->
-      val effect = GlassVisualEffect()
+      val effect = GlassRuntimeEffect()
       val context = TrackingVisualEffectContext()
 
       change(effect)
@@ -713,7 +836,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun update_clearingAbsoluteOverrideInvalidatesDrawAndLayerBounds() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(refractionStrength = 0.4f)
       resetDirtyTracker()
     }
@@ -728,12 +851,12 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun calculateLayerBounds_usesMaximumConfiguredInteractionRefractionStrength() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(refractionStrength = 0.6f)
       pressed { refractionMultiplier(2f) }
     }
     val rect = Rect(0f, 0f, 100f, 100f)
-    val baseBounds = GlassVisualEffect().apply {
+    val baseBounds = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(refractionStrength = 0.6f)
     }.calculateLayerBounds(rect, Density(1f))
 
@@ -745,7 +868,7 @@ class GlassVisualEffectLifecycleTest {
   @Test
   fun calculateLayerBounds_depthZeroDoesNotReserveBlurPadding() {
     val rect = Rect(0f, 0f, 100f, 100f)
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(depth = 0f, blurRadius = 40.dp, refractionStrength = 0f)
       edgeSoftness = 0.dp
       specularIntensity = 0f
@@ -756,7 +879,7 @@ class GlassVisualEffectLifecycleTest {
 
   @Test
   fun changingInteractionRefractionMaximum_invalidatesLayerBounds_butEquivalentDeclarationDoesNot() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = TrackingVisualEffectContext()
     effect.update(context)
     context.invalidateLayerBoundsCalls = 0
@@ -900,4 +1023,48 @@ private class StateBackedCornerSize(
   private val value: () -> Float,
 ) : CornerSize {
   override fun toPx(shapeSize: Size, density: Density): Float = value()
+}
+
+private class CountingGlassDelegate : GlassRuntimeEffect.Delegate, RetainedOutputDelegate {
+  private var ownsResource = true
+  var detachCalls = 0
+    private set
+  var releaseCalls = 0
+    private set
+  var finalReleaseCalls = 0
+    private set
+
+  override fun DrawScope.draw(context: VisualEffectContext) = Unit
+
+  override fun detach() {
+    detachCalls++
+    releaseResource()
+  }
+
+  override fun release() {
+    finalReleaseCalls++
+    detach()
+  }
+
+  override fun onTrimMemory(
+    context: VisualEffectContext,
+    level: dev.chrisbanes.haze.TrimMemoryLevel,
+  ) {
+    if (shouldReleaseRetainedGlass(level)) {
+      releaseResource()
+    }
+  }
+
+  override fun canDrawRetainedOutput(): Boolean = ownsResource
+
+  override fun clearRetainedOutput() {
+    releaseResource()
+  }
+
+  private fun releaseResource() {
+    if (ownsResource) {
+      ownsResource = false
+      releaseCalls++
+    }
+  }
 }

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.CompositionLocal
@@ -168,6 +169,41 @@ class GlassVisualEffectLifecycleTest {
 
     assertThat(delegates.first().finalReleaseCalls).isEqualTo(1)
     assertThat(delegates.last().finalReleaseCalls).isEqualTo(0)
+  }
+
+  @Test
+  fun fallbackRendererCache_releasesAndReseedsCallerReferences() {
+    val initialSource = MutableInteractionSource()
+    val initialShape = RoundedCornerShape(11.dp)
+    val configuration = GlassVisualEffect().apply {
+      interactionSource = initialSource
+      shape = initialShape
+    }
+    val renderer = configuration.createRenderer() as GlassRenderer
+    val runtime = renderer.runtimeForTest
+    val context = TrackingVisualEffectContext()
+    renderer.attach(context)
+    renderer.update(context)
+    runtime.prepareRenderBudget(context, runtimeShaderSupported = false)
+
+    renderer.detach(context)
+
+    assertThat(runtime.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(runtime.interactionSource).isNull()
+    assertThat(runtime.shape).isNotSameInstanceAs(initialShape)
+    assertThat(runtime.resolvedStyleCacheDensityForTest).isNull()
+
+    val replacementSource = MutableInteractionSource()
+    val replacementShape = RoundedCornerShape(23.dp)
+    configuration.interactionSource = replacementSource
+    configuration.shape = replacementShape
+    val reacquired = configuration.createRenderer() as GlassRenderer
+
+    assertThat(reacquired).isSameInstanceAs(renderer)
+    assertThat(runtime.interactionSource).isSameInstanceAs(replacementSource)
+    assertThat(runtime.shape).isSameInstanceAs(replacementShape)
+    reacquired.attach(context)
+    reacquired.detach(context)
   }
 
   @Test

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
@@ -56,7 +56,7 @@ class FallbackGlassDelegateTest {
 
   @Test
   fun boundedFractionalAlpha_preparesAndReusesGroupLayer() {
-    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val effect = GlassRuntimeEffect().apply { alpha = 0.5f }
     val delegate = FallbackGlassDelegate(effect)
     val context = FallbackRecordingContext(size = Size(100f, 100f))
 
@@ -70,7 +70,7 @@ class FallbackGlassDelegateTest {
 
   @Test
   fun alphaZero_releasesAndOwnsNoFallbackGroupLayer() {
-    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val effect = GlassRuntimeEffect().apply { alpha = 0.5f }
     val delegate = FallbackGlassDelegate(effect)
     val context = FallbackRecordingContext(size = Size(100f, 100f))
     delegate.prepare(context)
@@ -85,7 +85,7 @@ class FallbackGlassDelegateTest {
 
   @Test
   fun fallbackGroup_exceedingDimension_usesDirectAlphaWithoutAllocation() {
-    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val effect = GlassRuntimeEffect().apply { alpha = 0.5f }
     val delegate = FallbackGlassDelegate(effect)
     val context = FallbackRecordingContext(size = Size(4097f, 1f))
 
@@ -97,7 +97,7 @@ class FallbackGlassDelegateTest {
 
   @Test
   fun fallbackGroup_atExactPixelBoundary_isAllowed() {
-    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val effect = GlassRuntimeEffect().apply { alpha = 0.5f }
     val delegate = FallbackGlassDelegate(effect)
     val context = FallbackRecordingContext(size = Size(4096f, 4096f))
 
@@ -108,7 +108,7 @@ class FallbackGlassDelegateTest {
 
   @Test
   fun fallbackGroup_exceedingDimensionAndPixelLimit_usesDirectAlphaWithoutAllocation() {
-    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val effect = GlassRuntimeEffect().apply { alpha = 0.5f }
     val delegate = FallbackGlassDelegate(effect)
     val context = FallbackRecordingContext(size = Size(4096f, 4097f))
 
@@ -121,7 +121,7 @@ class FallbackGlassDelegateTest {
   @Test
   fun directAlphaDegradation_scalesEveryFallbackContribution() = runComposeUiTest {
     fun assertDirectAlphaHalvesContribution(
-      effect: GlassVisualEffect,
+      effect: GlassRuntimeEffect,
       sample: Offset,
       activateInteraction: Boolean = false,
     ) {
@@ -152,7 +152,7 @@ class FallbackGlassDelegateTest {
     }
 
     assertDirectAlphaHalvesContribution(
-      effect = GlassVisualEffect().apply {
+      effect = GlassRuntimeEffect().apply {
         tint = Color.Red
         specularIntensity = 0f
         edgeSoftness = 0.dp
@@ -160,7 +160,7 @@ class FallbackGlassDelegateTest {
       sample = Offset(60f, 60f),
     )
     assertDirectAlphaHalvesContribution(
-      effect = GlassVisualEffect().apply {
+      effect = GlassRuntimeEffect().apply {
         tint = Color.Transparent
         specularIntensity = 1f
         edgeSoftness = 0.dp
@@ -169,7 +169,7 @@ class FallbackGlassDelegateTest {
       sample = Offset(60f, 60f),
     )
     assertDirectAlphaHalvesContribution(
-      effect = GlassVisualEffect().apply {
+      effect = GlassRuntimeEffect().apply {
         tint = Color.Transparent
         specularIntensity = 0f
         ambientResponse = 1f
@@ -178,7 +178,7 @@ class FallbackGlassDelegateTest {
       sample = Offset(2f, 60f),
     )
     assertDirectAlphaHalvesContribution(
-      effect = GlassVisualEffect().apply {
+      effect = GlassRuntimeEffect().apply {
         tint = Color.Transparent
         specularIntensity = 0f
         edgeSoftness = 0.dp
@@ -191,7 +191,7 @@ class FallbackGlassDelegateTest {
 
   @Test
   fun foregroundLighting_drawsOverOpaqueContent() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       tint = Color.Transparent
       specularIntensity = 1f
       ambientResponse = 0f
@@ -220,7 +220,7 @@ class FallbackGlassDelegateTest {
 
   @Test
   fun stablePrepare_reusesResourcesUntilTheirSemanticInputsChange() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       tint = Color.Red
       specularIntensity = 1f
       ambientResponse = 1f
@@ -340,7 +340,7 @@ private data class PreparedResourcesForTest(
 private const val FALLBACK_TAG = "fallback"
 
 private class FallbackOnlyVisualEffect(
-  private val glass: GlassVisualEffect,
+  private val glass: GlassRuntimeEffect,
   private val fallback: FallbackGlassDelegate,
 ) : VisualEffect {
   private var prepareGroup = true

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassInteractionTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassInteractionTest.kt
@@ -20,11 +20,14 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeEffectNode
+import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class, InternalHazeApi::class)
 class FallbackGlassInteractionTest : ContextTest() {
 
   @Test
@@ -38,17 +41,21 @@ class FallbackGlassInteractionTest : ContextTest() {
       ambientResponse = 0f
       lightPosition = Offset(80f, 80f)
     }
+    lateinit var runtime: GlassRuntimeEffect
     setContent {
       Box(
         Modifier
           .size(100.dp)
           .testTag("glass")
-          .hazeEffect { visualEffect = effect }
+          .hazeEffect {
+            visualEffect = effect
+            runtime = ((this as HazeEffectNode).activeVisualEffect as GlassRenderer).runtimeForTest
+          }
           .background(Color.Black),
       )
     }
     waitForIdle()
-    effect.delegate = FallbackGlassDelegate(effect)
+    runtime.delegate = FallbackGlassDelegate(runtime)
 
     onNodeWithTag("glass").performTouchInput { down(Offset(20f, 20f)) }
     waitForIdle()

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -44,7 +44,10 @@ import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeArea
+import dev.chrisbanes.haze.HazeEffectNode
+import dev.chrisbanes.haze.HazeEffectScope
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
@@ -59,8 +62,13 @@ import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
-@OptIn(ExperimentalTestApi::class)
+@OptIn(
+  ExperimentalTestApi::class,
+  ExperimentalHazeApi::class,
+  InternalHazeApi::class,
+)
 class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
+  private val attachedRuntimes = mutableMapOf<GlassVisualEffect, GlassRuntimeEffect>()
 
   @Test
   fun alphaZero_clearsRetainedOutputUntilVisibleFrameRefreshesIt() = runComposeUiTest {
@@ -68,7 +76,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val sourceRecordsBeforeZero = delegate.sourceRecordCount
 
     effect.alpha = 0f
@@ -96,7 +104,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
           .testTag("glass")
           .hazeEffect {
             inputScale = HazeInputScale.None
-            visualEffect = effect
+            trackRenderer(effect)
           },
       ) {
         Box(Modifier.fillMaxSize().background(Color.Red))
@@ -104,8 +112,8 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     }
     waitForIdle()
 
-    assertThat(effect.delegate is RuntimeShaderGlassDelegate).isTrue()
-    val radii = checkNotNull(effect.preparedRender).params.cornerRadii
+    assertThat(runtime(effect).delegate is RuntimeShaderGlassDelegate).isTrue()
+    val radii = checkNotNull(runtime(effect).preparedRender).params.cornerRadii
     assertThat(radii.values().all { it.isFinite() && it >= 0f }).isTrue()
   }
 
@@ -122,16 +130,16 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
           .testTag("glass")
           .hazeEffect {
             inputScale = HazeInputScale.None
-            visualEffect = effect
+            trackRenderer(effect)
           },
       ) {
         Box(Modifier.fillMaxSize().background(Color.Red))
       }
     }
     waitForIdle()
-    effect.delegate = FallbackGlassDelegate(effect)
+    runtime(effect).delegate = FallbackGlassDelegate(runtime(effect))
 
-    assertThat(effect.delegate is FallbackGlassDelegate).isTrue()
+    assertThat(runtime(effect).delegate is FallbackGlassDelegate).isTrue()
     onNodeWithTag("glass").captureToImage()
   }
 
@@ -142,7 +150,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     assertThat(delegate.layers.hasInteractionOptical).isTrue()
     assertThat(delegate.layers.hasInteractionRefractionDetail).isTrue()
     assertThat(delegate.layers.hasInteractionRefractionDetailCoverage).isTrue()
@@ -169,7 +177,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
           .testTag("glass")
           .hazeEffect {
             inputScale = HazeInputScale.None
-            visualEffect = effect
+            trackRenderer(effect)
           },
       ) {
         Box(Modifier.fillMaxSize().background(Color.Red))
@@ -177,8 +185,8 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     }
     waitForIdle()
 
-    assertThat(effect.delegate is FallbackGlassDelegate).isTrue()
-    assertThat(effect.preparedRender).isNull()
+    assertThat(runtime(effect).delegate is FallbackGlassDelegate).isTrue()
+    assertThat(runtime(effect).preparedRender).isNull()
   }
 
   @Test
@@ -186,7 +194,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     val effect = runtimeInteractiveEffect()
     setContent { RuntimeGlassTestContent(effect, tag = "glass") }
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val opticalEffect = checkNotNull(delegate.opticalEffect)
 
     onNodeWithTag("glass").performTouchInput {
@@ -210,14 +218,14 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
-    effect.setPressedForTest(Offset(60f, 60f))
+    runtime(effect).setPressedForTest(Offset(60f, 60f))
     waitForIdle()
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val layer = checkNotNull(delegate.layers.interactionOptical)
     val stableEffect = checkNotNull(layer.renderEffect)
 
-    effect.setPressedForTest(Offset(60f, 60f))
+    runtime(effect).setPressedForTest(Offset(60f, 60f))
     waitForIdle()
 
     assertThat(layer.renderEffect).isSameInstanceAs(stableEffect)
@@ -252,40 +260,40 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     waitForIdle()
     mainClock.autoAdvance = false
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val source = checkNotNull(delegate.layers.source)
     val optical = checkNotNull(delegate.layers.optical)
     val detail = checkNotNull(delegate.layers.refractionDetail)
-    val decision = effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime
-    val plannedKinds = checkNotNull(effect.preparedRender).plan.layers.map { it.kind }
+    val decision = runtime(effect).preparedRenderBudget as GlassRenderBudgetDecision.Runtime
+    val plannedKinds = checkNotNull(runtime(effect).preparedRender).plan.layers.map { it.kind }
     val positions = listOf(Offset(200f, 150f), Offset(500f, 300f), Offset(800f, 450f))
 
     positions.forEach { position ->
-      effect.setPressedForTest(position)
+      runtime(effect).setPressedForTest(position)
       mainClock.advanceTimeByFrame()
       mainClock.advanceTimeByFrame()
 
-      assertThat(effect.delegate).isSameInstanceAs(delegate)
+      assertThat(runtime(effect).delegate).isSameInstanceAs(delegate)
       assertThat(delegate.layers.source).isSameInstanceAs(source)
       assertThat(delegate.layers.optical).isSameInstanceAs(optical)
       assertThat(delegate.layers.refractionDetail).isSameInstanceAs(detail)
-      assertThat((effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor)
+      assertThat((runtime(effect).preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor)
         .isEqualTo(decision.scaleFactor)
       assertThat(checkNotNull(delegate.layers.interactionOptical).size.width).isLessThan(source.size.width)
       assertThat(checkNotNull(delegate.layers.interactionOptical).size.height).isLessThan(source.size.height)
-      assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind }).isEqualTo(plannedKinds)
+      assertThat(checkNotNull(runtime(effect).preparedRender).plan.layers.map { it.kind }).isEqualTo(plannedKinds)
     }
 
-    effect.setPressedForTest(positions.last(), pressed = false)
+    runtime(effect).setPressedForTest(positions.last(), pressed = false)
     repeat(12) {
       mainClock.advanceTimeByFrame()
-      assertThat(effect.delegate).isSameInstanceAs(delegate)
+      assertThat(runtime(effect).delegate).isSameInstanceAs(delegate)
       assertThat(delegate.layers.source).isSameInstanceAs(source)
       assertThat(delegate.layers.optical).isSameInstanceAs(optical)
       assertThat(delegate.layers.refractionDetail).isSameInstanceAs(detail)
-      assertThat((effect.preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor)
+      assertThat((runtime(effect).preparedRenderBudget as GlassRenderBudgetDecision.Runtime).scaleFactor)
         .isEqualTo(decision.scaleFactor)
-      assertThat(checkNotNull(effect.preparedRender).plan.layers.map { it.kind }).isEqualTo(plannedKinds)
+      assertThat(checkNotNull(runtime(effect).preparedRender).plan.layers.map { it.kind }).isEqualTo(plannedKinds)
     }
     mainClock.autoAdvance = true
     setContent {}
@@ -302,13 +310,13 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeLargeGlassTestContent(effect) }
     waitForIdle()
 
-    effect.setPressedForTest(Offset(300f, 240f))
+    runtime(effect).setPressedForTest(Offset(300f, 240f))
     waitForIdle()
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val recordsAfterPress = delegate.interactionLightingRecordCount
 
-    effect.setPressedForTest(Offset(500f, 320f))
+    runtime(effect).setPressedForTest(Offset(500f, 320f))
     waitForIdle()
 
     assertThat(delegate.interactionLightingRecordCount).isEqualTo(recordsAfterPress)
@@ -324,17 +332,17 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeLargeGlassTestContent(effect) }
     waitForIdle()
 
-    effect.setPressedForTest(Offset(300f, 240f))
+    runtime(effect).setPressedForTest(Offset(300f, 240f))
     waitForIdle()
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val source = checkNotNull(delegate.layers.source)
     val optical = checkNotNull(delegate.layers.optical)
     val interactionOpticalRecords = delegate.interactionOpticalRecordCount
     val interactionDetailRecords = delegate.interactionDetailRecordCount
     val interactionCompositeRecords = delegate.interactionCompositeRecordCount
 
-    effect.setPressedForTest(Offset(500f, 320f))
+    runtime(effect).setPressedForTest(Offset(500f, 320f))
     waitForIdle()
 
     assertThat(delegate.layers.source).isSameInstanceAs(source)
@@ -350,11 +358,11 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
-    effect.setPressedForTest(Offset(60f, 60f))
+    runtime(effect).setPressedForTest(Offset(60f, 60f))
     mainClock.advanceTimeBy(500)
     waitForIdle()
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     RuntimeShaderGlassDelegate::class.java.getDeclaredField("preparedInteractionPatch").apply {
       isAccessible = true
       set(delegate, null)
@@ -363,7 +371,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     delegate.layers.interactionRefractionDetail = null
     delegate.layers.interactionLighting = null
 
-    assertThat(effect.currentInteractionSignals.pressed).isTrue()
+    assertThat(runtime(effect).currentInteractionSignals.pressed).isTrue()
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
   }
 
@@ -378,12 +386,12 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       mainClock.advanceTimeBy(500)
       waitForIdle()
 
-      val delegate = effect.delegate as RuntimeShaderGlassDelegate
+      val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
       val opticalEffect = delegate.interactionShaderHandle("interactionOpticalEffect")
       val detailEffect = delegate.interactionShaderHandle("interactionDetailEffect")
       val lightingEffect = delegate.interactionShaderHandle("interactionLightingEffect")
 
-      effect.setPressedForTest(Offset(80f, 60f))
+      runtime(effect).setPressedForTest(Offset(80f, 60f))
       mainClock.advanceTimeBy(16)
       waitForIdle()
       effect.ambientResponse = 0.6f
@@ -397,7 +405,10 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       assertThat(delegate.interactionShaderHandle("interactionLightingEffect"))
         .isSameInstanceAs(lightingEffect)
 
-      effect.onTrimMemory(checkNotNull(effect.attachedContextForTest), TrimMemoryLevel.UI_HIDDEN)
+      runtime(effect).onTrimMemory(
+        checkNotNull(runtime(effect).attachedContextForTest),
+        TrimMemoryLevel.UI_HIDDEN,
+      )
       assertThat(delegate.interactionShaderHandleOrNull("interactionOpticalEffect")).isNull()
       assertThat(delegate.interactionShaderHandleOrNull("interactionDetailEffect")).isNull()
       assertThat(delegate.interactionShaderHandleOrNull("interactionLightingEffect")).isNull()
@@ -417,7 +428,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeForegroundGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
-    assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(runtime(effect).delegate).isInstanceOf<FallbackGlassDelegate>()
     assertThat(creationAttempts).isEqualTo(1)
     val failureFrameCenter = onNodeWithTag("glass").captureToImage().toPixelMap()[60, 60]
     assertThat(failureFrameCenter.alpha).isGreaterThan(0.9f)
@@ -427,7 +438,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     effect.tint = Color.Blue.copy(alpha = 0.5f)
     waitForIdle()
 
-    assertThat(effect.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(runtime(effect).delegate).isInstanceOf<FallbackGlassDelegate>()
     assertThat(creationAttempts).isEqualTo(attemptsAfterDowngrade)
     onNodeWithTag("glass").captureToImage()
   }
@@ -445,11 +456,11 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     waitForIdle()
     val attemptsAfterPreparation = creationAttempts
 
-    effect.setPressedForTest(Offset(60f, 60f))
+    runtime(effect).setPressedForTest(Offset(60f, 60f))
     mainClock.advanceTimeBy(500)
     waitForIdle()
 
-    assertThat(effect.delegate).isInstanceOf<RuntimeShaderGlassDelegate>()
+    assertThat(runtime(effect).delegate).isInstanceOf<RuntimeShaderGlassDelegate>()
     assertThat(creationAttempts).isEqualTo(attemptsAfterPreparation)
   }
 
@@ -472,7 +483,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
             .testTag("glass")
             .hazeEffect(hazeState) {
               inputScale = HazeInputScale.None
-              visualEffect = effect
+              trackRenderer(effect)
             },
         )
       }
@@ -484,7 +495,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     }
     mainClock.advanceTimeBy(500)
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val sourceRecordsBeforeMutation = delegate.sourceRecordCount
     val interactionOpticalRecordsBeforeMutation = delegate.interactionOpticalRecordCount
     val interactionDetailRecordsBeforeMutation = delegate.interactionDetailRecordCount
@@ -494,7 +505,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     sourceColor.value = Color.Blue
     waitForIdle()
 
-    assertThat(effect.currentInteractionSignals.pressed).isTrue()
+    assertThat(runtime(effect).currentInteractionSignals.pressed).isTrue()
     assertThat(delegate.sourceRecordCount).isGreaterThan(sourceRecordsBeforeMutation)
     assertThat(delegate.interactionOpticalRecordCount)
       .isGreaterThan(interactionOpticalRecordsBeforeMutation)
@@ -512,9 +523,9 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val previousSnapshot = checkNotNull(delegate.lastSuccessfulSourceSnapshot)
-    val context = checkNotNull(effect.attachedContextForTest)
+    val context = checkNotNull(runtime(effect).attachedContextForTest)
     val trackedAreas = SizeReadTrackingList(context.areas)
     val trackingContext = object : VisualEffectContext by context {
       override val areas = trackedAreas
@@ -536,9 +547,9 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val previousSnapshot = checkNotNull(delegate.lastSuccessfulSourceSnapshot)
-    val context = checkNotNull(effect.attachedContextForTest)
+    val context = checkNotNull(runtime(effect).attachedContextForTest)
     val changedArea = context.areas.first()
     val trackedAreas = SizeReadTrackingList(context.areas)
     val trackingContext = object : VisualEffectContext by context {
@@ -579,14 +590,14 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
             .fillMaxSize()
             .hazeEffect(hazeState) {
               inputScale = HazeInputScale.None
-              visualEffect = effect
+              trackRenderer(effect)
             },
         )
       }
     }
     waitForIdle()
 
-    val context = checkNotNull(effect.attachedContextForTest)
+    val context = checkNotNull(runtime(effect).attachedContextForTest)
     val area = context.areas.single()
     val graphicsContext = context.requireGraphicsContext()
 
@@ -644,14 +655,14 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
             .fillMaxSize()
             .hazeEffect(hazeState) {
               inputScale = HazeInputScale.None
-              visualEffect = effect
+              trackRenderer(effect)
             },
         )
       }
     }
 
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val detailLayer = checkNotNull(delegate.layers.refractionDetail)
     val detailKey = checkNotNull(delegate.lastSuccessfulStageInputs?.detail)
     val sourceSnapshot = checkNotNull(delegate.lastSuccessfulSourceSnapshot)
@@ -662,7 +673,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     waitForIdle()
 
     assertThat(delegate.layers.refractionDetail).isSameInstanceAs(detailLayer)
-    assertThat(effect.delegate).isSameInstanceAs(delegate)
+    assertThat(runtime(effect).delegate).isSameInstanceAs(delegate)
     assertThat(delegate.lastSuccessfulSourceSnapshot).isSameInstanceAs(sourceSnapshot)
     assertThat(delegate.lastSuccessfulStageInputs?.detail).isNotNull().isEqualTo(detailKey)
     assertThat(delegate.layers.hasRefractionDetail).isTrue()
@@ -676,7 +687,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     setContent { RuntimeGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val beforeDetail = delegate.detailRecordCount
 
     effect.optics = (effect.optics as GlassOptics.Absolute).copy(refractionScale = 18f)
@@ -705,14 +716,14 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
             .fillMaxSize()
             .hazeEffect(hazeState) {
               inputScale = HazeInputScale.None
-              visualEffect = effect
+              trackRenderer(effect)
             },
         )
       }
     }
 
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     assertThat(delegate.lastSuccessfulStageInputs?.detail).isNull()
     assertThat(delegate.layers.hasRefractionDetail).isFalse()
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
@@ -731,14 +742,14 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
         Box(
           Modifier.fillMaxSize().hazeEffect(hazeState) {
             inputScale = HazeInputScale.None
-            visualEffect = effect
+            trackRenderer(effect)
           },
         )
       }
     }
 
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     assertThat(delegate.lastSuccessfulStageInputs?.detail).isNull()
     assertThat(delegate.layers.hasRefractionDetail).isFalse()
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
@@ -757,14 +768,14 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
         Box(
           Modifier.fillMaxSize().hazeEffect(hazeState) {
             inputScale = HazeInputScale.None
-            visualEffect = effect
+            trackRenderer(effect)
           },
         )
       }
     }
 
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     assertThat(delegate.lastSuccessfulStageInputs?.detail).isNotNull()
     assertThat(delegate.layers.hasRefractionDetail).isTrue()
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
@@ -788,14 +799,14 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
             .fillMaxSize()
             .hazeEffect(hazeState) {
               inputScale = HazeInputScale.None
-              visualEffect = effect
+              trackRenderer(effect)
             },
         )
       }
     }
 
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     assertThat(checkNotNull(delegate.layers.optical).alpha).isEqualTo(1f)
     assertThat(checkNotNull(delegate.layers.refractionDetail).alpha).isEqualTo(1f)
   }
@@ -813,9 +824,9 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     }
     waitForIdle()
 
-    val outputSize = checkNotNull(effect.attachedContextForTest).size.roundToIntSize()
-    val groupLayer = checkNotNull((effect.delegate as RuntimeShaderGlassDelegate).layers.groupAlpha.layer)
-    val groupPlan = checkNotNull(effect.preparedRender).plan.layers.single {
+    val outputSize = checkNotNull(runtime(effect).attachedContextForTest).size.roundToIntSize()
+    val groupLayer = checkNotNull((runtime(effect).delegate as RuntimeShaderGlassDelegate).layers.groupAlpha.layer)
+    val groupPlan = checkNotNull(runtime(effect).preparedRender).plan.layers.single {
       it.kind == GlassRetainedLayerKind.GroupComposite
     }
 
@@ -825,7 +836,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
 
   @Test
   fun initialBlurWorkingSizeSetup_doesNotInvalidateDraw() = runComposeUiTest {
-    val glassEffect = animatedStageEffect().apply { resetDirtyTracker() }
+    val glassEffect = GlassRuntimeEffect(animatedStageEffect()).apply { resetDirtyTracker() }
     val effect = InvalidationTrackingVisualEffect(glassEffect)
 
     setContent {
@@ -852,7 +863,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     val effect = animatedStageEffect()
     setContent { RuntimeForegroundGlassTestContent(effect) }
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
 
     val beforeAlpha = delegate.stageRecordCounts
     effect.alpha = 0.5f
@@ -883,7 +894,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     val effect = retainedBlurEffect()
     setContent { RuntimeForegroundGlassTestContent(effect) }
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
 
     val horizontalShader = checkNotNull(delegate.blurHorizontalShader)
     val verticalShader = checkNotNull(delegate.blurVerticalShader)
@@ -920,7 +931,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     )
     setContent { RuntimeForegroundGlassTestContent(effect) }
     waitForIdle()
-    val delegate = effect.delegate as RuntimeShaderGlassDelegate
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
 
     val horizontalShader = checkNotNull(delegate.progressiveBlurHorizontalShader)
     val verticalShader = checkNotNull(delegate.progressiveBlurVerticalShader)
@@ -986,6 +997,15 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     specularIntensity = 0f
   }
 
+  private fun HazeEffectScope.trackRenderer(effect: GlassVisualEffect) {
+    visualEffect = effect
+    attachedRuntimes[effect] =
+      ((this as HazeEffectNode).activeVisualEffect as GlassRenderer).runtimeForTest
+  }
+
+  private fun runtime(effect: GlassVisualEffect): GlassRuntimeEffect =
+    checkNotNull(attachedRuntimes[effect])
+
   @Composable
   private fun RuntimeForegroundGlassTestContent(
     effect: GlassVisualEffect,
@@ -997,7 +1017,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
         .then(if (tag != null) Modifier.testTag(tag) else Modifier)
         .hazeEffect {
           inputScale = HazeInputScale.None
-          visualEffect = effect
+          trackRenderer(effect)
         },
     ) {
       Box(Modifier.fillMaxSize().background(Color.Red))
@@ -1028,7 +1048,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   private class InvalidationTrackingVisualEffect(
-    private val delegate: GlassVisualEffect,
+    private val delegate: GlassRuntimeEffect,
   ) : VisualEffect, RetainedOutputVisualEffect {
     var invalidateDrawCalls = 0
       private set
@@ -1132,7 +1152,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
           .testTag(tag)
           .hazeEffect(hazeState) {
             this.inputScale = inputScale
-            visualEffect = effect
+            trackRenderer(effect)
           },
       )
     }
@@ -1148,7 +1168,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
           .fillMaxSize()
           .hazeEffect(hazeState) {
             inputScale = HazeInputScale.None
-            visualEffect = effect
+            trackRenderer(effect)
           },
       )
     }

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
@@ -76,7 +76,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun fractionalAlpha_reusesGroupLayerAndZeroReleasesIt() {
-    val effect = GlassVisualEffect().apply { alpha = 0.5f }
+    val effect = GlassRuntimeEffect().apply { alpha = 0.5f }
     val delegate = RuntimeShaderGlassDelegate(effect)
     val context = RecordingVisualEffectContext(
       size = Size(100f, 100f),
@@ -121,7 +121,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun prepareDraw_consumesTheSelectedPreparedRenderParamsInstance() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(depth = 0f)
     }
     val delegate = RuntimeShaderGlassDelegate(effect)
@@ -141,7 +141,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun prepareDraw_budgetScaleReductionReleasesAndRebuildsRuntimeLayers() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(
         refractionStrength = 0f,
         refractionScale = 0f,
@@ -177,7 +177,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun prepareDraw_releasesObsoleteTopologyBeforeCreatingReplacementLayers() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(
         refractionStrength = 0.5f,
         refractionScale = 20f,
@@ -229,7 +229,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun prepareDraw_budgetDecisionTransitionsRuntimeToFallbackToFreshRuntime() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val graphicsContext = TestGraphicsContext()
     val safeContext = RecordingVisualEffectContext(
       size = Size(100f, 100f),
@@ -270,7 +270,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
       }
       create()
     }
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(
         refractionStrength = 0.5f,
         refractionScale = 20f,
@@ -321,7 +321,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     val failingFactory = GlassRuntimeEffectFactory {
       throw unrelatedFailure
     }
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val context = RecordingVisualEffectContext(
       size = Size(100f, 100f),
       layerSize = Size(100f, 100f),
@@ -338,7 +338,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun prepareDraw_impossibleMaximumRefractionGeometryCreatesNoRuntimeLayers() {
-    val effect = GlassVisualEffect().apply {
+    val effect = GlassRuntimeEffect().apply {
       optics = GlassOptics.Absolute(
         refractionStrength = 1f,
         refractionScale = 16_384f,
@@ -445,7 +445,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun onTrimMemory_backgroundKeepsRetainedOutputAvailability() {
-    val delegate = RuntimeShaderGlassDelegate(GlassVisualEffect())
+    val delegate = RuntimeShaderGlassDelegate(GlassRuntimeEffect())
     val context = RecordingVisualEffectContext()
     delegate.layers.populate(context.graphicsContext)
     delegate.seedSuccessfulCacheMetadata()
@@ -478,7 +478,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun onTrimMemory_uiHiddenReleasesAllLayersAndInvalidatesDraw() {
-    val delegate = RuntimeShaderGlassDelegate(GlassVisualEffect())
+    val delegate = RuntimeShaderGlassDelegate(GlassRuntimeEffect())
     val context = RecordingVisualEffectContext(size = Size(100f, 100f), layerSize = Size(100f, 100f))
     delegate.layers.populate(context.graphicsContext)
     val retainedLayers = delegate.layers.allLayers()
@@ -495,7 +495,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun onTrimMemory_moderateClearsRetainedOutputAvailabilityAndInvalidatesDraw() {
-    val delegate = RuntimeShaderGlassDelegate(GlassVisualEffect())
+    val delegate = RuntimeShaderGlassDelegate(GlassRuntimeEffect())
     val context = RecordingVisualEffectContext()
     delegate.layers.populate(context.graphicsContext)
     delegate.seedSuccessfulCacheMetadata()
@@ -527,7 +527,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun onTrimMemory_completeClearsRetainedOutputAvailabilityAndInvalidatesDraw() {
-    val delegate = RuntimeShaderGlassDelegate(GlassVisualEffect())
+    val delegate = RuntimeShaderGlassDelegate(GlassRuntimeEffect())
     val context = RecordingVisualEffectContext()
     delegate.layers.populate(context.graphicsContext)
     delegate.seedSuccessfulCacheMetadata()
@@ -549,7 +549,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun detach_clearsSuccessfulCacheMetadata() {
-    val delegate = RuntimeShaderGlassDelegate(GlassVisualEffect())
+    val delegate = RuntimeShaderGlassDelegate(GlassRuntimeEffect())
     val context = RecordingVisualEffectContext()
     delegate.layers.populate(context.graphicsContext)
     val retainedLayers = delegate.layers.allLayers()
@@ -566,7 +566,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun clearRetainedOutput_releasesAllPrivateLayersIncludingDetail() {
-    val delegate = RuntimeShaderGlassDelegate(GlassVisualEffect())
+    val delegate = RuntimeShaderGlassDelegate(GlassRuntimeEffect())
     val context = RecordingVisualEffectContext()
     delegate.layers.populate(context.graphicsContext)
     val retainedLayers = delegate.layers.allLayers()
@@ -585,7 +585,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun canDrawRetainedOutput_activeDetailRequiresAvailableDetailLayer() {
-    val delegate = RuntimeShaderGlassDelegate(GlassVisualEffect())
+    val delegate = RuntimeShaderGlassDelegate(GlassRuntimeEffect())
     val context = RecordingVisualEffectContext()
     delegate.layers.populate(context.graphicsContext)
     delegate.seedSuccessfulCacheMetadata(detail = Any())
@@ -598,7 +598,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun canDrawRetainedOutput_inactiveDetailDoesNotRequireDetailLayer() {
-    val delegate = RuntimeShaderGlassDelegate(GlassVisualEffect())
+    val delegate = RuntimeShaderGlassDelegate(GlassRuntimeEffect())
     val context = RecordingVisualEffectContext()
     delegate.layers.populate(context.graphicsContext)
     delegate.seedSuccessfulCacheMetadata(detail = null)
@@ -646,7 +646,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
         failIfBuildRenderParamsReached = true,
       ),
     ).forEach { context ->
-      val effect = GlassVisualEffect()
+      val effect = GlassRuntimeEffect()
       val delegate = RuntimeShaderGlassDelegate(effect)
       val retainedLayers = delegate.prepareDrawWithRetainedLayers(context, effect)
 
@@ -659,7 +659,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
 
   @Test
   fun onTrimMemory_uiHiddenRecreatesSafeGraphWithFreshSourceAndOpticalLayers() {
-    val effect = GlassVisualEffect()
+    val effect = GlassRuntimeEffect()
     val delegate = RuntimeShaderGlassDelegate(effect)
     val context = RecordingVisualEffectContext(size = Size(100f, 100f), layerSize = Size(100f, 100f))
 
@@ -723,7 +723,7 @@ private fun GlassLayers.allLayers(): List<GraphicsLayer> = listOfNotNull(
 
 private fun RuntimeShaderGlassDelegate.prepareDrawWithRetainedLayers(
   context: RecordingVisualEffectContext,
-  effect: GlassVisualEffect,
+  effect: GlassRuntimeEffect,
 ): List<GraphicsLayer> {
   layers.populate(context.graphicsContext)
   val retainedLayers = layers.allLayers()
@@ -738,7 +738,7 @@ private fun RuntimeShaderGlassDelegate.prepareDrawWithRetainedLayers(
 
 private fun RuntimeShaderGlassDelegate.prepareDrawForTest(
   context: RecordingVisualEffectContext,
-  effect: GlassVisualEffect,
+  effect: GlassRuntimeEffect,
 ) {
   effect.prepareRenderBudget(context, runtimeShaderSupported = true)
   with(CanvasDrawScope()) {
@@ -746,7 +746,7 @@ private fun RuntimeShaderGlassDelegate.prepareDrawForTest(
   }
 }
 
-private fun GlassVisualEffect.prepareDrawForTest(context: RecordingVisualEffectContext) {
+private fun GlassRuntimeEffect.prepareDrawForTest(context: RecordingVisualEffectContext) {
   with(CanvasDrawScope()) {
     with(this@prepareDrawForTest) { prepareDraw(context) }
   }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -205,6 +205,11 @@ public class HazeEffectNode(
 
   private val contentDrawArea by lazy { HazeArea() }
 
+  /** The node-owned runtime currently serving [visualEffect]. */
+  @InternalHazeApi
+  public var activeVisualEffect: VisualEffect = EmptyVisualEffect
+    private set
+
   override var canDrawArea: ((HazeArea) -> Boolean)? = null
     set(value) {
       if (value != field) {
@@ -218,21 +223,27 @@ public class HazeEffectNode(
     set(value) {
       if (value != field) {
         HazeLogger.d(TAG) { "visualEffect changed. Current $field. New: $value" }
-        val oldEffect = field
-        pointerInputDelegate?.cancel(oldEffect as? InteractiveVisualEffect)
+        val oldConfiguredEffect = field
+        val oldRuntime = activeVisualEffect
+        pointerInputDelegate?.cancel(oldRuntime as? InteractiveVisualEffect)
         if (isAttached) {
-          attachVisualEffect(value)
+          val newRuntime = value.createRenderer()
+          attachVisualEffect(newRuntime)
           try {
-            clearRetainedOutput()
+            clearRetainedOutput(oldRuntime)
           } catch (throwable: Throwable) {
-            runCatching { detachVisualEffect(value) }
+            runCatching { detachVisualEffect(newRuntime) }
               .exceptionOrNull()
               ?.let(throwable::addSuppressed)
             throw throwable
           }
-          runCatching { detachVisualEffect(oldEffect) }
+          runCatching { detachVisualEffect(oldRuntime) }
+          activeVisualEffect = newRuntime
         } else {
-          clearRetainedOutput()
+          clearRetainedOutput(
+            activeVisualEffect.takeUnless { it === EmptyVisualEffect } ?: oldConfiguredEffect,
+          )
+          activeVisualEffect = EmptyVisualEffect
         }
         field = value
         dirtyTracker += DirtyFields.VisualEffectLayerBounds
@@ -312,10 +323,13 @@ public class HazeEffectNode(
   private var trimMemoryCallbackDisposable: DisposableHandle? = null
 
   override fun onAttach() {
-    attachVisualEffect(visualEffect)
+    val runtime = activeVisualEffect.takeUnless { it === EmptyVisualEffect }
+      ?: visualEffect.createRenderer()
+    attachVisualEffect(runtime)
+    activeVisualEffect = runtime
     trimMemoryCallbackDisposable = registerTrimMemoryCallback(
       requirePlatformContext(),
-    ) { level -> visualEffect.onTrimMemory(visualEffectContext, level) }
+    ) { level -> activeVisualEffect.onTrimMemory(visualEffectContext, level) }
     update()
   }
 
@@ -329,12 +343,16 @@ public class HazeEffectNode(
     contentDrawArea.releaseLayer()
     clearRetainedOutput()
     pointerInputDelegate?.let { delegate ->
-      delegate.cancel(visualEffect as? InteractiveVisualEffect)
+      delegate.cancel(activeVisualEffect as? InteractiveVisualEffect)
       undelegate(delegate)
     }
     pointerInputDelegate = null
     lastKnownCoordinates = null
-    detachVisualEffect(visualEffect)
+    try {
+      detachVisualEffect(activeVisualEffect)
+    } finally {
+      activeVisualEffect = EmptyVisualEffect
+    }
   }
 
   private fun HazeArea.releaseLayer() {
@@ -431,24 +449,24 @@ public class HazeEffectNode(
             hasDrawableSourceLayers
           }
           if (shouldDrawEffect) {
-            with(visualEffect) {
+            with(activeVisualEffect) {
               prepareDraw(visualEffectContext)
             }
           }
           withVisualEffectTransform {
             if (shouldDrawEffect) {
-              with(visualEffect) {
+              with(activeVisualEffect) {
                 draw(visualEffectContext)
               }
             }
             drawContentSafely()
             if (shouldDrawEffect) {
-              with(visualEffect) {
+              with(activeVisualEffect) {
                 drawForeground(visualEffectContext)
               }
             }
           }
-        } else if (visualEffect === EmptyVisualEffect) {
+        } else if (activeVisualEffect === EmptyVisualEffect) {
           contentDrawArea.releaseLayer()
           drawContentSafely()
         } else {
@@ -471,14 +489,17 @@ public class HazeEffectNode(
           if (!effectOnlyDraw) {
             contentDrawArea.contentVersion++
           }
-          with(visualEffect) {
+          with(activeVisualEffect) {
             prepareDraw(visualEffectContext)
           }
           withVisualEffectTransform {
-            if (drawContentBehind || visualEffect.shouldDrawContentBehind(visualEffectContext)) {
+            if (
+              drawContentBehind ||
+              activeVisualEffect.shouldDrawContentBehind(visualEffectContext)
+            ) {
               drawLayer(contentLayer)
             }
-            with(visualEffect) {
+            with(activeVisualEffect) {
               draw(visualEffectContext)
               drawForeground(visualEffectContext)
             }
@@ -620,13 +641,15 @@ public class HazeEffectNode(
 
     // Allow the current VisualEffect to update from CompositionLocals/state before calculating
     // bounds, so it can request a bounds refresh for values observed during this update.
-    visualEffect.update(visualEffectContext)
+    activeVisualEffect.update(visualEffectContext)
     syncPointerInputDelegate()
 
     if (dirtyTracker.any(LayerBoundsDirtyFields)) {
       if (state != null && areas.isNotEmpty() && size.isSpecified && position.isSpecified) {
         val clippedLayerBounds = Rect(position, size)
-          .letIf(shouldExpandLayer()) { visualEffect.calculateLayerBounds(it, requireDensity()) }
+          .letIf(shouldExpandLayer()) {
+            activeVisualEffect.calculateLayerBounds(it, requireDensity())
+          }
           .letIf(shouldClipToAreaBounds()) { rect ->
             var left = Float.POSITIVE_INFINITY
             var top = Float.POSITIVE_INFINITY
@@ -651,9 +674,14 @@ public class HazeEffectNode(
       } else if (shouldDrawRetainedOutput()) {
         // Keep the previous layer bounds for source transition gaps. Recomputing
         // bounds with no areas collapses to the node size and clears the retained layer.
-      } else if (state == null && size.isSpecified && !visualEffect.shouldClipToNodeBounds() && shouldExpandLayer()) {
+      } else if (
+        state == null &&
+        size.isSpecified &&
+        !activeVisualEffect.shouldClipToNodeBounds() &&
+        shouldExpandLayer()
+      ) {
         val rect = size.toRect()
-        val expanded = visualEffect.calculateLayerBounds(rect, requireDensity())
+        val expanded = activeVisualEffect.calculateLayerBounds(rect, requireDensity())
         _layerSize = expanded.size
         _layerOffset = rect.topLeft - expanded.topLeft
       } else {
@@ -765,18 +793,18 @@ public class HazeEffectNode(
     }
   }
 
-  private fun clearRetainedOutput() {
-    (visualEffect as? RetainedOutputVisualEffect)?.clearRetainedOutput()
+  private fun clearRetainedOutput(effect: VisualEffect = activeVisualEffect) {
+    (effect as? RetainedOutputVisualEffect)?.clearRetainedOutput()
   }
 
   private fun syncPointerInputDelegate() {
-    val interactive = visualEffect as? InteractiveVisualEffect
+    val interactive = activeVisualEffect as? InteractiveVisualEffect
     val required = interactive?.observesPointerEvents == true
     when {
       required && pointerInputDelegate == null -> {
         pointerInputDelegate = delegate(
           HazeEffectPointerInputNode(
-            interactiveEffect = { visualEffect as? InteractiveVisualEffect },
+            interactiveEffect = { activeVisualEffect as? InteractiveVisualEffect },
             context = { visualEffectContext },
           ),
         )
@@ -793,7 +821,7 @@ public class HazeEffectNode(
   private inline fun ContentDrawScope.withVisualEffectTransform(
     block: ContentDrawScope.() -> Unit,
   ) {
-    val transform = (visualEffect as? InteractiveVisualEffect)
+    val transform = (activeVisualEffect as? InteractiveVisualEffect)
       ?.currentContentTransform(visualEffectContext)
       ?: VisualEffectTransform.Identity
     if (transform == VisualEffectTransform.Identity) {
@@ -810,7 +838,8 @@ public class HazeEffectNode(
 
   private fun shouldDrawRetainedOutput(): Boolean {
     return retainOutputWhenSourceUnavailable &&
-      (visualEffect as? RetainedOutputVisualEffect)?.shouldDrawRetainedOutput(visualEffectContext) == true
+      (activeVisualEffect as? RetainedOutputVisualEffect)
+        ?.shouldDrawRetainedOutput(visualEffectContext) == true
   }
 
   private fun hasDrawableSourceLayers(): Boolean {
@@ -859,8 +888,11 @@ internal expect fun invalidateOnHazeAreaPreDraw(): Boolean
 
 internal fun HazeEffectNode.shouldClipToAreaBounds(): Boolean {
   clipToAreasBounds?.let { return it }
-  return visualEffect.shouldPreferClipToAreaBounds()
+  return activeVisualEffect.shouldPreferClipToAreaBounds()
 }
+
+private fun VisualEffect.createRenderer(): VisualEffect =
+  (this as? VisualEffectRendererFactory)?.createRenderer() ?: this
 
 // Tracks currently attached effect instances across all nodes.
 // Multiple entries are expected (different effect instances on different nodes),
@@ -885,13 +917,17 @@ internal fun HazeEffectNode.attachVisualEffect(effect: VisualEffect) {
 
   attachedEffectOwners += effect to this
 
-  runCatching {
+  try {
     effect.attach(visualEffectContext)
-  }.onFailure {
+  } catch (throwable: Throwable) {
+    runCatching { effect.detach(visualEffectContext) }
+      .exceptionOrNull()
+      ?.let(throwable::addSuppressed)
     attachedEffectOwners.removeAll { (attachedEffect, attachedNode) ->
       attachedEffect === effect && attachedNode === this
     }
-  }.getOrThrow()
+    throw throwable
+  }
 }
 
 internal fun HazeEffectNode.detachVisualEffect(effect: VisualEffect) {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/VisualEffect.kt
@@ -16,8 +16,9 @@ import androidx.compose.ui.unit.Density
  * access to geometry, configuration, and platform capabilities without direct coupling
  * to the underlying node implementation.
  *
- * VisualEffect instances are single-owner and must not be attached to multiple
- * `Modifier.hazeEffect` nodes at the same time. Reusing the same effect instance
+ * VisualEffect runtime instances are single-owner and must not be attached to multiple
+ * `Modifier.hazeEffect` nodes at the same time. A [VisualEffectRendererFactory] descriptor may be
+ * shared, but each runtime it creates remains single-owner. Reusing any other effect instance
  * across concurrently active nodes will throw an [IllegalStateException].
  *
  * The built-in [Empty] singleton is exempt from this restriction and may be shared
@@ -137,6 +138,15 @@ public interface VisualEffect {
 
 internal object EmptyVisualEffect : VisualEffect {
   override fun DrawScope.draw(context: VisualEffectContext) = Unit
+}
+
+/**
+ * Internal bridge for compatibility effects whose configuration can be shared while each
+ * `hazeEffect` node owns a distinct runtime [VisualEffect].
+ */
+@InternalHazeApi
+public interface VisualEffectRendererFactory : VisualEffect {
+  public fun createRenderer(): VisualEffect
 }
 
 @InternalHazeApi

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -26,6 +26,7 @@ import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.test.ContextTest
@@ -268,6 +269,63 @@ class VisualEffectLifecycleTest : ContextTest() {
   }
 
   @Test
+  fun visualEffect_rendererFactoryCreatesDistinctRuntimesForConcurrentNodes() = runComposeUiTest {
+    val descriptor = RecordingVisualEffectRendererFactory()
+    val showContent = mutableStateOf(true)
+
+    setContent {
+      if (showContent.value) {
+        Box(Modifier.size(200.dp)) {
+          Spacer(Modifier.size(100.dp).hazeEffect { visualEffect = descriptor })
+          Spacer(Modifier.size(100.dp).hazeEffect { visualEffect = descriptor })
+        }
+      }
+    }
+
+    waitForIdle()
+    assertThat(descriptor.runtimes.size).isEqualTo(2)
+    assertThat(descriptor.runtimes[0]).isNotSameInstanceAs(descriptor.runtimes[1])
+    assertThat(descriptor.attachCalls).isEqualTo(0)
+    assertThat(descriptor.runtimes.map { it.attachCalls }).isEqualTo(listOf(1, 1))
+
+    showContent.value = false
+    waitForIdle()
+
+    assertThat(descriptor.runtimes.map { it.detachCalls }).isEqualTo(listOf(1, 1))
+  }
+
+  @Test
+  fun visualEffect_rendererAttachmentFailureKeepsOldRuntimeAttached() = runComposeUiTest {
+    val oldEffect = RecordingVisualEffect()
+    val descriptor = ThrowingVisualEffectRendererFactory()
+    var effectNode: HazeEffectNode? = null
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(100.dp)
+          .hazeEffect {
+            effectNode = this as HazeEffectNode
+            visualEffect = oldEffect
+          },
+      )
+    }
+    waitForIdle()
+
+    assertFailure {
+      runOnIdle {
+        checkNotNull(effectNode).visualEffect = descriptor
+      }
+    }.isInstanceOf<IllegalStateException>()
+
+    assertThat(checkNotNull(effectNode).visualEffect).isSameInstanceAs(oldEffect)
+    assertThat(checkNotNull(effectNode).activeVisualEffect).isSameInstanceAs(oldEffect)
+    assertThat(oldEffect.detachCalls).isEqualTo(0)
+    assertThat(descriptor.runtime.attachCalls).isEqualTo(1)
+    assertThat(descriptor.runtime.detachCalls).isEqualTo(1)
+  }
+
+  @Test
   fun visualEffect_ownedReplacementFailureKeepsOldEffectAttached() = runComposeUiTest {
     val oldEffect = RecordingVisualEffect()
     val ownedEffect = RecordingVisualEffect()
@@ -500,7 +558,7 @@ class VisualEffectLifecycleTest : ContextTest() {
   }
 }
 
-internal class RecordingVisualEffect : VisualEffect {
+internal open class RecordingVisualEffect : VisualEffect {
   var attachCalls = 0
   var detachCalls = 0
   var updateCalls = 0
@@ -530,6 +588,27 @@ internal class RecordingVisualEffect : VisualEffect {
   override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
     trimMemoryCalls++
   }
+}
+
+internal class RecordingVisualEffectRendererFactory :
+  RecordingVisualEffect(),
+  VisualEffectRendererFactory {
+  val runtimes = mutableListOf<RecordingVisualEffect>()
+
+  override fun createRenderer(): VisualEffect = RecordingVisualEffect().also(runtimes::add)
+}
+
+private class ThrowingVisualEffectRendererFactory :
+  RecordingVisualEffect(),
+  VisualEffectRendererFactory {
+  val runtime = object : RecordingVisualEffect() {
+    override fun attach(context: VisualEffectContext) {
+      super.attach(context)
+      error("attach failed")
+    }
+  }
+
+  override fun createRenderer(): VisualEffect = runtime
 }
 
 internal class DrawBehindProbeVisualEffect(


### PR DESCRIPTION
## Summary

- separate public Glass configuration from node-owned renderer/runtime state
- materialize one isolated Glass runtime per Haze effect node while preserving the existing public compatibility surface
- make replacement, detach, trim-memory, cache eviction, and runtime-factory changes release only the correct node-owned resources

## Validation

- `./gradlew check --no-scan`
- both Haze and Glass Metalava compatibility checks
- focused JVM and Android-host lifecycle, direct-modifier, factory-reselection, resource-release, interaction, and screenshot invariants
- correctness/standards, reuse/clarity/efficiency, and over-engineering reviews clean on final HEAD

No API or screenshot baselines changed.

Fixes #1122