### PR TITLE
Introduce explicit Haze inputs and rendering policies

### DIFF
--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -44,7 +44,9 @@ Applies a visual effect to a composable, drawing blurred content from areas mark
 val style = HazeMaterials.thin()
 
 TopAppBar(
-    modifier = Modifier.hazeEffect(state = hazeState) {
+    modifier = Modifier.hazeEffect(
+        input = HazeInput.Sources(hazeState),
+    ) {
         blurEffect {
             this.style = style
         }
@@ -52,11 +54,70 @@ TopAppBar(
 )
 ```
 
-The effect is configured inside the lambda block using effect-specific builders.
+The required `input` makes the source mode explicit:
+
+- `HazeInput.Sources(hazeState)` consumes content captured by matching `hazeSource` modifiers.
+- `HazeInput.Content` captures the modifier's own content.
+
+The effect is configured inside the lambda block using effect-specific builders. The older
+nullable-state overloads remain available during the Haze 2 migration.
+
+#### Selecting sources
+
+`HazeInput.Sources` defaults to `HazeSourceSelection.Behind`. With a nearest ancestor
+`hazeSource` using the same state, this selects lower-z sources. Without one, it selects every
+source. Use `All` to bypass the ancestor relationship:
+
+```kotlin
+HazeInput.Sources(
+    state = hazeState,
+    selection = HazeSourceSelection.All,
+)
+```
+
+Refine either relationship with `where`. Predicates receive only an immutable snapshot of the
+source `key` and `zIndex`; renderer-owned geometry, content, and platform resources stay private.
+Repeated refinements combine with logical AND:
+
+```kotlin
+val selection = HazeSourceSelection.Behind
+    .where { source -> source.zIndex >= 1f }
+    .where { source -> source.key != "sensitive" }
+```
+
+#### Rendering policies
+
+The explicit-input overload also makes sampling and layer expansion structural:
+
+```kotlin
+Modifier.hazeEffect(
+    input = HazeInput.Sources(
+        state = hazeState,
+        retention = HazeSourceRetention.ClearWhenUnavailable,
+    ),
+    sampling = HazeSampling.Adaptive,
+    expandLayerBounds = false,
+) {
+    blurEffect { /* ... */ }
+}
+```
+
+- `HazeSourceRetention.KeepLastFrame` is the default and preserves smooth source transitions.
+  Use `ClearWhenUnavailable` for privacy-sensitive surfaces that must not display stale pixels.
+- `HazeSampling.Default` lets the effect choose, `FullResolution` disables scaling,
+  `Adaptive` requests the effect's adaptive policy, and `Fixed(scale)` uses a validated
+  `0 < scale <= 1` value.
+- `expandLayerBounds` is non-null and defaults to `true`. Set it to `false` to constrain the
+  effect layer to the composable's ordinary bounds.
+
+These structural arguments are authoritative on the explicit-input overload.
 
 ## HazeEffectScope
 
-The lambda block parameter of `Modifier.hazeEffect` receives a `HazeEffectScope`, which provides common properties applicable to all effects:
+The lambda block parameter of `Modifier.hazeEffect` receives a `HazeEffectScope`, which provides
+common properties applicable to all effects. `inputScale`, `canDrawArea`,
+`retainOutputWhenSourceUnavailable`, and nullable `expandLayerBounds` remain available for the
+legacy modifier overloads; prefer the structural contracts above on the explicit-input path.
 
 ### Common Properties
 
@@ -135,7 +196,9 @@ Box {
     }
     
     TopAppBar(
-        modifier = Modifier.hazeEffect(state = hazeState) {
+        modifier = Modifier.hazeEffect(
+            input = HazeInput.Sources(hazeState),
+        ) {
             blurEffect { /* ... */ }
         }
     )
@@ -148,7 +211,7 @@ The effect blurs the content within the composable itself. Only requires `hazeEf
 
 ```kotlin
 Box(
-    modifier = Modifier.hazeEffect {
+    modifier = Modifier.hazeEffect(input = HazeInput.Content) {
         blurEffect { /* ... */ }
     }
 ) {

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -23,6 +23,9 @@ The primary change in v2 is the extraction of blur functionality from the core `
   `HazeInputScale.None` to preserve explicit full-resolution blur input.
   `HazeInputScale.EffectDefault` is the new sealed subtype backing `Default`; exhaustive `when`
   expressions over `HazeInputScale` must handle it (or add an `else` branch).
+- **Explicit input and rendering policies:** The new `hazeEffect(input = ...)` overload uses
+  `HazeInput.Sources` or `HazeInput.Content`, metadata-only source selection,
+  `HazeSourceRetention`, `HazeSampling`, and a non-null `expandLayerBounds` argument.
 
 **What Hasn't Changed:**
 
@@ -257,6 +260,57 @@ GlassStyle(
     }
     ```
 
+### Adopt Explicit Inputs and Rendering Policies
+
+The nullable-state overloads remain available during the staged Haze 2 migration. New code can
+make foreground versus source-backed input explicit without waiting for the later effect-specific
+modifier APIs:
+
+```kotlin
+// Source-backed input
+Modifier.hazeEffect(
+    input = HazeInput.Sources(hazeState),
+) {
+    blurEffect { /* ... */ }
+}
+
+// The modifier's own content
+Modifier.hazeEffect(input = HazeInput.Content) {
+    blurEffect { /* ... */ }
+}
+```
+
+Map legacy scope policies to structural values as follows:
+
+```kotlin
+Modifier.hazeEffect(
+    input = HazeInput.Sources(
+        state = hazeState,
+        selection = HazeSourceSelection.Behind
+            .where { source -> source.key != "excluded" },
+        retention = HazeSourceRetention.ClearWhenUnavailable,
+    ),
+    sampling = HazeSampling.FullResolution,
+    expandLayerBounds = false,
+) {
+    blurEffect { /* ... */ }
+}
+```
+
+- Nullable `state` mode selection becomes `HazeInput.Sources(state)` or `HazeInput.Content`.
+- `canDrawArea` becomes `HazeSourceSelection.Behind.where { ... }` or
+  `HazeSourceSelection.All.where { ... }`. Predicates receive only `key` and `zIndex`, and
+  repeated `where` calls combine with logical AND.
+- `retainOutputWhenSourceUnavailable = true` maps to `KeepLastFrame`; `false` maps to
+  `ClearWhenUnavailable`. Prefer the clearing policy for privacy-sensitive surfaces.
+- `HazeInputScale.Default`, `None`, `Auto`, and `Fixed(scale)` map to `HazeSampling.Default`,
+  `FullResolution`, `Adaptive`, and `Fixed(scale)` respectively.
+- Nullable scope `expandLayerBounds` becomes a non-null modifier argument that defaults to `true`.
+
+The structural `input`, `sampling`, and `expandLayerBounds` arguments are authoritative on this
+overload. Existing nullable `hazeEffect` overloads and `HazeEffectScope` properties are not
+deprecated by this migration step.
+
 ## Complete API Mapping
 
 | V1 Location | V2 Location | Notes |
@@ -275,12 +329,13 @@ GlassStyle(
 | `HazeEffectScope.fallbackTint` | `BlurVisualEffect.fallbackTint` | Inside `blurEffect {}` |
 | `HazeEffectScope.alpha` | `BlurVisualEffect.alpha` | Inside `blurEffect {}` |
 | `HazeEffectScope.blurEnabled` | `BlurVisualEffect.blurEnabled` | Inside `blurEffect {}` |
-| `HazeEffectScope.inputScale` | `HazeEffectScope.inputScale` | **Unchanged** - still on scope |
+| `HazeEffectScope.inputScale` | `HazeSampling` | Structural on the explicit-input overload; the scope property remains on legacy overloads |
 | `HazeEffectScope.drawContentBehind` | `HazeEffectScope.drawContentBehind` | **Unchanged** - still on scope |
 | `HazeEffectScope.clipToAreasBounds` | `HazeEffectScope.clipToAreasBounds` | **Unchanged** - still on scope |
-| `HazeEffectScope.expandLayerBounds` | `HazeEffectScope.expandLayerBounds` | **Unchanged** - still on scope |
+| `HazeEffectScope.expandLayerBounds` | `Modifier.hazeEffect(expandLayerBounds = ...)` | Non-null and defaults to `true` on the explicit-input overload |
 | `HazeEffectScope.forceInvalidateOnPreDraw` | `HazeEffectScope.forceInvalidateOnPreDraw` | **Unchanged** - still on scope |
-| `HazeEffectScope.canDrawArea` | `HazeEffectScope.canDrawArea` | **Unchanged** - still on scope |
+| `HazeEffectScope.canDrawArea` | `HazeSourceSelection.where { ... }` | Metadata-only (`key`, `zIndex`) on the explicit-input overload; the scope property remains on legacy overloads |
+| `HazeEffectScope.retainOutputWhenSourceUnavailable` | `HazeSourceRetention` | `KeepLastFrame` or privacy-sensitive `ClearWhenUnavailable` on source-backed explicit input |
 | `rememberHazeState(blurEnabled)` | *Removed* | Use `blurEffect { blurEnabled = ... }` |
 | `HazeState.blurEnabled` | *Removed* | Use `blurEffect { blurEnabled = ... }` on each effect |
 | `HazeState.contentLayer` | *Removed* | Internal implementation detail from old single-source model |

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -29,6 +29,7 @@ package dev.chrisbanes.haze {
   }
 
   public final class HazeEffectKt {
+    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeInput input, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
     method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState? state, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
     method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
   }
@@ -104,6 +105,31 @@ package dev.chrisbanes.haze {
     property public abstract dev.chrisbanes.haze.HazeInputScale inputScale;
     property public abstract boolean retainOutputWhenSourceUnavailable;
     property public abstract dev.chrisbanes.haze.VisualEffect visualEffect;
+  }
+
+  public sealed exhaustive interface HazeInput {
+  }
+
+  public static final class HazeInput.Content implements dev.chrisbanes.haze.HazeInput {
+    field public static final dev.chrisbanes.haze.HazeInput.Content INSTANCE;
+  }
+
+  @androidx.compose.runtime.Stable public static final class HazeInput.Sources implements dev.chrisbanes.haze.HazeInput {
+    ctor public HazeInput.Sources(dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeSourceSelection selection, optional dev.chrisbanes.haze.HazeSourceRetention retention);
+    method public dev.chrisbanes.haze.HazeState component1();
+    method public dev.chrisbanes.haze.HazeSourceSelection component2();
+    method public dev.chrisbanes.haze.HazeSourceRetention component3();
+    method public dev.chrisbanes.haze.HazeInput.Sources copy(optional dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeSourceSelection selection, optional dev.chrisbanes.haze.HazeSourceRetention retention);
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeSourceRetention getRetention();
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeSourceSelection getSelection();
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeState getState();
+    property public dev.chrisbanes.haze.HazeSourceRetention retention;
+    property public dev.chrisbanes.haze.HazeSourceSelection selection;
+    property public dev.chrisbanes.haze.HazeState state;
+  }
+
+  public final class HazeInputKt {
+    method public static dev.chrisbanes.haze.HazeSourceSelection where(dev.chrisbanes.haze.HazeSourceSelection, kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeSourceInfo,java.lang.Boolean> predicate);
   }
 
   public sealed exhaustive interface HazeInputScale {
@@ -211,6 +237,35 @@ package dev.chrisbanes.haze {
     method @dev.chrisbanes.haze.InternalHazeApi public static androidx.compose.ui.graphics.Brush asBrush(dev.chrisbanes.haze.HazeProgressive, optional int numStops);
   }
 
+  public sealed exhaustive interface HazeSampling {
+  }
+
+  public static final class HazeSampling.Adaptive implements dev.chrisbanes.haze.HazeSampling {
+    field public static final dev.chrisbanes.haze.HazeSampling.Adaptive INSTANCE;
+  }
+
+  public static final class HazeSampling.Default implements dev.chrisbanes.haze.HazeSampling {
+    field public static final dev.chrisbanes.haze.HazeSampling.Default INSTANCE;
+  }
+
+  @kotlin.jvm.JvmInline public static final value class HazeSampling.Fixed implements dev.chrisbanes.haze.HazeSampling {
+    ctor @KotlinOnly public HazeSampling.Fixed(float scale);
+    method @InaccessibleFromKotlin public float getScale();
+    property public float scale;
+  }
+
+  public static final class HazeSampling.FullResolution implements dev.chrisbanes.haze.HazeSampling {
+    field public static final dev.chrisbanes.haze.HazeSampling.FullResolution INSTANCE;
+  }
+
+  public final class HazeSourceInfo {
+    ctor public HazeSourceInfo(Object? key, float zIndex);
+    method @InaccessibleFromKotlin public Object? getKey();
+    method @InaccessibleFromKotlin public float getZIndex();
+    property public Object? key;
+    property public float zIndex;
+  }
+
   @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeSourceNode extends androidx.compose.ui.Modifier.Node implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.node.ObserverModifierNode androidx.compose.ui.node.TraversableNode {
     ctor public HazeSourceNode(dev.chrisbanes.haze.HazeState state, optional float zIndex, optional Object? key);
     method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
@@ -229,6 +284,28 @@ package dev.chrisbanes.haze {
     property public Object traverseKey;
     property public float zIndex;
     field public static final String TAG = "HazeSource";
+  }
+
+  public sealed exhaustive interface HazeSourceRetention {
+  }
+
+  public static final class HazeSourceRetention.ClearWhenUnavailable implements dev.chrisbanes.haze.HazeSourceRetention {
+    field public static final dev.chrisbanes.haze.HazeSourceRetention.ClearWhenUnavailable INSTANCE;
+  }
+
+  public static final class HazeSourceRetention.KeepLastFrame implements dev.chrisbanes.haze.HazeSourceRetention {
+    field public static final dev.chrisbanes.haze.HazeSourceRetention.KeepLastFrame INSTANCE;
+  }
+
+  public sealed nonexhaustive interface HazeSourceSelection {
+  }
+
+  public static final class HazeSourceSelection.All implements dev.chrisbanes.haze.HazeSourceSelection {
+    field public static final dev.chrisbanes.haze.HazeSourceSelection.All INSTANCE;
+  }
+
+  public static final class HazeSourceSelection.Behind implements dev.chrisbanes.haze.HazeSourceSelection {
+    field public static final dev.chrisbanes.haze.HazeSourceSelection.Behind INSTANCE;
   }
 
   @androidx.compose.runtime.Stable public final class HazeState {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -118,6 +118,51 @@ public interface HazeEffectScope {
 }
 
 /**
+ * Input-sampling policies used by the explicit-input [hazeEffect] overload.
+ *
+ * These values adapt to the existing effect-facing [HazeInputScale] semantics so built-in
+ * effects keep their current default and adaptive behavior.
+ */
+public sealed interface HazeSampling {
+
+  /**
+   * Lets the configured [VisualEffect] choose its input-sampling policy.
+   */
+  public data object Default : HazeSampling
+
+  /**
+   * Samples the effect input at full resolution.
+   */
+  public data object FullResolution : HazeSampling
+
+  /**
+   * Requests the configured effect's adaptive input-sampling policy.
+   */
+  public data object Adaptive : HazeSampling
+
+  /**
+   * An input scale which uses a fixed scale factor.
+   *
+   * @param scale The scale factor, in the range 0 < x <= 1.
+   */
+  @JvmInline
+  public value class Fixed(public val scale: Float) : HazeSampling {
+    init {
+      require(scale > 0f && scale <= 1f) {
+        "scale needs to be in the range 0 < x <= 1f"
+      }
+    }
+  }
+}
+
+internal fun HazeSampling.toInputScale(): HazeInputScale = when (this) {
+  HazeSampling.Default -> HazeInputScale.Default
+  HazeSampling.FullResolution -> HazeInputScale.None
+  HazeSampling.Adaptive -> HazeInputScale.Auto
+  is HazeSampling.Fixed -> HazeInputScale.Fixed(scale)
+}
+
+/**
  * Input-scale policies used for [HazeEffectScope.inputScale].
  */
 public sealed interface HazeInputScale {
@@ -202,11 +247,45 @@ public fun Modifier.hazeEffect(
   block: (HazeEffectScope.() -> Unit)? = null,
 ): Modifier = thenHazeEffect(state = null, block = block)
 
+/**
+ * Draw the 'haze' effect using an explicit [input].
+ *
+ * @param input The content consumed by the configured effect.
+ * @param sampling The input-sampling policy. Defaults to the configured effect's policy.
+ * @param expandLayerBounds Whether effect-requested layer-bound expansion is enabled.
+ * @param block Optional configuration block for the existing visual-effect surface.
+ *
+ * The structural [input], [sampling], and [expandLayerBounds] values are authoritative over their
+ * legacy [HazeEffectScope] equivalents in [block].
+ */
+@Stable
+public fun Modifier.hazeEffect(
+  input: HazeInput,
+  sampling: HazeSampling = HazeSampling.Default,
+  expandLayerBounds: Boolean = true,
+  block: (HazeEffectScope.() -> Unit)? = null,
+): Modifier = thenHazeEffect(
+  state = (input as? HazeInput.Sources)?.state,
+  explicitInput = input,
+  explicitSampling = sampling,
+  explicitExpandLayerBounds = expandLayerBounds,
+  block = block,
+)
+
 private fun Modifier.thenHazeEffect(
   state: HazeState?,
+  explicitInput: HazeInput? = null,
+  explicitSampling: HazeSampling? = null,
+  explicitExpandLayerBounds: Boolean? = null,
   block: (HazeEffectScope.() -> Unit)?,
 ): Modifier {
-  val effect = this then HazeEffectNodeElement(state = state, block = block)
+  val effect = this then HazeEffectNodeElement(
+    state = state,
+    explicitInput = explicitInput,
+    explicitSampling = explicitSampling,
+    explicitExpandLayerBounds = explicitExpandLayerBounds,
+    block = block,
+  )
   return if (state == null) {
     effect.graphicsLayer() then ForegroundContentInvalidationElement
   } else {
@@ -216,15 +295,25 @@ private fun Modifier.thenHazeEffect(
 
 private data class HazeEffectNodeElement(
   val state: HazeState?,
+  val explicitInput: HazeInput? = null,
+  val explicitSampling: HazeSampling? = null,
+  val explicitExpandLayerBounds: Boolean? = null,
   val block: (HazeEffectScope.() -> Unit)? = null,
 ) : ModifierNodeElement<HazeEffectNode>() {
 
   override fun create(): HazeEffectNode = HazeEffectNode(
     state = state,
     block = block,
-  )
+  ).also { node ->
+    node.explicitInput = explicitInput
+    node.explicitSampling = explicitSampling
+    node.explicitExpandLayerBounds = explicitExpandLayerBounds
+  }
 
   override fun update(node: HazeEffectNode) {
+    node.explicitInput = explicitInput
+    node.explicitSampling = explicitSampling
+    node.explicitExpandLayerBounds = explicitExpandLayerBounds
     node.state = state
     node.block = block
     node.update()

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -7,6 +7,7 @@ package dev.chrisbanes.haze
 
 import androidx.collection.MutableObjectLongMap
 import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.runtime.snapshots.SnapshotStateObserver
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -41,6 +42,7 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlinx.coroutines.DisposableHandle
+import kotlinx.coroutines.launch
 
 /**
  * The [Modifier.Node] implementation used by [Modifier.hazeEffect].
@@ -85,19 +87,86 @@ public class HazeEffectNode(
       }
     }
 
+  internal var explicitInput: HazeInput? = null
+    set(value) {
+      if (value != field) {
+        HazeLogger.d(TAG) { "explicitInput changed. Current: $field. New: $value" }
+        val previous = field
+        clearRetainedOutput()
+        sourceSelectionSnapshotObserver?.clear(sourceSelectionObservationScope)
+        if ((value as? HazeInput.Sources)?.selection?.hasRefinements() != true) {
+          stopSourceSelectionSnapshotObserver()
+        }
+        dirtyTracker += DirtyFields.Areas
+        field = value
+        when {
+          value is HazeInput.Sources -> {
+            retainOutputWhenSourceUnavailable = value.retention.keepsLastFrame()
+          }
+          previous is HazeInput.Sources -> retainOutputWhenSourceUnavailable = true
+        }
+      }
+    }
+
   private var needsPreDrawInvalidation = false
   private var needsDirtyFieldsInvalidation = false
   private var needsVisualEffectInvalidation = false
   private var needsContentInvalidation = false
   private var isDrawing = false
+  private var isInvokingBlock = false
   private var lastKnownCoordinates: LayoutCoordinates? = null
+  private var sourceSelectionSnapshotObserver: SnapshotStateObserver? = null
+  private var sourceSelectionObserverGeneration: Int = 0
+  private val sourceSelectionObservationScope = Any()
+  private val onObservedSourceSelectionChanged: (Any) -> Unit = {
+    dirtyTracker += DirtyFields.Areas
+    updateEffect()
+  }
+
+  private fun getOrCreateSourceSelectionSnapshotObserver(): SnapshotStateObserver {
+    sourceSelectionSnapshotObserver?.let { return it }
+    val observerGeneration = ++sourceSelectionObserverGeneration
+    return SnapshotStateObserver { command ->
+      coroutineScope.launch {
+        if (isAttached && sourceSelectionObserverGeneration == observerGeneration) {
+          command()
+        }
+      }
+    }.also {
+      it.start()
+      sourceSelectionSnapshotObserver = it
+    }
+  }
+
+  private fun stopSourceSelectionSnapshotObserver() {
+    sourceSelectionObserverGeneration++
+    sourceSelectionSnapshotObserver?.stop()
+    sourceSelectionSnapshotObserver = null
+  }
 
   override var inputScale: HazeInputScale = HazeInputScale.Default
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "inputScale changed. Current: $field. New: $value" }
-        field = value
+      val resolvedValue = if (isInvokingBlock) {
+        explicitSampling?.toInputScale() ?: value
+      } else {
+        value
+      }
+      if (resolvedValue != field) {
+        HazeLogger.d(TAG) { "inputScale changed. Current: $field. New: $resolvedValue" }
+        field = resolvedValue
         dirtyTracker += DirtyFields.InputScale
+      }
+    }
+
+  internal var explicitSampling: HazeSampling? = null
+    set(value) {
+      if (value != field) {
+        val previous = field
+        field = value
+        when {
+          value != null -> inputScale = value.toInputScale()
+          previous != null -> inputScale = HazeInputScale.Default
+        }
       }
     }
 
@@ -265,24 +334,41 @@ public class HazeEffectNode(
 
   override var expandLayerBounds: Boolean? = null
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "expandLayer changed. Current $field. New: $value" }
+      val resolvedValue = if (isInvokingBlock) explicitExpandLayerBounds ?: value else value
+      if (resolvedValue != field) {
+        HazeLogger.d(TAG) { "expandLayer changed. Current $field. New: $resolvedValue" }
         dirtyTracker += DirtyFields.ExpandLayer
+        field = resolvedValue
+      }
+    }
+
+  internal var explicitExpandLayerBounds: Boolean? = null
+    set(value) {
+      if (value != field) {
         field = value
+        expandLayerBounds = value
       }
     }
 
   override var retainOutputWhenSourceUnavailable: Boolean = true
     set(value) {
-      if (value != field) {
+      val resolvedValue = if (isInvokingBlock) {
+        (explicitInput as? HazeInput.Sources)
+          ?.retention
+          ?.keepsLastFrame()
+          ?: value
+      } else {
+        value
+      }
+      if (resolvedValue != field) {
         HazeLogger.d(TAG) {
-          "retainOutputWhenSourceUnavailable changed. Current $field. New: $value"
+          "retainOutputWhenSourceUnavailable changed. Current $field. New: $resolvedValue"
         }
-        if (!value) {
+        if (!resolvedValue) {
           clearRetainedOutput()
         }
         dirtyTracker += DirtyFields.RetainOutput
-        field = value
+        field = resolvedValue
       }
     }
 
@@ -320,6 +406,7 @@ public class HazeEffectNode(
   }
 
   override fun onDetach() {
+    stopSourceSelectionSnapshotObserver()
     trimMemoryCallbackDisposable?.dispose()
     trimMemoryCallbackDisposable = null
     resetPendingInvalidations()
@@ -507,7 +594,12 @@ public class HazeEffectNode(
 
     // Invalidate if any of the effects triggered an invalidation, or we now have zero
     // effects but were previously showing some
-    block?.invoke(this)
+    isInvokingBlock = true
+    try {
+      block?.invoke(this)
+    } finally {
+      isInvokingBlock = false
+    }
 
     val state = this.state
     if (state != null) {
@@ -543,28 +635,70 @@ public class HazeEffectNode(
             ?.takeIf { it.state == this.state }
 
         val unfilteredAreas = stateAreas.orEmpty()
-        val filteredAreas = unfilteredAreas
-          .also {
-            HazeLogger.d(TAG) { "Background Areas observing: $it" }
+        val selection = (explicitInput as? HazeInput.Sources)?.selection
+        HazeLogger.d(TAG) { "Background Areas observing: $unfilteredAreas" }
+        val filteredAreas = when (val sourceSelection = selection) {
+          null -> {
+            unfilteredAreas
+              .asSequence()
+              .filter { area ->
+                val filter = canDrawArea
+                when {
+                  filter != null -> filter(area)
+                  ancestorSourceNode != null -> area.zIndex < ancestorSourceNode.zIndex
+                  else -> true
+                }.also { included ->
+                  HazeLogger.d(TAG) { "Background Area: $area. Included=$included" }
+                }
+              }
+              .toMutableList()
+              .apply { sortBy(HazeArea::zIndex) }
           }
-          .asSequence()
-          .filter { area ->
-            val filter = canDrawArea
-            when {
-              filter != null -> filter(area)
-              ancestorSourceNode != null -> area.zIndex < ancestorSourceNode.zIndex
-              else -> true
-            }.also { included ->
-              HazeLogger.d(TAG) { "Background Area: $area. Included=$included" }
+          else -> {
+            val relatedSources = unfilteredAreas.mapNotNull { area ->
+              val info = HazeSourceInfo(key = area.key, zIndex = area.zIndex)
+              val relationshipMatches = when (sourceSelection.baseSelection()) {
+                HazeSourceSelection.All -> true
+                HazeSourceSelection.Behind -> {
+                  ancestorSourceNode == null || info.zIndex < ancestorSourceNode.zIndex
+                }
+                else -> error("Unexpected base HazeSourceSelection")
+              }
+              if (relationshipMatches) area to info else null
             }
+            val selectedSources = if (sourceSelection.hasRefinements()) {
+              Snapshot.withoutReadObservation {
+                lateinit var result: List<Pair<HazeArea, HazeSourceInfo>>
+                getOrCreateSourceSelectionSnapshotObserver().observeReads(
+                  sourceSelectionObservationScope,
+                  onObservedSourceSelectionChanged,
+                ) {
+                  result = relatedSources.filter { (_, info) ->
+                    sourceSelection.matches(info)
+                  }
+                }
+                result
+              }
+            } else {
+              relatedSources
+            }
+            selectedSources
+              .sortedBy { (_, info) -> info.zIndex }
+              .map { (area) ->
+                HazeLogger.d(TAG) { "Background Area: $area. Included=true" }
+                area
+              }
           }
-          .toMutableList()
-          .apply { sortBy(HazeArea::zIndex) }
+        }
         _areas = filteredAreas
 
         if (!retainOutputWhenSourceUnavailable && !hasDrawableSourceLayers()) {
           clearRetainedOutput()
-        } else if (unfilteredAreas.isNotEmpty() && filteredAreas.isEmpty()) {
+        } else if (
+          explicitInput == null &&
+          unfilteredAreas.isNotEmpty() &&
+          filteredAreas.isEmpty()
+        ) {
           clearRetainedOutput()
         }
         updateAreaZIndexes(currentStateAreas)

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -92,7 +92,12 @@ public class HazeEffectNode(
       if (value != field) {
         HazeLogger.d(TAG) { "explicitInput changed. Current: $field. New: $value" }
         val previous = field
-        clearRetainedOutput()
+        val changesRetainedContent = previous !is HazeInput.Sources ||
+          value !is HazeInput.Sources ||
+          previous.state !== value.state
+        if (changesRetainedContent) {
+          clearRetainedOutput()
+        }
         sourceSelectionSnapshotObserver?.clear(sourceSelectionObservationScope)
         if ((value as? HazeInput.Sources)?.selection?.hasRefinements() != true) {
           stopSourceSelectionSnapshotObserver()

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
@@ -1,0 +1,113 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.runtime.Stable
+
+/**
+ * The content consumed by a Haze visual effect.
+ */
+public sealed interface HazeInput {
+
+  /**
+   * Content captured by [hazeSource] modifiers associated with [state].
+   */
+  @Stable
+  public data class Sources(
+    public val state: HazeState,
+    public val selection: HazeSourceSelection = HazeSourceSelection.Behind,
+    public val retention: HazeSourceRetention = HazeSourceRetention.KeepLastFrame,
+  ) : HazeInput
+
+  /**
+   * The content of the composable carrying the effect modifier.
+   */
+  public data object Content : HazeInput
+}
+
+/**
+ * Stable source metadata exposed to [HazeSourceSelection] refinements.
+ *
+ * Renderer-owned geometry, content, and platform resources are intentionally not exposed.
+ */
+public class HazeSourceInfo(
+  public val key: Any?,
+  public val zIndex: Float,
+)
+
+/**
+ * Selects source content for [HazeInput.Sources].
+ */
+public sealed interface HazeSourceSelection {
+
+  /**
+   * Sources behind the nearest ancestor [hazeSource], or every source when there is no matching
+   * ancestor.
+   */
+  public data object Behind : HazeSourceSelection
+
+  /**
+   * Every source associated with the input state.
+   */
+  public data object All : HazeSourceSelection
+}
+
+/**
+ * Refines this selection using immutable source metadata.
+ *
+ * Repeated refinements compose with logical AND.
+ */
+public fun HazeSourceSelection.where(
+  predicate: (HazeSourceInfo) -> Boolean,
+): HazeSourceSelection = FilteredHazeSourceSelection(
+  selection = this,
+  predicate = predicate,
+)
+
+private class FilteredHazeSourceSelection(
+  val selection: HazeSourceSelection,
+  val predicate: (HazeSourceInfo) -> Boolean,
+) : HazeSourceSelection
+
+internal fun HazeSourceSelection.baseSelection(): HazeSourceSelection = when (this) {
+  HazeSourceSelection.All,
+  HazeSourceSelection.Behind,
+  -> this
+  is FilteredHazeSourceSelection -> selection.baseSelection()
+}
+
+internal fun HazeSourceSelection.matches(info: HazeSourceInfo): Boolean = when (this) {
+  HazeSourceSelection.All,
+  HazeSourceSelection.Behind,
+  -> true
+  is FilteredHazeSourceSelection -> selection.matches(info) && predicate(info)
+}
+
+internal fun HazeSourceSelection.hasRefinements(): Boolean =
+  this is FilteredHazeSourceSelection
+
+/**
+ * Controls retained output when source content is temporarily unavailable.
+ */
+public sealed interface HazeSourceRetention {
+
+  /**
+   * Continue drawing the most recently rendered output.
+   *
+   * This visually compatible behavior is the default for source transitions.
+   */
+  public data object KeepLastFrame : HazeSourceRetention
+
+  /**
+   * Clear retained output as soon as no source content is available.
+   *
+   * Prefer this policy for privacy-sensitive surfaces where stale source pixels must not remain.
+   */
+  public data object ClearWhenUnavailable : HazeSourceRetention
+}
+
+internal fun HazeSourceRetention.keepsLastFrame(): Boolean = when (this) {
+  HazeSourceRetention.KeepLastFrame -> true
+  HazeSourceRetention.ClearWhenUnavailable -> false
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeInputTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeInputTest.kt
@@ -1,0 +1,39 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+
+class HazeInputTest {
+
+  @Test
+  fun sources_defaultsToBehindAndKeepLastFrame() {
+    val input = HazeInput.Sources(HazeState())
+
+    assertThat(input.selection).isEqualTo(HazeSourceSelection.Behind)
+    assertThat(input.retention).isEqualTo(HazeSourceRetention.KeepLastFrame)
+  }
+
+  @Test
+  fun sources_acceptsAllAndClearWhenUnavailable() {
+    val input = HazeInput.Sources(
+      state = HazeState(),
+      selection = HazeSourceSelection.All,
+      retention = HazeSourceRetention.ClearWhenUnavailable,
+    )
+
+    assertThat(input.selection).isEqualTo(HazeSourceSelection.All)
+    assertThat(input.retention).isEqualTo(HazeSourceRetention.ClearWhenUnavailable)
+  }
+
+  @Test
+  fun sourceInfo_exposesOnlyStableMetadataValues() {
+    val info = HazeSourceInfo(key = "source", zIndex = 2f)
+
+    assertThat(info.key).isEqualTo("source")
+    assertThat(info.zIndex).isEqualTo(2f)
+  }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeSamplingTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeSamplingTest.kt
@@ -1,0 +1,35 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
+import kotlin.test.Test
+
+class HazeSamplingTest {
+
+  @Test
+  fun policies_areDistinctAndFixedRetainsScale() {
+    assertThat(HazeSampling.Default).isNotEqualTo(HazeSampling.FullResolution)
+    assertThat(HazeSampling.Default).isNotEqualTo(HazeSampling.Adaptive)
+    assertThat(HazeSampling.Fixed(0.5f).scale).isEqualTo(0.5f)
+  }
+
+  @Test
+  fun fixed_rejectsInvalidScales() {
+    listOf(
+      0f,
+      -0.1f,
+      Float.NaN,
+      Float.POSITIVE_INFINITY,
+      1.1f,
+    ).forEach { scale ->
+      assertFailure { HazeSampling.Fixed(scale) }
+        .isInstanceOf<IllegalArgumentException>()
+    }
+  }
+}

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
@@ -1,0 +1,537 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class HazeEffectInputTest {
+
+  @Test
+  fun content_capturesTheModifierOwnContent() = runComposeUiTest {
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .testTag("effect")
+          .hazeEffect(input = HazeInput.Content) {
+            visualEffect = DrawSourceLayersVisualEffect
+          }
+          .background(Color.Red),
+      )
+    }
+
+    val pixels = onNodeWithTag("effect").captureToImage().toPixelMap()
+    assertThat(pixels[50, 50]).isEqualTo(Color.Red)
+  }
+
+  @Test
+  fun sourcesWhere_filtersStableInfoAndComposesWithAnd() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RecordingSourceKeysVisualEffect()
+    val selection = HazeSourceSelection.Behind
+      .where { info -> info.zIndex > 0f }
+      .where { info -> (info.key as? String)?.startsWith("keep") == true }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = 0f, key = "keep-low")
+            .background(Color.Red),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = 1f, key = "drop-high")
+            .background(Color.Blue),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = 2f, key = "keep-high")
+            .background(Color.Green),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(
+              input = HazeInput.Sources(state, selection = selection),
+            ) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    assertThat(effect.areaKeys).containsExactly("keep-high")
+  }
+
+  @Test
+  fun sourcesWhere_reactsToPredicateStateChanges() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RecordingSourceKeysVisualEffect()
+    val selectedKey = mutableStateOf("first")
+    val selection = HazeSourceSelection.All.where { info -> info.key == selectedKey.value }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.fillMaxSize().hazeSource(state, key = "first"))
+        Spacer(Modifier.fillMaxSize().hazeSource(state, key = "second"))
+        Spacer(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(input = HazeInput.Sources(state, selection = selection)) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+    assertThat(effect.areaKeys).containsExactly("first")
+
+    selectedKey.value = "second"
+    waitForIdle()
+
+    assertThat(effect.areaKeys).containsExactly("second")
+  }
+
+  @Test
+  fun sourcesWhere_doesNotReevaluateForUnrelatedObservedState() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RecordingSourceKeysVisualEffect()
+    val drawContentBehind = mutableStateOf(false)
+    var predicateCalls = 0
+    val selection = HazeSourceSelection.All.where {
+      predicateCalls++
+      true
+    }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.fillMaxSize().hazeSource(state, key = "first"))
+        Spacer(Modifier.fillMaxSize().hazeSource(state, key = "second"))
+        Spacer(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(input = HazeInput.Sources(state, selection = selection)) {
+              this.drawContentBehind = drawContentBehind.value
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    val callsBeforeBlockChange = predicateCalls
+    drawContentBehind.value = true
+    waitForIdle()
+
+    assertThat(predicateCalls).isEqualTo(callsBeforeBlockChange)
+  }
+
+  @Test
+  fun sourcesWhere_evaluatesOnceForSourceMetadataChanges() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RecordingSourceKeysVisualEffect()
+    val sourceKey = mutableStateOf("first")
+    var predicateCalls = 0
+    val selection = HazeSourceSelection.All.where {
+      predicateCalls++
+      true
+    }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.fillMaxSize().hazeSource(state, key = sourceKey.value))
+        Spacer(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(input = HazeInput.Sources(state, selection = selection)) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    predicateCalls = 0
+    sourceKey.value = "renamed"
+    waitForIdle()
+
+    assertThat(predicateCalls).isEqualTo(1)
+    assertThat(effect.areaKeys).containsExactly("renamed")
+  }
+
+  @Test
+  fun sources_reactsToKeyZIndexAndMembershipChanges() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RecordingSourceKeysVisualEffect()
+    val firstKey = mutableStateOf("first")
+    val firstZIndex = mutableStateOf(0f)
+    val showThird = mutableStateOf(false)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = firstZIndex.value, key = firstKey.value),
+        )
+        Spacer(Modifier.fillMaxSize().hazeSource(state, zIndex = 1f, key = "second"))
+        if (showThird.value) {
+          Spacer(Modifier.fillMaxSize().hazeSource(state, zIndex = 2f, key = "third"))
+        }
+        Spacer(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(input = HazeInput.Sources(state)) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+    assertThat(effect.areaKeys).containsExactly("first", "second")
+
+    firstKey.value = "renamed"
+    firstZIndex.value = 3f
+    showThird.value = true
+    waitForIdle()
+
+    assertThat(effect.areaKeys).containsExactly("second", "third", "renamed")
+  }
+
+  @Test
+  fun sourcesBehind_usesSameStateAncestorRelationship() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RecordingSourceKeysVisualEffect()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = 0f, key = "behind")
+            .background(Color.Red),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = 2f, key = "ahead")
+            .background(Color.Green),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = 1f, key = "ancestor")
+            .background(Color.Blue),
+        ) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .hazeEffect(input = HazeInput.Sources(state)) {
+                visualEffect = effect
+              },
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    assertThat(effect.areaKeys).containsExactly("behind")
+  }
+
+  @Test
+  fun sourcesAll_bypassesAncestorRelationship() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RecordingSourceKeysVisualEffect()
+    val selection = HazeSourceSelection.All.where { info -> info.key != "ancestor" }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = 0f, key = "behind")
+            .background(Color.Red),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = 2f, key = "ahead")
+            .background(Color.Green),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state, zIndex = 1f, key = "ancestor")
+            .background(Color.Blue),
+        ) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .hazeEffect(
+                input = HazeInput.Sources(state, selection = selection),
+              ) {
+                visualEffect = effect
+              },
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    assertThat(effect.areaKeys).containsExactly("behind", "ahead")
+  }
+
+  @Test
+  fun sampling_mapsAllChoicesToExistingEffectSemantics() = runComposeUiTest {
+    val sampling = mutableStateOf<HazeSampling>(HazeSampling.Default)
+    val effect = SamplingRecordingVisualEffect()
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .hazeEffect(
+            input = HazeInput.Content,
+            sampling = sampling.value,
+          ) {
+            inputScale = HazeInputScale.None
+            visualEffect = effect
+          },
+      )
+    }
+    waitForIdle()
+
+    assertThat(effect.inputScale).isEqualTo(HazeInputScale.Default)
+
+    sampling.value = HazeSampling.FullResolution
+    waitForIdle()
+    assertThat(effect.inputScale).isEqualTo(HazeInputScale.None)
+
+    sampling.value = HazeSampling.Adaptive
+    waitForIdle()
+    assertThat(effect.inputScale).isEqualTo(HazeInputScale.Auto)
+
+    sampling.value = HazeSampling.Fixed(0.6f)
+    waitForIdle()
+    assertThat(effect.inputScale).isEqualTo(HazeInputScale.Fixed(0.6f))
+  }
+
+  @Test
+  fun sourcesClearWhenUnavailable_clearsRetainedOutput() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    val showSource = mutableStateOf(true)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        if (showSource.value) {
+          Spacer(Modifier.size(100.dp).hazeSource(state))
+        }
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(
+              input = HazeInput.Sources(
+                state = state,
+                retention = HazeSourceRetention.ClearWhenUnavailable,
+              ),
+            ) {
+              retainOutputWhenSourceUnavailable = true
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    val drawsBeforeRemoval = effect.drawCalls
+    val clearsBeforeRemoval = effect.clearCalls
+    showSource.value = false
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isGreaterThan(clearsBeforeRemoval)
+    assertThat(effect.drawCalls).isEqualTo(drawsBeforeRemoval)
+  }
+
+  @Test
+  fun sourcesKeepLastFrame_preservesRetainedOutput() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    val showSource = mutableStateOf(true)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        if (showSource.value) {
+          Spacer(Modifier.size(100.dp).hazeSource(state))
+        }
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(input = HazeInput.Sources(state)) {
+              retainOutputWhenSourceUnavailable = false
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    val drawsBeforeRemoval = effect.drawCalls
+    val clearsBeforeRemoval = effect.clearCalls
+    showSource.value = false
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isEqualTo(clearsBeforeRemoval)
+    assertThat(effect.drawCalls).isGreaterThan(drawsBeforeRemoval)
+    assertThat(effect.lastDrawAreaCount).isEqualTo(0)
+  }
+
+  @Test
+  fun sourcesKeepLastFrame_preservesOutputWhenSelectionBecomesEmpty() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    val includeSource = mutableStateOf(true)
+    val selection = HazeSourceSelection.All.where { includeSource.value }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.size(100.dp).hazeSource(state))
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(
+              input = HazeInput.Sources(
+                state = state,
+                selection = selection,
+              ),
+            ) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    val drawsBeforeExclusion = effect.drawCalls
+    val clearsBeforeExclusion = effect.clearCalls
+    includeSource.value = false
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isEqualTo(clearsBeforeExclusion)
+    assertThat(effect.drawCalls).isGreaterThan(drawsBeforeExclusion)
+    assertThat(effect.lastDrawAreaCount).isEqualTo(0)
+  }
+
+  @Test
+  fun expandLayerBounds_defaultsEnabled() = runComposeUiTest {
+    val effect = BoundsExpandingVisualEffect()
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .hazeEffect(input = HazeInput.Content) {
+            expandLayerBounds = false
+            visualEffect = effect
+          },
+      )
+    }
+    waitForIdle()
+
+    assertThat(effect.layerSize).isEqualTo(
+      Size(
+        width = effect.size.width + 20f,
+        height = effect.size.height + 20f,
+      ),
+    )
+  }
+
+  @Test
+  fun expandLayerBounds_disabledSkipsEffectExpansion() = runComposeUiTest {
+    val effect = BoundsExpandingVisualEffect()
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .hazeEffect(
+            input = HazeInput.Content,
+            expandLayerBounds = false,
+          ) {
+            expandLayerBounds = true
+            visualEffect = effect
+          },
+      )
+    }
+    waitForIdle()
+
+    assertThat(effect.layerSize).isEqualTo(effect.size)
+  }
+}
+
+private data object DrawSourceLayersVisualEffect : VisualEffect {
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    context.areas.forEach { area ->
+      area.contentLayer?.let { drawLayer(it) }
+    }
+  }
+}
+
+private class RecordingSourceKeysVisualEffect : VisualEffect {
+  var areaKeys: List<Any?> = emptyList()
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    areaKeys = context.areas.map(HazeArea::key)
+  }
+}
+
+private class SamplingRecordingVisualEffect : VisualEffect {
+  var inputScale: HazeInputScale? = null
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    inputScale = context.inputScale
+  }
+}
+
+private class BoundsExpandingVisualEffect : VisualEffect {
+  var size: Size = Size.Unspecified
+  var layerSize: Size = Size.Unspecified
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect = rect.inflate(10f)
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    this@BoundsExpandingVisualEffect.size = context.size
+    layerSize = context.layerSize
+  }
+}

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
@@ -418,6 +418,103 @@ class HazeEffectInputTest {
   }
 
   @Test
+  fun sourcesKeepLastFrame_preservesOutputWhenEquivalentSelectionIsRebuilt() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    val recomposition = mutableStateOf(0)
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .testTag("root-${recomposition.value}"),
+      ) {
+        Spacer(Modifier.size(100.dp).hazeSource(state, key = "source"))
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(
+              input = HazeInput.Sources(
+                state = state,
+                selection = HazeSourceSelection.All.where { info -> info.key == "source" },
+                retention = HazeSourceRetention.KeepLastFrame,
+              ),
+            ) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    val clearsBeforeRecomposition = effect.clearCalls
+    recomposition.value++
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isEqualTo(clearsBeforeRecomposition)
+  }
+
+  @Test
+  fun sourcesStateChange_clearsRetainedOutput() = runComposeUiTest {
+    val inputState = mutableStateOf(HazeState())
+    val effect = RetainedOutputRecordingVisualEffect()
+
+    setContent {
+      val currentState = inputState.value
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.size(100.dp).hazeSource(currentState))
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(input = HazeInput.Sources(currentState)) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    val clearsBeforeStateChange = effect.clearCalls
+    inputState.value = HazeState()
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isGreaterThan(clearsBeforeStateChange)
+  }
+
+  @Test
+  fun inputModeChange_clearsRetainedOutput() = runComposeUiTest {
+    val state = HazeState()
+    val effect = RetainedOutputRecordingVisualEffect()
+    val useContentInput = mutableStateOf(false)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.size(100.dp).hazeSource(state))
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(
+              input = if (useContentInput.value) {
+                HazeInput.Content
+              } else {
+                HazeInput.Sources(state)
+              },
+            ) {
+              visualEffect = effect
+            },
+        )
+      }
+    }
+    waitForIdle()
+
+    val clearsBeforeModeChange = effect.clearCalls
+    useContentInput.value = true
+    waitForIdle()
+
+    assertThat(effect.clearCalls).isGreaterThan(clearsBeforeModeChange)
+  }
+
+  @Test
   fun sourcesKeepLastFrame_preservesOutputWhenSelectionBecomesEmpty() = runComposeUiTest {
     val state = HazeState()
     val effect = RetainedOutputRecordingVisualEffect()


### PR DESCRIPTION
## Summary

- add explicit `HazeInput` source/content modes with stable source-selection and retention contracts
- add typed sampling and layer-expansion policies and route them structurally through `Modifier.hazeEffect`
- preserve legacy nullable-state behavior while documenting the staged 2.0 migration
- observe only state read by explicit source predicates and keep dynamic key/z-index/membership changes reactive

## Validation

- `:haze:jvmTest :haze:metalavaCheckCompatibility :haze:spotlessCheck`
- documentation build
- correctness/standards, reuse/clarity/efficiency, and over-engineering reviews clean on final HEAD
- full `check` passed all non-visual modules

Two local Gallery JVM Product screenshots also fail byte-identically on clean `main` at `265ca34` (15.38% / 15.39%); this branch does not alter those pixels and no baselines were changed.

Fixes #1123