### PR TITLE
Add typed Haze effect factories

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,164 +1,95 @@
 # Architecture
 
-Haze v2 is built around a flexible architecture that supports multiple visual effects beyond just blur. This document explains the core concepts and how to extend Haze with custom effects.
+Haze separates shareable effect configuration from modifier-node rendering state.
 
-## Visual Effects Framework
+## Core model
 
-At the heart of Haze is the `VisualEffect` interface, which defines a common contract for all visual effects. This allows Haze to be extensible and support different types of effects on different platforms.
-
-### VisualEffect Interface
-
-The `VisualEffect` interface is the base contract for all visual effects. Implementations provide platform-specific rendering logic for creating the desired visual effect.
+The preferred custom-effect path has three parts:
 
 ```kotlin
-interface VisualEffect {
-    fun attach(context: VisualEffectContext)
-    fun update(context: VisualEffectContext)
-    fun detach(context: VisualEffectContext)
-    fun DrawScope.draw(context: VisualEffectContext)
+interface HazeEffectFactory<Style> {
+    fun createRenderer(): HazeEffectRenderer<Style>
+}
+
+interface HazeEffectRenderer<Style> {
+    fun HazeEffectDrawScope.draw(style: Style)
+    fun HazeEffectLayoutScope.calculateLayerBounds(style: Style): Rect = modifierBounds
+    fun onTrimMemory(level: TrimMemoryLevel) = Unit
+    fun dispose() = Unit
 }
 ```
 
-- **attach**: Called when the effect is first attached to a composable. Implementations can initialize platform-specific resources.
-- **update**: Called whenever the effect should update its state from composition locals or other sources.
-- **detach**: Called when the effect is removed. Implementations should clean up resources using the last attached context.
-- **draw**: Renders the effect using the `DrawScope` receiver.
+- A Style is the complete immutable effect configuration.
+- A factory is a stateless descriptor that can be shared by concurrent modifiers.
+- A renderer owns mutable rendering state and resources for exactly one modifier node.
 
-### HazeEffectScope
+Factory identity controls renderer ownership. Style, input, sampling, and layer-expansion updates
+reuse the current renderer. Replacing the factory or detaching the node disposes that renderer.
 
-The `HazeEffectScope` is a receiver scope passed to the lambda block of `Modifier.hazeEffect`. It provides common properties that apply across all effects:
+## Explicit input and policies
+
+The typed modifier makes structural behavior explicit:
 
 ```kotlin
-modifier = Modifier.hazeEffect(state) {
-    inputScale = HazeInputScale.Auto
-    drawContentBehind = true
-    // Effect-specific configuration
-}
+Modifier.hazeEffect(
+    factory = customEffect,
+    input = HazeInput.Sources(hazeState),
+    style = style,
+    sampling = HazeSampling.Adaptive,
+    expandLayerBounds = true,
+)
 ```
 
-Common properties include:
-- **inputScale**: Controls the resolution at which the effect is rendered (performance optimization)
-- **drawContentBehind**: Whether to draw the source content before applying the effect
-- **canDrawArea**: Optional filter to control which layers are included in the effect
+`HazeInput.Sources` selects content captured by `hazeSource`; `HazeInput.Content` selects the
+modifier's own content. Source selection, retained-output privacy, sampling, and layer expansion
+remain core policies rather than effect-specific mutable configuration.
 
-## Modular Effect Architecture
+## Semantic renderer scopes
 
-Each effect is provided in a separate module, allowing you to include only the effects you need:
+The draw scope exposes ordinary `DrawScope` operations, the modifier bounds in the effect layer,
+the selected sampling policy, tracked composition-local access, and one `drawInput()` operation for
+both input modes.
 
-- **haze** - Core infrastructure (`VisualEffect`, `HazeState`, modifiers)
-- **haze-blur** - Blur effect implementation
-- **haze-blur-materials** - Pre-built blur styles (Material, Cupertino, Fluent)
-- **haze-utils** - Shared utilities for platform-specific rendering
+The layout scope exposes density, modifier bounds, and tracked composition-local access. A renderer
+can request larger bounds without seeing the modifier node, source geometry, coordinates, windows,
+or captured layers.
 
-### Module Dependencies
+Reads are observed in the phase where they occur:
 
-```
-haze (core)
-├── haze-blur (blur effect)
-│   └── haze-blur-materials (blur styles)
-└── haze-utils (platform utilities)
-```
+- snapshot or composition-local reads in draw invalidate drawing;
+- reads while calculating layer bounds recalculate bounds and then redraw;
+- Style replacement invalidates both phases without replacing the renderer.
 
-Future effects will follow the same pattern:
-- **haze-glass** (source-only, not yet published) - Refraction-based Glass effect with rounded-shape SDF and optional chromatic aberration
-- Custom third-party effect modules
+## Internal node responsibilities
 
-## Effect Registration Pattern
+`HazeEffectNode` remains responsible for:
 
-Effect implementations provide builder extension functions on `HazeEffectScope` for convenient configuration:
+- source selection and z-ordering;
+- own-content capture;
+- coordinate-space and cross-window handling;
+- graphics-layer allocation and release;
+- trim-memory forwarding;
+- renderer replacement and disposal;
+- draw and bounds invalidation.
 
-```kotlin
-// Blur effect example
-val style = HazeMaterials.thin()
+Those details are intentionally absent from the public typed renderer scopes.
 
-modifier = Modifier.hazeEffect(state) {
-    blurEffect {
-        this.style = style
-        progressive = HazeProgressive.verticalGradient(...)
-    }
-}
-```
+## Modules
 
-Future effects will follow the same pattern:
-```kotlin
-modifier = Modifier.hazeEffect(state) {
-    glassEffect {
-        // Glass-specific properties
-    }
-}
-```
+- **haze** — core state, source capture, typed custom-effect orchestration, and the temporary legacy
+  path
+- **haze-blur** — blur effect implementation
+- **haze-blur-materials** — reusable blur presets
+- **haze-glass** — Glass effect implementation
+- **haze-utils** — shared platform rendering utilities
 
-## Platform Support
+Effect modules can keep platform-specific renderer internals behind their own `expect`/`actual`
+boundaries.
 
-Haze provides a `VisualEffectContext` that gives effects access to geometry, configuration, and platform capabilities:
+## Legacy compatibility
 
-```kotlin
-interface VisualEffectContext {
-    val position: Offset               // Position of the effect node
-    val size: Size                     // Size of the effect area
-    val layerSize: Size                // Size of the graphics layer (may differ from size)
-    val layerOffset: Offset            // Graphics layer offset relative to node position
-    val rootBounds: Rect               // Bounds of the root layout coordinates on screen
-    val inputScale: HazeInputScale     // Input scale factor configuration
-    val windowId: Any?                 // Identifier for the containing window
-    val areas: List<HazeArea>          // Source areas this effect should process
-    val state: HazeState?              // Associated HazeState (null for foreground blur)
-    val coroutineScope: CoroutineScope // CoroutineScope tied to the node lifecycle
+`VisualEffect`, `VisualEffectContext`, `HazeEffectScope`, and the lambda-based modifier overloads
+remain temporarily available for Blur, Glass, and third-party migration. They expose more lifecycle
+and rendering internals and are no longer the recommended contract for new custom effects.
 
-    fun requireDensity(): Density
-    fun <T> currentValueOf(local: CompositionLocal<T>): T
-    fun requireGraphicsContext(): GraphicsContext
-    fun invalidateDraw()
-}
-```
-
-Effects can detect platform capabilities and provide the best implementation available. For example:
-
-- **Android 13+**: Uses `RenderEffect.createBlurEffect()`
-- **Android 12**: Uses `RenderNode` with shader-based blur
-- **Android 11 and below**: Uses Renderscript blur
-- **Desktop/iOS**: Uses Skia shaders
-- **Web**: Uses canvas filters
-- **WASM**: Uses custom shader implementations
-
-## Implementing Custom Effects
-
-To create a custom effect, implement the `VisualEffect` interface and provide a builder extension:
-
-```kotlin
-class CustomVisualEffect : VisualEffect {
-    override fun attach(context: VisualEffectContext) {
-        // Initialize resources
-    }
-
-    override fun update(context: VisualEffectContext) {
-        // Update state from composition locals or snapshot state
-    }
-
-    override fun detach(context: VisualEffectContext) {
-        // Clean up resources
-    }
-
-    override fun DrawScope.draw(context: VisualEffectContext) {
-        // Render the effect using the DrawScope receiver
-    }
-}
-
-// Provide a builder extension
-fun HazeEffectScope.customEffect(block: CustomVisualEffect.() -> Unit = {}) {
-    visualEffect = CustomVisualEffect().apply(block)
-}
-```
-
-See the [haze-blur](https://github.com/chrisbanes/haze/tree/main/haze-blur) module for a complete reference implementation.
-
-## Styling Resolution
-
-When multiple sources of styling are provided, Haze resolves values using the following precedence:
-
-1. Value set directly in the effect builder (e.g., `blurEffect { }`)
-2. Value set via the `style` property
-3. Value set via `LocalHazeBlurStyle` composition local
-4. Default value
-
-This allows flexible composition of styles from different sources while maintaining predictable behavior.
+See [Custom effects](custom-effects.md) for the preferred API.

--- a/docs/custom-effects.md
+++ b/docs/custom-effects.md
@@ -1,312 +1,150 @@
-# Custom Effects
+# Custom effects
 
-This guide shows how to build and ship custom `VisualEffect` implementations for Haze.
+Build custom effects with a shareable `HazeEffectFactory<Style>` and a renderer owned by each
+`hazeEffect` modifier node.
 
-If you want a complete production implementation, see the [haze-blur](https://github.com/chrisbanes/haze/tree/main/haze-blur) module.
+## Define a complete Style
 
-## Overview
+Keep effect configuration immutable and free of renderer or platform resources:
 
-Haze is extensible by design. `Modifier.hazeEffect { ... }` is driven by a `VisualEffect` instance, and you can provide your own implementation.
+```kotlin
+@Immutable
+data class SparkStyle(
+    val color: Color,
+    val alpha: Float,
+)
+```
 
-For most real-world usage, start with **background mode** (`hazeSource` + `hazeEffect(state = hazeState)`), since that is where Haze shines: applying effects to transformed background graphics layers.
+Haze passes the complete current Style to every draw and bounds evaluation. Replacing the Style
+updates the existing renderer, so values from an earlier evaluation cannot stick accidentally.
 
-Typical workflow:
+## Create a shareable factory
 
-1. Implement `VisualEffect`
-2. Provide a `HazeEffectScope` builder extension for ergonomic configuration
-3. Use your builder from `Modifier.hazeEffect { ... }`
+A factory is a stateless descriptor. The same instance can be used by concurrent modifiers, but it
+must create an independent renderer for each one:
 
-## Background source layers (primary pattern)
+```kotlin
+data object SparkEffect : HazeEffectFactory<SparkStyle> {
+    override fun createRenderer(): HazeEffectRenderer<SparkStyle> = SparkRenderer()
+}
 
-Use one `HazeState` shared by transformed source layers and your effect target:
+private class SparkRenderer : HazeEffectRenderer<SparkStyle> {
+    override fun HazeEffectDrawScope.draw(style: SparkStyle) {
+        drawInput()
+        drawRect(style.color.copy(alpha = style.alpha))
+    }
+
+    override fun HazeEffectLayoutScope.calculateLayerBounds(style: SparkStyle): Rect {
+        val extra = 12.dp.toPx()
+        return modifierBounds.inflate(extra)
+    }
+
+    override fun onTrimMemory(level: TrimMemoryLevel) {
+        // Release caches that can be rebuilt on the next draw.
+    }
+
+    override fun dispose() {
+        // Release all renderer-owned resources.
+    }
+}
+```
+
+Mutable caches, shaders, and other disposable resources belong in the renderer. Haze creates one
+renderer per modifier node, reuses it for Style and input-policy updates, and disposes it when the
+factory is replaced or the node detaches.
+
+## Draw source-backed input
+
+Use an explicit `HazeInput.Sources` when the effect consumes content captured by `hazeSource`:
 
 ```kotlin
 val hazeState = rememberHazeState()
 
-Box(Modifier.fillMaxSize()) {
-    AsyncImage(
-        model = rememberRandomSampleImageUrl(),
+Box {
+    Image(
+        painter = painter,
         contentDescription = null,
         modifier = Modifier
             .fillMaxSize()
-            .graphicsLayer {
-                scaleX = 1.06f
-                translationX = 24f
-            }
-            .hazeSource(state = hazeState),
+            .hazeSource(hazeState),
     )
 
     Box(
-        modifier = Modifier
-            .size(260.dp, 180.dp)
-            .graphicsLayer { rotationZ = 10f }
-            .hazeSource(state = hazeState, zIndex = 1f),
-    )
-
-    Box(
-        modifier = Modifier
-            .align(Alignment.Center)
-            .hazeEffect(state = hazeState) {
-                sparkEffect { }
-            },
+        Modifier.hazeEffect(
+            factory = SparkEffect,
+            input = HazeInput.Sources(hazeState),
+            style = SparkStyle(color = Color.Blue, alpha = 0.3f),
+            sampling = HazeSampling.FullResolution,
+        ),
     )
 }
 ```
 
-The key point is that Haze samples the transformed `hazeSource` layers behind the target node. Your custom `VisualEffect` then controls how that sampled content is rendered.
-
-## Implementing VisualEffect
-
-Create a class implementing `VisualEffect`:
+Source selection and retention remain explicit:
 
 ```kotlin
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.DrawScope
-import dev.chrisbanes.haze.ExperimentalHazeApi
-import dev.chrisbanes.haze.VisualEffect
-import dev.chrisbanes.haze.VisualEffectContext
+input = HazeInput.Sources(
+    state = hazeState,
+    selection = HazeSourceSelection.All.where { it.key == "hero" },
+    retention = HazeSourceRetention.ClearWhenUnavailable,
+)
+```
 
-@OptIn(ExperimentalHazeApi::class)
-class SparkVisualEffect : VisualEffect {
-    var color: Color = Color.Black
-    var alpha: Float = 0.2f
+`drawInput()` draws the already-selected source content. It does not expose source areas,
+coordinates, captured layers, windows, or renderer ownership internals.
 
-    override fun attach(context: VisualEffectContext) {
-        // Allocate expensive resources if needed.
-    }
+## Draw the modifier's own content
 
-    override fun update(context: VisualEffectContext) {
-        // Read composition locals or snapshot state.
-        // Call context.invalidateDraw() if output changes.
-    }
+Use `HazeInput.Content` when the effect consumes the composable carrying the modifier:
 
-    override fun detach(context: VisualEffectContext) {
-        // Release resources from attach().
-    }
-
-    override fun DrawScope.draw(context: VisualEffectContext) {
-        drawRect(
-            color = color.copy(alpha = alpha),
-            size = context.size,
+```kotlin
+Box(
+    Modifier
+        .hazeEffect(
+            factory = SparkEffect,
+            input = HazeInput.Content,
+            style = SparkStyle(color = Color.Blue, alpha = 0.3f),
         )
-    }
-}
+        .background(Color.White),
+)
 ```
 
-### Lifecycle methods
+The renderer uses the same `drawInput()` operation for both input modes.
 
-#### `attach(context: VisualEffectContext)`
+## Semantic scopes
 
-Called when the effect is attached to a node.
+`HazeEffectDrawScope` is a `DrawScope` with:
 
-- Allocate long-lived resources here (shaders, caches, delegates)
-- Geometry may not be resolved yet, so treat `position`, `size`, `layerSize`, and `layerOffset` as potentially unspecified/zero during attach
+- `modifierBounds`, expressed in the current effect layer
+- the structural `HazeSampling` value
+- `drawInput()` for the selected input
+- tracked composition-local access through `currentValueOf`
 
-#### `update(context: VisualEffectContext)`
+`HazeEffectLayoutScope` is a `Density` with the modifier bounds and tracked composition-local
+access. Return the bounds required by the effect in the same coordinate space. Setting
+`expandLayerBounds = false` on the modifier skips renderer-requested expansion.
 
-Called when the effect should refresh state from composition locals or snapshot-backed data.
+Snapshot state and composition locals read while drawing invalidate drawing. Values read while
+calculating bounds recalculate the bounds and then redraw.
 
-- Snapshot reads are tracked
-- When read state changes, `update` is invoked again
-- Call `context.invalidateDraw()` when visual output should be re-drawn
+## Ownership and lifecycle
 
-```kotlin
-override fun update(context: VisualEffectContext) {
-    val newColor = context.currentValueOf(LocalSparkColor)
-    if (newColor != color) {
-        color = newColor
-        context.invalidateDraw()
-    }
-}
-```
+- Share the immutable Style and factory freely.
+- Never return the same mutable renderer from more than one `createRenderer()` call.
+- Release rebuildable caches in `onTrimMemory`.
+- Release all renderer-owned resources in `dispose`.
+- Keep pointer interaction and retained-output behavior inside your effect module until those
+  capabilities have dedicated public contracts.
 
-#### `detach(context: VisualEffectContext)`
+Platform-specific renderer internals can use `expect`/`actual` declarations in the effect module.
+The public renderer contract intentionally does not expose platform delegates or captured layers.
 
-Called when the effect is detached.
+## Temporary legacy path
 
-- Release resources acquired in `attach`
-- Cancel work tied to effect internals
+`VisualEffect`, `VisualEffectContext`, `HazeEffectScope`, and the lambda-based `hazeEffect`
+overloads remain available while built-in and existing third-party effects migrate. They are a
+temporary compatibility path, not the recommended extension seam for new effects.
 
-```kotlin
-override fun detach(context: VisualEffectContext) {
-    shader?.release()
-    shader = null
-}
-```
-
-#### `onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel)`
-
-Called on memory pressure/background transitions.
-
-- Free heavy caches and temporary buffers
-- Keep this fast and safe to call repeatedly
-- Optionally call `context.invalidateDraw()` after release
-
-#### `draw(context: VisualEffectContext)`
-
-Called during rendering.
-
-- Keep this path hot and allocation-light
-- Use `context.size`/`context.layerSize` to align your output to the requested bounds
-
-## VisualEffectContext
-
-`VisualEffectContext` provides geometry, environment, and lifecycle helpers:
-
-```kotlin
-interface VisualEffectContext {
-    val position: Offset
-    val size: Size
-    val layerSize: Size
-    val layerOffset: Offset
-    val rootBounds: Rect
-
-    val inputScale: HazeInputScale
-    val windowId: Any?
-    val areas: List<HazeArea>
-    val state: HazeState?
-
-    val coroutineScope: CoroutineScope
-
-    fun requireDensity(): Density
-    fun <T> currentValueOf(local: CompositionLocal<T>): T
-    fun requireGraphicsContext(): GraphicsContext
-    fun invalidateDraw()
-}
-```
-
-Mode semantics:
-
-- `state != null`: background mode (`hazeEffect(state = hazeState)`)
-- `state == null`: foreground/content mode (`hazeEffect { ... }`)
-
-Input-scale semantics:
-
-- `HazeInputScale.Default` is passed through unchanged so a custom effect can choose its normal
-  policy.
-- `HazeInputScale.None` explicitly requests `1.0`.
-- `HazeInputScale.Auto` asks the custom effect to apply its automatic policy; core does not impose
-  the built-in blur or Glass rules.
-- `HazeInputScale.Fixed` supplies the caller's exact scale.
-
-Custom effects should document how they interpret `Default` and `Auto`, and should preserve
-explicit `None` and `Fixed` choices.
-
-## HazeEffectScope
-
-The `Modifier.hazeEffect { ... }` lambda uses `HazeEffectScope`:
-
-```kotlin
-interface HazeEffectScope {
-    var visualEffect: VisualEffect
-    var inputScale: HazeInputScale
-    var drawContentBehind: Boolean
-    var clipToAreasBounds: Boolean?
-    var expandLayerBounds: Boolean?
-    var forceInvalidateOnPreDraw: Boolean
-    var canDrawArea: ((HazeArea) -> Boolean)?
-}
-```
-
-## Builder extension pattern
-
-Expose your effect through a `HazeEffectScope` extension:
-
-```kotlin
-@OptIn(ExperimentalHazeApi::class)
-fun HazeEffectScope.sparkEffect(
-    block: SparkVisualEffect.() -> Unit,
-) {
-    val effect = visualEffect as? SparkVisualEffect ?: SparkVisualEffect()
-    visualEffect = effect
-    effect.block()
-}
-```
-
-Usage:
-
-```kotlin
-Modifier.hazeEffect(state = hazeState) {
-    sparkEffect {
-        color = Color.Blue
-        alpha = 0.3f
-    }
-}
-```
-
-## Ownership model
-
-`VisualEffect` instances are single-owner.
-
-- One effect instance can only be attached to one active `hazeEffect` node at a time
-- Do not share the same effect instance across multiple active nodes
-- Prefer creating/reusing instances per node via your builder pattern
-
-## Layer bounds behavior
-
-Override `calculateLayerBounds(rect, density)` if your effect needs extra sampling space:
-
-```kotlin
-override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
-    val extra = with(density) { 24.dp.toPx() }
-    return rect.inflate(extra)
-}
-```
-
-Coordinate-space contract:
-
-- Return bounds in the same coordinate space as `rect`
-- In background mode (`context.state != null`), Haze passes a root/screen-aligned rect
-- In foreground mode (`context.state == null`), Haze passes a local node rect
-
-## Platform-specific implementations
-
-Use `expect`/`actual` for platform-specific rendering internals:
-
-```kotlin
-// commonMain
-expect fun createPlatformShader(size: Size): Shader
-
-@OptIn(ExperimentalHazeApi::class)
-class ShaderEffect : VisualEffect {
-    private lateinit var shader: Shader
-
-    override fun attach(context: VisualEffectContext) {
-        shader = createPlatformShader(context.size)
-    }
-}
-```
-
-```kotlin
-// androidMain
-actual fun createPlatformShader(size: Size): Shader {
-    // Android implementation
-}
-```
-
-```kotlin
-// desktopMain / skikoMain
-actual fun createPlatformShader(size: Size): Shader {
-    // Desktop implementation
-}
-```
-
-## Sample
-
-See the dedicated custom effect sample:
-
-- [CustomVisualEffectSample.kt](https://github.com/chrisbanes/haze/blob/main/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CustomVisualEffectSample.kt)
-
-## Best practices
-
-1. Allocate in `attach`, release in `detach`
-2. Keep `draw` allocation-free where possible
-3. Use `update` for tracked state reads and controlled invalidation
-4. Respect `inputScale` and bounds contracts for performance and correctness
-5. Validate behavior with screenshot tests for visual regressions
-
-## Next steps
-
-- Read [Architecture](architecture.md) for internals
-- Review [haze-blur](https://github.com/chrisbanes/haze/tree/main/haze-blur) for a full production effect
-- Browse the [sample app](https://github.com/chrisbanes/haze/tree/main/sample)
+See
+[`CustomVisualEffectSample.kt`](https://github.com/chrisbanes/haze/blob/main/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CustomVisualEffectSample.kt)
+for a complete typed example.

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -28,15 +28,36 @@ package dev.chrisbanes.haze {
     property public androidx.compose.ui.geometry.Offset screenPosition;
   }
 
+  public interface HazeEffectDrawScope extends androidx.compose.ui.graphics.drawscope.DrawScope {
+    method public <T> T currentValueOf(androidx.compose.runtime.CompositionLocal<T> local);
+    method public void drawInput();
+    method @InaccessibleFromKotlin public androidx.compose.ui.geometry.Rect getModifierBounds();
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeSampling getSampling();
+    property public abstract androidx.compose.ui.geometry.Rect modifierBounds;
+    property public abstract dev.chrisbanes.haze.HazeSampling sampling;
+  }
+
+  public fun interface HazeEffectFactory<Style> {
+    method public dev.chrisbanes.haze.HazeEffectRenderer<Style> createRenderer();
+  }
+
   public final class HazeEffectKt {
+    method @androidx.compose.runtime.Stable public static <Style> androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeEffectFactory<Style> factory, dev.chrisbanes.haze.HazeInput input, Style style, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds);
     method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeInput input, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
     method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeState? state, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
     method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
   }
 
+  public interface HazeEffectLayoutScope extends androidx.compose.ui.unit.Density {
+    method public <T> T currentValueOf(androidx.compose.runtime.CompositionLocal<T> local);
+    method @InaccessibleFromKotlin public androidx.compose.ui.geometry.Rect getModifierBounds();
+    property public abstract androidx.compose.ui.geometry.Rect modifierBounds;
+  }
+
   @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeEffectNode extends androidx.compose.ui.node.DelegatingNode implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode dev.chrisbanes.haze.HazeEffectScope androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.modifier.ModifierLocalModifierNode androidx.compose.ui.node.ObserverModifierNode androidx.compose.ui.node.TraversableNode {
     ctor public HazeEffectNode(optional dev.chrisbanes.haze.HazeState? state, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
     method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.VisualEffect getActiveVisualEffect();
     method @InaccessibleFromKotlin public java.util.List<dev.chrisbanes.haze.HazeArea> getAreas();
     method @InaccessibleFromKotlin public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? getBlock();
     method @InaccessibleFromKotlin public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeArea,java.lang.Boolean>? getCanDrawArea();
@@ -61,6 +82,7 @@ package dev.chrisbanes.haze {
     method @InaccessibleFromKotlin public void setRetainOutputWhenSourceUnavailable(boolean);
     method @InaccessibleFromKotlin public void setState(dev.chrisbanes.haze.HazeState?);
     method @InaccessibleFromKotlin public void setVisualEffect(dev.chrisbanes.haze.VisualEffect);
+    property @dev.chrisbanes.haze.InternalHazeApi public dev.chrisbanes.haze.VisualEffect activeVisualEffect;
     property public java.util.List<dev.chrisbanes.haze.HazeArea> areas;
     property public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block;
     property public kotlin.jvm.functions.Function1<dev.chrisbanes.haze.HazeArea,java.lang.Boolean>? canDrawArea;
@@ -78,6 +100,13 @@ package dev.chrisbanes.haze {
     property public dev.chrisbanes.haze.HazeState? state;
     property public Object traverseKey;
     property public dev.chrisbanes.haze.VisualEffect visualEffect;
+  }
+
+  public interface HazeEffectRenderer<Style> {
+    method public default androidx.compose.ui.geometry.Rect calculateLayerBounds(dev.chrisbanes.haze.HazeEffectLayoutScope, Style style);
+    method public default void dispose();
+    method public void draw(dev.chrisbanes.haze.HazeEffectDrawScope, Style style);
+    method public default void onTrimMemory(dev.chrisbanes.haze.TrimMemoryLevel level);
   }
 
   public interface HazeEffectScope {
@@ -395,6 +424,10 @@ package dev.chrisbanes.haze {
 
   public final class VisualEffectContextKt {
     method @dev.chrisbanes.haze.ExperimentalHazeApi public static inline <R> R withGraphicsLayer(dev.chrisbanes.haze.VisualEffectContext, kotlin.jvm.functions.Function1<? super androidx.compose.ui.graphics.layer.GraphicsLayer,? extends R> block);
+  }
+
+  @dev.chrisbanes.haze.InternalHazeApi public interface VisualEffectRendererFactory extends dev.chrisbanes.haze.VisualEffect {
+    method public dev.chrisbanes.haze.VisualEffect createRenderer();
   }
 
   @dev.chrisbanes.haze.InternalHazeApi public final class VisualEffectTransform {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -272,6 +272,41 @@ public fun Modifier.hazeEffect(
   block = block,
 )
 
+/**
+ * Draws a typed custom effect using an explicit [input].
+ *
+ * [factory] is a stateless descriptor that may be shared by concurrent modifiers. Haze creates
+ * one renderer for each modifier node and passes the complete current [style] to its draw and
+ * layer-layout evaluations.
+ *
+ * @param factory The shareable descriptor that creates node-owned renderers.
+ * @param input The source-backed or own-content input consumed by the renderer.
+ * @param style The complete effect configuration accepted by [factory].
+ * @param sampling The input-sampling policy visible to the renderer.
+ * @param expandLayerBounds Whether renderer-requested layer-bound expansion is enabled.
+ */
+@Stable
+public fun <Style> Modifier.hazeEffect(
+  factory: HazeEffectFactory<Style>,
+  input: HazeInput,
+  style: Style,
+  sampling: HazeSampling = HazeSampling.Default,
+  expandLayerBounds: Boolean = true,
+): Modifier {
+  val effect = this then TypedHazeEffectNodeElement(
+    factory = factory,
+    input = input,
+    style = style,
+    sampling = sampling,
+    expandLayerBounds = expandLayerBounds,
+  )
+  return if (input === HazeInput.Content) {
+    effect.graphicsLayer() then ForegroundContentInvalidationElement
+  } else {
+    effect
+  }
+}
+
 private fun Modifier.thenHazeEffect(
   state: HazeState?,
   explicitInput: HazeInput? = null,
@@ -290,6 +325,60 @@ private fun Modifier.thenHazeEffect(
     effect.graphicsLayer() then ForegroundContentInvalidationElement
   } else {
     effect
+  }
+}
+
+private class TypedHazeEffectNodeElement<Style>(
+  val factory: HazeEffectFactory<Style>,
+  val input: HazeInput,
+  val style: Style,
+  val sampling: HazeSampling,
+  val expandLayerBounds: Boolean,
+) : ModifierNodeElement<HazeEffectNode>() {
+
+  override fun create(): HazeEffectNode = HazeEffectNode(
+    state = (input as? HazeInput.Sources)?.state,
+  ).also { node ->
+    node.explicitInput = input
+    node.explicitSampling = sampling
+    node.explicitExpandLayerBounds = expandLayerBounds
+    node.updateTypedEffect(factory, style, sampling)
+  }
+
+  override fun update(node: HazeEffectNode) {
+    node.explicitInput = input
+    node.explicitSampling = sampling
+    node.explicitExpandLayerBounds = expandLayerBounds
+    node.state = (input as? HazeInput.Sources)?.state
+    node.updateTypedEffect(factory, style, sampling)
+    node.update()
+  }
+
+  override fun InspectorInfo.inspectableProperties() {
+    name = "HazeEffect"
+    properties["factory"] = factory
+    properties["input"] = input
+    properties["style"] = style
+    properties["sampling"] = sampling
+    properties["expandLayerBounds"] = expandLayerBounds
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is TypedHazeEffectNodeElement<*>) return false
+    return factory === other.factory &&
+      input == other.input &&
+      style == other.style &&
+      sampling == other.sampling &&
+      expandLayerBounds == other.expandLayerBounds
+  }
+
+  override fun hashCode(): Int {
+    var result = 0
+    result = 31 * result + input.hashCode()
+    result = 31 * result + (style?.hashCode() ?: 0)
+    result = 31 * result + sampling.hashCode()
+    return 31 * result + expandLayerBounds.hashCode()
   }
 }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -1,0 +1,211 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.runtime.CompositionLocal
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.unit.Density
+
+/**
+ * A stateless, shareable descriptor that creates a renderer for one `hazeEffect` modifier node.
+ *
+ * The factory may be shared by any number of nodes. Each call to [createRenderer] must return an
+ * independently owned renderer.
+ */
+public fun interface HazeEffectFactory<Style> {
+  public fun createRenderer(): HazeEffectRenderer<Style>
+}
+
+/**
+ * Node-owned rendering state for a custom Haze effect.
+ *
+ * Haze passes the complete current [Style] to every evaluation. Mutable rendering resources may
+ * be held by the renderer and released in [dispose], but must not be stored in the factory or
+ * Style.
+ */
+public interface HazeEffectRenderer<Style> {
+
+  /** Draws the effect for the complete current [style]. */
+  public fun HazeEffectDrawScope.draw(style: Style)
+
+  /**
+   * Returns the layer bounds required by the effect.
+   *
+   * The returned rect uses the same coordinate space as [HazeEffectLayoutScope.modifierBounds].
+   */
+  public fun HazeEffectLayoutScope.calculateLayerBounds(style: Style): Rect = modifierBounds
+
+  /** Releases cached resources in response to system memory pressure. */
+  public fun onTrimMemory(level: TrimMemoryLevel): Unit = Unit
+
+  /**
+   * Releases all renderer-owned resources.
+   *
+   * Haze calls this once when the factory is replaced or the modifier node detaches.
+   */
+  public fun dispose(): Unit = Unit
+}
+
+/**
+ * Semantic drawing scope for a custom Haze effect.
+ *
+ * Source geometry and captured layers remain internal. Use [drawInput] to draw the input selected
+ * by the modifier's [HazeInput].
+ */
+public interface HazeEffectDrawScope : DrawScope {
+
+  /** Bounds of the modifier in the current effect layer. */
+  public val modifierBounds: Rect
+
+  /** Input-sampling policy supplied to the typed `hazeEffect` modifier. */
+  public val sampling: HazeSampling
+
+  /** Draws the modifier's selected source-backed or own-content input. */
+  public fun drawInput()
+
+  /** Returns the current value of [local] and observes it for redraw. */
+  public fun <T> currentValueOf(local: CompositionLocal<T>): T
+}
+
+/**
+ * Semantic layer-layout scope for a custom Haze effect.
+ *
+ * [modifierBounds] is initially aligned to the modifier. Bounds returned by
+ * [HazeEffectRenderer.calculateLayerBounds] define the required effect layer around it.
+ */
+public interface HazeEffectLayoutScope : Density {
+
+  /** Bounds of the modifier in the effect layer's coordinate space. */
+  public val modifierBounds: Rect
+
+  /** Returns the current value of [local] and observes it for bounds recalculation. */
+  public fun <T> currentValueOf(local: CompositionLocal<T>): T
+}
+
+internal interface TypedHazeEffectVisualEffect {
+  fun update(style: Any?, sampling: HazeSampling)
+  fun onTrimMemory(level: TrimMemoryLevel)
+}
+
+@OptIn(ExperimentalHazeApi::class)
+internal class TypedHazeEffectVisualEffectImpl<Style>(
+  private val renderer: HazeEffectRenderer<Style>,
+  style: Style,
+  private var sampling: HazeSampling,
+) : VisualEffect, TypedHazeEffectVisualEffect {
+  private var style: Style = style
+  private var context: VisualEffectContext? = null
+  private var disposed = false
+
+  override fun attach(context: VisualEffectContext) {
+    this.context = context
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    val scope = HazeEffectDrawScopeImpl(
+      drawScope = this,
+      context = context,
+      sampling = sampling,
+    )
+    with(renderer) {
+      scope.draw(style)
+    }
+  }
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
+    val context = checkNotNull(context) { "Typed Haze renderer is not attached" }
+    val modifierBounds = Rect(offset = Offset.Zero, size = rect.size)
+    val scope = HazeEffectLayoutScopeImpl(
+      density = density,
+      context = context,
+      modifierBounds = modifierBounds,
+    )
+    val requiredBounds = with(renderer) {
+      scope.calculateLayerBounds(style)
+    }
+    return Rect(
+      offset = rect.topLeft + requiredBounds.topLeft,
+      size = requiredBounds.size,
+    )
+  }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    onTrimMemory(level)
+  }
+
+  override fun onTrimMemory(level: TrimMemoryLevel) {
+    renderer.onTrimMemory(level)
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    this.context = null
+    if (!disposed) {
+      disposed = true
+      renderer.dispose()
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  override fun update(style: Any?, sampling: HazeSampling) {
+    this.style = style as Style
+    this.sampling = sampling
+  }
+}
+
+private class HazeEffectDrawScopeImpl(
+  private val drawScope: DrawScope,
+  private val context: VisualEffectContext,
+  override val sampling: HazeSampling,
+) : HazeEffectDrawScope, DrawScope by drawScope {
+
+  override val modifierBounds: Rect
+    get() = Rect(offset = context.layerOffset, size = context.size)
+
+  override fun drawInput() {
+    val layerOffset = context.layerOffset
+    val effectPosition = context.position
+    val areas = context.areas
+    with(drawScope) {
+      translate(left = layerOffset.x, top = layerOffset.y) {
+        for (area in areas) {
+          val sourcePosition = Snapshot.withoutReadObservation {
+            this@HazeEffectDrawScopeImpl.context.positionOf(area)
+          }
+          val relativePosition = (
+            sourcePosition.takeIf(Offset::isSpecified) ?: Offset.Zero
+            ) - effectPosition
+          translate(left = relativePosition.x, top = relativePosition.y) {
+            val layer = area.contentLayer
+              ?.takeUnless { it.isReleased }
+              ?.takeUnless { it.size.width <= 0 || it.size.height <= 0 }
+            if (layer != null) {
+              drawLayer(layer)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  override fun <T> currentValueOf(local: CompositionLocal<T>): T {
+    return context.currentValueOf(local)
+  }
+}
+
+private class HazeEffectLayoutScopeImpl(
+  density: Density,
+  private val context: VisualEffectContext,
+  override val modifierBounds: Rect,
+) : HazeEffectLayoutScope, Density by density {
+
+  override fun <T> currentValueOf(local: CompositionLocal<T>): T {
+    return context.currentValueOf(local)
+  }
+}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -89,9 +89,12 @@ public interface HazeEffectLayoutScope : Density {
   public fun <T> currentValueOf(local: CompositionLocal<T>): T
 }
 
-internal interface TypedHazeEffectVisualEffect {
+internal interface TypedHazeEffectVisualEffect : RetainedOutputVisualEffect {
   fun update(style: Any?, sampling: HazeSampling)
   fun onTrimMemory(level: TrimMemoryLevel)
+
+  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean = true
+  override fun clearRetainedOutput() = Unit
 }
 
 @OptIn(ExperimentalHazeApi::class)

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -117,6 +117,7 @@ public class HazeEffectNode(
   private var needsDirtyFieldsInvalidation = false
   private var needsVisualEffectInvalidation = false
   private var needsContentInvalidation = false
+  private var hasRenderedTypedSourceOutput = false
   private var isDrawing = false
   private var isInvokingBlock = false
   private var lastKnownCoordinates: LayoutCoordinates? = null
@@ -603,6 +604,12 @@ public class HazeEffectNode(
               with(activeVisualEffect) {
                 draw(visualEffectContext)
               }
+              if (
+                activeVisualEffect is TypedHazeEffectVisualEffect &&
+                hasDrawableSourceLayers
+              ) {
+                hasRenderedTypedSourceOutput = true
+              }
             }
             drawContentSafely()
             if (shouldDrawEffect) {
@@ -986,6 +993,9 @@ public class HazeEffectNode(
   }
 
   private fun clearRetainedOutput(effect: VisualEffect = activeVisualEffect) {
+    if (effect === activeVisualEffect) {
+      hasRenderedTypedSourceOutput = false
+    }
     (effect as? RetainedOutputVisualEffect)?.clearRetainedOutput()
   }
 
@@ -1030,6 +1040,10 @@ public class HazeEffectNode(
 
   private fun shouldDrawRetainedOutput(): Boolean {
     return retainOutputWhenSourceUnavailable &&
+      (
+        activeVisualEffect !is TypedHazeEffectVisualEffect ||
+          hasRenderedTypedSourceOutput
+        ) &&
       (activeVisualEffect as? RetainedOutputVisualEffect)
         ?.shouldDrawRetainedOutput(visualEffectContext) == true
   }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -284,6 +284,11 @@ public class HazeEffectNode(
   public var activeVisualEffect: VisualEffect = EmptyVisualEffect
     private set
 
+  private var typedEffectFactory: Any? = null
+  private var typedEffectStyle: Any? = null
+  private var typedEffectSampling: HazeSampling? = null
+  private var createTypedRuntime: (() -> VisualEffect)? = null
+
   override var canDrawArea: ((HazeArea) -> Boolean)? = null
     set(value) {
       if (value != field) {
@@ -302,17 +307,7 @@ public class HazeEffectNode(
         pointerInputDelegate?.cancel(oldRuntime as? InteractiveVisualEffect)
         if (isAttached) {
           val newRuntime = value.createRenderer()
-          attachVisualEffect(newRuntime)
-          try {
-            clearRetainedOutput(oldRuntime)
-          } catch (throwable: Throwable) {
-            runCatching { detachVisualEffect(newRuntime) }
-              .exceptionOrNull()
-              ?.let(throwable::addSuppressed)
-            throw throwable
-          }
-          runCatching { detachVisualEffect(oldRuntime) }
-          activeVisualEffect = newRuntime
+          replaceActiveVisualEffect(newRuntime)
         } else {
           clearRetainedOutput(
             activeVisualEffect.takeUnless { it === EmptyVisualEffect } ?: oldConfiguredEffect,
@@ -327,6 +322,56 @@ public class HazeEffectNode(
         }
       }
     }
+
+  internal fun <Style> updateTypedEffect(
+    factory: HazeEffectFactory<Style>,
+    style: Style,
+    sampling: HazeSampling,
+  ) {
+    val createRuntime = {
+      TypedHazeEffectVisualEffectImpl(
+        renderer = factory.createRenderer(),
+        style = style,
+        sampling = sampling,
+      )
+    }
+    if (typedEffectFactory !== factory) {
+      if (isAttached) {
+        replaceActiveVisualEffect(createRuntime())
+      }
+      typedEffectFactory = factory
+      typedEffectStyle = style
+      typedEffectSampling = sampling
+      createTypedRuntime = createRuntime
+      dirtyTracker += DirtyFields.VisualEffectLayerBounds
+      if (isAttached) {
+        invalidateVisualEffectDraw()
+      }
+    } else if (typedEffectStyle != style || typedEffectSampling != sampling) {
+      typedEffectStyle = style
+      typedEffectSampling = sampling
+      createTypedRuntime = createRuntime
+      (activeVisualEffect as? TypedHazeEffectVisualEffect)?.update(style, sampling)
+      invalidateVisualEffectLayerBounds()
+    } else {
+      createTypedRuntime = createRuntime
+    }
+  }
+
+  private fun replaceActiveVisualEffect(newRuntime: VisualEffect) {
+    val oldRuntime = activeVisualEffect
+    attachVisualEffect(newRuntime)
+    try {
+      clearRetainedOutput(oldRuntime)
+    } catch (throwable: Throwable) {
+      runCatching { detachVisualEffect(newRuntime) }
+        .exceptionOrNull()
+        ?.let(throwable::addSuppressed)
+      throw throwable
+    }
+    runCatching { detachVisualEffect(oldRuntime) }
+    activeVisualEffect = newRuntime
+  }
 
   private var pointerInputDelegate: HazeEffectPointerInputNode? = null
 
@@ -415,12 +460,20 @@ public class HazeEffectNode(
 
   override fun onAttach() {
     val runtime = activeVisualEffect.takeUnless { it === EmptyVisualEffect }
+      ?: createTypedRuntime?.invoke()
       ?: visualEffect.createRenderer()
     attachVisualEffect(runtime)
     activeVisualEffect = runtime
     trimMemoryCallbackDisposable = registerTrimMemoryCallback(
       requirePlatformContext(),
-    ) { level -> activeVisualEffect.onTrimMemory(visualEffectContext, level) }
+    ) { level ->
+      val activeEffect = activeVisualEffect
+      if (activeEffect is TypedHazeEffectVisualEffect) {
+        activeEffect.onTrimMemory(level)
+      } else {
+        activeEffect.onTrimMemory(visualEffectContext, level)
+      }
+    }
     update()
   }
 
@@ -1165,6 +1218,7 @@ internal val AreaOffsetsDirtyFields: Int =
 internal val LayerBoundsDirtyFields: Int =
   DirtyFields.Position or
     DirtyFields.AreaOffsets or
+    DirtyFields.AreaPositionReads or
     DirtyFields.Size or
     DirtyFields.Areas or
     DirtyFields.ExpandLayer or

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectFactoryLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectFactoryLifecycleTest.kt
@@ -1,0 +1,228 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.referentialEqualityPolicy
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotSameInstanceAs
+import assertk.assertions.isSameInstanceAs
+import dev.chrisbanes.haze.test.ContextTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class HazeEffectFactoryLifecycleTest : ContextTest() {
+
+  @Test
+  fun sharedFactory_createsOneRendererPerNode() = runComposeUiTest {
+    val factory = RecordingFactory()
+
+    setContent {
+      Box {
+        Spacer(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Content,
+              style = RecordingStyle("first"),
+            ),
+        )
+        Spacer(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Content,
+              style = RecordingStyle("second"),
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    assertThat(factory.renderers.size).isEqualTo(2)
+    assertThat(factory.renderers[0]).isNotSameInstanceAs(factory.renderers[1])
+  }
+
+  @Test
+  fun styleReplacement_reusesRenderer() = runComposeUiTest {
+    val factory = RecordingFactory()
+    val style = mutableStateOf(RecordingStyle("first"))
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(10.dp)
+          .hazeEffect(
+            factory = factory,
+            input = HazeInput.Content,
+            style = style.value,
+          ),
+      )
+    }
+    waitForIdle()
+
+    val renderer = factory.renderers.single()
+
+    style.value = RecordingStyle("second")
+    waitForIdle()
+
+    assertThat(factory.renderers.single()).isSameInstanceAs(renderer)
+  }
+
+  @Test
+  fun factoryReplacementAndDetach_disposeEachRendererExactlyOnce() = runComposeUiTest {
+    val firstFactory = RecordingFactory()
+    val secondFactory = RecordingFactory()
+    val factory = mutableStateOf<HazeEffectFactory<RecordingStyle>>(firstFactory)
+    val showEffect = mutableStateOf(true)
+
+    setContent {
+      if (showEffect.value) {
+        Spacer(
+          Modifier
+            .size(10.dp)
+            .hazeEffect(
+              factory = factory.value,
+              input = HazeInput.Content,
+              style = RecordingStyle("style"),
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    factory.value = secondFactory
+    waitForIdle()
+
+    val firstRenderer = firstFactory.renderers.single()
+    val secondRenderer = secondFactory.renderers.single()
+    assertThat(firstRenderer.disposeCalls).isEqualTo(1)
+    assertThat(secondRenderer.disposeCalls).isEqualTo(0)
+
+    showEffect.value = false
+    waitForIdle()
+
+    assertThat(firstRenderer.disposeCalls).isEqualTo(1)
+    assertThat(secondRenderer.disposeCalls).isEqualTo(1)
+  }
+
+  @Test
+  fun equalButDistinctFactoryReplacement_usesFactoryIdentity() = runComposeUiTest {
+    val firstFactory = EqualRecordingFactory()
+    val secondFactory = EqualRecordingFactory()
+    val factory = mutableStateOf<HazeEffectFactory<RecordingStyle>>(
+      firstFactory,
+      referentialEqualityPolicy(),
+    )
+
+    setContent {
+      Spacer(
+        Modifier
+          .size(10.dp)
+          .hazeEffect(
+            factory = factory.value,
+            input = HazeInput.Content,
+            style = RecordingStyle("style"),
+          ),
+      )
+    }
+    waitForIdle()
+
+    factory.value = secondFactory
+    waitForIdle()
+
+    assertThat(firstFactory.renderers.single().disposeCalls).isEqualTo(1)
+    assertThat(secondFactory.renderers.single().disposeCalls).isEqualTo(0)
+  }
+
+  @Test
+  fun trimMemory_forwardsOnlyToTheTargetRenderer() {
+    val first = RecordingRenderer()
+    val second = RecordingRenderer()
+    val firstRuntime = TypedHazeEffectVisualEffectImpl(
+      renderer = first,
+      style = RecordingStyle("first"),
+      sampling = HazeSampling.Default,
+    )
+    val secondRuntime = TypedHazeEffectVisualEffectImpl(
+      renderer = second,
+      style = RecordingStyle("second"),
+      sampling = HazeSampling.Default,
+    )
+
+    firstRuntime.onTrimMemory(TrimMemoryLevel.BACKGROUND)
+    assertThat(first.trimLevels).containsExactly(TrimMemoryLevel.BACKGROUND)
+    assertThat(second.trimLevels).isEmpty()
+
+    secondRuntime.onTrimMemory(TrimMemoryLevel.COMPLETE)
+    assertThat(first.trimLevels).containsExactly(TrimMemoryLevel.BACKGROUND)
+    assertThat(second.trimLevels).containsExactly(TrimMemoryLevel.COMPLETE)
+  }
+}
+
+@Poko
+private class RecordingStyle(val value: String)
+
+private class RecordingFactory : HazeEffectFactory<RecordingStyle> {
+  val renderers = mutableListOf<RecordingRenderer>()
+
+  override fun createRenderer(): HazeEffectRenderer<RecordingStyle> {
+    return RecordingRenderer().also(renderers::add)
+  }
+}
+
+private class EqualRecordingFactory : HazeEffectFactory<RecordingStyle> {
+  val renderers = mutableListOf<RecordingRenderer>()
+
+  override fun createRenderer(): HazeEffectRenderer<RecordingStyle> {
+    return RecordingRenderer().also(renderers::add)
+  }
+
+  override fun equals(other: Any?): Boolean = other is EqualRecordingFactory
+
+  override fun hashCode(): Int = 0
+}
+
+private class RecordingRenderer : HazeEffectRenderer<RecordingStyle> {
+  val trimLevels = mutableListOf<TrimMemoryLevel>()
+  var disposeCalls = 0
+
+  override fun HazeEffectDrawScope.draw(style: RecordingStyle) = Unit
+
+  override fun HazeEffectLayoutScope.calculateLayerBounds(style: RecordingStyle): Rect {
+    return modifierBounds
+  }
+
+  override fun dispose() {
+    disposeCalls++
+  }
+
+  override fun onTrimMemory(level: TrimMemoryLevel) {
+    trimLevels += level
+  }
+}
+
+@Suppress("unused")
+private fun <Style> typedPairingCompiles(
+  factory: HazeEffectFactory<Style>,
+  style: Style,
+): Modifier = Modifier.hazeEffect(
+  factory = factory,
+  input = HazeInput.Content,
+  style = style,
+)

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectFactoryDrawTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectFactoryDrawTest.kt
@@ -60,6 +60,97 @@ class HazeEffectFactoryDrawTest {
   }
 
   @Test
+  fun sourceDisappears_keepLastFrameDrawsRetainedTypedOutput() = runComposeUiTest {
+    val state = HazeState()
+    val factory = RecordingDrawFactory()
+    val showSource = mutableStateOf(true)
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .background(Color.White),
+      ) {
+        if (showSource.value) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .hazeSource(state),
+          )
+        }
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("effect")
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Sources(state),
+              style = DrawStyle(overlay = Color.Blue),
+            ),
+        )
+      }
+    }
+
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Blue)
+    val drawsBeforeRemoval = factory.renderer.drawCalls
+
+    showSource.value = false
+    waitForIdle()
+
+    assertThat(factory.renderer.drawCalls).isGreaterThan(drawsBeforeRemoval)
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Blue)
+  }
+
+  @Test
+  fun sourceDisappears_clearWhenUnavailableSkipsRetainedTypedOutput() = runComposeUiTest {
+    val state = HazeState()
+    val factory = RecordingDrawFactory()
+    val showSource = mutableStateOf(true)
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .background(Color.White),
+      ) {
+        if (showSource.value) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .hazeSource(state),
+          )
+        }
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("effect")
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Sources(
+                state = state,
+                retention = HazeSourceRetention.ClearWhenUnavailable,
+              ),
+              style = DrawStyle(overlay = Color.Blue),
+            ),
+        )
+      }
+    }
+
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Blue)
+    val drawsBeforeRemoval = factory.renderer.drawCalls
+
+    showSource.value = false
+    waitForIdle()
+
+    assertThat(factory.renderer.drawCalls).isEqualTo(drawsBeforeRemoval)
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.White)
+  }
+
+  @Test
   fun drawInput_drawsModifierOwnContent() = runComposeUiTest {
     setContent {
       Box(

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectFactoryDrawTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectFactoryDrawTest.kt
@@ -1,0 +1,374 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class HazeEffectFactoryDrawTest {
+
+  @Test
+  fun drawInput_drawsSelectedSourceContent() = runComposeUiTest {
+    val state = HazeState()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state)
+            .background(Color.Red),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("effect")
+            .hazeEffect(
+              factory = InputDrawingFactory,
+              input = HazeInput.Sources(state),
+              style = DrawStyle(),
+            ),
+        )
+      }
+    }
+
+    val pixels = onNodeWithTag("effect").captureToImage().toPixelMap()
+    assertThat(pixels[50, 50]).isEqualTo(Color.Red)
+  }
+
+  @Test
+  fun drawInput_drawsModifierOwnContent() = runComposeUiTest {
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .testTag("effect")
+          .hazeEffect(
+            factory = InputDrawingFactory,
+            input = HazeInput.Content,
+            style = DrawStyle(),
+          )
+          .background(Color.Red),
+      )
+    }
+
+    val pixels = onNodeWithTag("effect").captureToImage().toPixelMap()
+    assertThat(pixels[50, 50]).isEqualTo(Color.Red)
+  }
+
+  @Test
+  fun styleReplacement_updatesOutputWithoutRecreatingRenderer() = runComposeUiTest {
+    val factory = RecordingDrawFactory()
+    val style = mutableStateOf(DrawStyle(overlay = Color.Red))
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .testTag("effect")
+          .hazeEffect(
+            factory = factory,
+            input = HazeInput.Content,
+            style = style.value,
+          )
+          .background(Color.White),
+      )
+    }
+
+    var pixels = onNodeWithTag("effect").captureToImage().toPixelMap()
+    assertThat(pixels[50, 50]).isEqualTo(Color.Red)
+
+    style.value = DrawStyle(overlay = Color.Blue)
+    waitForIdle()
+
+    pixels = onNodeWithTag("effect").captureToImage().toPixelMap()
+    assertThat(pixels[50, 50]).isEqualTo(Color.Blue)
+    assertThat(factory.createCalls).isEqualTo(1)
+  }
+
+  @Test
+  fun drawScope_exposesExpandedModifierBoundsAndEverySamplingValue() = runComposeUiTest {
+    val factory = RecordingDrawFactory(expandBy = 10f)
+    val sampling = mutableStateOf<HazeSampling>(HazeSampling.Default)
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .hazeEffect(
+            factory = factory,
+            input = HazeInput.Content,
+            style = DrawStyle(),
+            sampling = sampling.value,
+          ),
+      )
+    }
+    waitForIdle()
+
+    val renderer = factory.renderer
+    assertThat(renderer.lastModifierBounds).isEqualTo(Rect(10f, 10f, 110f, 110f))
+    assertThat(renderer.lastSampling).isEqualTo(HazeSampling.Default)
+
+    val choices = listOf(
+      HazeSampling.FullResolution,
+      HazeSampling.Adaptive,
+      HazeSampling.Fixed(0.6f),
+    )
+    for (choice in choices) {
+      sampling.value = choice
+      waitForIdle()
+      assertThat(renderer.lastSampling).isEqualTo(choice)
+    }
+    assertThat(factory.createCalls).isEqualTo(1)
+  }
+
+  @Test
+  fun drawScopeReads_invalidateOnlyDraw() = runComposeUiTest {
+    val drawState = mutableIntStateOf(0)
+    val drawLocal = mutableIntStateOf(0)
+    val factory = ObservationFactory(
+      drawState = { drawState.intValue },
+      drawLocal = { currentValueOf(LocalDrawObservation) },
+    )
+
+    setContent {
+      CompositionLocalProvider(LocalDrawObservation provides drawLocal.intValue) {
+        Box(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Content,
+              style = DrawStyle(),
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val renderer = factory.renderer
+    val initialDraws = renderer.drawCalls
+    val initialLayouts = renderer.layoutCalls
+
+    drawState.intValue++
+    waitForIdle()
+
+    assertThat(renderer.drawCalls).isGreaterThan(initialDraws)
+    assertThat(renderer.layoutCalls).isEqualTo(initialLayouts)
+
+    val drawsBeforeLocalChange = renderer.drawCalls
+    drawLocal.intValue++
+    waitForIdle()
+
+    assertThat(renderer.drawCalls).isGreaterThan(drawsBeforeLocalChange)
+    assertThat(renderer.layoutCalls).isEqualTo(initialLayouts)
+  }
+
+  @Test
+  fun layoutScopeReads_recalculateBoundsAndDependentDraw() = runComposeUiTest {
+    val layoutState = mutableIntStateOf(5)
+    val layoutLocal = mutableIntStateOf(7)
+    val factory = ObservationFactory(
+      layoutState = { layoutState.intValue },
+      layoutLocal = { currentValueOf(LocalLayoutObservation) },
+    )
+
+    setContent {
+      CompositionLocalProvider(LocalLayoutObservation provides layoutLocal.intValue) {
+        Box(
+          Modifier
+            .size(100.dp)
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Content,
+              style = DrawStyle(),
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val renderer = factory.renderer
+    val initialLayouts = renderer.layoutCalls
+    val initialDraws = renderer.drawCalls
+
+    layoutState.intValue++
+    waitForIdle()
+
+    assertThat(renderer.layoutCalls).isGreaterThan(initialLayouts)
+    assertThat(renderer.drawCalls).isGreaterThan(initialDraws)
+    assertThat(renderer.lastExpansion).isEqualTo(13f)
+
+    val layoutsBeforeLocalChange = renderer.layoutCalls
+    layoutLocal.intValue++
+    waitForIdle()
+
+    assertThat(renderer.layoutCalls).isGreaterThan(layoutsBeforeLocalChange)
+    assertThat(renderer.lastExpansion).isEqualTo(14f)
+  }
+
+  @Test
+  fun styleReplacement_recalculatesBoundsWithoutRecreatingRenderer() = runComposeUiTest {
+    val factory = RecordingDrawFactory()
+    val style = mutableStateOf(DrawStyle(expandBy = 5f))
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .hazeEffect(
+            factory = factory,
+            input = HazeInput.Content,
+            style = style.value,
+          ),
+      )
+    }
+    waitForIdle()
+    val renderer = factory.renderer
+    assertThat(renderer.lastLayoutStyle).isEqualTo(DrawStyle(expandBy = 5f))
+
+    style.value = DrawStyle(expandBy = 12f)
+    waitForIdle()
+
+    assertThat(factory.renderer).isEqualTo(renderer)
+    assertThat(factory.createCalls).isEqualTo(1)
+    assertThat(renderer.lastLayoutStyle).isEqualTo(DrawStyle(expandBy = 12f))
+  }
+
+  @Test
+  fun expandLayerBoundsFalse_skipsRendererExpansion() = runComposeUiTest {
+    val factory = RecordingDrawFactory(expandBy = 10f)
+
+    setContent {
+      Box(
+        Modifier
+          .size(100.dp)
+          .hazeEffect(
+            factory = factory,
+            input = HazeInput.Content,
+            style = DrawStyle(),
+            expandLayerBounds = false,
+          ),
+      )
+    }
+    waitForIdle()
+
+    assertThat(factory.renderer.layoutCalls).isEqualTo(0)
+    assertThat(factory.renderer.lastModifierBounds).isEqualTo(Rect(0f, 0f, 100f, 100f))
+  }
+}
+
+@Poko
+private class DrawStyle(
+  val overlay: Color = Color.Transparent,
+  val expandBy: Float = 0f,
+)
+
+private val LocalDrawObservation = compositionLocalOf { 0 }
+private val LocalLayoutObservation = compositionLocalOf { 0 }
+
+private object InputDrawingFactory : HazeEffectFactory<DrawStyle> {
+  override fun createRenderer(): HazeEffectRenderer<DrawStyle> = DrawingRenderer()
+}
+
+private class RecordingDrawFactory(
+  private val expandBy: Float = 0f,
+) : HazeEffectFactory<DrawStyle> {
+  var createCalls = 0
+  lateinit var renderer: DrawingRenderer
+
+  override fun createRenderer(): HazeEffectRenderer<DrawStyle> {
+    createCalls++
+    return DrawingRenderer(expandBy).also { renderer = it }
+  }
+}
+
+private class DrawingRenderer(
+  private val expandBy: Float = 0f,
+) : HazeEffectRenderer<DrawStyle> {
+  var lastModifierBounds: Rect? = null
+  var lastSampling: HazeSampling? = null
+  var lastLayoutStyle: DrawStyle? = null
+  var drawCalls = 0
+  var layoutCalls = 0
+
+  override fun HazeEffectDrawScope.draw(style: DrawStyle) {
+    drawCalls++
+    lastModifierBounds = modifierBounds
+    lastSampling = sampling
+    drawInput()
+    if (style.overlay.isSpecified) {
+      drawRect(style.overlay)
+    }
+  }
+
+  override fun HazeEffectLayoutScope.calculateLayerBounds(style: DrawStyle): Rect {
+    layoutCalls++
+    lastLayoutStyle = style
+    return modifierBounds.inflate(maxOf(expandBy, style.expandBy))
+  }
+}
+
+private class ObservationFactory(
+  private val drawState: () -> Int = { 0 },
+  private val drawLocal: HazeEffectDrawScope.() -> Int = { 0 },
+  private val layoutState: () -> Int = { 0 },
+  private val layoutLocal: HazeEffectLayoutScope.() -> Int = { 0 },
+) : HazeEffectFactory<DrawStyle> {
+  lateinit var renderer: ObservationRenderer
+
+  override fun createRenderer(): HazeEffectRenderer<DrawStyle> {
+    return ObservationRenderer(
+      drawState = drawState,
+      drawLocal = drawLocal,
+      layoutState = layoutState,
+      layoutLocal = layoutLocal,
+    ).also { renderer = it }
+  }
+}
+
+private class ObservationRenderer(
+  private val drawState: () -> Int,
+  private val drawLocal: HazeEffectDrawScope.() -> Int,
+  private val layoutState: () -> Int,
+  private val layoutLocal: HazeEffectLayoutScope.() -> Int,
+) : HazeEffectRenderer<DrawStyle> {
+  var drawCalls = 0
+  var layoutCalls = 0
+  var lastExpansion = 0f
+
+  override fun HazeEffectDrawScope.draw(style: DrawStyle) {
+    drawCalls++
+    drawState()
+    drawLocal()
+  }
+
+  override fun HazeEffectLayoutScope.calculateLayerBounds(style: DrawStyle): Rect {
+    layoutCalls++
+    lastExpansion = (layoutState() + layoutLocal()).toFloat()
+    return modifierBounds.inflate(lastExpansion)
+  }
+}

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
   id("dev.chrisbanes.android.library")
   id("dev.chrisbanes.kotlin.multiplatform")
   id("dev.chrisbanes.compose")
+  id("dev.drewhamilton.poko")
 }
 
 kotlin {
@@ -122,4 +123,8 @@ kotlin {
       baseName = "HazeSamplesKt"
     }
   }
+}
+
+poko {
+  pokoAnnotation.set("dev/chrisbanes/haze/Poko")
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CustomVisualEffectSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CustomVisualEffectSample.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -46,7 +47,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
@@ -54,10 +54,11 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
-import dev.chrisbanes.haze.ExperimentalHazeApi
-import dev.chrisbanes.haze.HazeEffectScope
-import dev.chrisbanes.haze.VisualEffect
-import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.HazeEffectDrawScope
+import dev.chrisbanes.haze.HazeEffectFactory
+import dev.chrisbanes.haze.HazeEffectRenderer
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.Poko
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
@@ -75,13 +76,9 @@ private val SparkOptions = listOf(
   SparkOption(label = "Mint", color = Color(0xFF00A887)),
 )
 
-private val LocalSparkColor = compositionLocalOf { SparkOptions.first().color }
-private val LocalSparkAlpha = compositionLocalOf { 0.3f }
-private val LocalSparkEnabled = compositionLocalOf { true }
-private val LocalSparkleEnabled = compositionLocalOf { true }
 private val LocalSparklePhase = compositionLocalOf { 0f }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CustomVisualEffectSample(
   navController: NavHostController,
@@ -89,7 +86,6 @@ fun CustomVisualEffectSample(
 ) {
   val hazeState = rememberHazeState()
   var selectedSparkIndex by remember { mutableIntStateOf(0) }
-  var drawContentBehind by remember { mutableStateOf(false) }
   var sparkAlpha by remember { mutableFloatStateOf(0.30f) }
   var animateBackgroundLayers by remember { mutableStateOf(true) }
   var showSecondarySource by remember { mutableStateOf(true) }
@@ -181,10 +177,6 @@ fun CustomVisualEffectSample(
       }
 
       CompositionLocalProvider(
-        LocalSparkColor provides SparkOptions[selectedSparkIndex].color,
-        LocalSparkAlpha provides sparkAlpha,
-        LocalSparkEnabled provides blurEnabled,
-        LocalSparkleEnabled provides sparkleEnabled,
         LocalSparklePhase provides animatedPhase,
       ) {
         Box(
@@ -192,10 +184,16 @@ fun CustomVisualEffectSample(
             .align(Alignment.Center)
             .size(width = 300.dp, height = 180.dp)
             .clip(RoundedCornerShape(24.dp))
-            .hazeEffect(state = hazeState) {
-              this.drawContentBehind = drawContentBehind
-              sparkEffect()
-            },
+            .hazeEffect(
+              factory = SparkEffectFactory,
+              input = HazeInput.Sources(hazeState),
+              style = SparkStyle(
+                color = SparkOptions[selectedSparkIndex].color,
+                alpha = sparkAlpha,
+                enabled = blurEnabled,
+                sparkleEnabled = sparkleEnabled,
+              ),
+            ),
         ) {
           Text(
             text = "Custom effect node",
@@ -257,16 +255,6 @@ fun CustomVisualEffectSample(
           Switch(checked = sparkleEnabled, onCheckedChange = { sparkleEnabled = it })
         }
 
-        Row(
-          verticalAlignment = Alignment.CenterVertically,
-          horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-          // Note: drawContentBehind only applies to foreground mode (hazeEffect without state).
-          // This sample uses background mode, so this toggle has no visual effect.
-          Text("Draw content behind")
-          Switch(checked = drawContentBehind, onCheckedChange = { drawContentBehind = it })
-        }
-
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
           OutlinedButton(onClick = { sparkAlpha = (sparkAlpha - 0.1f).coerceAtLeast(0.1f) }) {
             Text("- alpha")
@@ -281,51 +269,37 @@ fun CustomVisualEffectSample(
   }
 }
 
-@OptIn(ExperimentalHazeApi::class)
-private class SparkVisualEffect : VisualEffect {
-  private var sparkColor: Color = Color.Transparent
-  private var sparkAlpha: Float = 0.3f
-  private var sparkEnabled: Boolean = true
-  private var sparkleEnabled: Boolean = true
-  private var sparklePhase: Float = 0f
+@Immutable
+@Poko
+private class SparkStyle(
+  val color: Color,
+  val alpha: Float,
+  val enabled: Boolean,
+  val sparkleEnabled: Boolean,
+)
 
-  override fun update(context: VisualEffectContext) {
-    val currentColor = context.currentValueOf(LocalSparkColor)
-    val currentAlpha = context.currentValueOf(LocalSparkAlpha)
-    val currentEnabled = context.currentValueOf(LocalSparkEnabled)
-    val currentSparkleEnabled = context.currentValueOf(LocalSparkleEnabled)
-    val currentSparklePhase = context.currentValueOf(LocalSparklePhase)
-    if (
-      currentColor != sparkColor ||
-      currentAlpha != sparkAlpha ||
-      currentEnabled != sparkEnabled ||
-      currentSparkleEnabled != sparkleEnabled ||
-      currentSparklePhase != sparklePhase
-    ) {
-      sparkColor = currentColor
-      sparkAlpha = currentAlpha
-      sparkEnabled = currentEnabled
-      sparkleEnabled = currentSparkleEnabled
-      sparklePhase = currentSparklePhase
-      context.invalidateDraw()
-    }
-  }
+private data object SparkEffectFactory : HazeEffectFactory<SparkStyle> {
+  override fun createRenderer(): HazeEffectRenderer<SparkStyle> = SparkEffectRenderer()
+}
 
-  override fun DrawScope.draw(context: VisualEffectContext) {
-    if (!sparkEnabled) return
+private class SparkEffectRenderer : HazeEffectRenderer<SparkStyle> {
+  override fun HazeEffectDrawScope.draw(style: SparkStyle) {
+    if (!style.enabled) return
 
-    val tintAlpha = sparkAlpha.coerceIn(0f, 1f)
-    drawRect(color = sparkColor.copy(alpha = tintAlpha), size = size)
+    drawInput()
+    val tintAlpha = style.alpha.coerceIn(0f, 1f)
+    drawRect(color = style.color.copy(alpha = tintAlpha), size = size)
 
-    if (!sparkleEnabled || tintAlpha <= 0f) return
+    if (!style.sparkleEnabled || tintAlpha <= 0f) return
 
+    val sparklePhase = currentValueOf(LocalSparklePhase)
     val bandCenterX = (-size.width * 0.4f) + ((size.width * 1.8f) * sparklePhase)
     val shimmer = Brush.linearGradient(
       colors = listOf(
         Color.Transparent,
-        sparkColor.copy(alpha = tintAlpha * 0.16f),
+        style.color.copy(alpha = tintAlpha * 0.16f),
         Color.White.copy(alpha = tintAlpha * 0.38f),
-        sparkColor.copy(alpha = tintAlpha * 0.16f),
+        style.color.copy(alpha = tintAlpha * 0.16f),
         Color.Transparent,
       ),
       start = androidx.compose.ui.geometry.Offset(x = bandCenterX - (size.width * 0.3f), y = 0f),
@@ -342,11 +316,4 @@ private class SparkVisualEffect : VisualEffect {
       style = Stroke(width = strokeWidth),
     )
   }
-}
-
-@OptIn(ExperimentalHazeApi::class)
-private fun HazeEffectScope.sparkEffect(block: SparkVisualEffect.() -> Unit = {}) {
-  val effect = visualEffect as? SparkVisualEffect ?: SparkVisualEffect()
-  visualEffect = effect
-  effect.block()
 }


### PR DESCRIPTION
Closes #1130

## Summary
- add typed Haze effect factory and per-node renderer contracts with semantic draw and layout scopes
- move renderer creation, replacement, invalidation observation, and disposal into HazeEffectNode lifecycle ownership
- migrate the custom Spark sample and documentation while retaining the temporary VisualEffect seam
- add lifecycle, draw-input, sampling, bounds, invalidation, API, and compatibility coverage

## Validation
- ./gradlew :haze:check :sample:shared:check
- ./gradlew :haze:metalavaGenerateSignature :haze:metalavaCheckCompatibility
- ./gradlew :sample:shared:compileKotlinJvm :sample:shared:compileKotlinWasmJs :sample:shared:compileKotlinIosArm64
- ./gradlew spotlessApply
- full docs build

## Known base-only screenshot state
The Desktop Glass Gallery portrait and landscape comparisons fail identically from an untouched main checkout. This PR does not change screenshot baselines or rendering output.