### PR TITLE
Add shareable Glass style API

### DIFF
--- a/haze-glass/api/api.txt
+++ b/haze-glass/api/api.txt
@@ -6,28 +6,28 @@ package dev.chrisbanes.haze.glass {
     enum_constant public static final dev.chrisbanes.haze.glass.ChromaticAberrationMode Simple;
   }
 
-  @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassColor {
-    ctor public GlassColor();
-    ctor public GlassColor(optional float alpha, optional float contrast, optional float whitePoint, optional float chromaMultiplier);
-    method public float component1();
-    method public float component2();
-    method public float component3();
-    method public float component4();
-    method public dev.chrisbanes.haze.glass.GlassColor copy(optional float alpha, optional float contrast, optional float whitePoint, optional float chromaMultiplier);
-    method @InaccessibleFromKotlin public float getAlpha();
-    method @InaccessibleFromKotlin public float getChromaMultiplier();
-    method @InaccessibleFromKotlin public float getContrast();
-    method @InaccessibleFromKotlin public float getWhitePoint();
-    property public float alpha;
-    property public float chromaMultiplier;
-    property public float contrast;
-    property public float whitePoint;
-    field public static final dev.chrisbanes.haze.glass.GlassColor.Companion Companion;
+  @Deprecated @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassColor {
+    ctor @Deprecated public GlassColor();
+    ctor @Deprecated public GlassColor(optional float alpha, optional float contrast, optional float whitePoint, optional float chromaMultiplier);
+    method @Deprecated public float component1();
+    method @Deprecated public float component2();
+    method @Deprecated public float component3();
+    method @Deprecated public float component4();
+    method @Deprecated public dev.chrisbanes.haze.glass.GlassColor copy(optional float alpha, optional float contrast, optional float whitePoint, optional float chromaMultiplier);
+    method @InaccessibleFromKotlin @Deprecated public float getAlpha();
+    method @InaccessibleFromKotlin @Deprecated public float getChromaMultiplier();
+    method @InaccessibleFromKotlin @Deprecated public float getContrast();
+    method @InaccessibleFromKotlin @Deprecated public float getWhitePoint();
+    property @Deprecated public float alpha;
+    property @Deprecated public float chromaMultiplier;
+    property @Deprecated public float contrast;
+    property @Deprecated public float whitePoint;
+    field @Deprecated public static final dev.chrisbanes.haze.glass.GlassColor.Companion Companion;
   }
 
-  public static final class GlassColor.Companion {
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.GlassColor getUnspecified();
-    property public dev.chrisbanes.haze.glass.GlassColor Unspecified;
+  @Deprecated public static final class GlassColor.Companion {
+    method @InaccessibleFromKotlin @Deprecated public dev.chrisbanes.haze.glass.GlassColor getUnspecified();
+    property @Deprecated public dev.chrisbanes.haze.glass.GlassColor Unspecified;
   }
 
   @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassDefaults {
@@ -85,30 +85,30 @@ package dev.chrisbanes.haze.glass {
     method public void whitePointDelta(float delta);
   }
 
-  @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassLighting {
-    ctor public GlassLighting();
-    ctor @KotlinOnly public GlassLighting(optional float specularIntensity, optional float specularExponent, optional float fresnelExponent, optional float ambientResponse, optional androidx.compose.ui.geometry.Offset lightPosition);
-    method public float component1();
-    method public float component2();
-    method public float component3();
-    method public float component4();
-    method @KotlinOnly public operator androidx.compose.ui.geometry.Offset component5();
-    method @KotlinOnly public dev.chrisbanes.haze.glass.GlassLighting copy(optional float specularIntensity, optional float specularExponent, optional float fresnelExponent, optional float ambientResponse, optional androidx.compose.ui.geometry.Offset lightPosition);
-    method @InaccessibleFromKotlin public float getAmbientResponse();
-    method @InaccessibleFromKotlin public float getFresnelExponent();
-    method @InaccessibleFromKotlin public float getSpecularExponent();
-    method @InaccessibleFromKotlin public float getSpecularIntensity();
-    property public float ambientResponse;
-    property public float fresnelExponent;
-    property public androidx.compose.ui.geometry.Offset lightPosition;
-    property public float specularExponent;
-    property public float specularIntensity;
-    field public static final dev.chrisbanes.haze.glass.GlassLighting.Companion Companion;
+  @Deprecated @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassLighting {
+    ctor @Deprecated public GlassLighting();
+    ctor @KotlinOnly @Deprecated public GlassLighting(optional float specularIntensity, optional float specularExponent, optional float fresnelExponent, optional float ambientResponse, optional androidx.compose.ui.geometry.Offset lightPosition);
+    method @Deprecated public float component1();
+    method @Deprecated public float component2();
+    method @Deprecated public float component3();
+    method @Deprecated public float component4();
+    method @KotlinOnly @Deprecated public operator androidx.compose.ui.geometry.Offset component5();
+    method @KotlinOnly @Deprecated public dev.chrisbanes.haze.glass.GlassLighting copy(optional float specularIntensity, optional float specularExponent, optional float fresnelExponent, optional float ambientResponse, optional androidx.compose.ui.geometry.Offset lightPosition);
+    method @InaccessibleFromKotlin @Deprecated public float getAmbientResponse();
+    method @InaccessibleFromKotlin @Deprecated public float getFresnelExponent();
+    method @InaccessibleFromKotlin @Deprecated public float getSpecularExponent();
+    method @InaccessibleFromKotlin @Deprecated public float getSpecularIntensity();
+    property @Deprecated public float ambientResponse;
+    property @Deprecated public float fresnelExponent;
+    property @Deprecated public androidx.compose.ui.geometry.Offset lightPosition;
+    property @Deprecated public float specularExponent;
+    property @Deprecated public float specularIntensity;
+    field @Deprecated public static final dev.chrisbanes.haze.glass.GlassLighting.Companion Companion;
   }
 
-  public static final class GlassLighting.Companion {
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.GlassLighting getUnspecified();
-    property public dev.chrisbanes.haze.glass.GlassLighting Unspecified;
+  @Deprecated public static final class GlassLighting.Companion {
+    method @InaccessibleFromKotlin @Deprecated public dev.chrisbanes.haze.glass.GlassLighting getUnspecified();
+    property @Deprecated public dev.chrisbanes.haze.glass.GlassLighting Unspecified;
   }
 
   @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public sealed exhaustive interface GlassOptics {
@@ -146,59 +146,39 @@ package dev.chrisbanes.haze.glass {
     enum_constant public static final dev.chrisbanes.haze.glass.GlassReducedMotionPolicy System;
   }
 
-  @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassRendering {
-    ctor public GlassRendering();
-    ctor @KotlinOnly public GlassRendering(optional androidx.compose.ui.unit.Dp edgeSoftness, optional float contentNormalBlend, optional dev.chrisbanes.haze.glass.SurfaceProfile? surfaceProfile, optional float chromaticAberrationStrength, optional dev.chrisbanes.haze.glass.ChromaticAberrationMode? chromaticAberrationMode);
-    method @KotlinOnly public operator androidx.compose.ui.unit.Dp component1();
-    method public float component2();
-    method public dev.chrisbanes.haze.glass.SurfaceProfile? component3();
-    method public float component4();
-    method public dev.chrisbanes.haze.glass.ChromaticAberrationMode? component5();
-    method @KotlinOnly public dev.chrisbanes.haze.glass.GlassRendering copy(optional androidx.compose.ui.unit.Dp edgeSoftness, optional float contentNormalBlend, optional dev.chrisbanes.haze.glass.SurfaceProfile? surfaceProfile, optional float chromaticAberrationStrength, optional dev.chrisbanes.haze.glass.ChromaticAberrationMode? chromaticAberrationMode);
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.ChromaticAberrationMode? getChromaticAberrationMode();
-    method @InaccessibleFromKotlin public float getChromaticAberrationStrength();
-    method @InaccessibleFromKotlin public float getContentNormalBlend();
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.SurfaceProfile? getSurfaceProfile();
-    property public dev.chrisbanes.haze.glass.ChromaticAberrationMode? chromaticAberrationMode;
-    property public float chromaticAberrationStrength;
-    property public float contentNormalBlend;
-    property public androidx.compose.ui.unit.Dp edgeSoftness;
-    property public dev.chrisbanes.haze.glass.SurfaceProfile? surfaceProfile;
-    field public static final dev.chrisbanes.haze.glass.GlassRendering.Companion Companion;
+  @Deprecated @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassRendering {
+    ctor @Deprecated public GlassRendering();
+    ctor @KotlinOnly @Deprecated public GlassRendering(optional androidx.compose.ui.unit.Dp edgeSoftness, optional float contentNormalBlend, optional dev.chrisbanes.haze.glass.SurfaceProfile? surfaceProfile, optional float chromaticAberrationStrength, optional dev.chrisbanes.haze.glass.ChromaticAberrationMode? chromaticAberrationMode);
+    method @KotlinOnly @Deprecated public operator androidx.compose.ui.unit.Dp component1();
+    method @Deprecated public float component2();
+    method @Deprecated public dev.chrisbanes.haze.glass.SurfaceProfile? component3();
+    method @Deprecated public float component4();
+    method @Deprecated public dev.chrisbanes.haze.glass.ChromaticAberrationMode? component5();
+    method @KotlinOnly @Deprecated public dev.chrisbanes.haze.glass.GlassRendering copy(optional androidx.compose.ui.unit.Dp edgeSoftness, optional float contentNormalBlend, optional dev.chrisbanes.haze.glass.SurfaceProfile? surfaceProfile, optional float chromaticAberrationStrength, optional dev.chrisbanes.haze.glass.ChromaticAberrationMode? chromaticAberrationMode);
+    method @InaccessibleFromKotlin @Deprecated public dev.chrisbanes.haze.glass.ChromaticAberrationMode? getChromaticAberrationMode();
+    method @InaccessibleFromKotlin @Deprecated public float getChromaticAberrationStrength();
+    method @InaccessibleFromKotlin @Deprecated public float getContentNormalBlend();
+    method @InaccessibleFromKotlin @Deprecated public dev.chrisbanes.haze.glass.SurfaceProfile? getSurfaceProfile();
+    property @Deprecated public dev.chrisbanes.haze.glass.ChromaticAberrationMode? chromaticAberrationMode;
+    property @Deprecated public float chromaticAberrationStrength;
+    property @Deprecated public float contentNormalBlend;
+    property @Deprecated public androidx.compose.ui.unit.Dp edgeSoftness;
+    property @Deprecated public dev.chrisbanes.haze.glass.SurfaceProfile? surfaceProfile;
+    field @Deprecated public static final dev.chrisbanes.haze.glass.GlassRendering.Companion Companion;
   }
 
-  public static final class GlassRendering.Companion {
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.GlassRendering getUnspecified();
-    property public dev.chrisbanes.haze.glass.GlassRendering Unspecified;
+  @Deprecated public static final class GlassRendering.Companion {
+    method @InaccessibleFromKotlin @Deprecated public dev.chrisbanes.haze.glass.GlassRendering getUnspecified();
+    property @Deprecated public dev.chrisbanes.haze.glass.GlassRendering Unspecified;
   }
 
-  @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassStyle {
-    ctor public GlassStyle();
-    ctor @KotlinOnly public GlassStyle(optional androidx.compose.ui.graphics.Color tint, optional androidx.compose.foundation.shape.RoundedCornerShape? shape, optional dev.chrisbanes.haze.glass.GlassOptics? optics, optional dev.chrisbanes.haze.glass.GlassLighting lighting, optional dev.chrisbanes.haze.glass.GlassColor color, optional dev.chrisbanes.haze.glass.GlassRendering rendering);
-    method @KotlinOnly public operator androidx.compose.ui.graphics.Color component1();
-    method public androidx.compose.foundation.shape.RoundedCornerShape? component2();
-    method public dev.chrisbanes.haze.glass.GlassOptics? component3();
-    method public dev.chrisbanes.haze.glass.GlassLighting component4();
-    method public dev.chrisbanes.haze.glass.GlassColor component5();
-    method public dev.chrisbanes.haze.glass.GlassRendering component6();
-    method @KotlinOnly public dev.chrisbanes.haze.glass.GlassStyle copy(optional androidx.compose.ui.graphics.Color tint, optional androidx.compose.foundation.shape.RoundedCornerShape? shape, optional dev.chrisbanes.haze.glass.GlassOptics? optics, optional dev.chrisbanes.haze.glass.GlassLighting lighting, optional dev.chrisbanes.haze.glass.GlassColor color, optional dev.chrisbanes.haze.glass.GlassRendering rendering);
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.GlassColor getColor();
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.GlassLighting getLighting();
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.GlassOptics? getOptics();
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.GlassRendering getRendering();
-    method @InaccessibleFromKotlin public androidx.compose.foundation.shape.RoundedCornerShape? getShape();
-    property public dev.chrisbanes.haze.glass.GlassColor color;
-    property public dev.chrisbanes.haze.glass.GlassLighting lighting;
-    property public dev.chrisbanes.haze.glass.GlassOptics? optics;
-    property public dev.chrisbanes.haze.glass.GlassRendering rendering;
-    property public androidx.compose.foundation.shape.RoundedCornerShape? shape;
-    property public androidx.compose.ui.graphics.Color tint;
+  @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public sealed nonexhaustive interface GlassStyle {
     field public static final dev.chrisbanes.haze.glass.GlassStyle.Companion Companion;
   }
 
-  public static final class GlassStyle.Companion {
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.GlassStyle getUnspecified();
-    property public dev.chrisbanes.haze.glass.GlassStyle Unspecified;
+  public static final class GlassStyle.Companion implements dev.chrisbanes.haze.glass.GlassStyle {
+    method @InaccessibleFromKotlin @Deprecated public dev.chrisbanes.haze.glass.GlassStyle getUnspecified();
+    property @Deprecated public dev.chrisbanes.haze.glass.GlassStyle Unspecified;
   }
 
   @dev.chrisbanes.haze.InternalHazeApi public interface GlassStyleConfiguration {
@@ -253,8 +233,32 @@ package dev.chrisbanes.haze.glass {
   }
 
   public final class GlassStyleKt {
+    method @KotlinOnly @Deprecated @dev.chrisbanes.haze.ExperimentalHazeApi public static dev.chrisbanes.haze.glass.GlassStyle GlassStyle(optional androidx.compose.ui.graphics.Color tint, optional androidx.compose.foundation.shape.RoundedCornerShape? shape, optional dev.chrisbanes.haze.glass.GlassOptics? optics, optional dev.chrisbanes.haze.glass.GlassLighting lighting, optional dev.chrisbanes.haze.glass.GlassColor color, optional dev.chrisbanes.haze.glass.GlassRendering rendering);
+    method @dev.chrisbanes.haze.ExperimentalHazeApi public static dev.chrisbanes.haze.glass.GlassStyle GlassStyle(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassStyleScope,kotlin.Unit> block);
     method @InaccessibleFromKotlin public static androidx.compose.runtime.ProvidableCompositionLocal<dev.chrisbanes.haze.glass.GlassStyle> getLocalGlassStyle();
+    method @dev.chrisbanes.haze.ExperimentalHazeApi public static infix dev.chrisbanes.haze.glass.GlassStyle then(dev.chrisbanes.haze.glass.GlassStyle, dev.chrisbanes.haze.glass.GlassStyle other);
+    method @dev.chrisbanes.haze.ExperimentalHazeApi public static dev.chrisbanes.haze.glass.GlassStyle then(dev.chrisbanes.haze.glass.GlassStyle, kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassStyleScope,kotlin.Unit> block);
     property @dev.chrisbanes.haze.ExperimentalHazeApi public static androidx.compose.runtime.ProvidableCompositionLocal<dev.chrisbanes.haze.glass.GlassStyle> LocalGlassStyle;
+  }
+
+  @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassStyleScope {
+    method public void alpha(float value);
+    method public void ambientResponse(float value);
+    method public void chromaMultiplier(float value);
+    method public void chromaticAberrationMode(dev.chrisbanes.haze.glass.ChromaticAberrationMode value);
+    method public void chromaticAberrationStrength(float value);
+    method public void contentNormalBlend(float value);
+    method public void contrast(float value);
+    method @KotlinOnly public void edgeSoftness(androidx.compose.ui.unit.Dp value);
+    method public void fresnelExponent(float value);
+    method @KotlinOnly public void lightPosition(androidx.compose.ui.geometry.Offset value);
+    method public void optics(dev.chrisbanes.haze.glass.GlassOptics value);
+    method public void shape(androidx.compose.foundation.shape.RoundedCornerShape value);
+    method public void specularExponent(float value);
+    method public void specularIntensity(float value);
+    method public void surfaceProfile(dev.chrisbanes.haze.glass.SurfaceProfile value);
+    method @KotlinOnly public void tint(androidx.compose.ui.graphics.Color value);
+    method public void whitePoint(float value);
   }
 
   @dev.chrisbanes.haze.ExperimentalHazeApi public enum GlassTransformPivot {
@@ -364,6 +368,10 @@ package dev.chrisbanes.haze.glass {
 
   public final class HazeEffectScopeKt {
     method @dev.chrisbanes.haze.ExperimentalHazeApi public static inline void glassEffect(dev.chrisbanes.haze.HazeEffectScope, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassVisualEffect,kotlin.Unit> block);
+  }
+
+  public final class HazeGlassKt {
+    method @androidx.compose.runtime.Stable @dev.chrisbanes.haze.ExperimentalHazeApi public static androidx.compose.ui.Modifier hazeGlass(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeInput input, optional dev.chrisbanes.haze.glass.GlassStyle style, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds, optional androidx.compose.foundation.interaction.InteractionSource? interactionSource);
   }
 
   @dev.chrisbanes.haze.ExperimentalHazeApi public enum SurfaceProfile {

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -1,6 +1,8 @@
 // Copyright 2026, Christopher Banes and the Haze project contributors
 // SPDX-License-Identifier: Apache-2.0
 
+@file:Suppress("DEPRECATION")
+
 package dev.chrisbanes.haze.glass
 
 import android.graphics.Bitmap

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
@@ -86,29 +86,27 @@ public object GlassDefaults {
   /** Default exponent controlling the falloff of the Fresnel response. */
   public const val fresnelExponent: Float = 3f
 
-  /** Default [GlassStyle] for use with [GlassVisualEffect]. */
-  public val style: GlassStyle = GlassStyle(
-    tint = tint,
-    shape = shape,
-    optics = optics,
-    lighting = GlassLighting(
-      specularIntensity = specularIntensity,
-      specularExponent = specularExponent,
-      fresnelExponent = fresnelExponent,
-      ambientResponse = ambientResponse,
-    ),
-    color = GlassColor(
-      alpha = alpha,
-      contrast = contrast,
-      whitePoint = whitePoint,
-      chromaMultiplier = chromaMultiplier,
-    ),
-    rendering = GlassRendering(
-      edgeSoftness = edgeSoftness,
-      contentNormalBlend = contentNormalBlend,
-      surfaceProfile = surfaceProfile,
-      chromaticAberrationStrength = chromaticAberrationStrength,
-      chromaticAberrationMode = chromaticAberrationMode,
-    ),
-  )
+  /**
+   * Complete default [GlassStyle].
+   *
+   * Glass evaluates this Style before [LocalGlassStyle] and an explicit modifier Style.
+   */
+  public val style: GlassStyle = GlassStyle {
+    tint(tint)
+    shape(shape)
+    optics(optics)
+    specularIntensity(specularIntensity)
+    specularExponent(specularExponent)
+    fresnelExponent(fresnelExponent)
+    ambientResponse(ambientResponse)
+    alpha(alpha)
+    contrast(contrast)
+    whitePoint(whitePoint)
+    chromaMultiplier(chromaMultiplier)
+    edgeSoftness(edgeSoftness)
+    contentNormalBlend(contentNormalBlend)
+    surfaceProfile(surfaceProfile)
+    chromaticAberrationStrength(chromaticAberrationStrength)
+    chromaticAberrationMode(chromaticAberrationMode)
+  }
 }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -1,6 +1,8 @@
 // Copyright 2025, Christopher Banes and the Haze project contributors
 // SPDX-License-Identifier: Apache-2.0
 
+@file:Suppress("DEPRECATION")
+
 package dev.chrisbanes.haze.glass
 
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -9,32 +11,222 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.Poko
 
 /**
- * A [ProvidableCompositionLocal] which provides the default [GlassStyle] for all
- * [dev.chrisbanes.haze.hazeEffect] layout nodes placed within this composition local's content.
+ * A [ProvidableCompositionLocal] which provides inherited Glass appearance.
+ *
+ * A Glass node evaluates [GlassDefaults.style], this Style, and its explicit [GlassStyle] in that
+ * order. Each node uses a fresh accumulator, so a Style may be shared safely by concurrent nodes.
  */
 @ExperimentalHazeApi
 public val LocalGlassStyle: ProvidableCompositionLocal<GlassStyle> =
-  compositionLocalOf { GlassDefaults.style }
+  compositionLocalOf { GlassStyle }
 
+/**
+ * An opaque, stateless, replayable Glass appearance program.
+ *
+ * Create a Style with [GlassStyle] and combine Styles with [then]. Writes run in order and the last
+ * write to a property wins. The companion object is the empty Style and performs no writes.
+ *
+ * A Style contains no renderer or mutable evaluation state. Each `hazeGlass` node evaluates it
+ * into a fresh node-owned snapshot.
+ */
 @ExperimentalHazeApi
 @Immutable
-public data class GlassStyle(
-  val tint: Color = Color.Unspecified,
-  val shape: RoundedCornerShape? = null,
-  val optics: GlassOptics? = null,
-  val lighting: GlassLighting = GlassLighting.Unspecified,
-  val color: GlassColor = GlassColor.Unspecified,
-  val rendering: GlassRendering = GlassRendering.Unspecified,
-) {
-  public companion object {
-    public val Unspecified: GlassStyle = GlassStyle()
+public sealed interface GlassStyle {
+  public companion object : GlassStyle {
+    /**
+     * Temporary compatibility name for the empty Style.
+     */
+    @Deprecated("Use GlassStyle directly as the empty Style.")
+    public val Unspecified: GlassStyle get() = this
   }
 }
 
+/**
+ * Creates a replayable [GlassStyle].
+ *
+ * The [block] is retained as immutable configuration and replayed into fresh node-local state.
+ */
+@ExperimentalHazeApi
+public fun GlassStyle(block: GlassStyleScope.() -> Unit): GlassStyle = BlockGlassStyle(block)
+
+/**
+ * Returns a Style which evaluates this Style followed by [other].
+ *
+ * When both Styles write the same property, [other] wins.
+ */
+@ExperimentalHazeApi
+public infix fun GlassStyle.then(other: GlassStyle): GlassStyle = when {
+  this === GlassStyle -> other
+  other === GlassStyle -> this
+  else -> CombinedGlassStyle(this, other)
+}
+
+/**
+ * Returns a Style which evaluates this Style followed by [block].
+ *
+ * Writes in [block] take precedence over earlier writes.
+ */
+@ExperimentalHazeApi
+public fun GlassStyle.then(block: GlassStyleScope.() -> Unit): GlassStyle =
+  this then GlassStyle(block)
+
+@Immutable
+private class BlockGlassStyle(
+  val block: GlassStyleScope.() -> Unit,
+) : GlassStyle
+
+@Immutable
+private class CombinedGlassStyle(
+  val first: GlassStyle,
+  val second: GlassStyle,
+) : GlassStyle
+
+/**
+ * Receiver for Glass appearance property writes.
+ *
+ * Property functions canonicalize values as they are written. Calling a function again replaces
+ * its previous value in the current evaluation.
+ */
+@ExperimentalHazeApi
+public class GlassStyleScope internal constructor(
+  private val values: GlassStyleValues,
+) {
+  public fun shape(value: RoundedCornerShape) {
+    values.shape = value
+  }
+
+  public fun optics(value: GlassOptics) {
+    values.optics = value
+  }
+
+  public fun specularIntensity(value: Float) {
+    values.specularIntensity = value.coerceIn(0f, 1f)
+  }
+
+  public fun ambientResponse(value: Float) {
+    values.ambientResponse = value.coerceIn(0f, 1f)
+  }
+
+  public fun tint(value: Color) {
+    require(value.isSpecified) { "tint must be specified" }
+    values.tint = value
+  }
+
+  public fun edgeSoftness(value: Dp) {
+    require(value.isSpecified) { "edgeSoftness must be specified" }
+    values.edgeSoftness = value.coerceAtLeast(0.dp)
+  }
+
+  /**
+   * Sets the virtual light position. [Offset.Unspecified] keeps the automatic material center.
+   */
+  public fun lightPosition(value: Offset) {
+    require(
+      value == Offset.Unspecified ||
+        (value.x.isFinite() && value.y.isFinite()),
+    ) {
+      "lightPosition must be finite or Offset.Unspecified"
+    }
+    values.lightPosition = value
+  }
+
+  public fun chromaticAberrationStrength(value: Float) {
+    values.chromaticAberrationStrength = value.coerceIn(0f, 1f)
+  }
+
+  public fun surfaceProfile(value: SurfaceProfile) {
+    values.surfaceProfile = value
+  }
+
+  public fun chromaticAberrationMode(value: ChromaticAberrationMode) {
+    values.chromaticAberrationMode = value
+  }
+
+  public fun alpha(value: Float) {
+    values.alpha = value.coerceIn(0f, 1f)
+  }
+
+  public fun contrast(value: Float) {
+    values.contrast = value.coerceIn(-1f, 1f)
+  }
+
+  public fun whitePoint(value: Float) {
+    values.whitePoint = value.coerceIn(-1f, 1f)
+  }
+
+  public fun chromaMultiplier(value: Float) {
+    values.chromaMultiplier = value.coerceIn(0f, 2f)
+  }
+
+  public fun contentNormalBlend(value: Float) {
+    values.contentNormalBlend = value.coerceIn(0f, 1f)
+  }
+
+  public fun specularExponent(value: Float) {
+    values.specularExponent = value.coerceAtLeast(0f)
+  }
+
+  public fun fresnelExponent(value: Float) {
+    values.fresnelExponent = value.coerceAtLeast(0f)
+  }
+}
+
+@Poko
+internal class GlassStyleValues(
+  var shape: RoundedCornerShape = GlassDefaults.shape,
+  var optics: GlassOptics = GlassDefaults.optics,
+  var specularIntensity: Float = GlassDefaults.specularIntensity,
+  var ambientResponse: Float = GlassDefaults.ambientResponse,
+  var tint: Color = GlassDefaults.tint,
+  var edgeSoftness: Dp = GlassDefaults.edgeSoftness,
+  var lightPosition: Offset = Offset.Unspecified,
+  var chromaticAberrationStrength: Float = GlassDefaults.chromaticAberrationStrength,
+  var surfaceProfile: SurfaceProfile = GlassDefaults.surfaceProfile,
+  var chromaticAberrationMode: ChromaticAberrationMode = GlassDefaults.chromaticAberrationMode,
+  var alpha: Float = GlassDefaults.alpha,
+  var contrast: Float = GlassDefaults.contrast,
+  var whitePoint: Float = GlassDefaults.whitePoint,
+  var chromaMultiplier: Float = GlassDefaults.chromaMultiplier,
+  var contentNormalBlend: Float = GlassDefaults.contentNormalBlend,
+  var specularExponent: Float = GlassDefaults.specularExponent,
+  var fresnelExponent: Float = GlassDefaults.fresnelExponent,
+)
+
+internal fun resolveGlassStyleValues(
+  localStyle: GlassStyle,
+  explicitStyle: GlassStyle,
+): GlassStyleValues = GlassStyleValues().also { values ->
+  val scope = GlassStyleScope(values)
+  GlassDefaults.style.applyTo(scope)
+  localStyle.applyTo(scope)
+  explicitStyle.applyTo(scope)
+}
+
+private fun GlassStyle.applyTo(scope: GlassStyleScope) {
+  when (this) {
+    GlassStyle -> Unit
+    is BlockGlassStyle -> scope.block()
+    is CombinedGlassStyle -> {
+      first.applyTo(scope)
+      second.applyTo(scope)
+    }
+  }
+}
+
+/**
+ * Legacy grouped lighting patch retained temporarily for source migration.
+ *
+ * New code should use property functions in [GlassStyleScope].
+ */
+@Deprecated("Use GlassStyle { specularIntensity(...); ambientResponse(...); ... }.")
 @ExperimentalHazeApi
 @Immutable
 public data class GlassLighting(
@@ -49,6 +241,12 @@ public data class GlassLighting(
   }
 }
 
+/**
+ * Legacy grouped color patch retained temporarily for source migration.
+ *
+ * New code should use property functions in [GlassStyleScope].
+ */
+@Deprecated("Use GlassStyle { alpha(...); contrast(...); ... }.")
 @ExperimentalHazeApi
 @Immutable
 public data class GlassColor(
@@ -62,6 +260,12 @@ public data class GlassColor(
   }
 }
 
+/**
+ * Legacy grouped rendering patch retained temporarily for source migration.
+ *
+ * New code should use property functions in [GlassStyleScope].
+ */
+@Deprecated("Use GlassStyle { edgeSoftness(...); contentNormalBlend(...); ... }.")
 @ExperimentalHazeApi
 @Immutable
 public data class GlassRendering(
@@ -74,4 +278,42 @@ public data class GlassRendering(
   public companion object {
     public val Unspecified: GlassRendering = GlassRendering()
   }
+}
+
+/**
+ * Temporary constructor adapter for the legacy grouped Style surface.
+ *
+ * Sentinel interpretation is confined to this adapter; ordinary Style evaluation only replays
+ * explicit property writes.
+ */
+@Deprecated("Use GlassStyle { property(value) }.")
+@ExperimentalHazeApi
+@Suppress("DEPRECATION")
+public fun GlassStyle(
+  tint: Color = Color.Unspecified,
+  shape: RoundedCornerShape? = null,
+  optics: GlassOptics? = null,
+  lighting: GlassLighting = GlassLighting.Unspecified,
+  color: GlassColor = GlassColor.Unspecified,
+  rendering: GlassRendering = GlassRendering.Unspecified,
+): GlassStyle = GlassStyle {
+  if (tint.isSpecified) tint(tint)
+  shape?.let(::shape)
+  optics?.let(::optics)
+  if (!lighting.specularIntensity.isNaN()) specularIntensity(lighting.specularIntensity)
+  if (!lighting.specularExponent.isNaN()) specularExponent(lighting.specularExponent)
+  if (!lighting.fresnelExponent.isNaN()) fresnelExponent(lighting.fresnelExponent)
+  if (!lighting.ambientResponse.isNaN()) ambientResponse(lighting.ambientResponse)
+  if (lighting.lightPosition != Offset.Unspecified) lightPosition(lighting.lightPosition)
+  if (!color.alpha.isNaN()) alpha(color.alpha)
+  if (!color.contrast.isNaN()) contrast(color.contrast)
+  if (!color.whitePoint.isNaN()) whitePoint(color.whitePoint)
+  if (!color.chromaMultiplier.isNaN()) chromaMultiplier(color.chromaMultiplier)
+  if (rendering.edgeSoftness.isSpecified) edgeSoftness(rendering.edgeSoftness)
+  if (!rendering.contentNormalBlend.isNaN()) contentNormalBlend(rendering.contentNormalBlend)
+  rendering.surfaceProfile?.let(::surfaceProfile)
+  if (!rendering.chromaticAberrationStrength.isNaN()) {
+    chromaticAberrationStrength(rendering.chromaticAberrationStrength)
+  }
+  rendering.chromaticAberrationMode?.let(::chromaticAberrationMode)
 }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -531,7 +531,7 @@ public class GlassVisualEffect() :
    * [clearOpticsOverride] to restore the next complete inherited value.
    */
   override var optics: GlassOptics
-    get() = _optics ?: style.optics ?: compositionLocalStyle.optics ?: GlassDefaults.optics
+    get() = _optics ?: inheritedStyleValues.optics
     set(value) {
       if (value != _optics) {
         HazeLogger.d(TAG) { "optics changed. Current: $_optics. New: $value" }
@@ -558,15 +558,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.specularIntensity] value set in [style], if specified.
-   *  - [GlassStyle.specularIntensity] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.specularIntensity] value set in [style], if specified.
+   *  - [GlassStyleScope.specularIntensity] value set in [LocalGlassStyle], if specified.
    */
   internal var _specularIntensity: Float = Float.NaN
   override var specularIntensity: Float
     get() = _specularIntensity
-      .takeOrElse { styleLighting.specularIntensity }
-      .takeOrElse { localLighting.specularIntensity }
-      .takeOrElse { GlassDefaults.specularIntensity }
+      .takeOrElse { inheritedStyleValues.specularIntensity }
     set(value) {
       val normalized = value.coerceIn(0f, 1f)
       if (!_specularIntensity.hasSameOverrideValueAs(normalized)) {
@@ -582,15 +580,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.ambientResponse] value set in [style], if specified.
-   *  - [GlassStyle.ambientResponse] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.ambientResponse] value set in [style], if specified.
+   *  - [GlassStyleScope.ambientResponse] value set in [LocalGlassStyle], if specified.
    */
   internal var _ambientResponse: Float = Float.NaN
   override var ambientResponse: Float
     get() = _ambientResponse
-      .takeOrElse { styleLighting.ambientResponse }
-      .takeOrElse { localLighting.ambientResponse }
-      .takeOrElse { GlassDefaults.ambientResponse }
+      .takeOrElse { inheritedStyleValues.ambientResponse }
     set(value) {
       val normalized = value.coerceIn(0f, 1f)
       if (!_ambientResponse.hasSameOverrideValueAs(normalized)) {
@@ -606,15 +602,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.tint] value set in [style], if specified.
-   *  - [GlassStyle.tint] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.tint] value set in [style], if specified.
+   *  - [GlassStyleScope.tint] value set in [LocalGlassStyle], if specified.
    */
   internal var _tint: Color = Color.Unspecified
   override var tint: Color
     get() = _tint
-      .takeOrElse { style.tint }
-      .takeOrElse { compositionLocalStyle.tint }
-      .takeOrElse { GlassDefaults.tint }
+      .takeOrElse { inheritedStyleValues.tint }
     set(value) {
       if (_tint != value) {
         HazeLogger.d(TAG) { "tint changed. Current: $_tint. New: $value" }
@@ -629,15 +623,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.edgeSoftness] value set in [style], if specified.
-   *  - [GlassStyle.edgeSoftness] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.edgeSoftness] value set in [style], if specified.
+   *  - [GlassStyleScope.edgeSoftness] value set in [LocalGlassStyle], if specified.
    */
   internal var _edgeSoftness: Dp = Dp.Unspecified
   override var edgeSoftness: Dp
     get() = _edgeSoftness
-      .takeOrElse { styleRendering.edgeSoftness }
-      .takeOrElse { localRendering.edgeSoftness }
-      .takeOrElse { GlassDefaults.edgeSoftness }
+      .takeOrElse { inheritedStyleValues.edgeSoftness }
     set(value) {
       if (_edgeSoftness != value) {
         HazeLogger.d(TAG) { "edgeSoftness changed. Current: $_edgeSoftness. New: $value" }
@@ -652,8 +644,8 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.lightPosition] value set in [style], if specified.
-   *  - [GlassStyle.lightPosition] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.lightPosition] value set in [style], if specified.
+   *  - [GlassStyleScope.lightPosition] value set in [LocalGlassStyle], if specified.
    *
    * If no value is specified through any of the above, the delegate falls back to the
    * center of the layer at draw time.
@@ -661,8 +653,7 @@ public class GlassVisualEffect() :
   internal var _lightPosition: Offset = Offset.Unspecified
   override var lightPosition: Offset
     get() = _lightPosition
-      .takeOrElse { styleLighting.lightPosition }
-      .takeOrElse { localLighting.lightPosition }
+      .takeOrElse { inheritedStyleValues.lightPosition }
     set(value) {
       if (_lightPosition != value) {
         HazeLogger.d(TAG) { "lightPosition changed. Current: $_lightPosition. New: $value" }
@@ -677,15 +668,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.chromaticAberrationStrength] value set in [style], if specified.
-   *  - [GlassStyle.chromaticAberrationStrength] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.chromaticAberrationStrength] value set in [style], if specified.
+   *  - [GlassStyleScope.chromaticAberrationStrength] value set in [LocalGlassStyle], if specified.
    */
   internal var _chromaticAberrationStrength: Float = Float.NaN
   override var chromaticAberrationStrength: Float
     get() = _chromaticAberrationStrength
-      .takeOrElse { styleRendering.chromaticAberrationStrength }
-      .takeOrElse { localRendering.chromaticAberrationStrength }
-      .takeOrElse { GlassDefaults.chromaticAberrationStrength }
+      .takeOrElse { inheritedStyleValues.chromaticAberrationStrength }
     set(value) {
       val normalized = value.coerceIn(0f, 1f)
       if (!_chromaticAberrationStrength.hasSameOverrideValueAs(normalized)) {
@@ -703,13 +692,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.surfaceProfile] value set in [style], if specified.
-   *  - [GlassStyle.surfaceProfile] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.surfaceProfile] value set in [style], if specified.
+   *  - [GlassStyleScope.surfaceProfile] value set in [LocalGlassStyle], if specified.
    */
   internal var _surfaceProfile: SurfaceProfile? = null
 
   override var surfaceProfile: SurfaceProfile
-    get() = _surfaceProfile ?: styleRendering.surfaceProfile ?: localRendering.surfaceProfile ?: GlassDefaults.surfaceProfile
+    get() = _surfaceProfile ?: inheritedStyleValues.surfaceProfile
     set(value) {
       if (value != _surfaceProfile) {
         HazeLogger.d(TAG) { "surfaceProfile changed. Current: $_surfaceProfile. New: $value" }
@@ -736,13 +725,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.chromaticAberrationMode] value set in [style], if specified.
-   *  - [GlassStyle.chromaticAberrationMode] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.chromaticAberrationMode] value set in [style], if specified.
+   *  - [GlassStyleScope.chromaticAberrationMode] value set in [LocalGlassStyle], if specified.
    */
   internal var _chromaticAberrationMode: ChromaticAberrationMode? = null
 
   override var chromaticAberrationMode: ChromaticAberrationMode
-    get() = _chromaticAberrationMode ?: styleRendering.chromaticAberrationMode ?: localRendering.chromaticAberrationMode ?: GlassDefaults.chromaticAberrationMode
+    get() = _chromaticAberrationMode ?: inheritedStyleValues.chromaticAberrationMode
     set(value) {
       if (value != _chromaticAberrationMode) {
         HazeLogger.d(TAG) { "chromaticAberrationMode changed. Current: $_chromaticAberrationMode. New: $value" }
@@ -769,13 +758,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.shape] value set in [style], if specified.
-   *  - [GlassStyle.shape] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.shape] value set in [style], if specified.
+   *  - [GlassStyleScope.shape] value set in [LocalGlassStyle], if specified.
    */
   internal var _shape: RoundedCornerShape? = null
 
   override var shape: RoundedCornerShape
-    get() = _shape ?: style.shape ?: compositionLocalStyle.shape ?: GlassDefaults.shape
+    get() = _shape ?: inheritedStyleValues.shape
     set(value) {
       if (value != _shape) {
         HazeLogger.d(TAG) { "shape changed. Current: $_shape. New: $value" }
@@ -805,15 +794,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.alpha] value set in [style], if specified.
-   *  - [GlassStyle.alpha] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.alpha] value set in [style], if specified.
+   *  - [GlassStyleScope.alpha] value set in [LocalGlassStyle], if specified.
    */
   internal var _alpha: Float = Float.NaN
   override var alpha: Float
     get() = _alpha
-      .takeOrElse { styleColor.alpha }
-      .takeOrElse { localColor.alpha }
-      .takeOrElse { GlassDefaults.alpha }
+      .takeOrElse { inheritedStyleValues.alpha }
     set(value) {
       val normalized = value.coerceIn(0f, 1f)
       if (!_alpha.hasSameOverrideValueAs(normalized)) {
@@ -829,15 +816,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.contrast] value set in [style], if specified.
-   *  - [GlassStyle.contrast] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.contrast] value set in [style], if specified.
+   *  - [GlassStyleScope.contrast] value set in [LocalGlassStyle], if specified.
    */
   internal var _contrast: Float = Float.NaN
   override var contrast: Float
     get() = _contrast
-      .takeOrElse { styleColor.contrast }
-      .takeOrElse { localColor.contrast }
-      .takeOrElse { GlassDefaults.contrast }
+      .takeOrElse { inheritedStyleValues.contrast }
     set(value) {
       val normalized = value.coerceIn(-1f, 1f)
       if (!_contrast.hasSameOverrideValueAs(normalized)) {
@@ -853,15 +838,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.whitePoint] value set in [style], if specified.
-   *  - [GlassStyle.whitePoint] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.whitePoint] value set in [style], if specified.
+   *  - [GlassStyleScope.whitePoint] value set in [LocalGlassStyle], if specified.
    */
   internal var _whitePoint: Float = Float.NaN
   override var whitePoint: Float
     get() = _whitePoint
-      .takeOrElse { styleColor.whitePoint }
-      .takeOrElse { localColor.whitePoint }
-      .takeOrElse { GlassDefaults.whitePoint }
+      .takeOrElse { inheritedStyleValues.whitePoint }
     set(value) {
       val normalized = value.coerceIn(-1f, 1f)
       if (!_whitePoint.hasSameOverrideValueAs(normalized)) {
@@ -877,15 +860,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.chromaMultiplier] value set in [style], if specified.
-   *  - [GlassStyle.chromaMultiplier] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.chromaMultiplier] value set in [style], if specified.
+   *  - [GlassStyleScope.chromaMultiplier] value set in [LocalGlassStyle], if specified.
    */
   internal var _chromaMultiplier: Float = Float.NaN
   override var chromaMultiplier: Float
     get() = _chromaMultiplier
-      .takeOrElse { styleColor.chromaMultiplier }
-      .takeOrElse { localColor.chromaMultiplier }
-      .takeOrElse { GlassDefaults.chromaMultiplier }
+      .takeOrElse { inheritedStyleValues.chromaMultiplier }
     set(value) {
       val normalized = value.coerceIn(0f, 2f)
       if (!_chromaMultiplier.hasSameOverrideValueAs(normalized)) {
@@ -901,15 +882,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.contentNormalBlend] value set in [style], if specified.
-   *  - [GlassStyle.contentNormalBlend] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.contentNormalBlend] value set in [style], if specified.
+   *  - [GlassStyleScope.contentNormalBlend] value set in [LocalGlassStyle], if specified.
    */
   internal var _contentNormalBlend: Float = Float.NaN
   override var contentNormalBlend: Float
     get() = _contentNormalBlend
-      .takeOrElse { styleRendering.contentNormalBlend }
-      .takeOrElse { localRendering.contentNormalBlend }
-      .takeOrElse { GlassDefaults.contentNormalBlend }
+      .takeOrElse { inheritedStyleValues.contentNormalBlend }
     set(value) {
       val normalized = value.coerceIn(0f, 1f)
       if (!_contentNormalBlend.hasSameOverrideValueAs(normalized)) {
@@ -925,15 +904,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.specularExponent] value set in [style], if specified.
-   *  - [GlassStyle.specularExponent] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.specularExponent] value set in [style], if specified.
+   *  - [GlassStyleScope.specularExponent] value set in [LocalGlassStyle], if specified.
    */
   internal var _specularExponent: Float = Float.NaN
   override var specularExponent: Float
     get() = _specularExponent
-      .takeOrElse { styleLighting.specularExponent }
-      .takeOrElse { localLighting.specularExponent }
-      .takeOrElse { GlassDefaults.specularExponent }
+      .takeOrElse { inheritedStyleValues.specularExponent }
     set(value) {
       val normalized = value.coerceAtLeast(0f)
       if (!_specularExponent.hasSameOverrideValueAs(normalized)) {
@@ -949,15 +926,13 @@ public class GlassVisualEffect() :
    * There are precedence rules to how this styling property is applied:
    *
    *  - This property value, if specified.
-   *  - [GlassStyle.fresnelExponent] value set in [style], if specified.
-   *  - [GlassStyle.fresnelExponent] value set in the [LocalGlassStyle] composition local.
+   *  - [GlassStyleScope.fresnelExponent] value set in [style], if specified.
+   *  - [GlassStyleScope.fresnelExponent] value set in [LocalGlassStyle], if specified.
    */
   internal var _fresnelExponent: Float = Float.NaN
   override var fresnelExponent: Float
     get() = _fresnelExponent
-      .takeOrElse { styleLighting.fresnelExponent }
-      .takeOrElse { localLighting.fresnelExponent }
-      .takeOrElse { GlassDefaults.fresnelExponent }
+      .takeOrElse { inheritedStyleValues.fresnelExponent }
     set(value) {
       val normalized = value.coerceAtLeast(0f)
       if (!_fresnelExponent.hasSameOverrideValueAs(normalized)) {
@@ -977,31 +952,34 @@ public class GlassVisualEffect() :
    *  - Value set here in [style], if specified.
    *  - Value set in the [LocalGlassStyle] composition local.
    */
-  override var style: GlassStyle = GlassStyle.Unspecified
+  override var style: GlassStyle = GlassStyle
     set(value) {
-      if (field != value) {
+      if (field !== value) {
         HazeLogger.d(TAG) { "style changed. Current: $field. New: $value" }
-        onStyleChanged(old = field, new = value)
         field = value
+        updateInheritedStyleValues()
         markDirty(GlassDirtyFields.Style)
       }
     }
 
-  private val styleLighting: GlassLighting get() = style.lighting
-  private val localLighting: GlassLighting get() = compositionLocalStyle.lighting
-  private val styleColor: GlassColor get() = style.color
-  private val localColor: GlassColor get() = compositionLocalStyle.color
-  private val styleRendering: GlassRendering get() = style.rendering
-  private val localRendering: GlassRendering get() = compositionLocalStyle.rendering
-
-  internal var compositionLocalStyle: GlassStyle = GlassDefaults.style
+  internal var compositionLocalStyle: GlassStyle = GlassStyle
     set(value) {
-      if (field != value) {
+      if (field !== value) {
         HazeLogger.d(TAG) { "LocalGlassStyle changed. Current: $field. New: $value" }
-        onStyleChanged(field, value)
         field = value
+        updateInheritedStyleValues()
       }
     }
+
+  private var inheritedStyleValues: GlassStyleValues =
+    resolveGlassStyleValues(compositionLocalStyle, style)
+
+  private fun updateInheritedStyleValues() {
+    val resolved = resolveGlassStyleValues(compositionLocalStyle, style)
+    val previous = inheritedStyleValues
+    inheritedStyleValues = resolved
+    onStyleChanged(old = previous, new = resolved)
+  }
 
   private fun markDirty(fields: Int) {
     if (trackConfigurationVersions) {
@@ -1017,39 +995,23 @@ public class GlassVisualEffect() :
     onConfigurationChanged?.invoke(fields)
   }
 
-  private fun onStyleChanged(old: GlassStyle, new: GlassStyle) {
+  private fun onStyleChanged(old: GlassStyleValues, new: GlassStyleValues) {
     if (old.optics != new.optics) {
       markDirty(GlassDirtyFields.Optics)
     }
-    if (
-      !old.lighting.specularIntensity.hasSameNormalizedOverrideValueAs(
-        new.lighting.specularIntensity,
-      ) { it.coerceIn(0f, 1f) }
-    ) {
+    if (old.specularIntensity != new.specularIntensity) {
       markDirty(GlassDirtyFields.SpecularIntensity)
     }
-    if (
-      !old.lighting.ambientResponse.hasSameNormalizedOverrideValueAs(
-        new.lighting.ambientResponse,
-      ) { it.coerceIn(0f, 1f) }
-    ) {
+    if (old.ambientResponse != new.ambientResponse) {
       markDirty(GlassDirtyFields.AmbientResponse)
     }
-    if (old.lighting.lightPosition != new.lighting.lightPosition) {
+    if (old.lightPosition != new.lightPosition) {
       markDirty(GlassDirtyFields.LightPosition)
     }
-    if (
-      !old.lighting.specularExponent.hasSameNormalizedOverrideValueAs(
-        new.lighting.specularExponent,
-      ) { it.coerceAtLeast(0f) }
-    ) {
+    if (old.specularExponent != new.specularExponent) {
       markDirty(GlassDirtyFields.SpecularExponent)
     }
-    if (
-      !old.lighting.fresnelExponent.hasSameNormalizedOverrideValueAs(
-        new.lighting.fresnelExponent,
-      ) { it.coerceAtLeast(0f) }
-    ) {
+    if (old.fresnelExponent != new.fresnelExponent) {
       markDirty(GlassDirtyFields.FresnelExponent)
     }
     if (old.tint != new.tint) {
@@ -1058,53 +1020,31 @@ public class GlassVisualEffect() :
     if (old.shape != new.shape) {
       markDirty(GlassDirtyFields.Shape)
     }
-    if (
-      !old.color.alpha.hasSameNormalizedOverrideValueAs(new.color.alpha) { it.coerceIn(0f, 1f) }
-    ) {
+    if (old.alpha != new.alpha) {
       markDirty(GlassDirtyFields.Alpha)
     }
-    if (
-      !old.color.contrast.hasSameNormalizedOverrideValueAs(new.color.contrast) {
-        it.coerceIn(-1f, 1f)
-      }
-    ) {
+    if (old.contrast != new.contrast) {
       markDirty(GlassDirtyFields.Contrast)
     }
-    if (
-      !old.color.whitePoint.hasSameNormalizedOverrideValueAs(new.color.whitePoint) {
-        it.coerceIn(-1f, 1f)
-      }
-    ) {
+    if (old.whitePoint != new.whitePoint) {
       markDirty(GlassDirtyFields.WhitePoint)
     }
-    if (
-      !old.color.chromaMultiplier.hasSameNormalizedOverrideValueAs(new.color.chromaMultiplier) {
-        it.coerceIn(0f, 2f)
-      }
-    ) {
+    if (old.chromaMultiplier != new.chromaMultiplier) {
       markDirty(GlassDirtyFields.ChromaMultiplier)
     }
-    if (old.rendering.edgeSoftness != new.rendering.edgeSoftness) {
+    if (old.edgeSoftness != new.edgeSoftness) {
       markDirty(GlassDirtyFields.EdgeSoftness)
     }
-    if (
-      !old.rendering.contentNormalBlend.hasSameNormalizedOverrideValueAs(
-        new.rendering.contentNormalBlend,
-      ) { it.coerceIn(0f, 1f) }
-    ) {
+    if (old.contentNormalBlend != new.contentNormalBlend) {
       markDirty(GlassDirtyFields.ContentNormalBlend)
     }
-    if (old.rendering.surfaceProfile != new.rendering.surfaceProfile) {
+    if (old.surfaceProfile != new.surfaceProfile) {
       markDirty(GlassDirtyFields.SurfaceProfile)
     }
-    if (
-      !old.rendering.chromaticAberrationStrength.hasSameNormalizedOverrideValueAs(
-        new.rendering.chromaticAberrationStrength,
-      ) { it.coerceIn(0f, 1f) }
-    ) {
+    if (old.chromaticAberrationStrength != new.chromaticAberrationStrength) {
       markDirty(GlassDirtyFields.ChromaticAberration)
     }
-    if (old.rendering.chromaticAberrationMode != new.rendering.chromaticAberrationMode) {
+    if (old.chromaticAberrationMode != new.chromaticAberrationMode) {
       markDirty(GlassDirtyFields.ChromaticAberrationMode)
     }
   }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -967,8 +967,8 @@ public class GlassVisualEffect() :
       if (field !== value) {
         HazeLogger.d(TAG) { "LocalGlassStyle changed. Current: $field. New: $value" }
         field = value
-        updateInheritedStyleValues()
       }
+      updateInheritedStyleValues()
     }
 
   private var inheritedStyleValues: GlassStyleValues =

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
@@ -1,0 +1,147 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(dev.chrisbanes.haze.InternalHazeApi::class)
+
+package dev.chrisbanes.haze.glass
+
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEvent
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeEffectFactory
+import dev.chrisbanes.haze.HazeEffectFactoryVisualEffect
+import dev.chrisbanes.haze.HazeEffectRenderer
+import dev.chrisbanes.haze.HazeEffectVisualEffectFactory
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeSampling
+import dev.chrisbanes.haze.InteractiveVisualEffect
+import dev.chrisbanes.haze.Poko
+import dev.chrisbanes.haze.RetainedOutputVisualEffect
+import dev.chrisbanes.haze.VisualEffect
+import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.VisualEffectTransform
+import dev.chrisbanes.haze.hazeEffect
+
+/**
+ * Draws a Glass material using an explicit Haze [input].
+ *
+ * [style] is a stateless, replayable appearance program. Haze evaluates
+ * [GlassDefaults.style] → [LocalGlassStyle] → [style] into a fresh snapshot owned by this modifier
+ * node. The same Style may therefore be shared by concurrent nodes.
+ *
+ * [input], [sampling], [expandLayerBounds], and [interactionSource] are structural modifier
+ * configuration rather than Style properties. Recomposition replaces each value completely,
+ * including a `null` interaction source.
+ *
+ * @param input Source-backed content or this modifier's own content.
+ * @param style Explicit appearance applied after defaults and [LocalGlassStyle].
+ * @param sampling Input sampling policy. [HazeSampling.Default] preserves Glass's unscaled default.
+ * @param expandLayerBounds Whether Glass may expand its capture layer for optical sampling.
+ * @param interactionSource Optional external interaction source for the legacy interaction model.
+ */
+@Stable
+@ExperimentalHazeApi
+public fun Modifier.hazeGlass(
+  input: HazeInput,
+  style: GlassStyle = GlassStyle,
+  sampling: HazeSampling = HazeSampling.Default,
+  expandLayerBounds: Boolean = true,
+  interactionSource: InteractionSource? = null,
+): Modifier = hazeGlass(
+  factory = GlassHazeEffectFactory,
+  input = input,
+  style = style,
+  sampling = sampling,
+  expandLayerBounds = expandLayerBounds,
+  interactionSource = interactionSource,
+)
+
+internal fun Modifier.hazeGlass(
+  factory: HazeEffectFactory<GlassNodeConfiguration>,
+  input: HazeInput,
+  style: GlassStyle,
+  sampling: HazeSampling,
+  expandLayerBounds: Boolean,
+  interactionSource: InteractionSource?,
+): Modifier = hazeEffect(
+  factory = factory,
+  input = input,
+  style = GlassNodeConfiguration(style, interactionSource),
+  sampling = sampling,
+  expandLayerBounds = expandLayerBounds,
+)
+
+@Poko
+internal class GlassNodeConfiguration(
+  val style: GlassStyle,
+  val interactionSource: InteractionSource?,
+)
+
+internal object GlassHazeEffectFactory :
+  HazeEffectFactory<GlassNodeConfiguration>,
+  HazeEffectVisualEffectFactory<GlassNodeConfiguration> {
+
+  override fun createRenderer(): HazeEffectRenderer<GlassNodeConfiguration> {
+    error("Glass uses the built-in full VisualEffect adapter")
+  }
+
+  override fun createVisualEffect(
+    style: GlassNodeConfiguration,
+    sampling: HazeSampling,
+  ): HazeEffectFactoryVisualEffect<GlassNodeConfiguration> {
+    val configuration = GlassVisualEffect().apply {
+      this.style = style.style
+      interactionSource = style.interactionSource
+    }
+    return GlassHazeEffectFactoryVisualEffect(
+      configuration = configuration,
+      renderer = configuration.createRenderer(),
+    )
+  }
+}
+
+internal class GlassHazeEffectFactoryVisualEffect(
+  internal val configuration: GlassVisualEffect,
+  internal val renderer: VisualEffect,
+) : HazeEffectFactoryVisualEffect<GlassNodeConfiguration>,
+  VisualEffect by renderer,
+  InteractiveVisualEffect,
+  RetainedOutputVisualEffect {
+
+  private val interactiveRenderer: InteractiveVisualEffect?
+    get() = renderer as? InteractiveVisualEffect
+
+  private val retainedRenderer: RetainedOutputVisualEffect?
+    get() = renderer as? RetainedOutputVisualEffect
+
+  override fun updateStyle(style: GlassNodeConfiguration, sampling: HazeSampling) {
+    configuration.style = style.style
+    configuration.interactionSource = style.interactionSource
+  }
+
+  override val observesPointerEvents: Boolean
+    get() = interactiveRenderer?.observesPointerEvents == true
+
+  override fun onPointerEvent(event: PointerEvent, context: VisualEffectContext) {
+    interactiveRenderer?.onPointerEvent(event, context)
+  }
+
+  override fun onCancelPointerInput(context: VisualEffectContext) {
+    interactiveRenderer?.onCancelPointerInput(context)
+  }
+
+  override fun currentContentTransform(context: VisualEffectContext): VisualEffectTransform =
+    interactiveRenderer?.currentContentTransform(context) ?: VisualEffectTransform.Identity
+
+  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean =
+    retainedRenderer?.canDrawRetainedOutput(context) == true
+
+  override fun shouldDrawRetainedOutput(context: VisualEffectContext): Boolean =
+    retainedRenderer?.shouldDrawRetainedOutput(context) == true
+
+  override fun clearRetainedOutput() {
+    retainedRenderer?.clearRetainedOutput()
+  }
+}

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassOpticsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassOpticsTest.kt
@@ -16,7 +16,8 @@ class GlassOpticsTest {
   @Test
   fun adaptive_isTheDefaultOptics() {
     assertThat(GlassDefaults.optics).isEqualTo(GlassOptics.Adaptive)
-    assertThat(GlassDefaults.style.optics).isEqualTo(GlassOptics.Adaptive)
+    assertThat(resolveGlassStyleValues(GlassStyle, GlassDefaults.style).optics)
+      .isEqualTo(GlassOptics.Adaptive)
   }
 
   @Test

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -1,6 +1,8 @@
 // Copyright 2026, Christopher Banes and the Haze project contributors
 // SPDX-License-Identifier: Apache-2.0
 
+@file:Suppress("DEPRECATION")
+
 package dev.chrisbanes.haze.glass
 
 import androidx.compose.foundation.shape.CornerSize

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -33,141 +33,105 @@ import kotlinx.coroutines.CoroutineScope
 class GlassStyleTest {
 
   @Test
-  fun styleChange_dirtiesOnlyTheSpecifiedScalarAndStyleFields() {
-    val effect = GlassVisualEffect()
-    effect.resetDirtyTracker()
-
-    effect.style = GlassStyle(color = GlassColor(alpha = 0.5f))
-
-    assertThat(GlassDirtyFields.stringify(effect.dirtyTracker))
-      .isEqualTo("[Alpha, Style]")
-  }
-
-  @Test
-  fun defaultsStyle_resolvesToGlassDefaults() {
-    val effect = GlassVisualEffect().apply {
-      compositionLocalStyle = GlassDefaults.style
+  fun styleChain_appliesWritesInOrder() {
+    val style = GlassStyle {
+      tint(Color.Red)
+      alpha(0.25f)
+    }.then {
+      tint(Color.Blue)
+      alpha(0.75f)
     }
 
-    assertThat(effect.tint).isEqualTo(GlassDefaults.tint)
-    assertThat(effect.shape).isEqualTo(GlassDefaults.shape)
-    assertThat(effect.optics).isEqualTo(GlassDefaults.optics)
-    assertThat(effect.specularIntensity).isEqualTo(GlassDefaults.specularIntensity)
-    assertThat(effect.specularExponent).isEqualTo(GlassDefaults.specularExponent)
-    assertThat(effect.fresnelExponent).isEqualTo(GlassDefaults.fresnelExponent)
-    assertThat(effect.ambientResponse).isEqualTo(GlassDefaults.ambientResponse)
-    assertThat(effect.alpha).isEqualTo(GlassDefaults.alpha)
-    assertThat(effect.contrast).isEqualTo(GlassDefaults.contrast)
-    assertThat(effect.whitePoint).isEqualTo(GlassDefaults.whitePoint)
-    assertThat(effect.chromaMultiplier).isEqualTo(GlassDefaults.chromaMultiplier)
-    assertThat(effect.edgeSoftness).isEqualTo(GlassDefaults.edgeSoftness)
-    assertThat(effect.contentNormalBlend).isEqualTo(GlassDefaults.contentNormalBlend)
-    assertThat(effect.surfaceProfile).isEqualTo(GlassDefaults.surfaceProfile)
-    assertThat(effect.chromaticAberrationStrength).isEqualTo(GlassDefaults.chromaticAberrationStrength)
-    assertThat(effect.chromaticAberrationMode).isEqualTo(GlassDefaults.chromaticAberrationMode)
-  }
-
-  @Test
-  fun optics_resolvesDirectStyleLocalAndDefaultPrecedence() {
-    val localOptics = GlassOptics.Absolute(refractionStrength = 0.2f)
-    val directOptics = GlassOptics.Absolute(refractionStrength = 0.9f)
-    val effect = GlassVisualEffect().apply {
-      compositionLocalStyle = GlassStyle(optics = localOptics)
-    }
-    assertThat(effect.optics).isEqualTo(localOptics)
-
-    effect.style = GlassStyle(optics = GlassOptics.Adaptive)
-    assertThat(effect.optics).isEqualTo(GlassOptics.Adaptive)
-
-    effect.optics = directOptics
-    assertThat(effect.optics).isEqualTo(directOptics)
-
-    effect.clearOpticsOverride()
-    assertThat(effect.optics).isEqualTo(GlassOptics.Adaptive)
-
-    effect.style = GlassStyle.Unspecified
-    effect.compositionLocalStyle = GlassStyle.Unspecified
-    assertThat(effect.optics).isEqualTo(GlassDefaults.optics)
-  }
-
-  @Test
-  fun groupedStyle_partiallySpecifiedValuesInheritFromCompositionLocal() {
-    val localStyle = GlassStyle(
-      tint = Color.Blue,
-      shape = RoundedCornerShape(12.dp),
-      optics = GlassOptics.Absolute(
-        refractionStrength = 0.2f,
-        refractionDisplacement = 8.dp,
-        depth = 0.3f,
-      ),
-      lighting = GlassLighting(
-        specularIntensity = 0.25f,
-        lightPosition = Offset(4f, 8f),
-      ),
-      color = GlassColor(alpha = 0.7f, contrast = 0.4f),
-      rendering = GlassRendering(
-        edgeSoftness = 6.dp,
-        surfaceProfile = SurfaceProfile.Concave,
-      ),
+    val resolved = resolveGlassStyleValues(
+      localStyle = GlassStyle,
+      explicitStyle = style,
     )
-    val directOptics = GlassOptics.Absolute(refractionStrength = 0.9f)
-    val directStyle = GlassStyle(
-      optics = directOptics,
-      lighting = GlassLighting(ambientResponse = 0.8f),
-      color = GlassColor(whitePoint = 0.1f),
-      rendering = GlassRendering(chromaticAberrationStrength = 0.5f),
+
+    assertThat(resolved.tint).isEqualTo(Color.Blue)
+    assertThat(resolved.alpha).isEqualTo(0.75f)
+  }
+
+  @Test
+  fun resolution_appliesDefaultsLocalAndExplicitStyle() {
+    val local = GlassStyle {
+      tint(Color.Red)
+      alpha(0.5f)
+      contrast(0.25f)
+    }
+    val explicit = GlassStyle {
+      tint(Color.Blue)
+      alpha(0.75f)
+    }
+
+    val resolved = resolveGlassStyleValues(
+      localStyle = local,
+      explicitStyle = explicit,
     )
-    val effect = GlassVisualEffect().apply {
-      compositionLocalStyle = localStyle
-      style = directStyle
-    }
 
-    assertThat(effect.optics).isEqualTo(directOptics)
-    assertThat(effect.ambientResponse).isEqualTo(0.8f)
-    assertThat(effect.specularIntensity).isEqualTo(0.25f)
-    assertThat(effect.lightPosition).isEqualTo(Offset(4f, 8f))
-    assertThat(effect.alpha).isEqualTo(0.7f)
-    assertThat(effect.contrast).isEqualTo(0.4f)
-    assertThat(effect.whitePoint).isEqualTo(0.1f)
-    assertThat(effect.edgeSoftness).isEqualTo(6.dp)
-    assertThat(effect.surfaceProfile).isEqualTo(SurfaceProfile.Concave)
-    assertThat(effect.chromaticAberrationStrength).isEqualTo(0.5f)
+    assertThat(resolved.tint).isEqualTo(Color.Blue)
+    assertThat(resolved.alpha).isEqualTo(0.75f)
+    assertThat(resolved.contrast).isEqualTo(0.25f)
+    assertThat(resolved.shape).isEqualTo(GlassDefaults.shape)
   }
 
   @Test
-  fun directPropertiesOverrideGroupedStyle() {
-    val effect = GlassVisualEffect().apply {
-      style = GlassStyle(
-        tint = Color.Blue,
-        optics = GlassOptics.Absolute(refractionStrength = 0.2f),
-        lighting = GlassLighting(ambientResponse = 0.3f),
-        color = GlassColor(alpha = 0.4f),
-        rendering = GlassRendering(edgeSoftness = 6.dp),
-      )
-      tint = Color.Red
-      optics = GlassOptics.Absolute(refractionStrength = 0.8f)
-      ambientResponse = 0.9f
-      alpha = 0.5f
-      edgeSoftness = 10.dp
+  fun evaluation_startsFromFreshAccumulator() {
+    val style = GlassStyle {
+      tint(Color.Blue)
+      alpha(0.5f)
     }
+    val first = resolveGlassStyleValues(GlassStyle, style)
+    val replacement = resolveGlassStyleValues(GlassStyle, GlassStyle { contrast(0.4f) })
+    val second = resolveGlassStyleValues(GlassStyle, style)
 
-    assertThat(effect.tint).isEqualTo(Color.Red)
-    assertThat(effect.optics).isEqualTo(GlassOptics.Absolute(refractionStrength = 0.8f))
-    assertThat(effect.ambientResponse).isEqualTo(0.9f)
-    assertThat(effect.alpha).isEqualTo(0.5f)
-    assertThat(effect.edgeSoftness).isEqualTo(10.dp)
+    assertThat(first).isEqualTo(second)
+    assertThat(replacement.tint).isEqualTo(GlassDefaults.tint)
+    assertThat(replacement.alpha).isEqualTo(GlassDefaults.alpha)
+    assertThat(replacement.contrast).isEqualTo(0.4f)
   }
 
   @Test
-  fun fallbackEdgeAlpha_clampsRawStyleAmbientResponse() {
-    val effect = GlassVisualEffect().apply {
-      style = GlassStyle(
-        lighting = GlassLighting(ambientResponse = 2f),
-      )
+  fun staticPropertyWrites_preserveCanonicalization() {
+    val optics = GlassOptics.Absolute(refractionStrength = 0.3f)
+    val shape = RoundedCornerShape(12.dp)
+    val style = GlassStyle {
+      shape(shape)
+      optics(optics)
+      specularIntensity(2f)
+      ambientResponse(-1f)
+      tint(Color.Blue)
+      edgeSoftness(6.dp)
+      lightPosition(Offset(4f, 8f))
+      chromaticAberrationStrength(2f)
+      surfaceProfile(SurfaceProfile.Concave)
+      chromaticAberrationMode(ChromaticAberrationMode.Full)
+      alpha(2f)
+      contrast(-2f)
+      whitePoint(2f)
+      chromaMultiplier(3f)
+      contentNormalBlend(-1f)
+      specularExponent(-1f)
+      fresnelExponent(-1f)
     }
+    val resolved = resolveGlassStyleValues(GlassStyle, style)
 
-    assertThat(fallbackEdgeAlpha(effect.ambientResponse)).isEqualTo(0.18f)
-    assertThat(fallbackEdgeAlpha(-1f)).isEqualTo(0f)
+    assertThat(resolved.shape).isEqualTo(shape)
+    assertThat(resolved.optics).isEqualTo(optics)
+    assertThat(resolved.specularIntensity).isEqualTo(1f)
+    assertThat(resolved.ambientResponse).isEqualTo(0f)
+    assertThat(resolved.tint).isEqualTo(Color.Blue)
+    assertThat(resolved.edgeSoftness).isEqualTo(6.dp)
+    assertThat(resolved.lightPosition).isEqualTo(Offset(4f, 8f))
+    assertThat(resolved.chromaticAberrationStrength).isEqualTo(1f)
+    assertThat(resolved.surfaceProfile).isEqualTo(SurfaceProfile.Concave)
+    assertThat(resolved.chromaticAberrationMode).isEqualTo(ChromaticAberrationMode.Full)
+    assertThat(resolved.alpha).isEqualTo(1f)
+    assertThat(resolved.contrast).isEqualTo(-1f)
+    assertThat(resolved.whitePoint).isEqualTo(1f)
+    assertThat(resolved.chromaMultiplier).isEqualTo(2f)
+    assertThat(resolved.contentNormalBlend).isEqualTo(0f)
+    assertThat(resolved.specularExponent).isEqualTo(0f)
+    assertThat(resolved.fresnelExponent).isEqualTo(0f)
   }
 
   @Test

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectLifecycleTest.kt
@@ -36,6 +36,7 @@ import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeArea
 import dev.chrisbanes.haze.HazeInputScale
+import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.PlatformContext
@@ -50,6 +51,103 @@ import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
 class GlassVisualEffectLifecycleTest {
+
+  @Test
+  fun sharedStyle_resolvesIndependentlyPerTypedRenderer() {
+    val sharedStyle = GlassStyle { alpha(0.4f) }
+    val first = GlassHazeEffectFactory.createVisualEffect(
+      GlassNodeConfiguration(sharedStyle, interactionSource = null),
+      HazeSampling.Default,
+    ) as GlassHazeEffectFactoryVisualEffect
+    val second = GlassHazeEffectFactory.createVisualEffect(
+      GlassNodeConfiguration(sharedStyle, interactionSource = null),
+      HazeSampling.Default,
+    ) as GlassHazeEffectFactoryVisualEffect
+    val firstContext = TrackingVisualEffectContext(
+      localStyle = GlassStyle { tint(androidx.compose.ui.graphics.Color.Red) },
+    )
+    val secondContext = TrackingVisualEffectContext(
+      localStyle = GlassStyle { tint(androidx.compose.ui.graphics.Color.Blue) },
+    )
+
+    first.attach(firstContext)
+    second.attach(secondContext)
+    first.update(firstContext)
+    second.update(secondContext)
+
+    val firstRenderer = first.renderer as GlassRenderer
+    val secondRenderer = second.renderer as GlassRenderer
+    assertThat(firstRenderer).isNotSameInstanceAs(secondRenderer)
+    assertThat(firstRenderer.runtimeForTest.tint)
+      .isEqualTo(androidx.compose.ui.graphics.Color.Red)
+    assertThat(secondRenderer.runtimeForTest.tint)
+      .isEqualTo(androidx.compose.ui.graphics.Color.Blue)
+    assertThat(firstRenderer.runtimeForTest.alpha).isEqualTo(0.4f)
+    assertThat(secondRenderer.runtimeForTest.alpha).isEqualTo(0.4f)
+
+    first.detach(firstContext)
+    second.detach(secondContext)
+  }
+
+  @Test
+  fun styleReplacement_omittedPropertyFallsBackImmediatelyWithoutRendererReplacement() {
+    val initialSource = MutableInteractionSource()
+    val effect = GlassHazeEffectFactory.createVisualEffect(
+      GlassNodeConfiguration(
+        style = GlassStyle {
+          tint(androidx.compose.ui.graphics.Color.Blue)
+          alpha(0.4f)
+        },
+        interactionSource = initialSource,
+      ),
+      HazeSampling.Default,
+    ) as GlassHazeEffectFactoryVisualEffect
+    val context = TrackingVisualEffectContext(
+      localStyle = GlassStyle { tint(androidx.compose.ui.graphics.Color.Red) },
+    )
+    val renderer = effect.renderer as GlassRenderer
+    effect.attach(context)
+    effect.update(context)
+
+    effect.updateStyle(
+      GlassNodeConfiguration(
+        style = GlassStyle { contrast(0.2f) },
+        interactionSource = null,
+      ),
+      HazeSampling.Adaptive,
+    )
+    effect.update(context)
+
+    assertThat(effect.renderer).isSameInstanceAs(renderer)
+    assertThat(renderer.runtimeForTest.tint).isEqualTo(androidx.compose.ui.graphics.Color.Red)
+    assertThat(renderer.runtimeForTest.alpha).isEqualTo(GlassDefaults.alpha)
+    assertThat(renderer.runtimeForTest.contrast).isEqualTo(0.2f)
+    assertThat(renderer.runtimeForTest.interactionSource).isNull()
+    effect.detach(context)
+  }
+
+  @Test
+  fun localStyleChange_replacesResolvedSnapshot() {
+    val effect = GlassHazeEffectFactory.createVisualEffect(
+      GlassNodeConfiguration(GlassStyle, interactionSource = null),
+      HazeSampling.Default,
+    ) as GlassHazeEffectFactoryVisualEffect
+    val context = TrackingVisualEffectContext(
+      localStyle = GlassStyle { tint(androidx.compose.ui.graphics.Color.Red) },
+    )
+    val renderer = effect.renderer as GlassRenderer
+    effect.attach(context)
+    effect.update(context)
+    assertThat(renderer.runtimeForTest.tint)
+      .isEqualTo(androidx.compose.ui.graphics.Color.Red)
+
+    context.localStyle = GlassStyle { tint(androidx.compose.ui.graphics.Color.Blue) }
+    effect.update(context)
+
+    assertThat(renderer.runtimeForTest.tint)
+      .isEqualTo(androidx.compose.ui.graphics.Color.Blue)
+    effect.detach(context)
+  }
 
   @Test
   fun sharedConfiguration_createsDistinctRenderersAndControllers() {
@@ -1000,6 +1098,7 @@ private class TrackingVisualEffectContext(
   effectSize: Size = Size(100f, 100f),
   layerSize: Size = effectSize,
   coroutineScope: CoroutineScope? = null,
+  var localStyle: GlassStyle = GlassDefaults.style,
 ) : VisualEffectContext {
   override val position: Offset = Offset.Zero
   override val size: Size = effectSize
@@ -1023,7 +1122,7 @@ private class TrackingVisualEffectContext(
 
   @Suppress("UNCHECKED_CAST")
   override fun <T> currentValueOf(local: CompositionLocal<T>): T = when (local) {
-    LocalGlassStyle -> GlassDefaults.style
+    LocalGlassStyle -> localStyle
     LocalLayoutDirection -> LayoutDirection.Ltr
     else -> error("Unused composition local")
   } as T

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectOverrideTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffectOverrideTest.kt
@@ -1,6 +1,8 @@
 // Copyright 2026, Christopher Banes and the Haze project contributors
 // SPDX-License-Identifier: Apache-2.0
 
+@file:Suppress("DEPRECATION")
+
 package dev.chrisbanes.haze.glass
 
 import androidx.compose.animation.core.tween
@@ -28,6 +30,21 @@ class GlassVisualEffectOverrideTest {
   private val localShape = RoundedCornerShape(8.dp)
   private val styleShape = RoundedCornerShape(16.dp)
   private val directShape = RoundedCornerShape(24.dp)
+
+  @Test
+  fun legacyDirectOverride_remainsHighestCompatibilityTier() {
+    val effect = GlassVisualEffect().apply {
+      compositionLocalStyle = GlassStyle { tint(Color.Red) }
+      style = GlassStyle { tint(Color.Blue) }
+      tint = Color.Green
+    }
+
+    effect.compositionLocalStyle = GlassStyle { tint(Color.Yellow) }
+    effect.style = GlassStyle { contrast(0.25f) }
+
+    assertThat(effect.tint).isEqualTo(Color.Green)
+    assertThat(effect.contrast).isEqualTo(0.25f)
+  }
 
   @Test
   fun inputScale_defaultRemainsUnscaledAndExplicitAutoRemainsGlassSpecific() {

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
@@ -1,0 +1,314 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(dev.chrisbanes.haze.InternalHazeApi::class)
+
+package dev.chrisbanes.haze.glass
+
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isNotSameInstanceAs
+import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeEffectFactory
+import dev.chrisbanes.haze.HazeEffectFactoryVisualEffect
+import dev.chrisbanes.haze.HazeEffectRenderer
+import dev.chrisbanes.haze.HazeEffectVisualEffectFactory
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeInputScale
+import dev.chrisbanes.haze.HazeSampling
+import dev.chrisbanes.haze.HazeSourceRetention
+import dev.chrisbanes.haze.HazeSourceSelection
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.RetainedOutputVisualEffect
+import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.test.ContextTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
+class HazeGlassModifierTest : ContextTest() {
+
+  @Test
+  fun structuralPolicies_reachTypedGlassRuntime() = runComposeUiTest {
+    val hazeState = HazeState()
+    val inputs = listOf(
+      HazeInput.Content,
+      HazeInput.Sources(
+        state = hazeState,
+        selection = HazeSourceSelection.All,
+        retention = HazeSourceRetention.KeepLastFrame,
+      ),
+      HazeInput.Sources(
+        state = hazeState,
+        selection = HazeSourceSelection.All,
+        retention = HazeSourceRetention.ClearWhenUnavailable,
+      ),
+    )
+    val samplingPolicies = listOf(
+      HazeSampling.Default,
+      HazeSampling.FullResolution,
+      HazeSampling.Adaptive,
+      HazeSampling.Fixed(0.5f),
+    )
+    val cases = buildList {
+      inputs.forEach { input ->
+        samplingPolicies.forEach { sampling ->
+          listOf(true, false).forEach { expandLayerBounds ->
+            add(StructuralCase(input, sampling, expandLayerBounds))
+          }
+        }
+      }
+    }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Spacer(Modifier.size(100.dp).hazeSource(hazeState))
+        cases.forEachIndexed { index, case ->
+          Spacer(
+            Modifier
+              .size(10.dp)
+              .testTag("glass-$index")
+              .hazeGlass(
+                factory = case.factory,
+                input = case.input,
+                style = GlassStyle,
+                sampling = case.sampling,
+                expandLayerBounds = case.expandLayerBounds,
+                interactionSource = null,
+              ),
+          )
+        }
+      }
+    }
+    waitForIdle()
+    onRoot().captureToImage()
+
+    cases.forEach { case ->
+      val effect = case.factory.effects.single()
+      val renderer = effect.delegate.renderer as GlassRenderer
+      val context = checkNotNull(renderer.runtimeForTest.attachedContextForTest)
+      val expectedState = (case.input as? HazeInput.Sources)?.state
+      if (expectedState == null) {
+        assertThat(context.state).isNull()
+      } else {
+        assertThat(context.state).isSameInstanceAs(expectedState)
+      }
+      assertThat(effect.sampling).isEqualTo(case.sampling)
+      assertThat(context.inputScale).isEqualTo(case.sampling.expectedInputScale())
+      val boundsCalls = assertThat(
+        effect.calculateLayerBoundsCalls,
+        name = "${case.input}/${case.sampling}/expand=${case.expandLayerBounds}",
+      )
+      if (case.input is HazeInput.Sources && case.expandLayerBounds) {
+        boundsCalls.isGreaterThan(0)
+      } else {
+        boundsCalls.isEqualTo(0)
+      }
+    }
+  }
+
+  @Test
+  fun sourceRetention_reactsToUnavailableSourceWithoutReplacingRuntime() = runComposeUiTest {
+    val hazeState = HazeState()
+    val retention = mutableStateOf<HazeSourceRetention>(HazeSourceRetention.KeepLastFrame)
+    val showSource = mutableStateOf(true)
+    val factory = RecordingGlassFactory()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        if (showSource.value) {
+          Spacer(Modifier.size(100.dp).hazeSource(hazeState))
+        }
+        Spacer(
+          Modifier
+            .size(10.dp)
+            .hazeGlass(
+              factory = factory,
+              input = HazeInput.Sources(
+                hazeState,
+                selection = HazeSourceSelection.All,
+                retention = retention.value,
+              ),
+              style = GlassStyle,
+              sampling = HazeSampling.Default,
+              expandLayerBounds = true,
+              interactionSource = null,
+            ),
+        )
+      }
+    }
+    waitForIdle()
+    onRoot().captureToImage()
+    val effect = factory.effects.single()
+    val clearCallsBeforeKeepUnavailable = effect.clearRetainedOutputCalls
+    val retainedDecisionsBeforeKeepUnavailable = effect.retainedDrawDecisions
+
+    showSource.value = false
+    waitForIdle()
+    onRoot().captureToImage()
+
+    assertThat(factory.effects.single()).isSameInstanceAs(effect)
+    assertThat(effect.clearRetainedOutputCalls).isEqualTo(clearCallsBeforeKeepUnavailable)
+    assertThat(effect.retainedDrawDecisions)
+      .isGreaterThan(retainedDecisionsBeforeKeepUnavailable)
+
+    showSource.value = true
+    waitForIdle()
+    onRoot().captureToImage()
+
+    retention.value = HazeSourceRetention.ClearWhenUnavailable
+    waitForIdle()
+    onRoot().captureToImage()
+    val clearCallsBeforeClearUnavailable = effect.clearRetainedOutputCalls
+
+    showSource.value = false
+    waitForIdle()
+    onRoot().captureToImage()
+
+    assertThat(factory.effects.single()).isSameInstanceAs(effect)
+    assertThat(effect.clearRetainedOutputCalls).isGreaterThan(clearCallsBeforeClearUnavailable)
+  }
+
+  @Test
+  fun recomposition_replacesConfigurationWithoutSharingNodeRuntime() = runComposeUiTest {
+    val firstStyle = GlassStyle { tint(Color.Red) }
+    val secondStyle = GlassStyle { contrast(0.25f) }
+    val sharedStyle = mutableStateOf(firstStyle)
+    val initialInteractionSource = MutableInteractionSource()
+    val interactionSource = mutableStateOf<InteractionSource?>(initialInteractionSource)
+    val factory = RecordingGlassFactory()
+
+    setContent {
+      Box {
+        repeat(2) {
+          Spacer(
+            Modifier
+              .size(10.dp)
+              .hazeGlass(
+                factory = factory,
+                input = HazeInput.Content,
+                style = sharedStyle.value,
+                sampling = HazeSampling.Default,
+                expandLayerBounds = true,
+                interactionSource = interactionSource.value,
+              ),
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val first = factory.effects[0]
+    val second = factory.effects[1]
+    val firstRenderer = first.delegate.renderer
+    val secondRenderer = second.delegate.renderer
+    assertThat(first).isNotSameInstanceAs(second)
+    assertThat(first.delegate.configuration).isNotSameInstanceAs(second.delegate.configuration)
+    assertThat(firstRenderer).isNotSameInstanceAs(secondRenderer)
+    assertThat(first.delegate.configuration.style).isSameInstanceAs(firstStyle)
+    assertThat(second.delegate.configuration.style).isSameInstanceAs(firstStyle)
+    assertThat(first.delegate.configuration.interactionSource)
+      .isSameInstanceAs(initialInteractionSource)
+    assertThat(second.delegate.configuration.interactionSource)
+      .isSameInstanceAs(initialInteractionSource)
+
+    sharedStyle.value = secondStyle
+    interactionSource.value = null
+    waitForIdle()
+
+    assertThat(factory.effects.size).isEqualTo(2)
+    assertThat(first.delegate.renderer).isSameInstanceAs(firstRenderer)
+    assertThat(second.delegate.renderer).isSameInstanceAs(secondRenderer)
+    assertThat(first.delegate.configuration.style).isSameInstanceAs(secondStyle)
+    assertThat(second.delegate.configuration.style).isSameInstanceAs(secondStyle)
+    assertThat(first.delegate.configuration.interactionSource).isNull()
+    assertThat(second.delegate.configuration.interactionSource).isNull()
+  }
+}
+
+private class StructuralCase(
+  val input: HazeInput,
+  val sampling: HazeSampling,
+  val expandLayerBounds: Boolean,
+) {
+  val factory = RecordingGlassFactory()
+}
+
+private class RecordingGlassFactory :
+  HazeEffectFactory<GlassNodeConfiguration>,
+  HazeEffectVisualEffectFactory<GlassNodeConfiguration> {
+  val effects = mutableListOf<RecordingGlassVisualEffect>()
+
+  override fun createRenderer(): HazeEffectRenderer<GlassNodeConfiguration> {
+    error("The full VisualEffect bridge must take precedence")
+  }
+
+  override fun createVisualEffect(
+    style: GlassNodeConfiguration,
+    sampling: HazeSampling,
+  ): HazeEffectFactoryVisualEffect<GlassNodeConfiguration> {
+    val delegate = GlassHazeEffectFactory.createVisualEffect(
+      style = style,
+      sampling = sampling,
+    ) as GlassHazeEffectFactoryVisualEffect
+    return RecordingGlassVisualEffect(delegate, sampling).also(effects::add)
+  }
+}
+
+private class RecordingGlassVisualEffect(
+  val delegate: GlassHazeEffectFactoryVisualEffect,
+  val sampling: HazeSampling,
+) :
+  HazeEffectFactoryVisualEffect<GlassNodeConfiguration> by delegate,
+  RetainedOutputVisualEffect {
+  private val retainedDelegate = delegate as RetainedOutputVisualEffect
+
+  var calculateLayerBoundsCalls = 0
+  var clearRetainedOutputCalls = 0
+  var retainedDrawDecisions = 0
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
+    calculateLayerBoundsCalls++
+    return delegate.calculateLayerBounds(rect, density)
+  }
+
+  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean =
+    retainedDelegate.canDrawRetainedOutput(context)
+
+  override fun shouldDrawRetainedOutput(context: VisualEffectContext): Boolean {
+    return retainedDelegate.shouldDrawRetainedOutput(context).also { shouldDraw ->
+      if (shouldDraw) retainedDrawDecisions++
+    }
+  }
+
+  override fun clearRetainedOutput() {
+    clearRetainedOutputCalls++
+    retainedDelegate.clearRetainedOutput()
+  }
+}
+
+private fun HazeSampling.expectedInputScale(): HazeInputScale = when (this) {
+  HazeSampling.Default -> HazeInputScale.Default
+  HazeSampling.FullResolution -> HazeInputScale.None
+  HazeSampling.Adaptive -> HazeInputScale.Auto
+  is HazeSampling.Fixed -> HazeInputScale.Fixed(scale)
+}

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
@@ -242,6 +243,48 @@ class HazeGlassModifierTest : ContextTest() {
     assertThat(second.delegate.configuration.style).isSameInstanceAs(secondStyle)
     assertThat(first.delegate.configuration.interactionSource).isNull()
     assertThat(second.delegate.configuration.interactionSource).isNull()
+  }
+
+  @Test
+  fun reusedStateBackedStyle_replaysInEachNodeWhenSnapshotChanges() = runComposeUiTest {
+    val alpha = mutableFloatStateOf(0.2f)
+    val sharedStyle = GlassStyle { alpha(alpha.floatValue) }
+    val factory = RecordingGlassFactory()
+
+    setContent {
+      Box {
+        repeat(2) {
+          Spacer(
+            Modifier
+              .size(10.dp)
+              .hazeGlass(
+                factory = factory,
+                input = HazeInput.Content,
+                style = sharedStyle,
+                sampling = HazeSampling.Default,
+                expandLayerBounds = true,
+                interactionSource = null,
+              ),
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    val firstRuntime =
+      (factory.effects[0].delegate.renderer as GlassRenderer).runtimeForTest
+    val secondRuntime =
+      (factory.effects[1].delegate.renderer as GlassRenderer).runtimeForTest
+    assertThat(firstRuntime).isNotSameInstanceAs(secondRuntime)
+    assertThat(firstRuntime.alpha).isEqualTo(0.2f)
+    assertThat(secondRuntime.alpha).isEqualTo(0.2f)
+
+    alpha.floatValue = 0.8f
+    waitForIdle()
+
+    assertThat(factory.effects.size).isEqualTo(2)
+    assertThat(firstRuntime.alpha).isEqualTo(0.8f)
+    assertThat(secondRuntime.alpha).isEqualTo(0.8f)
   }
 }
 

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
@@ -12,9 +12,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
-import dev.chrisbanes.haze.glass.GlassLighting
 import dev.chrisbanes.haze.glass.GlassOptics
-import dev.chrisbanes.haze.glass.GlassRendering
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.glass.GlassVisualEffect
 import dev.chrisbanes.haze.glass.SurfaceProfile
@@ -265,20 +263,18 @@ class GlassContentScreenshotTest : ScreenshotTest() {
   companion object {
     val DefaultTint = Color.White.copy(alpha = 0.1f)
 
-    val VibrantStyle = GlassStyle(
-      tint = Color(0xFF49E1FF).copy(alpha = 0.35f),
-      optics = GlassOptics.Absolute(
-        refractionStrength = 0.5f,
-        depth = 0.35f,
-      ),
-      lighting = GlassLighting(
-        specularIntensity = 0.75f,
-        ambientResponse = 0.75f,
-        lightPosition = Offset(48f, -32f),
-      ),
-      rendering = GlassRendering(
-        edgeSoftness = 12.dp,
-      ),
-    )
+    val VibrantStyle = GlassStyle {
+      tint(Color(0xFF49E1FF).copy(alpha = 0.35f))
+      optics(
+        GlassOptics.Absolute(
+          refractionStrength = 0.5f,
+          depth = 0.35f,
+        ),
+      )
+      specularIntensity(0.75f)
+      ambientResponse(0.75f)
+      lightPosition(Offset(48f, -32f))
+      edgeSoftness(12.dp)
+    }
   }
 }

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
@@ -34,9 +34,7 @@ import assertk.assertThat
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isLessThanOrEqualTo
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
-import dev.chrisbanes.haze.glass.GlassLighting
 import dev.chrisbanes.haze.glass.GlassOptics
-import dev.chrisbanes.haze.glass.GlassRendering
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.glass.GlassVisualEffect
 import dev.chrisbanes.haze.glass.SurfaceProfile
@@ -531,21 +529,19 @@ class GlassScreenshotTest : ScreenshotTest() {
   companion object {
     val DefaultTint = Color.White.copy(alpha = 0.1f)
 
-    val VibrantStyle = GlassStyle(
-      tint = Color(0xFF3F8CFF).copy(alpha = 0.35f),
-      optics = GlassOptics.Absolute(
-        refractionStrength = 0.55f,
-        depth = 0.4f,
-      ),
-      lighting = GlassLighting(
-        specularIntensity = 0.75f,
-        ambientResponse = 0.8f,
-        lightPosition = Offset(64f, -48f),
-      ),
-      rendering = GlassRendering(
-        edgeSoftness = 14.dp,
-      ),
-    )
+    val VibrantStyle = GlassStyle {
+      tint(Color(0xFF3F8CFF).copy(alpha = 0.35f))
+      optics(
+        GlassOptics.Absolute(
+          refractionStrength = 0.55f,
+          depth = 0.4f,
+        ),
+      )
+      specularIntensity(0.75f)
+      ambientResponse(0.8f)
+      lightPosition(Offset(64f, -48f))
+      edgeSoftness(14.dp)
+    }
   }
 }
 

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -41,6 +41,10 @@ package dev.chrisbanes.haze {
     method public dev.chrisbanes.haze.HazeEffectRenderer<Style> createRenderer();
   }
 
+  @dev.chrisbanes.haze.InternalHazeApi public interface HazeEffectFactoryVisualEffect<Style> extends dev.chrisbanes.haze.VisualEffect {
+    method public void updateStyle(Style style, dev.chrisbanes.haze.HazeSampling sampling);
+  }
+
   public final class HazeEffectKt {
     method @androidx.compose.runtime.Stable public static <Style> androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeEffectFactory<Style> factory, dev.chrisbanes.haze.HazeInput input, Style style, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds);
     method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeEffect(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeInput input, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
@@ -134,6 +138,10 @@ package dev.chrisbanes.haze {
     property public abstract dev.chrisbanes.haze.HazeInputScale inputScale;
     property public abstract boolean retainOutputWhenSourceUnavailable;
     property public abstract dev.chrisbanes.haze.VisualEffect visualEffect;
+  }
+
+  @dev.chrisbanes.haze.InternalHazeApi public interface HazeEffectVisualEffectFactory<Style> {
+    method public dev.chrisbanes.haze.HazeEffectFactoryVisualEffect<Style> createVisualEffect(Style style, dev.chrisbanes.haze.HazeSampling sampling);
   }
 
   public sealed exhaustive interface HazeInput {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -24,6 +24,31 @@ public fun interface HazeEffectFactory<Style> {
 }
 
 /**
+ * Built-in-only bridge for effects that require the complete legacy [VisualEffect] lifecycle.
+ *
+ * This keeps pointer input, foreground drawing, retained output, and platform resources internal
+ * while ordinary custom effects continue to use [HazeEffectRenderer]'s semantic scopes.
+ */
+@InternalHazeApi
+public interface HazeEffectVisualEffectFactory<Style> {
+  public fun createVisualEffect(
+    style: Style,
+    sampling: HazeSampling,
+  ): HazeEffectFactoryVisualEffect<Style>
+}
+
+/**
+ * Node-owned full-runtime effect created by [HazeEffectVisualEffectFactory].
+ *
+ * Haze calls [updateStyle] with the complete replacement Style and sampling policy. Implementations
+ * must not retain Style evaluation state outside this node-owned runtime.
+ */
+@InternalHazeApi
+public interface HazeEffectFactoryVisualEffect<Style> : VisualEffect {
+  public fun updateStyle(style: Style, sampling: HazeSampling)
+}
+
+/**
  * Node-owned rendering state for a custom Haze effect.
  *
  * Haze passes the complete current [Style] to every evaluation. Mutable rendering resources may
@@ -159,6 +184,90 @@ internal class TypedHazeEffectVisualEffectImpl<Style>(
   override fun update(style: Any?, sampling: HazeSampling) {
     this.style = style as Style
     this.sampling = sampling
+  }
+}
+
+@OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
+internal class HazeEffectFactoryVisualEffectBridge<Style>(
+  private val effect: HazeEffectFactoryVisualEffect<Style>,
+) : VisualEffect, TypedHazeEffectVisualEffect, InteractiveVisualEffect {
+  private var attachedContext: VisualEffectContext? = null
+
+  override val observesPointerEvents: Boolean
+    get() = (effect as? InteractiveVisualEffect)?.observesPointerEvents == true
+
+  override fun attach(context: VisualEffectContext) {
+    effect.attach(context)
+    attachedContext = context
+  }
+
+  override fun update(context: VisualEffectContext) {
+    effect.update(context)
+  }
+
+  override fun DrawScope.prepareDraw(context: VisualEffectContext) {
+    with(effect) { prepareDraw(context) }
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    with(effect) { draw(context) }
+  }
+
+  override fun DrawScope.drawForeground(context: VisualEffectContext) {
+    with(effect) { drawForeground(context) }
+  }
+
+  override fun shouldDrawContentBehind(context: VisualEffectContext): Boolean =
+    effect.shouldDrawContentBehind(context)
+
+  override fun shouldClipToNodeBounds(): Boolean = effect.shouldClipToNodeBounds()
+
+  override fun shouldPreferClipToAreaBounds(): Boolean = effect.shouldPreferClipToAreaBounds()
+
+  override fun calculateLayerBounds(rect: Rect, density: Density): Rect =
+    effect.calculateLayerBounds(rect, density)
+
+  override fun onPointerEvent(event: androidx.compose.ui.input.pointer.PointerEvent, context: VisualEffectContext) {
+    (effect as? InteractiveVisualEffect)?.onPointerEvent(event, context)
+  }
+
+  override fun onCancelPointerInput(context: VisualEffectContext) {
+    (effect as? InteractiveVisualEffect)?.onCancelPointerInput(context)
+  }
+
+  override fun currentContentTransform(context: VisualEffectContext): VisualEffectTransform =
+    (effect as? InteractiveVisualEffect)?.currentContentTransform(context)
+      ?: VisualEffectTransform.Identity
+
+  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean =
+    (effect as? RetainedOutputVisualEffect)?.canDrawRetainedOutput(context) == true
+
+  override fun shouldDrawRetainedOutput(context: VisualEffectContext): Boolean =
+    (effect as? RetainedOutputVisualEffect)?.shouldDrawRetainedOutput(context) == true
+
+  override fun clearRetainedOutput() {
+    (effect as? RetainedOutputVisualEffect)?.clearRetainedOutput()
+  }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    effect.onTrimMemory(context, level)
+  }
+
+  override fun onTrimMemory(level: TrimMemoryLevel) {
+    attachedContext?.let { effect.onTrimMemory(it, level) }
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    try {
+      effect.detach(context)
+    } finally {
+      attachedContext = null
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  override fun update(style: Any?, sampling: HazeSampling) {
+    effect.updateStyle(style as Style, sampling)
   }
 }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -329,12 +329,20 @@ public class HazeEffectNode(
     style: Style,
     sampling: HazeSampling,
   ) {
+    @Suppress("UNCHECKED_CAST")
+    val visualEffectFactory = factory as? HazeEffectVisualEffectFactory<Style>
     val createRuntime = {
-      TypedHazeEffectVisualEffectImpl(
-        renderer = factory.createRenderer(),
-        style = style,
-        sampling = sampling,
-      )
+      if (visualEffectFactory != null) {
+        HazeEffectFactoryVisualEffectBridge(
+          visualEffectFactory.createVisualEffect(style, sampling),
+        )
+      } else {
+        TypedHazeEffectVisualEffectImpl(
+          renderer = factory.createRenderer(),
+          style = style,
+          sampling = sampling,
+        )
+      }
     }
     if (typedEffectFactory !== factory) {
       if (isAttached) {

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectFactoryVisualEffectBridgeTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectFactoryVisualEffectBridgeTest.kt
@@ -1,0 +1,187 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(InternalHazeApi::class)
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.test.ContextTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class HazeEffectFactoryVisualEffectBridgeTest : ContextTest() {
+
+  @Test
+  fun fullLifecycle_styleAndFactoryReplacement_preserveExactOwnership() = runComposeUiTest {
+    val firstFactory = RecordingVisualEffectFactory()
+    val secondFactory = RecordingVisualEffectFactory()
+    val factory = mutableStateOf<HazeEffectFactory<String>>(firstFactory)
+    val style = mutableStateOf("first")
+    val show = mutableStateOf(true)
+
+    setContent {
+      if (show.value) {
+        Spacer(
+          Modifier
+            .size(10.dp)
+            .testTag("effect")
+            .hazeEffect(
+              factory = factory.value,
+              input = HazeInput.Content,
+              style = style.value,
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val effect = firstFactory.effects.single()
+    assertThat(effect.attachCalls).isEqualTo(1)
+    onNodeWithTag("effect").performTouchInput { click() }
+    waitForIdle()
+
+    assertThat(effect.updateCalls).isGreaterThan(0)
+    assertThat(effect.prepareDrawCalls).isGreaterThan(0)
+    assertThat(effect.drawCalls).isGreaterThan(0)
+    assertThat(effect.drawForegroundCalls).isGreaterThan(0)
+    assertThat(effect.pointerEventCalls).isGreaterThan(0)
+
+    val directEffect = RecordingFactoryVisualEffect("direct")
+    val directBridge = HazeEffectFactoryVisualEffectBridge(directEffect)
+    val context = checkNotNull(effect.attachedContext)
+    directBridge.attach(context)
+    directBridge.canDrawRetainedOutput(context)
+    directBridge.onTrimMemory(TrimMemoryLevel.BACKGROUND)
+    directBridge.clearRetainedOutput()
+    directBridge.detach(context)
+    assertThat(directEffect.trimMemoryCalls).isEqualTo(1)
+    assertThat(directEffect.retainedAvailabilityCalls).isEqualTo(1)
+    assertThat(directEffect.clearRetainedOutputCalls).isEqualTo(1)
+    assertThat(directEffect.detachCalls).isEqualTo(1)
+
+    style.value = "second"
+    waitForIdle()
+
+    assertThat(firstFactory.effects.size).isEqualTo(1)
+    assertThat(effect.styles).containsExactly("first", "second")
+
+    factory.value = secondFactory
+    waitForIdle()
+
+    val replacement = secondFactory.effects.single()
+    assertThat(effect.detachCalls).isEqualTo(1)
+    assertThat(replacement.attachCalls).isEqualTo(1)
+
+    show.value = false
+    waitForIdle()
+
+    assertThat(effect.detachCalls).isEqualTo(1)
+    assertThat(replacement.detachCalls).isEqualTo(1)
+  }
+}
+
+private class RecordingVisualEffectFactory :
+  HazeEffectFactory<String>,
+  HazeEffectVisualEffectFactory<String> {
+  val effects = mutableListOf<RecordingFactoryVisualEffect>()
+
+  override fun createRenderer(): HazeEffectRenderer<String> {
+    error("The built-in VisualEffect bridge must take precedence")
+  }
+
+  override fun createVisualEffect(
+    style: String,
+    sampling: HazeSampling,
+  ): HazeEffectFactoryVisualEffect<String> {
+    return RecordingFactoryVisualEffect(style).also(effects::add)
+  }
+}
+
+private class RecordingFactoryVisualEffect(
+  initialStyle: String,
+) : HazeEffectFactoryVisualEffect<String>,
+  InteractiveVisualEffect,
+  RetainedOutputVisualEffect {
+  val styles = mutableListOf(initialStyle)
+  var attachCalls = 0
+  var updateCalls = 0
+  var prepareDrawCalls = 0
+  var drawCalls = 0
+  var drawForegroundCalls = 0
+  var pointerEventCalls = 0
+  var retainedAvailabilityCalls = 0
+  var trimMemoryCalls = 0
+  var clearRetainedOutputCalls = 0
+  var detachCalls = 0
+  var attachedContext: VisualEffectContext? = null
+
+  override fun updateStyle(style: String, sampling: HazeSampling) {
+    styles += style
+  }
+
+  override fun attach(context: VisualEffectContext) {
+    attachCalls++
+    attachedContext = context
+  }
+
+  override fun update(context: VisualEffectContext) {
+    updateCalls++
+  }
+
+  override fun DrawScope.prepareDraw(context: VisualEffectContext) {
+    prepareDrawCalls++
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) {
+    drawCalls++
+  }
+
+  override fun DrawScope.drawForeground(context: VisualEffectContext) {
+    drawForegroundCalls++
+  }
+
+  override val observesPointerEvents: Boolean = true
+
+  override fun onPointerEvent(
+    event: androidx.compose.ui.input.pointer.PointerEvent,
+    context: VisualEffectContext,
+  ) {
+    pointerEventCalls++
+  }
+
+  override fun onCancelPointerInput(context: VisualEffectContext) = Unit
+
+  override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean {
+    retainedAvailabilityCalls++
+    return false
+  }
+
+  override fun clearRetainedOutput() {
+    clearRetainedOutputCalls++
+  }
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    trimMemoryCalls++
+  }
+
+  override fun detach(context: VisualEffectContext) {
+    detachCalls++
+    attachedContext = null
+  }
+}

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
@@ -80,9 +80,42 @@ public enum class GlassLabPresetId {
 
 internal val SelectableGlassLabPresets = GlassLabPresetId.entries - GlassLabPresetId.Custom
 
-public fun glassLabPresetStyle(id: GlassLabPresetId): GlassStyle = when (id) {
-  GlassLabPresetId.Adaptive -> GlassDefaults.style
-  GlassLabPresetId.Clear -> GlassDefaults.style.copy(
+@Immutable
+internal data class GlassLabStyleValues(
+  val tint: Color = GlassDefaults.tint,
+  val optics: GlassOptics = GlassDefaults.optics,
+  val specularIntensity: Float = GlassDefaults.specularIntensity,
+  val ambientResponse: Float = GlassDefaults.ambientResponse,
+  val alpha: Float = GlassDefaults.alpha,
+  val contrast: Float = GlassDefaults.contrast,
+  val whitePoint: Float = GlassDefaults.whitePoint,
+  val chromaMultiplier: Float = GlassDefaults.chromaMultiplier,
+  val edgeSoftness: androidx.compose.ui.unit.Dp = GlassDefaults.edgeSoftness,
+  val contentNormalBlend: Float = GlassDefaults.contentNormalBlend,
+  val surfaceProfile: SurfaceProfile = GlassDefaults.surfaceProfile,
+  val chromaticAberrationStrength: Float = GlassDefaults.chromaticAberrationStrength,
+  val chromaticAberrationMode: ChromaticAberrationMode = GlassDefaults.chromaticAberrationMode,
+) {
+  fun toStyle(): GlassStyle = GlassStyle {
+    tint(tint)
+    optics(optics)
+    specularIntensity(specularIntensity)
+    ambientResponse(ambientResponse)
+    alpha(alpha)
+    contrast(contrast)
+    whitePoint(whitePoint)
+    chromaMultiplier(chromaMultiplier)
+    edgeSoftness(edgeSoftness)
+    contentNormalBlend(contentNormalBlend)
+    surfaceProfile(surfaceProfile)
+    chromaticAberrationStrength(chromaticAberrationStrength)
+    chromaticAberrationMode(chromaticAberrationMode)
+  }
+}
+
+private fun glassLabPresetValues(id: GlassLabPresetId): GlassLabStyleValues = when (id) {
+  GlassLabPresetId.Adaptive -> GlassLabStyleValues()
+  GlassLabPresetId.Clear -> GlassLabStyleValues(
     tint = Color.White.copy(alpha = 0.06f),
     optics = GlassOptics.Absolute(
       refractionStrength = 0.85f,
@@ -91,25 +124,13 @@ public fun glassLabPresetStyle(id: GlassLabPresetId): GlassStyle = when (id) {
       depth = 0.1f,
       blurRadius = 2.dp,
     ),
-    lighting = GlassDefaults.style.lighting.copy(
-      specularIntensity = 0.55f,
-      ambientResponse = 0.42f,
-    ),
-    color = GlassDefaults.style.color.copy(
-      alpha = 1f,
-      contrast = 0.08f,
-      whitePoint = 0.02f,
-      chromaMultiplier = 1.05f,
-    ),
-    rendering = GlassDefaults.style.rendering.copy(
-      edgeSoftness = 2.dp,
-      contentNormalBlend = 0.15f,
-      surfaceProfile = SurfaceProfile.Circle,
-      chromaticAberrationStrength = 0f,
-      chromaticAberrationMode = ChromaticAberrationMode.Simple,
-    ),
+    specularIntensity = 0.55f,
+    ambientResponse = 0.42f,
+    contrast = 0.08f,
+    whitePoint = 0.02f,
+    chromaMultiplier = 1.05f,
   )
-  GlassLabPresetId.Frosted -> GlassDefaults.style.copy(
+  GlassLabPresetId.Frosted -> GlassLabStyleValues(
     tint = Color.White.copy(alpha = 0.18f),
     optics = GlassOptics.Absolute(
       refractionStrength = 0.45f,
@@ -118,25 +139,15 @@ public fun glassLabPresetStyle(id: GlassLabPresetId): GlassStyle = when (id) {
       depth = 0.9f,
       blurRadius = 24.dp,
     ),
-    lighting = GlassDefaults.style.lighting.copy(
-      specularIntensity = 0.35f,
-      ambientResponse = 0.55f,
-    ),
-    color = GlassDefaults.style.color.copy(
-      alpha = 1f,
-      contrast = -0.08f,
-      whitePoint = 0.08f,
-      chromaMultiplier = 0.72f,
-    ),
-    rendering = GlassDefaults.style.rendering.copy(
-      edgeSoftness = 8.dp,
-      contentNormalBlend = 0.08f,
-      surfaceProfile = SurfaceProfile.Circle,
-      chromaticAberrationStrength = 0f,
-      chromaticAberrationMode = ChromaticAberrationMode.Simple,
-    ),
+    specularIntensity = 0.35f,
+    ambientResponse = 0.55f,
+    contrast = -0.08f,
+    whitePoint = 0.08f,
+    chromaMultiplier = 0.72f,
+    edgeSoftness = 8.dp,
+    contentNormalBlend = 0.08f,
   )
-  GlassLabPresetId.Deep -> GlassDefaults.style.copy(
+  GlassLabPresetId.Deep -> GlassLabStyleValues(
     tint = Color.White.copy(alpha = 0.1f),
     optics = GlassOptics.Absolute(
       refractionStrength = 0.9f,
@@ -145,25 +156,16 @@ public fun glassLabPresetStyle(id: GlassLabPresetId): GlassStyle = when (id) {
       depth = 0.78f,
       blurRadius = 16.dp,
     ),
-    lighting = GlassDefaults.style.lighting.copy(
-      specularIntensity = 0.75f,
-      ambientResponse = 0.62f,
-    ),
-    color = GlassDefaults.style.color.copy(
-      alpha = 1f,
-      contrast = 0.05f,
-      whitePoint = 0.02f,
-      chromaMultiplier = 1f,
-    ),
-    rendering = GlassDefaults.style.rendering.copy(
-      edgeSoftness = 10.dp,
-      contentNormalBlend = 0.2f,
-      surfaceProfile = SurfaceProfile.Squircle,
-      chromaticAberrationStrength = 0.05f,
-      chromaticAberrationMode = ChromaticAberrationMode.Simple,
-    ),
+    specularIntensity = 0.75f,
+    ambientResponse = 0.62f,
+    contrast = 0.05f,
+    whitePoint = 0.02f,
+    edgeSoftness = 10.dp,
+    contentNormalBlend = 0.2f,
+    surfaceProfile = SurfaceProfile.Squircle,
+    chromaticAberrationStrength = 0.05f,
   )
-  GlassLabPresetId.Prism -> GlassDefaults.style.copy(
+  GlassLabPresetId.Prism -> GlassLabStyleValues(
     tint = Color.White.copy(alpha = 0.08f),
     optics = GlassOptics.Absolute(
       refractionStrength = 0.82f,
@@ -172,26 +174,22 @@ public fun glassLabPresetStyle(id: GlassLabPresetId): GlassStyle = when (id) {
       depth = 0.35f,
       blurRadius = 8.dp,
     ),
-    lighting = GlassDefaults.style.lighting.copy(
-      specularIntensity = 0.72f,
-      ambientResponse = 0.58f,
-    ),
-    color = GlassDefaults.style.color.copy(
-      alpha = 1f,
-      contrast = 0.1f,
-      whitePoint = 0.02f,
-      chromaMultiplier = 1.15f,
-    ),
-    rendering = GlassDefaults.style.rendering.copy(
-      edgeSoftness = 8.dp,
-      contentNormalBlend = 0.18f,
-      surfaceProfile = SurfaceProfile.Squircle,
-      chromaticAberrationStrength = 0.22f,
-      chromaticAberrationMode = ChromaticAberrationMode.Full,
-    ),
+    specularIntensity = 0.72f,
+    ambientResponse = 0.58f,
+    contrast = 0.1f,
+    whitePoint = 0.02f,
+    chromaMultiplier = 1.15f,
+    edgeSoftness = 8.dp,
+    contentNormalBlend = 0.18f,
+    surfaceProfile = SurfaceProfile.Squircle,
+    chromaticAberrationStrength = 0.22f,
+    chromaticAberrationMode = ChromaticAberrationMode.Full,
   )
   GlassLabPresetId.Custom -> error("Custom style must come from GlassLabState")
 }
+
+public fun glassLabPresetStyle(id: GlassLabPresetId): GlassStyle =
+  glassLabPresetValues(id).toStyle()
 
 internal enum class GlassLabInteractionMode {
   Off,
@@ -215,15 +213,23 @@ internal data class GlassLabState(
   val backdrop: GlassGalleryBackdropId = GlassGalleryBackdropId.Gallery,
   val interaction: GlassLabInteractionMode = GlassLabInteractionMode.All,
   val advancedExpanded: Boolean = false,
-  val style: GlassStyle = glassLabPresetStyle(GlassLabPresetId.Adaptive),
+  val styleValues: GlassLabStyleValues = glassLabPresetValues(preset),
 ) {
+  val style: GlassStyle = styleValues.toStyle()
+
   fun selectPreset(id: GlassLabPresetId): GlassLabState {
     require(id != GlassLabPresetId.Custom)
-    return copy(preset = id, style = glassLabPresetStyle(id))
+    val values = glassLabPresetValues(id)
+    return copy(preset = id, styleValues = values)
   }
 
-  fun editStyle(transform: (GlassStyle) -> GlassStyle): GlassLabState =
-    copy(preset = GlassLabPresetId.Custom, style = transform(style))
+  fun editStyle(transform: (GlassLabStyleValues) -> GlassLabStyleValues): GlassLabState {
+    val values = transform(styleValues)
+    return copy(
+      preset = GlassLabPresetId.Custom,
+      styleValues = values,
+    )
+  }
 
   fun reset(): GlassLabState = GlassLabState()
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
@@ -41,6 +41,7 @@ import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.glass.GlassVisualEffect
 import dev.chrisbanes.haze.glass.glassEffect
+import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 
@@ -183,7 +184,9 @@ internal fun DemoChrome(
   val shape = RoundedCornerShape(24.dp)
   GlassSurface(
     hazeState = hazeState,
-    style = GlassDefaults.style.copy(tint = Color.Black.copy(alpha = 0.08f)),
+    style = GlassDefaults.style.then {
+      tint(Color.Black.copy(alpha = 0.08f))
+    },
     shape = shape,
     modifier = modifier,
   ) {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
@@ -129,7 +129,7 @@ public fun GlassLabScreenshotContent(
   modifier: Modifier = Modifier,
 ) {
   GlassLabSampleContent(
-    state = GlassLabState(preset = preset, backdrop = backdrop, style = glassLabPresetStyle(preset)),
+    state = GlassLabState(preset = preset, backdrop = backdrop),
     recordingMode = true,
     onStateChanged = {},
     onRecordingModeChanged = {},
@@ -258,10 +258,8 @@ private fun <T : Enum<T>> LabChipGroup(
 
 @Composable
 private fun LabAdvancedControls(state: GlassLabState, onStateChanged: (GlassLabState) -> Unit) {
-  val absolute = (state.style.optics as? GlassOptics.Absolute) ?: GlassOptics.Absolute()
-  val lighting = state.style.lighting
-  val color = state.style.color
-  val rendering = state.style.rendering
+  val values = state.styleValues
+  val absolute = (values.optics as? GlassOptics.Absolute) ?: GlassOptics.Absolute()
   Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
     Text("Optics", style = MaterialTheme.typography.titleMedium)
     LabSlider("Refraction", absolute.refractionStrength, 0f..1f) { value ->
@@ -274,36 +272,34 @@ private fun LabAdvancedControls(state: GlassLabState, onStateChanged: (GlassLabS
       onStateChanged(state.editStyle { it.copy(optics = absolute.copy(blurRadius = value.dp)) })
     }
     Text("Lighting", style = MaterialTheme.typography.titleMedium)
-    LabSlider("Specular", lighting.specularIntensity, 0f..1f) { value ->
+    LabSlider("Specular", values.specularIntensity, 0f..1f) { value ->
       onStateChanged(
-        state.editStyle { it.copy(optics = absolute, lighting = lighting.copy(specularIntensity = value)) },
+        state.editStyle { it.copy(optics = absolute, specularIntensity = value) },
       )
     }
-    LabSlider("Ambient", lighting.ambientResponse, 0f..1f) { value ->
+    LabSlider("Ambient", values.ambientResponse, 0f..1f) { value ->
       onStateChanged(
-        state.editStyle { it.copy(optics = absolute, lighting = lighting.copy(ambientResponse = value)) },
+        state.editStyle { it.copy(optics = absolute, ambientResponse = value) },
       )
     }
     Text("Colour", style = MaterialTheme.typography.titleMedium)
-    LabSlider("Contrast", color.contrast, -1f..1f) { value ->
-      onStateChanged(state.editStyle { it.copy(optics = absolute, color = color.copy(contrast = value)) })
+    LabSlider("Contrast", values.contrast, -1f..1f) { value ->
+      onStateChanged(state.editStyle { it.copy(optics = absolute, contrast = value) })
     }
-    LabSlider("Chroma", color.chromaMultiplier, 0f..2f) { value ->
+    LabSlider("Chroma", values.chromaMultiplier, 0f..2f) { value ->
       onStateChanged(
-        state.editStyle { it.copy(optics = absolute, color = color.copy(chromaMultiplier = value)) },
+        state.editStyle { it.copy(optics = absolute, chromaMultiplier = value) },
       )
     }
     Text("Rendering", style = MaterialTheme.typography.titleMedium)
-    LabSlider("Edge softness", rendering.edgeSoftness.value, 0f..24f) { value ->
+    LabSlider("Edge softness", values.edgeSoftness.value, 0f..24f) { value ->
       onStateChanged(
-        state.editStyle { it.copy(optics = absolute, rendering = rendering.copy(edgeSoftness = value.dp)) },
+        state.editStyle { it.copy(optics = absolute, edgeSoftness = value.dp) },
       )
     }
-    LabSlider("Chromatic", rendering.chromaticAberrationStrength, 0f..0.4f) { value ->
+    LabSlider("Chromatic", values.chromaticAberrationStrength, 0f..0.4f) { value ->
       onStateChanged(
-        state.editStyle {
-          it.copy(optics = absolute, rendering = rendering.copy(chromaticAberrationStrength = value))
-        },
+        state.editStyle { it.copy(optics = absolute, chromaticAberrationStrength = value) },
       )
     }
   }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimeline.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimeline.kt
@@ -13,6 +13,7 @@ import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.then
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
@@ -77,7 +78,7 @@ internal fun glassPlaygroundFrame(progress: Float): GlassPlaygroundFrame {
 internal fun glassPlaygroundStyle(id: GlassPlaygroundSurfaceId): GlassStyle = when (id) {
   GlassPlaygroundSurfaceId.Lens,
   GlassPlaygroundSurfaceId.Pill,
-  -> GlassDefaults.style.copy(optics = GlassOptics.Adaptive)
+  -> GlassDefaults.style.then { optics(GlassOptics.Adaptive) }
   GlassPlaygroundSurfaceId.Card -> glassLabPresetStyle(GlassLabPresetId.Deep)
   GlassPlaygroundSurfaceId.Prism -> glassLabPresetStyle(GlassLabPresetId.Prism)
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassProductSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassProductSample.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.rememberHazeState
@@ -76,10 +75,10 @@ public fun GlassProductSample(navController: NavHostController) {
   )
 }
 
-internal fun productGlassStyle(isDark: Boolean): GlassStyle = GlassDefaults.style.copy(
-  tint = if (isDark) Color.Black.copy(alpha = 0.08f) else Color.White.copy(alpha = 0.1f),
-  optics = GlassOptics.Adaptive,
-)
+internal fun productGlassStyle(isDark: Boolean): GlassStyle = GlassStyle {
+  tint(if (isDark) Color.Black.copy(alpha = 0.08f) else Color.White.copy(alpha = 0.1f))
+  optics(GlassOptics.Adaptive)
+}
 
 @Composable
 public fun GlassProductSampleContent(

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
@@ -11,7 +11,6 @@ import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isLessThan
 import assertk.assertions.isNotEqualTo
-import assertk.assertions.isNotNull
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
@@ -22,7 +21,7 @@ import kotlin.test.Test
 class GlassGalleryModelsTest {
   @Test
   fun adaptivePreset_usesBuiltInAdaptiveOptics() {
-    assertThat(glassLabPresetStyle(GlassLabPresetId.Adaptive).optics)
+    assertThat(GlassLabState().styleValues.optics)
       .isEqualTo(GlassOptics.Adaptive)
   }
 
@@ -37,12 +36,12 @@ class GlassGalleryModelsTest {
     assertThat(clear.depth).isLessThan(deep.depth)
     assertThat(prism).isNotEqualTo(deep)
     assertThat(
-      glassLabPresetStyle(GlassLabPresetId.Prism).rendering.chromaticAberrationMode,
+      GlassLabState(preset = GlassLabPresetId.Prism).styleValues.chromaticAberrationMode,
     ).isEqualTo(
       ChromaticAberrationMode.Full,
     )
     assertThat(
-      glassLabPresetStyle(GlassLabPresetId.Prism).rendering.chromaticAberrationStrength,
+      GlassLabState(preset = GlassLabPresetId.Prism).styleValues.chromaticAberrationStrength,
     ).isEqualTo(
       0.22f,
     )
@@ -50,12 +49,12 @@ class GlassGalleryModelsTest {
 
   @Test
   fun editingAdaptiveStyle_changesSelectionToCustomAndLiteralOptics() {
-    val edited = GlassLabState().editStyle { style ->
-      style.copy(optics = GlassOptics.Absolute(refractionStrength = 0.6f))
+    val edited = GlassLabState().editStyle { values ->
+      values.copy(optics = GlassOptics.Absolute(refractionStrength = 0.6f))
     }
 
     assertThat(edited.preset).isEqualTo(GlassLabPresetId.Custom)
-    assertThat(edited.style.optics).isNotNull().isInstanceOf<GlassOptics.Absolute>()
+    assertThat(edited.styleValues.optics).isInstanceOf<GlassOptics.Absolute>()
   }
 
   @Test
@@ -86,7 +85,7 @@ class GlassGalleryModelsTest {
       backdrop = GlassGalleryBackdropId.Grid,
       interaction = GlassLabInteractionMode.Off,
       advancedExpanded = true,
-      style = glassLabPresetStyle(GlassLabPresetId.Prism),
+      styleValues = GlassLabStyleValues(optics = GlassOptics.Absolute()),
     )
 
     assertThat(changed.reset()).isEqualTo(GlassLabState())
@@ -94,7 +93,7 @@ class GlassGalleryModelsTest {
 }
 
 private fun absoluteOpticsFor(id: GlassLabPresetId): GlassOptics.Absolute {
-  val optics = glassLabPresetStyle(id).optics
-  assertThat(optics).isNotNull().isInstanceOf<GlassOptics.Absolute>()
+  val optics = GlassLabState(preset = id).styleValues.optics
+  assertThat(optics).isInstanceOf<GlassOptics.Absolute>()
   return optics as GlassOptics.Absolute
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
@@ -14,9 +14,9 @@ import assertk.assertions.isGreaterThanOrEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isLessThanOrEqualTo
 import assertk.assertions.isNotEqualTo
-import assertk.assertions.isNotNull
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassVisualEffect
 import kotlin.test.Test
 
 class GlassPlaygroundTimelineTest {
@@ -79,15 +79,13 @@ class GlassPlaygroundTimelineTest {
 
   @Test
   fun smallSurfacesUseAdaptiveAndFeatureSurfacesUseLiteralOptics() {
-    assertThat(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Lens).optics)
+    assertThat(resolvedOptics(GlassPlaygroundSurfaceId.Lens))
       .isEqualTo(GlassOptics.Adaptive)
-    assertThat(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Pill).optics)
+    assertThat(resolvedOptics(GlassPlaygroundSurfaceId.Pill))
       .isEqualTo(GlassOptics.Adaptive)
-    assertThat(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Card).optics)
-      .isNotNull()
+    assertThat(resolvedOptics(GlassPlaygroundSurfaceId.Card))
       .isInstanceOf<GlassOptics.Absolute>()
-    assertThat(glassPlaygroundStyle(GlassPlaygroundSurfaceId.Prism).optics)
-      .isNotNull()
+    assertThat(resolvedOptics(GlassPlaygroundSurfaceId.Prism))
       .isInstanceOf<GlassOptics.Absolute>()
   }
 
@@ -104,3 +102,8 @@ class GlassPlaygroundTimelineTest {
     assertThat(frame.position(GlassPlaygroundSurfaceId.Prism)).isEqualTo(Offset(0.8f, 0.8f))
   }
 }
+
+private fun resolvedOptics(id: GlassPlaygroundSurfaceId): GlassOptics =
+  GlassVisualEffect().apply {
+    style = glassPlaygroundStyle(id)
+  }.optics

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassProductSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassProductSampleTest.kt
@@ -18,21 +18,12 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.v2.runComposeUiTest
-import assertk.assertThat
-import assertk.assertions.isEqualTo
 import dev.chrisbanes.haze.ExperimentalHazeApi
-import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
 class GlassProductSampleTest : ContextTest() {
-  @Test
-  fun productGlassStyle_alwaysUsesAdaptiveOptics() {
-    assertThat(productGlassStyle(isDark = false).optics).isEqualTo(GlassOptics.Adaptive)
-    assertThat(productGlassStyle(isDark = true).optics).isEqualTo(GlassOptics.Adaptive)
-  }
-
   @Test
   fun normalMode_showsProductSceneTopBar() = runComposeUiTest {
     setContent {


### PR DESCRIPTION
Closes #1125

## Summary
- replace sentinel-based GlassStyle data with an opaque replayable style program and ordered GlassStyleScope property writes
- resolve defaults, composition-local style, and explicit style into a fresh node-local snapshot
- add typed Modifier.hazeGlass over the merged typed factory lifecycle while preserving full Glass foreground, pointer, retained-output, trim, and expansion behavior
- keep legacy GlassVisualEffect/glassEffect compatibility adapters for downstream migration
- migrate focused samples and add runtime-observing coverage for sampling, input state, expansion, retention, replacement, reuse, and node isolation

## Validation
- focused core + Glass JVM and Android-host suites
- Metalava generation/compatibility and Spotless
- library screenshot suites
- ./gradlew check --continue (1,032 tasks)

## Known base-only screenshot state
The Glass Gallery product portrait and landscape comparisons fail from the environment-sensitive system dark theme at 15.21% and 15.32%. Both pixel counts reproduce exactly on untouched main; this PR does not change screenshot baselines.