### PR TITLE
Move Glass interaction into Style state blocks

### DIFF
--- a/haze-glass/api/api.txt
+++ b/haze-glass/api/api.txt
@@ -250,9 +250,12 @@ package dev.chrisbanes.haze.glass {
     method public void contentNormalBlend(float value);
     method public void contrast(float value);
     method @KotlinOnly public void edgeSoftness(androidx.compose.ui.unit.Dp value);
+    method public void focused(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> block);
     method public void fresnelExponent(float value);
+    method public void hovered(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> block);
     method @KotlinOnly public void lightPosition(androidx.compose.ui.geometry.Offset value);
     method public void optics(dev.chrisbanes.haze.glass.GlassOptics value);
+    method public void pressed(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> block);
     method public void shape(androidx.compose.foundation.shape.RoundedCornerShape value);
     method public void specularExponent(float value);
     method public void specularIntensity(float value);
@@ -371,7 +374,7 @@ package dev.chrisbanes.haze.glass {
   }
 
   public final class HazeGlassKt {
-    method @androidx.compose.runtime.Stable @dev.chrisbanes.haze.ExperimentalHazeApi public static androidx.compose.ui.Modifier hazeGlass(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeInput input, optional dev.chrisbanes.haze.glass.GlassStyle style, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds, optional androidx.compose.foundation.interaction.InteractionSource? interactionSource);
+    method @androidx.compose.runtime.Stable @dev.chrisbanes.haze.ExperimentalHazeApi public static androidx.compose.ui.Modifier hazeGlass(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeInput input, optional dev.chrisbanes.haze.glass.GlassStyle style, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds, optional androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional float interactionLightRadiusFraction, optional dev.chrisbanes.haze.glass.GlassTransformTarget interactionTransformTarget, optional dev.chrisbanes.haze.glass.GlassTransformPivot interactionTransformPivot, optional androidx.compose.animation.core.FiniteAnimationSpec<androidx.compose.ui.geometry.Offset> interactionPositionAnimationSpec, optional dev.chrisbanes.haze.glass.GlassReducedMotionPolicy interactionReducedMotionPolicy);
   }
 
   @dev.chrisbanes.haze.ExperimentalHazeApi public enum SurfaceProfile {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
@@ -412,6 +412,7 @@ internal class GlassRuntimeEffect private constructor(
   override fun update(context: VisualEffectContext) {
     dirtyTrackerVersion
     compositionLocalStyle = context.currentValueOf(LocalGlassStyle)
+    resolvedConfiguration.updateStyleInteractionSlots()
     syncInteractionController(context)
 
     if (dirtyTracker.any(GlassDirtyFields.LayerBoundsFlags)) {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -34,8 +34,10 @@ public val LocalGlassStyle: ProvidableCompositionLocal<GlassStyle> =
  * Create a Style with [GlassStyle] and combine Styles with [then]. Writes run in order and the last
  * write to a property wins. The companion object is the empty Style and performs no writes.
  *
- * A Style contains no renderer or mutable evaluation state. Each `hazeGlass` node evaluates it
- * into a fresh node-owned snapshot.
+ * A Style contains no renderer or mutable evaluation state. [GlassStyleScope.hovered],
+ * [GlassStyleScope.focused], and [GlassStyleScope.pressed] record declarative responses only;
+ * each `hazeGlass` node evaluates them into a fresh node-owned snapshot and owns its signals,
+ * animations, pointer observation, and renderer resources.
  */
 @ExperimentalHazeApi
 @Immutable
@@ -99,6 +101,26 @@ private class CombinedGlassStyle(
 public class GlassStyleScope internal constructor(
   private val values: GlassStyleValues,
 ) {
+  /**
+   * Declares the response evaluated by each node while it is hovered.
+   *
+   * The last declaration for this state wins. Pointer observation is installed only when hover or
+   * press has a declaration, and observes without consuming application input.
+   */
+  public fun hovered(block: GlassInteractionScope.() -> Unit) {
+    values.hoveredInteraction = buildGlassInteractionResponse(block)
+  }
+
+  /** Declares the response evaluated by each node while it is focused. */
+  public fun focused(block: GlassInteractionScope.() -> Unit) {
+    values.focusedInteraction = buildGlassInteractionResponse(block)
+  }
+
+  /** Declares the response evaluated by each node while it is pressed. */
+  public fun pressed(block: GlassInteractionScope.() -> Unit) {
+    values.pressedInteraction = buildGlassInteractionResponse(block)
+  }
+
   public fun shape(value: RoundedCornerShape) {
     values.shape = value
   }
@@ -198,6 +220,9 @@ internal class GlassStyleValues(
   var contentNormalBlend: Float = GlassDefaults.contentNormalBlend,
   var specularExponent: Float = GlassDefaults.specularExponent,
   var fresnelExponent: Float = GlassDefaults.fresnelExponent,
+  var hoveredInteraction: GlassInteractionResponse? = null,
+  var focusedInteraction: GlassInteractionResponse? = null,
+  var pressedInteraction: GlassInteractionResponse? = null,
 )
 
 internal fun resolveGlassStyleValues(
@@ -208,6 +233,19 @@ internal fun resolveGlassStyleValues(
   GlassDefaults.style.applyTo(scope)
   localStyle.applyTo(scope)
   explicitStyle.applyTo(scope)
+}
+
+/** Evaluates stateless Style declarations into a fresh, node-owned response snapshot. */
+internal fun resolveGlassStyleInteractionSlots(
+  localStyle: GlassStyle,
+  explicitStyle: GlassStyle,
+): GlassInteractionSlots {
+  val values = resolveGlassStyleValues(localStyle, explicitStyle)
+  return GlassInteractionSlots(
+    focused = values.focusedInteraction?.let { GlassInteractionSlot(1L, it) },
+    hovered = values.hoveredInteraction?.let { GlassInteractionSlot(1L, it) },
+    pressed = values.pressedInteraction?.let { GlassInteractionSlot(1L, it) },
+  )
 }
 
 private fun GlassStyle.applyTo(scope: GlassStyleScope) {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -81,6 +81,9 @@ public class GlassVisualEffect() :
     hoveredSlot = other.hoveredSlot
     focusedSlot = other.focusedSlot
     pressedSlot = other.pressedSlot
+    styleHoveredSlot = other.styleHoveredSlot
+    styleFocusedSlot = other.styleFocusedSlot
+    stylePressedSlot = other.stylePressedSlot
     _interactionSource = other._interactionSource
     _interactionLightRadiusFraction = other._interactionLightRadiusFraction
     _interactionTransformTarget = other._interactionTransformTarget
@@ -152,6 +155,9 @@ public class GlassVisualEffect() :
         hoveredSlot = other.hoveredSlot
         focusedSlot = other.focusedSlot
         pressedSlot = other.pressedSlot
+        styleHoveredSlot = other.styleHoveredSlot
+        styleFocusedSlot = other.styleFocusedSlot
+        stylePressedSlot = other.stylePressedSlot
         _interactionSource = other._interactionSource
         _interactionLightRadiusFraction = other._interactionLightRadiusFraction
         _interactionTransformTarget = other._interactionTransformTarget
@@ -234,6 +240,11 @@ public class GlassVisualEffect() :
   internal var pressedSlot: GlassInteractionSlot? by mutableStateOf(null)
     private set
 
+  // A Style contains only declarations. Each attached effect owns these evaluated slots.
+  private var styleHoveredSlot: GlassInteractionSlot? by mutableStateOf(null)
+  private var styleFocusedSlot: GlassInteractionSlot? by mutableStateOf(null)
+  private var stylePressedSlot: GlassInteractionSlot? by mutableStateOf(null)
+
   private var interactionSlotsSnapshot: GlassInteractionSlots = GlassInteractionSlots()
   private var currentInteractionTopology = interactionSlotsSnapshot.resolveInteractionTopology()
 
@@ -258,7 +269,7 @@ public class GlassVisualEffect() :
   private var interactionSlotTransaction: InteractionSlotTransaction? = null
 
   override val observesPointerEvents: Boolean
-    get() = hoveredSlot != null || pressedSlot != null
+    get() = interactionSlotsSnapshot.hovered != null || interactionSlotsSnapshot.pressed != null
 
   internal var _interactionSource: InteractionSource? by mutableStateOf(
     null,
@@ -468,14 +479,30 @@ public class GlassVisualEffect() :
 
   private fun refreshInteractionSnapshots() {
     val slots = GlassInteractionSlots(
-      focused = focusedSlot,
-      hovered = hoveredSlot,
-      pressed = pressedSlot,
+      focused = styleFocusedSlot ?: focusedSlot,
+      hovered = styleHoveredSlot ?: hoveredSlot,
+      pressed = stylePressedSlot ?: pressedSlot,
     )
     if (slots != interactionSlotsSnapshot) {
       interactionSlotsSnapshot = slots
       currentInteractionTopology = slots.resolveInteractionTopology()
     }
+  }
+
+  internal fun updateStyleInteractionSlots() {
+    val resolved = resolveGlassStyleInteractionSlots(compositionLocalStyle, style)
+    if (
+      styleHoveredSlot?.response == resolved.hovered?.response &&
+      styleFocusedSlot?.response == resolved.focused?.response &&
+      stylePressedSlot?.response == resolved.pressed?.response
+    ) {
+      return
+    }
+    val previousRefractionMultiplier = maximumInteractionRefractionMultiplier()
+    styleHoveredSlot = resolved.hovered?.let { GlassInteractionSlot(++nextInteractionRevision, it.response) }
+    styleFocusedSlot = resolved.focused?.let { GlassInteractionSlot(++nextInteractionRevision, it.response) }
+    stylePressedSlot = resolved.pressed?.let { GlassInteractionSlot(++nextInteractionRevision, it.response) }
+    onInteractionConfigurationChanged(previousRefractionMultiplier)
   }
 
   @PublishedApi

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -479,9 +479,9 @@ public class GlassVisualEffect() :
 
   private fun refreshInteractionSnapshots() {
     val slots = GlassInteractionSlots(
-      focused = styleFocusedSlot ?: focusedSlot,
-      hovered = styleHoveredSlot ?: hoveredSlot,
-      pressed = stylePressedSlot ?: pressedSlot,
+      focused = focusedSlot ?: styleFocusedSlot,
+      hovered = hoveredSlot ?: styleHoveredSlot,
+      pressed = pressedSlot ?: stylePressedSlot,
     )
     if (slots != interactionSlotsSnapshot) {
       interactionSlotsSnapshot = slots
@@ -499,10 +499,19 @@ public class GlassVisualEffect() :
       return
     }
     val previousRefractionMultiplier = maximumInteractionRefractionMultiplier()
-    styleHoveredSlot = resolved.hovered?.let { GlassInteractionSlot(++nextInteractionRevision, it.response) }
-    styleFocusedSlot = resolved.focused?.let { GlassInteractionSlot(++nextInteractionRevision, it.response) }
-    stylePressedSlot = resolved.pressed?.let { GlassInteractionSlot(++nextInteractionRevision, it.response) }
+    styleHoveredSlot = updateStyleSlot(styleHoveredSlot, resolved.hovered)
+    styleFocusedSlot = updateStyleSlot(styleFocusedSlot, resolved.focused)
+    stylePressedSlot = updateStyleSlot(stylePressedSlot, resolved.pressed)
     onInteractionConfigurationChanged(previousRefractionMultiplier)
+  }
+
+  private fun updateStyleSlot(
+    previous: GlassInteractionSlot?,
+    next: GlassInteractionSlot?,
+  ): GlassInteractionSlot? = when {
+    previous?.response == next?.response -> previous
+    next == null -> null
+    else -> GlassInteractionSlot(++nextInteractionRevision, next.response)
   }
 
   @PublishedApi

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -81,6 +81,9 @@ public class GlassVisualEffect() :
     hoveredSlot = other.hoveredSlot
     focusedSlot = other.focusedSlot
     pressedSlot = other.pressedSlot
+    hoveredOverride = other.hoveredOverride
+    focusedOverride = other.focusedOverride
+    pressedOverride = other.pressedOverride
     styleHoveredSlot = other.styleHoveredSlot
     styleFocusedSlot = other.styleFocusedSlot
     stylePressedSlot = other.stylePressedSlot
@@ -155,6 +158,9 @@ public class GlassVisualEffect() :
         hoveredSlot = other.hoveredSlot
         focusedSlot = other.focusedSlot
         pressedSlot = other.pressedSlot
+        hoveredOverride = other.hoveredOverride
+        focusedOverride = other.focusedOverride
+        pressedOverride = other.pressedOverride
         styleHoveredSlot = other.styleHoveredSlot
         styleFocusedSlot = other.styleFocusedSlot
         stylePressedSlot = other.stylePressedSlot

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassVisualEffect.kt
@@ -239,6 +239,9 @@ public class GlassVisualEffect() :
 
   internal var pressedSlot: GlassInteractionSlot? by mutableStateOf(null)
     private set
+  private var hoveredOverride = false
+  private var focusedOverride = false
+  private var pressedOverride = false
 
   // A Style contains only declarations. Each attached effect owns these evaluated slots.
   private var styleHoveredSlot: GlassInteractionSlot? by mutableStateOf(null)
@@ -395,6 +398,7 @@ public class GlassVisualEffect() :
       return
     }
     val previousRefractionMultiplier = maximumInteractionRefractionMultiplier()
+    hoveredOverride = true
     hoveredSlot = null
     onInteractionConfigurationChanged(previousRefractionMultiplier)
   }
@@ -405,6 +409,7 @@ public class GlassVisualEffect() :
       return
     }
     val previousRefractionMultiplier = maximumInteractionRefractionMultiplier()
+    focusedOverride = true
     focusedSlot = null
     onInteractionConfigurationChanged(previousRefractionMultiplier)
   }
@@ -415,6 +420,7 @@ public class GlassVisualEffect() :
       return
     }
     val previousRefractionMultiplier = maximumInteractionRefractionMultiplier()
+    pressedOverride = true
     pressedSlot = null
     onInteractionConfigurationChanged(previousRefractionMultiplier)
   }
@@ -427,6 +433,9 @@ public class GlassVisualEffect() :
       return
     }
     val previousRefractionMultiplier = maximumInteractionRefractionMultiplier()
+    hoveredOverride = true
+    focusedOverride = true
+    pressedOverride = true
     hoveredSlot = null
     focusedSlot = null
     pressedSlot = null
@@ -438,8 +447,9 @@ public class GlassVisualEffect() :
       it.hovered = response
       return
     }
-    if (hoveredSlot?.response == response) return
+    if (hoveredOverride && hoveredSlot?.response == response) return
     val previousRefractionMultiplier = maximumInteractionRefractionMultiplier()
+    hoveredOverride = true
     hoveredSlot = GlassInteractionSlot(++nextInteractionRevision, response)
     onInteractionConfigurationChanged(previousRefractionMultiplier)
   }
@@ -449,8 +459,9 @@ public class GlassVisualEffect() :
       it.focused = response
       return
     }
-    if (focusedSlot?.response == response) return
+    if (focusedOverride && focusedSlot?.response == response) return
     val previousRefractionMultiplier = maximumInteractionRefractionMultiplier()
+    focusedOverride = true
     focusedSlot = GlassInteractionSlot(++nextInteractionRevision, response)
     onInteractionConfigurationChanged(previousRefractionMultiplier)
   }
@@ -460,8 +471,9 @@ public class GlassVisualEffect() :
       it.pressed = response
       return
     }
-    if (pressedSlot?.response == response) return
+    if (pressedOverride && pressedSlot?.response == response) return
     val previousRefractionMultiplier = maximumInteractionRefractionMultiplier()
+    pressedOverride = true
     pressedSlot = GlassInteractionSlot(++nextInteractionRevision, response)
     onInteractionConfigurationChanged(previousRefractionMultiplier)
   }
@@ -479,9 +491,9 @@ public class GlassVisualEffect() :
 
   private fun refreshInteractionSnapshots() {
     val slots = GlassInteractionSlots(
-      focused = focusedSlot ?: styleFocusedSlot,
-      hovered = hoveredSlot ?: styleHoveredSlot,
-      pressed = pressedSlot ?: stylePressedSlot,
+      focused = if (focusedOverride) focusedSlot else styleFocusedSlot,
+      hovered = if (hoveredOverride) hoveredSlot else styleHoveredSlot,
+      pressed = if (pressedOverride) pressedSlot else stylePressedSlot,
     )
     if (slots != interactionSlotsSnapshot) {
       interactionSlotsSnapshot = slots

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
@@ -72,6 +72,32 @@ public fun Modifier.hazeGlass(
   interactionReducedMotionPolicy = interactionReducedMotionPolicy,
 )
 
+/** Binary-compatible bridge for callers compiled against the original typed Glass modifier. */
+@Deprecated(
+  message = "Use the overload with interaction configuration to opt into explicit motion policy.",
+  level = DeprecationLevel.HIDDEN,
+)
+@Stable
+@ExperimentalHazeApi
+public fun Modifier.hazeGlass(
+  input: HazeInput,
+  style: GlassStyle = GlassStyle,
+  sampling: HazeSampling = HazeSampling.Default,
+  expandLayerBounds: Boolean = true,
+  interactionSource: InteractionSource? = null,
+): Modifier = hazeGlass(
+  input = input,
+  style = style,
+  sampling = sampling,
+  expandLayerBounds = expandLayerBounds,
+  interactionSource = interactionSource,
+  interactionLightRadiusFraction = GlassDefaults.interactionLightRadiusFraction,
+  interactionTransformTarget = GlassTransformTarget.MaterialOnly,
+  interactionTransformPivot = GlassTransformPivot.Pointer,
+  interactionPositionAnimationSpec = GlassDefaults.positionAnimationSpec,
+  interactionReducedMotionPolicy = GlassReducedMotionPolicy.System,
+)
+
 internal fun Modifier.hazeGlass(
   factory: HazeEffectFactory<GlassNodeConfiguration>,
   input: HazeInput,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
@@ -5,9 +5,11 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEvent
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeEffectFactory
@@ -29,7 +31,8 @@ import dev.chrisbanes.haze.hazeEffect
  *
  * [style] is a stateless, replayable appearance program. Haze evaluates
  * [GlassDefaults.style] → [LocalGlassStyle] → [style] into a fresh snapshot owned by this modifier
- * node. The same Style may therefore be shared by concurrent nodes.
+ * node. The same Style may therefore be shared by concurrent nodes. Its hover, focus, and press
+ * response blocks are likewise evaluated and animated by each node independently.
  *
  * [input], [sampling], [expandLayerBounds], and [interactionSource] are structural modifier
  * configuration rather than Style properties. Recomposition replaces each value completely,
@@ -39,7 +42,8 @@ import dev.chrisbanes.haze.hazeEffect
  * @param style Explicit appearance applied after defaults and [LocalGlassStyle].
  * @param sampling Input sampling policy. [HazeSampling.Default] preserves Glass's unscaled default.
  * @param expandLayerBounds Whether Glass may expand its capture layer for optical sampling.
- * @param interactionSource Optional external interaction source for the legacy interaction model.
+ * @param interactionSource Optional external interaction source owned by this modifier node.
+ * @param interactionReducedMotionPolicy Motion policy for this node's Style responses.
  */
 @Stable
 @ExperimentalHazeApi
@@ -49,6 +53,11 @@ public fun Modifier.hazeGlass(
   sampling: HazeSampling = HazeSampling.Default,
   expandLayerBounds: Boolean = true,
   interactionSource: InteractionSource? = null,
+  interactionLightRadiusFraction: Float = GlassDefaults.interactionLightRadiusFraction,
+  interactionTransformTarget: GlassTransformTarget = GlassTransformTarget.MaterialOnly,
+  interactionTransformPivot: GlassTransformPivot = GlassTransformPivot.Pointer,
+  interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> = GlassDefaults.positionAnimationSpec,
+  interactionReducedMotionPolicy: GlassReducedMotionPolicy = GlassReducedMotionPolicy.System,
 ): Modifier = hazeGlass(
   factory = GlassHazeEffectFactory,
   input = input,
@@ -56,6 +65,11 @@ public fun Modifier.hazeGlass(
   sampling = sampling,
   expandLayerBounds = expandLayerBounds,
   interactionSource = interactionSource,
+  interactionLightRadiusFraction = interactionLightRadiusFraction,
+  interactionTransformTarget = interactionTransformTarget,
+  interactionTransformPivot = interactionTransformPivot,
+  interactionPositionAnimationSpec = interactionPositionAnimationSpec,
+  interactionReducedMotionPolicy = interactionReducedMotionPolicy,
 )
 
 internal fun Modifier.hazeGlass(
@@ -65,10 +79,23 @@ internal fun Modifier.hazeGlass(
   sampling: HazeSampling,
   expandLayerBounds: Boolean,
   interactionSource: InteractionSource?,
+  interactionLightRadiusFraction: Float = GlassDefaults.interactionLightRadiusFraction,
+  interactionTransformTarget: GlassTransformTarget = GlassTransformTarget.MaterialOnly,
+  interactionTransformPivot: GlassTransformPivot = GlassTransformPivot.Pointer,
+  interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> = GlassDefaults.positionAnimationSpec,
+  interactionReducedMotionPolicy: GlassReducedMotionPolicy = GlassReducedMotionPolicy.System,
 ): Modifier = hazeEffect(
   factory = factory,
   input = input,
-  style = GlassNodeConfiguration(style, interactionSource),
+  style = GlassNodeConfiguration(
+    style = style,
+    interactionSource = interactionSource,
+    interactionLightRadiusFraction = interactionLightRadiusFraction,
+    interactionTransformTarget = interactionTransformTarget,
+    interactionTransformPivot = interactionTransformPivot,
+    interactionPositionAnimationSpec = interactionPositionAnimationSpec,
+    interactionReducedMotionPolicy = interactionReducedMotionPolicy,
+  ),
   sampling = sampling,
   expandLayerBounds = expandLayerBounds,
 )
@@ -77,6 +104,11 @@ internal fun Modifier.hazeGlass(
 internal class GlassNodeConfiguration(
   val style: GlassStyle,
   val interactionSource: InteractionSource?,
+  val interactionLightRadiusFraction: Float = GlassDefaults.interactionLightRadiusFraction,
+  val interactionTransformTarget: GlassTransformTarget = GlassTransformTarget.MaterialOnly,
+  val interactionTransformPivot: GlassTransformPivot = GlassTransformPivot.Pointer,
+  val interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> = GlassDefaults.positionAnimationSpec,
+  val interactionReducedMotionPolicy: GlassReducedMotionPolicy = GlassReducedMotionPolicy.System,
 )
 
 internal object GlassHazeEffectFactory :
@@ -94,6 +126,11 @@ internal object GlassHazeEffectFactory :
     val configuration = GlassVisualEffect().apply {
       this.style = style.style
       interactionSource = style.interactionSource
+      interactionLightRadiusFraction = style.interactionLightRadiusFraction
+      interactionTransformTarget = style.interactionTransformTarget
+      interactionTransformPivot = style.interactionTransformPivot
+      interactionPositionAnimationSpec = style.interactionPositionAnimationSpec
+      interactionReducedMotionPolicy = style.interactionReducedMotionPolicy
     }
     return GlassHazeEffectFactoryVisualEffect(
       configuration = configuration,
@@ -119,6 +156,11 @@ internal class GlassHazeEffectFactoryVisualEffect(
   override fun updateStyle(style: GlassNodeConfiguration, sampling: HazeSampling) {
     configuration.style = style.style
     configuration.interactionSource = style.interactionSource
+    configuration.interactionLightRadiusFraction = style.interactionLightRadiusFraction
+    configuration.interactionTransformTarget = style.interactionTransformTarget
+    configuration.interactionTransformPivot = style.interactionTransformPivot
+    configuration.interactionPositionAnimationSpec = style.interactionPositionAnimationSpec
+    configuration.interactionReducedMotionPolicy = style.interactionReducedMotionPolicy
   }
 
   override val observesPointerEvents: Boolean

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.CompositionLocal
 import androidx.compose.ui.geometry.Offset
@@ -31,6 +32,27 @@ import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalHazeApi::class)
 class GlassStyleTest {
+
+  @Test
+  fun interactionBlocks_chainAndReplacePerState() {
+    val style = GlassStyle {
+      hovered { lightingIntensity(0.2f) }
+      pressed {
+        animate(tween(100), tween(200)) {
+          refractionMultiplier(1.1f)
+        }
+      }
+    }.then {
+      hovered { lightingIntensity(0.6f) }
+    }
+
+    val slots = resolveGlassStyleInteractionSlots(GlassStyle, style)
+
+    assertThat(slots.hovered?.response?.lightingIntensity?.value).isEqualTo(0.6f)
+    assertThat(slots.pressed?.response?.refractionMultiplier?.value).isEqualTo(1.1f)
+    assertThat(slots.pressed?.response?.refractionMultiplier?.toSpec).isEqualTo(tween(100))
+    assertThat(slots.focused).isEqualTo(null)
+  }
 
   @Test
   fun styleChain_appliesWritesInOrder() {

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -34,6 +34,20 @@ import kotlinx.coroutines.CoroutineScope
 class GlassStyleTest {
 
   @Test
+  fun directInteractionOverride_canClearInheritedStyleResponse() {
+    val effect = GlassVisualEffect().apply {
+      style = GlassStyle { pressed { lightingIntensity(0.8f) } }
+      updateStyleInteractionSlots()
+    }
+    assertThat(effect.resolvedInteractionSlots.pressed?.response?.lightingIntensity?.value)
+      .isEqualTo(0.8f)
+
+    effect.clearPressed()
+
+    assertThat(effect.resolvedInteractionSlots.pressed).isEqualTo(null)
+  }
+
+  @Test
   fun interactionBlocks_chainAndReplacePerState() {
     val style = GlassStyle {
       hovered { lightingIntensity(0.2f) }

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
@@ -286,6 +286,42 @@ class HazeGlassModifierTest : ContextTest() {
     assertThat(firstRuntime.alpha).isEqualTo(0.8f)
     assertThat(secondRuntime.alpha).isEqualTo(0.8f)
   }
+
+  @Test
+  fun typedStyle_responseReplacement_updatesPointerTopologyWithoutReplacingRenderer() = runComposeUiTest {
+    val style = mutableStateOf(GlassStyle { focused { lightingIntensity(0.2f) } })
+    val factory = RecordingGlassFactory()
+
+    setContent {
+      Spacer(
+        Modifier.size(10.dp).hazeGlass(
+          factory = factory,
+          input = HazeInput.Content,
+          style = style.value,
+          sampling = HazeSampling.Default,
+          expandLayerBounds = true,
+          interactionSource = null,
+        ),
+      )
+    }
+    waitForIdle()
+
+    val effect = factory.effects.single()
+    val renderer = effect.delegate.renderer
+    assertThat(effect.delegate.observesPointerEvents).isEqualTo(false)
+
+    style.value = GlassStyle { pressed { lightingIntensity(0.8f) } }
+    waitForIdle()
+
+    assertThat(effect.delegate.renderer).isSameInstanceAs(renderer)
+    assertThat(effect.delegate.observesPointerEvents).isEqualTo(true)
+
+    style.value = GlassStyle
+    waitForIdle()
+
+    assertThat(effect.delegate.renderer).isSameInstanceAs(renderer)
+    assertThat(effect.delegate.observesPointerEvents).isEqualTo(false)
+  }
 }
 
 private class StructuralCase(


### PR DESCRIPTION
## Summary

- add declarative hover, focus, and press response blocks to shareable `GlassStyle`
- materialize interaction declarations into node-owned animation, signal, transform, and renderer state
- make typed `hazeGlass` pointer observation follow resolved responses while preserving its existing JVM entrypoint
- cover response replacement, pointer opt-in, and renderer reuse

## Validation

- focused `haze-glass` JVM and modifier tests
- Android host and API compatibility checks
- Metalava signature generation and compatibility
- Spotless
- repository-wide `check`
- library and Gallery screenshot suites; only the two known Gallery environment diffs reproduced from `main` (15.21% portrait, 15.32% landscape), with no baseline changes

Closes #1126
