### PR TITLE
Move Blur to replayable Style and typed hazeBlur

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,19 @@ Reads are observed in the phase where they occur:
 
 Those details are intentionally absent from the public typed renderer scopes.
 
+## Built-in Blur
+
+Blur uses the same typed node lifecycle through a narrow internal full-`VisualEffect` bridge. The
+bridge preserves the existing platform Blur implementations without exposing `VisualEffectContext`,
+source geometry, captured layers, platform contexts, delegates, or caches in the public semantic
+renderer scopes.
+
+`HazeBlurStyle` and the shared Blur factory are stateless. Each modifier node creates one
+`BlurVisualEffect` runtime that owns its resolved snapshot, invalidation state, adaptive-sampling
+history, delegate, retained output, render-effect cache, and platform resources. Style replacement
+replays defaults, the current composition-local Style, and the explicit Style into a fresh snapshot
+on that same runtime.
+
 ## Modules
 
 - **haze** — core state, source capture, typed custom-effect orchestration, and the temporary legacy
@@ -88,8 +101,10 @@ boundaries.
 
 ## Legacy compatibility
 
-`VisualEffect`, `VisualEffectContext`, `HazeEffectScope`, and the lambda-based modifier overloads
-remain temporarily available for Blur, Glass, and third-party migration. They expose more lifecycle
-and rendering internals and are no longer the recommended contract for new custom effects.
+`VisualEffect`, `VisualEffectContext`, `HazeEffectScope`, `BlurVisualEffect`,
+`HazeEffectScope.blurEffect`, and the lambda-based modifier overloads remain temporarily available
+for Blur, Glass, and third-party migration. They expose more lifecycle and rendering internals and
+are no longer the recommended contract for new Blur or custom effects. New Blur code uses
+`hazeBlur`; new custom effects use `HazeEffectFactory`.
 
 See [Custom effects](custom-effects.md) for the preferred API.

--- a/docs/blur/index.md
+++ b/docs/blur/index.md
@@ -37,7 +37,7 @@ The blur effect is supported on all platforms with platform-optimized implementa
 
 ## Basic Usage
 
-The blur effect is applied using the `blurEffect {}` builder within `Modifier.hazeEffect`:
+Apply Blur with the typed `Modifier.hazeBlur` API:
 
 ```kotlin
 val hazeState = rememberHazeState()
@@ -53,12 +53,10 @@ Box {
     }
 
     TopAppBar(
-        modifier = Modifier
-            .hazeEffect(state = hazeState) {
-                blurEffect {
-                    this.style = style
-                }
-            }
+        modifier = Modifier.hazeBlur(
+            input = HazeInput.Sources(hazeState),
+            style = style,
+        ),
     )
 }
 ```

--- a/docs/blur/materials.md
+++ b/docs/blur/materials.md
@@ -1,115 +1,56 @@
-# Blur Materials
+# Blur materials
 
-Pre-built blur style implementations that match common design systems.
-
-## Download
-
-[![Maven Central](https://img.shields.io/maven-central/v/dev.chrisbanes.haze/haze-blur-materials)](https://search.maven.org/search?q=g:dev.chrisbanes.haze)
+The `haze-blur-materials` artifact provides replayable Blur Styles for common design systems:
 
 ```kotlin
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    implementation("dev.chrisbanes.haze:haze-blur-materials:<version>")
+  implementation("dev.chrisbanes.haze:haze-blur-materials:<version>")
 }
 ```
 
-## HazeMaterials
+## Material
 
-Implementations of Material Design blur styles, inspired by SwiftUI Material APIs. These don't attempt to replicate exact iOS effects, but rather provide pleasant blur styles compatible with Material Design.
-
-![](../media/hazematerials.webp)
-
-Class reference: [HazeMaterials](../api/haze-materials/dev.chrisbanes.haze.blur.materials/-haze-materials/index.html).
-
-### Usage
+`HazeMaterials` provides `ultraThin()`, `thin()`, `regular()`, `thick()`, and `ultraThick()`:
 
 ```kotlin
-Box {
-  val style = HazeMaterials.thin()
-
-  LazyColumn(
-    modifier = Modifier.hazeSource(state = hazeState)
-  ) {
-    // content
-  }
-
-  TopAppBar(
-    modifier = Modifier.hazeEffect(state = hazeState) {
-      blurEffect {
-        this.style = style
-      }
-    }
-  )
-}
-```
-
-Available levels: `thin()`, `regular()`, `thick()`, and more.
-
-## CupertinoMaterials
-
-Blur styles matching Apple platforms (iOS, macOS). Values are taken from the [iOS 18 Figma](https://www.figma.com/community/file/1385659531316001292) file published by Apple.
-
-Use these for consistency when mixing Compose Multiplatform with SwiftUI.
-
-![](../media/cupertinomaterials.webp)
-
-Class reference: [CupertinoMaterials](../api/haze-materials/dev.chrisbanes.haze.blur.materials/-cupertino-materials/index.html).
-
-### Usage
-
-```kotlin
-val style = CupertinoMaterials.thin()
-
-blurEffect {
-  this.style = style
-}
-```
-
-## FluentMaterials
-
-Blur styles matching Windows platforms (WinUI 3). Values are taken from the WinUI 3 Figma file published by Microsoft.
-
-Use these for consistency when mixing Compose Multiplatform with WinUI.
-
-![](../media/fluentmaterials.webp)
-
-Class reference: [FluentMaterials](../api/haze-materials/dev.chrisbanes.haze.blur.materials/-fluent-materials/index.html).
-
-### Usage
-
-```kotlin
-val style = FluentMaterials.thin()
-
-blurEffect {
-  this.style = style
-}
-```
-
-## Custom Styles
-
-To create custom blur styles, use the [HazeBlurStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-haze-blur-style/index.html) data class:
-
-```kotlin
-val customStyle = HazeBlurStyle(
-  blurRadius = 15.dp,
-  colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.2f))),
-  noiseFactor = 0.1f
+Modifier.hazeBlur(
+  input = HazeInput.Sources(hazeState),
+  style = HazeMaterials.thin(),
 )
-
-blurEffect {
-  style = customStyle
-}
 ```
 
-Or set properties directly in the `blurEffect` block:
+## Cupertino
+
+`CupertinoMaterials` follows Apple platform materials:
 
 ```kotlin
-blurEffect {
-  blurRadius = 15.dp
-  colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.2f)))
-  noiseFactor = 0.1f
+Modifier.hazeBlur(
+  input = HazeInput.Sources(hazeState),
+  style = CupertinoMaterials.regular(),
+)
+```
+
+## Fluent
+
+`FluentMaterials` provides acrylic and Mica presets:
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Sources(hazeState),
+  style = FluentMaterials.acrylicDefault(),
+)
+```
+
+## Customizing a preset
+
+Material presets are ordinary replayable Styles. Chain additional writes without copying readable
+fields:
+
+```kotlin
+val compact = HazeMaterials.thin().then {
+  blurRadius(12.dp)
+  noiseFactor(0f)
 }
 ```
+
+The chained Style remains stateless and can be reused by concurrent modifiers.

--- a/docs/blur/platforms.md
+++ b/docs/blur/platforms.md
@@ -27,14 +27,15 @@ You can disable this behavior by setting the [preferPerformance](../api/haze/dev
 ```kotlin hl_lines="7"
 LargeTopAppBar(
   // ...
-  modifier = Modifier.hazeEffect(hazeState) {
-    blurEffect {
-      progressive = HazeProgressive.verticalGradient(
+  modifier = Modifier.hazeBlur(
+    input = HazeInput.Sources(hazeState),
+    style = HazeBlurStyle {
+      progressive(HazeProgressive.verticalGradient(
         // ...
         preferPerformance = true,
-      )
-    }
-  }
+      ))
+    },
+  )
 )
 ```
 

--- a/docs/blur/usage.md
+++ b/docs/blur/usage.md
@@ -1,14 +1,9 @@
-# Blur Usage
+# Blur usage
 
-This guide covers the blur effect in detail, including all available features and patterns.
+Blur works with either source-backed content or the modifier's own content. Both modes use the
+typed `hazeBlur` modifier and the same replayable Style.
 
-## Modes
-
-Blur works in two modes: 'background blurring' and 'foreground blurring'. Both modes use the same APIs and features, with the main difference being whether you need a `HazeState`.
-
-### Background Blurring (Most Common)
-
-Blurs content from elsewhere in the UI that's marked with `hazeSource`:
+## Source-backed Blur
 
 ```kotlin
 val hazeState = rememberHazeState()
@@ -18,370 +13,165 @@ Box {
   LazyColumn(
     modifier = Modifier
       .fillMaxSize()
-      .hazeSource(state = hazeState)
+      .hazeSource(hazeState),
   ) {
-    // scrollable content
+    // Content
   }
 
   TopAppBar(
-    modifier = Modifier
-      .hazeEffect(state = hazeState) {
-        blurEffect {
-          this.style = style
-        }
-      }
-      .fillMaxWidth(),
+    modifier = Modifier.hazeBlur(
+      input = HazeInput.Sources(hazeState),
+      style = style,
+    ),
   )
 }
 ```
 
-#### Retained Output
-
-Background blur may keep drawing the last captured output when all source areas disappear. This is
-intentional and helps source transitions avoid flashing to empty content. If the source may contain
-private content, disable retained output on the effect scope:
+`HazeInput.Sources` also owns source selection and retained-output behavior. The default
+`KeepLastFrame` policy avoids an empty flash during source transitions. Use
+`ClearWhenUnavailable` for privacy-sensitive content:
 
 ```kotlin
-Modifier.hazeEffect(state = hazeState) {
-  retainOutputWhenSourceUnavailable = false
-  blurEffect {
-    // ...
-  }
-}
-```
-
-### Foreground Blurring
-
-Blurs the content within the composable itself. No `HazeState` or `hazeSource` needed:
-
-```kotlin
-@Composable
-fun HazeExample(modifier: Modifier = Modifier) {
-  val style = HazeMaterials.thin()
-
-  Box(modifier = modifier) {
-    Foreground(
-      modifier = Modifier
-        .hazeEffect {
-          blurEffect {
-            this.style = style
-          }
-        }
-        .fillMaxSize()
-    )
-  }
-}
-```
-
-## Styling
-
-Blur appearance is controlled via the [HazeBlurStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-haze-blur-style/index.html) class or properties in the `blurEffect` block:
-
-Styles can be provided in multiple ways:
-
-- [LocalHazeBlurStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-local-haze-blur-style.html) composition local
-- `style` property inside `blurEffect {}` block
-- Individual properties in the `blurEffect {}` block
-
-### HazeEffectScope Lambda
-
-The `blurEffect` block receives properties you can set dynamically:
-
-```kotlin
-TopAppBar(
-  modifier = Modifier
-    .hazeEffect(state = hazeState) {
-      blurEffect {
-        alpha = if (listState.firstVisibleItemIndex == 0) {
-          listState.layoutInfo.visibleItemsInfo.first().let {
-            (it.offset / it.size.height.toFloat()).absoluteValue
-          }
-        } else {
-          1f
-        }
-      }
-    },
+Modifier.hazeBlur(
+  input = HazeInput.Sources(
+    state = hazeState,
+    retention = HazeSourceRetention.ClearWhenUnavailable,
+  ),
 )
 ```
 
-### Styling Resolution
+## Own-content Blur
 
-Each styling property is resolved using the following precedence:
-
-1. Value set in `blurEffect {}` block (if specified)
-2. Value set via `style` property in `blurEffect {}` (if specified)
-3. Value set in [LocalHazeBlurStyle](../api/haze-blur/dev.chrisbanes.haze.blur/-local-haze-blur-style.html) composition local
-4. Default value
-
-### Styling Properties
-
-#### Blur Radius
-
-Controls how strong the blur effect is. Defaults to `20.dp`. Larger values may be needed to keep foreground control (text) legible.
+Use `HazeInput.Content` when the modifier's own content is the input:
 
 ```kotlin
-blurEffect {
-  blurRadius = 20.dp
-}
-```
-
-#### Tint
-
-A tint effect is applied primarily to maintain contrast and legibility. By default, the provided background color is used at 70% opacity. You can provide multiple color effects applied in sequence:
-
-```kotlin
-blurEffect {
-  colorEffects = listOf(
-    HazeColorEffect.tint(Color.Black.copy(alpha = 0.2f)),
-    HazeColorEffect.tint(Color.Blue.copy(alpha = 0.1f))
-  )
-}
-```
-
-#### Noise
-
-Visual noise provides tactility. Defaults to `0.15f` (15% strength). Disable by setting to `0f`:
-
-```kotlin
-blurEffect {
-  noiseFactor = 0f  // Disable noise
-}
-```
-
-## Progressive (Gradient) Blurs
-
-Progressive blurs vary the blur radius across a dimension. This effect is common on iOS:
-
-![type:video](../media/progressive.mp4)
-
-Enable by setting the `progressive` property on [HazeEffectScope](../api/haze/dev.chrisbanes.haze/-haze-effect-scope/index.html):
-
-```kotlin
-TopAppBar(
-  modifier = Modifier.hazeEffect(hazeState) {
-    blurEffect {
-      progressive = HazeProgressive.verticalGradient(
-        startIntensity = 1f,
-        endIntensity = 0f
-      )
-    }
-  }
-)
-```
-
-### Linear Gradient
-
-Vertical, horizontal, or custom-angle gradients:
-
-```kotlin
-progressive = HazeProgressive.verticalGradient(
-  startIntensity = 1f,
-  endIntensity = 0f
-)
-
-// or horizontal
-progressive = HazeProgressive.horizontalGradient(
-  startIntensity = 1f,
-  endIntensity = 0f
-)
-```
-
-Class documentation: [HazeProgressive.LinearGradient](../api/haze/dev.chrisbanes.haze/-haze-progressive/-linear-gradient/index.html)
-
-### Radial Gradient
-
-A gradient radiating from a center point:
-
-```kotlin
-progressive = HazeProgressive.RadialGradient()
-```
-
-Class documentation: [HazeProgressive.RadialGradient](../api/haze/dev.chrisbanes.haze/-haze-progressive/-radial-gradient/index.html)
-
-### Custom Brush
-
-Use any [Brush](https://developer.android.com/develop/ui/compose/graphics/draw/brush) as an alpha mask:
-
-```kotlin
-progressive = HazeProgressive.Brush(
-  brush = Brush.verticalGradient(...)
-)
-```
-
-Class documentation: [HazeProgressive.Brush](../api/haze/dev.chrisbanes.haze/-haze-progressive/-brush/index.html)
-
-!!! warning "Performance of Progressive Blur"
-
-    Progressive blur comes with a performance cost. See the [Performance](../performance.md) page for benchmarks.
-
-    Quick summary: Android 13+ costs ~25% more than non-progressive. On Android 12 it's about 2x. Consider using masking below for better performance.
-
-## Masking
-
-Apply any [Brush](https://developer.android.com/develop/ui/compose/graphics/draw/brush) as an opacity mask:
-
-```kotlin
-TopAppBar(
-  modifier = Modifier.hazeEffect(state = hazeState) {
-    blurEffect {
-      mask = Brush.verticalGradient(
-        colors = listOf(Color.Black, Color.Transparent)
-      )
-    }
-  }
-)
-```
-
-!!! info "Mask vs Progressive"
-
-    Masks fade the effect through opacity only and may not feel as refined as progressive blur. However, masks are much faster with negligible performance cost.
-
-## Input Scale
-
-Blur effects adapt their input resolution by default. The policy considers the resolved blur radius
-in physical pixels and the expanded capture-layer pixel area, then chooses `1.0`, `0.8`, or `0.5`.
-Both inputs must cross a tier boundary, and hysteresis avoids retained-layer reallocations when an
-animated radius or resizing surface hovers near a boundary.
-
-![](../media/inputscale.png)
-
-```kotlin
-TopAppBar(
-  modifier = Modifier.hazeEffect(state = hazeState) {
-    blurEffect {
-      // ...
-    }
-  }
-)
-```
-
-[HazeInputScale](../api/haze/dev.chrisbanes.haze/-haze-input-scale/index.html) options:
-
-- `HazeInputScale.Default`: Let the visual effect choose. Blur adapts; Glass stays at `1.0`.
-- `HazeInputScale.None`: Explicitly disable scaling.
-- `HazeInputScale.Auto`: Explicitly request the effect's automatic policy.
-- `HazeInputScale.Fixed(...)`: Use the exact custom scaling factor (greater than `0.0`, up to `1.0`).
-
-The ordinary blur ladder uses:
-
-- `0.8` — 36% fewer input pixels for medium workloads.
-- `0.5` — 75% fewer input pixels for large surfaces with strong blur.
-
-Progressive blur stays at `1.0` for smaller workloads and never goes below `0.8`. A non-progressive
-mask uses the ordinary ladder. Scrim fallback does not perform a blur and remains at `1.0`.
-
-!!! info "Experimentation Recommended"
-
-    The default is quality-gated and intentionally conservative, but device backends and content
-    vary. Use `None` or `Fixed` when your own visual review or benchmarks call for a different
-    tradeoff.
-
-## Overlapping Blurred Layouts
-
-A layout can use both `hazeEffect` (drawing blur from other areas) and `hazeSource` (serving as a blur source for others):
-
-![](../media/overlap.webp)
-
-This enables overlapping blurred cards:
-
-```kotlin
-Box {
-  val hazeState = rememberHazeState()
-
-  Background(
-    modifier = Modifier.hazeSource(hazeState, zIndex = 0f)
-  )
-
-  // Rear card
-  CreditCard(
-    modifier = Modifier
-      .hazeSource(hazeState, zIndex = 1f)
-      .hazeEffect(hazeState)
-  )
-
-  // Middle card
-  CreditCard(
-    modifier = Modifier
-      .hazeSource(hazeState, zIndex = 2f)
-      .hazeEffect(hazeState),
-  )
-
-  // Front card
-  CreditCard(
-    modifier = Modifier
-      .hazeSource(hazeState, zIndex = 3f)
-      .hazeEffect(hazeState)
-  )
-}
-```
-
-The `zIndex` parameter tells Haze which layers to draw. By default, a `hazeEffect` draws all layers with a `zIndex` less than its sibling `hazeSource`.
-
-### Filtering Areas
-
-Control which layers are included via the `canDrawArea` filter:
-
-```kotlin
-CreditCard(
-  modifier = Modifier
-    .hazeSource(hazeState, zIndex = 2f, key = "foo")
-    .hazeEffect(hazeState) {
-      canDrawArea = { area ->
-        area.key != "foo"  // Exclude self
-      }
-    },
+Image(
+  modifier = Modifier.hazeBlur(
+    input = HazeInput.Content,
+    style = HazeMaterials.thin(),
+  ),
 )
 ```
 
 ## Enabling Blur
 
-Control whether blurring is active on individual effects:
+Blur is enabled by default only where Haze considers the platform implementation reliable. To
+override that decision, write `blurEnabled` in a Style:
 
 ```kotlin
-blurEffect {
-  blurEnabled = true  // or false to disable
+Modifier.hazeBlur(
+  input = HazeInput.Sources(hazeState),
+  style = HazeBlurStyle {
+    blurEnabled(true)
+  },
+)
+```
+
+When Blur is disabled, Haze draws the configured fallback scrim instead.
+
+## Replayable Styles
+
+`HazeBlurStyle` is an opaque program of Blur-specific writes:
+
+```kotlin
+val style = HazeBlurStyle {
+  blurEnabled(true)
+  blurRadius(20.dp)
+  noiseFactor(0.15f)
+  backgroundColor(Color.Black)
+  colorEffects(
+    listOf(
+      HazeColorEffect.tint(Color.White.copy(alpha = 0.12f)),
+    ),
+  )
+  fallbackColorEffect(HazeColorEffect.tint(Color.Black.copy(alpha = 0.7f)))
+  alpha(1f)
+  mask(null)
+  progressive(null)
+  blurredEdgeTreatment(BlurredEdgeTreatment.Rectangle)
 }
 ```
 
-## Dialogs
+Style resolution always replays these tiers in order:
 
-You can blur dialog backgrounds over content. **Important**: Tints display as a scrim over background with dialogs, so use a translucent dialog background color instead:
+1. `HazeBlurDefaults.style`
+2. `LocalHazeBlurStyle`
+3. The explicit `hazeBlur` Style
+
+The last write to a property wins, both across tiers and within a Style chain:
 
 ```kotlin
-val hazeState = rememberHazeState()
-var showDialog by remember { mutableStateOf(false) }
-val style = HazeMaterials.regular()
-
-Box {
-  if (showDialog) {
-    Dialog(onDismissRequest = { showDialog = false }) {
-      Surface(
-        modifier = Modifier
-          .fillMaxWidth()
-          .fillMaxHeight(fraction = .5f),
-        shape = MaterialTheme.shapes.extraLarge,
-        // Set translucent background instead of using tints
-        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.2f),
-      ) {
-        Box(
-          Modifier.hazeEffect(state = hazeState) {
-            blurEffect {
-              this.style = style
-            }
-          },
-        ) {
-          // Dialog content
-        }
-      }
-    }
-  }
-
-  LazyVerticalGrid(
-    modifier = Modifier.hazeSource(state = hazeState),
-  ) {
-    // Background content
-  }
+val compact = HazeMaterials.thin().then {
+  blurRadius(12.dp)
+  noiseFactor(0f)
 }
 ```
 
-Complete sample: [DialogSample](https://github.com/chrisbanes/haze/blob/main/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt)
+Every evaluation starts from fresh defaults. If a replacement Style omits `blurRadius`, the local
+or default value becomes visible immediately; the previous explicit value cannot stick. A Style
+can be shared by concurrent modifiers because it contains no renderer, delegate, cache, retained
+layer, or lifecycle state.
+
+Caller-owned color-effect lists are snapshotted when the Style is created. An explicit empty list
+clears inherited color effects:
+
+```kotlin
+val noColorEffects = HazeBlurStyle {
+  colorEffects(emptyList())
+}
+```
+
+## Progressive Blur and masks
+
+Progressive Blur varies intensity across the surface:
+
+```kotlin
+val progressiveStyle = HazeBlurStyle {
+  progressive(
+    HazeProgressive.verticalGradient(
+      startIntensity = 1f,
+      endIntensity = 0f,
+    ),
+  )
+}
+```
+
+A mask fades the effect's opacity and is usually cheaper:
+
+```kotlin
+val maskedStyle = HazeBlurStyle {
+  mask(
+    Brush.verticalGradient(
+      colors = listOf(Color.Black, Color.Transparent),
+    ),
+  )
+}
+```
+
+## Input scale
+
+### Sampling and layer expansion
+
+Sampling and layer expansion are structural modifier policies, not Style properties:
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Sources(hazeState),
+  style = style,
+  sampling = HazeSampling.Adaptive,
+  expandLayerBounds = true,
+)
+```
+
+- `HazeSampling.Default` uses Blur's adaptive policy.
+- `HazeSampling.FullResolution` disables input downscaling.
+- `HazeSampling.Adaptive` explicitly requests the adaptive policy.
+- `HazeSampling.Fixed(scale)` uses a fixed scale in `0 < scale <= 1`.
+
+Adaptive Blur considers the physical Blur radius and expanded capture-layer area, with hysteresis
+between its quality tiers.
+
+## Temporary legacy boundary
+
+`BlurVisualEffect`, `HazeEffectScope.blurEffect`, and the lambda-based `hazeEffect` overloads remain
+temporarily available for staged migration. New code should use `hazeBlur` and replayable Styles.

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -1,359 +1,344 @@
-# Core Concepts
+# Core concepts
 
-This page explains the fundamental concepts and patterns used throughout Haze, regardless of which effect you're using.
+Haze separates captured input, shareable configuration, and node-owned rendering resources.
 
-## HazeState
+## Sources
 
-`HazeState` is a state holder that manages the rendering targets for visual effects. You create one using `rememberHazeState()`:
+`HazeState` connects one or more `hazeSource` modifiers to source-backed effects:
 
 ```kotlin
 val hazeState = rememberHazeState()
-```
 
-This state is then shared between a `Modifier.hazeSource` (content to blur from) and one or more `Modifier.hazeEffect` (content to apply the blur to).
-
-## Modifiers
-
-Haze provides two main modifiers that work together:
-
-### Modifier.hazeSource
-
-Marks a composable as a source of content that can be blurred by effects elsewhere in the hierarchy.
-
-```kotlin
 LazyColumn(
-    modifier = Modifier
-        .fillMaxSize()
-        .hazeSource(state = hazeState)
+  modifier = Modifier.hazeSource(hazeState),
 ) {
-    // content
+  // Content
 }
 ```
 
-Parameters:
+Sources can have a `zIndex` and metadata `key`. `HazeSourceSelection.Behind` is the default. With
+a nearest ancestor `hazeSource` using the same state, it selects lower-z sources; without one, it
+selects every source. `HazeSourceSelection.All` bypasses the ancestor relationship.
 
-- **state**: The `HazeState` instance to share
-- **zIndex**: Optional z-index for layering (when using overlapping effects)
-- **key**: Optional identifier for filtering which areas to draw
-
-### Modifier.hazeEffect
-
-Applies a visual effect to a composable, drawing blurred content from areas marked with `Modifier.hazeSource`.
-
-```kotlin
-val style = HazeMaterials.thin()
-
-TopAppBar(
-    modifier = Modifier.hazeEffect(
-        input = HazeInput.Sources(hazeState),
-    ) {
-        blurEffect {
-            this.style = style
-        }
-    }
-)
-```
-
-The required `input` makes the source mode explicit:
-
-- `HazeInput.Sources(hazeState)` consumes content captured by matching `hazeSource` modifiers.
-- `HazeInput.Content` captures the modifier's own content.
-
-The effect is configured inside the lambda block using effect-specific builders. The older
-nullable-state overloads remain available during the Haze 2 migration.
-
-#### Selecting sources
-
-`HazeInput.Sources` defaults to `HazeSourceSelection.Behind`. With a nearest ancestor
-`hazeSource` using the same state, this selects lower-z sources. Without one, it selects every
-source. Use `All` to bypass the ancestor relationship:
-
-```kotlin
-HazeInput.Sources(
-    state = hazeState,
-    selection = HazeSourceSelection.All,
-)
-```
-
-Refine either relationship with `where`. Predicates receive only an immutable snapshot of the
-source `key` and `zIndex`; renderer-owned geometry, content, and platform resources stay private.
-Repeated refinements combine with logical AND:
+Refine either selection with `where`. Predicates receive only immutable `key` and `zIndex`
+metadata, not captured pixels or renderer resources. Repeated refinements combine with logical
+AND:
 
 ```kotlin
 val selection = HazeSourceSelection.Behind
-    .where { source -> source.zIndex >= 1f }
-    .where { source -> source.key != "sensitive" }
+  .where { source -> source.zIndex >= 1f }
+  .where { source -> source.key != "sensitive" }
 ```
 
-#### Rendering policies
+## Explicit inputs
 
-The explicit-input overload also makes sampling and layer expansion structural:
+Typed effects always declare what they consume:
+
+- `HazeInput.Sources(hazeState)` consumes captured source content.
+- `HazeInput.Content` consumes the modifier's own content.
+
+Source-backed input also declares retention:
 
 ```kotlin
-Modifier.hazeEffect(
-    input = HazeInput.Sources(
-        state = hazeState,
-        retention = HazeSourceRetention.ClearWhenUnavailable,
-    ),
-    sampling = HazeSampling.Adaptive,
-    expandLayerBounds = false,
-) {
-    blurEffect { /* ... */ }
+HazeInput.Sources(
+  state = hazeState,
+  retention = HazeSourceRetention.ClearWhenUnavailable,
+)
+```
+
+`KeepLastFrame` smooths temporary source gaps. `ClearWhenUnavailable` clears retained output as
+soon as no selected source is drawable.
+
+## Typed Blur
+
+Blur has an ordinary typed modifier:
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Sources(hazeState),
+  style = HazeMaterials.thin(),
+  sampling = HazeSampling.Default,
+  expandLayerBounds = true,
+)
+```
+
+Use `HazeInput.Content` for own-content Blur. The structural input, retention, sampling, and layer
+expansion policies do not live in `HazeBlurStyle`.
+
+`HazeBlurStyle` is an opaque replayable program:
+
+```kotlin
+val style = HazeBlurStyle {
+  blurRadius(20.dp)
+  colorEffects(
+    listOf(HazeColorEffect.tint(Color.White.copy(alpha = 0.12f))),
+  )
+}.then {
+  noiseFactor(0f)
 }
 ```
 
-- `HazeSourceRetention.KeepLastFrame` is the default and preserves smooth source transitions.
-  Use `ClearWhenUnavailable` for privacy-sensitive surfaces that must not display stale pixels.
-- `HazeSampling.Default` lets the effect choose, `FullResolution` disables scaling,
-  `Adaptive` requests the effect's adaptive policy, and `Fixed(scale)` uses a validated
-  `0 < scale <= 1` value.
-- `expandLayerBounds` is non-null and defaults to `true`. Set it to `false` to constrain the
-  effect layer to the composable's ordinary bounds.
+Resolution replays `HazeBlurDefaults.style`, `LocalHazeBlurStyle`, and the explicit Style in order.
+The last write wins, and every evaluation starts fresh. Styles contain no mutable renderer or
+platform state and can be shared by concurrent modifiers.
 
-These structural arguments are authoritative on the explicit-input overload.
+## Typed custom effects
 
-## HazeEffectScope
-
-The lambda block parameter of `Modifier.hazeEffect` receives a `HazeEffectScope`, which provides
-common properties applicable to all effects. `inputScale`, `canDrawArea`,
-`retainOutputWhenSourceUnavailable`, and nullable `expandLayerBounds` remain available for the
-legacy modifier overloads; prefer the structural contracts above on the explicit-input path.
-
-### Common Properties
+Custom effects use a stateless factory and one renderer per modifier node:
 
 ```kotlin
-modifier = Modifier.hazeEffect(state = hazeState) {
-    // Common properties
-    inputScale = HazeInputScale.Auto
-    drawContentBehind = true
-    canDrawArea = { area -> true }
-    retainOutputWhenSourceUnavailable = true
-
-    // Effect-specific configuration
-    blurEffect {
-        // ...
+val factory = HazeEffectFactory<MyStyle> {
+  object : HazeEffectRenderer<MyStyle> {
+    override fun HazeEffectDrawScope.draw(style: MyStyle) {
+      drawInput()
+      // Draw the effect.
     }
+  }
 }
+
+Modifier.hazeEffect(
+  factory = factory,
+  input = HazeInput.Content,
+  style = MyStyle(...),
+)
 ```
 
-#### inputScale
+The renderer can own mutable resources and releases them in `dispose`. Style replacement updates
+the existing renderer. Factory replacement and detachment dispose it exactly once.
 
-Controls the resolution at which the effect source content is rendered. This is a performance optimization that allows the effect to be applied at a lower resolution before being scaled back up.
+## Sampling
 
-Options:
+- `HazeSampling.Default` lets the effect choose.
+- `HazeSampling.FullResolution` uses the full input resolution.
+- `HazeSampling.Adaptive` requests the effect's adaptive policy.
+- `HazeSampling.Fixed(scale)` uses `0 < scale <= 1`.
 
-- `HazeInputScale.Default`: Let the visual effect choose its policy. Blur adapts to physical
-  workload; Glass remains unscaled.
-- `HazeInputScale.None`: Explicitly disable scaling.
-- `HazeInputScale.Auto`: Explicitly request the visual effect's automatic policy.
-- `HazeInputScale.Fixed(value)`: Use the exact fixed scale (greater than `0.0`, up to `1.0`).
+Blur's default policy is adaptive. It considers physical Blur radius and capture-layer area, with
+hysteresis between quality tiers.
 
-#### drawContentBehind
+## Layer bounds
 
-When `true`, the original source content is drawn before the effect is applied. When `false`, only the effect is drawn. Defaults to `false`.
+`expandLayerBounds` lets an effect request a larger capture layer. Blur normally expands by its
+resolved radius to avoid edge artifacts. Disable it only when the surrounding pixels must not be
+captured.
 
-#### canDrawArea
+## Legacy effect scope
 
-An optional filter function that controls which source areas should be included in the effect rendering. Useful for excluding specific layers:
-
-```kotlin
-canDrawArea = { area ->
-    // return true to include, false to exclude
-    area.key != "exclude_me"
-}
-```
-
-#### retainOutputWhenSourceUnavailable
-
-Some effects can retain and redraw their last output when all source areas disappear. This keeps
-source transitions visually smooth, for example when content is temporarily removed while an
-effect surface remains visible.
-
-The default is `true`. For privacy-sensitive UI, set this to `false` so stale source pixels are
-cleared as soon as there is no source content to draw:
+Lambda-based `Modifier.hazeEffect` receives a `HazeEffectScope`. It remains available while
+existing custom effects and Blur callers migrate:
 
 ```kotlin
 Modifier.hazeEffect(state = hazeState) {
-    retainOutputWhenSourceUnavailable = false
-    blurEffect { /* ... */ }
+  inputScale = HazeInputScale.Auto
+  drawContentBehind = true
+  canDrawArea = { area -> area.key != "excluded" }
+  retainOutputWhenSourceUnavailable = true
+
+  blurEffect {
+    // Legacy Blur configuration
+  }
 }
 ```
 
-## Foreground vs Background Effects
+### Input scale
 
-Haze supports two modes of applying effects:
+`inputScale` controls the resolution used to render source content:
 
-### Background Effect (Most Common)
+- `HazeInputScale.Default` lets the visual effect choose. Blur uses its adaptive policy; Glass
+  remains unscaled.
+- `HazeInputScale.None` disables scaling.
+- `HazeInputScale.Auto` requests the effect's automatic policy.
+- `HazeInputScale.Fixed(value)` uses an exact value greater than `0f` and at most `1f`.
 
-The effect blurs content from elsewhere (behind the composable). Requires both `hazeSource` and `hazeEffect`:
+Typed effects express the same choice through `HazeSampling`.
+
+### Drawing content behind
+
+`drawContentBehind` draws the original source content before the effect. It defaults to `false`.
+Built-in typed effects select the required behavior themselves.
+
+### Filtering source areas
+
+`canDrawArea` filters legacy `HazeArea` instances:
+
+```kotlin
+canDrawArea = { area -> area.key != "excluded" }
+```
+
+Typed source input uses `HazeSourceSelection.where`, which intentionally exposes only immutable
+`key` and `zIndex` metadata.
+
+### Retained output
+
+Some effects can redraw their last output while source areas are temporarily unavailable.
+`retainOutputWhenSourceUnavailable` defaults to `true` for the legacy API. Set it to `false` when
+stale source pixels must be cleared immediately:
+
+```kotlin
+Modifier.hazeEffect(state = hazeState) {
+  retainOutputWhenSourceUnavailable = false
+  blurEffect {
+    // Legacy Blur configuration
+  }
+}
+```
+
+Typed source input expresses this policy with `HazeSourceRetention.KeepLastFrame` or
+`ClearWhenUnavailable`.
+
+## Temporary legacy APIs
+
+The `VisualEffect`, `HazeEffectScope`, and lambda-based `hazeEffect` APIs remain during the staged
+2.0 migration. Blur code should move to `hazeBlur`; custom effects should use
+`HazeEffectFactory`.
+
+## Background and foreground effects
+
+Source-backed effects render captured content from elsewhere in the hierarchy:
 
 ```kotlin
 Box {
-    LazyColumn(
-        modifier = Modifier.hazeSource(state = hazeState)
-    ) {
-        // content
-    }
-    
-    TopAppBar(
-        modifier = Modifier.hazeEffect(
-            input = HazeInput.Sources(hazeState),
-        ) {
-            blurEffect { /* ... */ }
-        }
-    )
+  LazyColumn(
+    modifier = Modifier.hazeSource(hazeState),
+  ) {
+    // Content
+  }
+
+  TopAppBar(
+    modifier = Modifier.hazeBlur(
+      input = HazeInput.Sources(hazeState),
+    ),
+  )
 }
 ```
 
-### Foreground Effect
-
-The effect blurs the content within the composable itself. Only requires `hazeEffect`:
+Own-content effects capture and transform the modifier's content:
 
 ```kotlin
 Box(
-    modifier = Modifier.hazeEffect(input = HazeInput.Content) {
-        blurEffect { /* ... */ }
-    }
+  modifier = Modifier.hazeBlur(input = HazeInput.Content),
 ) {
-    // This content will be blurred
+  // This content is blurred.
 }
 ```
 
-## Deep UI Hierarchies
+## Deep UI hierarchies
 
-When `HazeState` needs to be passed through many levels of nested composables, you can use a composition local instead:
+When `HazeState` would otherwise pass through many composables, provide it through a composition
+local:
 
 ```kotlin
 val LocalHazeState = compositionLocalOf { HazeState() }
 
 @Composable
 fun HazeExample() {
-    val hazeState = rememberHazeState()
-    
-    CompositionLocalProvider(LocalHazeState provides hazeState) {
-        Box {
-            Background()
-            Foreground()
-        }
+  val hazeState = rememberHazeState()
+
+  CompositionLocalProvider(LocalHazeState provides hazeState) {
+    Box {
+      Background()
+      Foreground()
     }
+  }
 }
 
 @Composable
 fun Foreground() {
-    Text(
-        modifier = Modifier.hazeEffect(state = LocalHazeState.current) {
-            blurEffect { /* ... */ }
-        }
-    )
+  Text(
+    modifier = Modifier.hazeBlur(
+      input = HazeInput.Sources(LocalHazeState.current),
+    ),
+  )
 }
 ```
 
-## Overlapping Effects
+## Overlapping effects
 
-You can have multiple composables that both draw effects from the same source and serve as sources for other effects. This enables complex layering:
+One composable can both consume lower sources and become a source for a higher effect. Give each
+source an explicit `zIndex`:
 
 ```kotlin
 Box {
-    val hazeState = rememberHazeState()
-    
-    Background(
-        modifier = Modifier.hazeSource(hazeState, zIndex = 0f)
-    )
-    
-    Card(
-        modifier = Modifier
-            .hazeSource(hazeState, zIndex = 1f)
-            .hazeEffect(hazeState)
-    )
-    
-    TopAppBar(
-        modifier = Modifier
-            .hazeSource(hazeState, zIndex = 2f)
-            .hazeEffect(hazeState)
-    )
+  Background(
+    modifier = Modifier.hazeSource(hazeState, zIndex = 0f),
+  )
+
+  Card(
+    modifier = Modifier
+      .hazeSource(hazeState, zIndex = 1f)
+      .hazeBlur(input = HazeInput.Sources(hazeState)),
+  )
+
+  TopAppBar(
+    modifier = Modifier
+      .hazeSource(hazeState, zIndex = 2f)
+      .hazeBlur(input = HazeInput.Sources(hazeState)),
+  )
 }
 ```
 
-In this example:
-- Background is at zIndex 0
-- Card at zIndex 1 draws the background through its effect
-- TopAppBar at zIndex 2 draws both background and card through its effect
+The Card consumes the Background, while the TopAppBar consumes both lower sources.
 
 ## Dialogs
 
-When using effects with dialogs, the effect source must be marked before the dialog is shown:
+Mark the source before showing a dialog. Haze can then align a source and effect that live in
+different windows:
 
 ```kotlin
-val hazeState = rememberHazeState()
-var showDialog by remember { mutableStateOf(false) }
-
 Box {
-    LazyColumn(
-        modifier = Modifier.hazeSource(state = hazeState)
-    ) {
-        // background content
+  LazyColumn(
+    modifier = Modifier.hazeSource(hazeState),
+  ) {
+    // Background content
+  }
+
+  if (showDialog) {
+    Dialog(onDismissRequest = { showDialog = false }) {
+      Surface(
+        modifier = Modifier.hazeBlur(
+          input = HazeInput.Sources(hazeState),
+        ),
+      ) {
+        // Dialog content
+      }
     }
-    
-    if (showDialog) {
-        Dialog(onDismissRequest = { showDialog = false }) {
-            Surface(
-                modifier = Modifier.hazeEffect(state = hazeState) {
-                    blurEffect { /* ... */ }
-                }
-            ) {
-                // dialog content
-            }
-        }
-    }
+  }
 }
 ```
 
-## Position Strategy
+## Position strategy
 
-Haze needs to calculate the position of source and effect nodes to align the blur correctly. By default, `HazeState` uses `HazePositionStrategy.Auto`, which works for most scenarios without any configuration.
+`HazePositionStrategy.Auto` is the default. It uses root-relative coordinates when source and
+effect share a window, and screen coordinates for cross-window arrangements such as dialogs and
+popups.
 
 ```kotlin
-val hazeState = rememberHazeState() // Auto strategy (default)
+val hazeState = rememberHazeState()
 ```
 
-### How it works
-
-- **Same window**: Haze uses root-relative coordinates (`positionInRoot()`). This is the most common case and the most performant.
-- **Cross-window** (dialogs, popups): Haze automatically detects when source and effect are in different windows and promotes to screen-level coordinates.
-
-### Manual override
-
-In rare cases you may want to force a specific strategy:
+Override the strategy only when the host window arrangement requires a fixed coordinate space:
 
 ```kotlin
-// Force root-relative coordinates (same-window only)
-val hazeState = rememberHazeState(positionStrategy = HazePositionStrategy.Local)
-
-// Force screen-level coordinates
-val hazeState = rememberHazeState(positionStrategy = HazePositionStrategy.Screen)
+val localState = rememberHazeState(positionStrategy = HazePositionStrategy.Local)
+val screenState = rememberHazeState(positionStrategy = HazePositionStrategy.Screen)
 ```
 
 | Strategy | Coordinates | Use case |
-|----------|-------------|----------|
-| `Auto` | Adapts automatically | Default — handles everything |
-| `Local` | `positionInRoot()` | Same-window; immune to split-window offset issues |
-| `Screen` | `positionOnScreen()` | Cross-window setups |
+| --- | --- | --- |
+| `Auto` | Adapts automatically | Default for same- and cross-window layouts |
+| `Local` | Root-relative | Same-window layouts |
+| `Screen` | Screen-relative | Explicit cross-window layouts |
 
-## Screenshot Testing
+## Screenshot testing
 
-Haze supports screenshot testing with platform-specific considerations:
-
-### Android with Robolectric
-
-The `RenderEffect.createBlurEffect()` tile mode support was only recently added to Robolectric. For correct results at effect edges, run tests against SDK 35+:
+On Android, run Robolectric screenshot tests against SDK 35 or newer. Earlier Robolectric SDK
+levels do not fully reproduce the blur tile modes used at effect edges:
 
 ```kotlin
 @Config(sdk = [35])
 class MyScreenshotTest {
-    // tests
+  // Tests
 }
 ```
 
-Without this, you may see strange results at effect boundaries on earlier SDK levels (though this doesn't affect real devices).
-
-Other screenshot testing libraries may work but haven't been tested. YMMV.
+This limitation affects the test environment, not the equivalent effect on a physical device.

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -1,481 +1,284 @@
 # Migrating to Haze 2.0
 
-Haze 2.0 introduces a major architectural refactor that improves modularity and extensibility by introducing a pluggable visual effects system. While this is a breaking change, the migration path is straightforward and the core usage patterns remain familiar.
+Haze 2.0 separates structural input policy, shareable Style, and node-owned rendering resources.
+The preferred Blur API is now the typed `Modifier.hazeBlur`.
 
-## Overview of Changes
+## Dependencies and imports
 
-The primary change in v2 is the extraction of blur functionality from the core `haze` module into a separate `haze-blur` module. This is part of a new architecture that introduces the `VisualEffect` interface, allowing Haze to support different types of visual effects beyond just blurring.
-
-**Key Changes:**
-
-- **Hard source break:** v1 blur convenience names and root-package aliases are removed in v2.
-- **New module dependency:** Blur functionality now requires the `haze-blur` module
-- **Materials artifact rename:** Blur material presets are now published as `haze-blur-materials`.
-- **API nesting:** All blur properties now require a `blurEffect {}` wrapper
-- **Package changes:** Blur APIs moved to `dev.chrisbanes.haze.blur`; blur materials moved to `dev.chrisbanes.haze.blur.materials`.
-- **Removed v1 aliases:** `haze`, `hazeChild`, `HazeDefaults`, `HazeStyle`, `HazeTint`, `LocalHazeStyle`, and `HazeDialog` are removed.
-- **Glass style grouping:** `GlassStyle` parameters are grouped into `optics`, `lighting`, `color`, and `rendering`.
-- **Removed APIs:** `HazeState.blurEnabled` and the `rememberHazeState(blurEnabled)` parameter removed.
-- **Position strategy:** New `HazePositionStrategy` configuration on `HazeState`
-- **Geometry changes:** `HazeArea.positionOnScreen` is replaced by `HazeArea.coordinates`; `VisualEffectContext` now exposes `position`, `rootBounds`, `positionOf(area)`, and `boundsOf(area)`.
-- **Adaptive blur input scaling:** `HazeInputScale.Default` now lets each visual effect choose its
-  policy. Blur uses a quality-gated adaptive ladder; Glass remains unscaled. Set
-  `HazeInputScale.None` to preserve explicit full-resolution blur input.
-  `HazeInputScale.EffectDefault` is the new sealed subtype backing `Default`; exhaustive `when`
-  expressions over `HazeInputScale` must handle it (or add an `else` branch).
-- **Explicit input and rendering policies:** The new `hazeEffect(input = ...)` overload uses
-  `HazeInput.Sources` or `HazeInput.Content`, metadata-only source selection,
-  `HazeSourceRetention`, `HazeSampling`, and a non-null `expandLayerBounds` argument.
-
-**What Hasn't Changed:**
-
-- `hazeSource` remains in the core module
-- `hazeEffect` remains in the core module, but blur-specific style parameters moved into `blurEffect {}`.
-- Platform support unchanged
-- `HazeEffectScope` properties like `drawContentBehind` and `canDrawArea` unchanged
-
-## Dependency Changes
-
-### Add the haze-blur Module
-
-In addition to the core `haze` module, you now need to explicitly add the `haze-blur` module to use blur effects:
+Blur lives in `haze-blur`, with optional presets in `haze-blur-materials`:
 
 ```kotlin
 dependencies {
-  implementation("dev.chrisbanes.haze:haze:2.0.0-alpha03")
-  implementation("dev.chrisbanes.haze:haze-blur:2.0.0-alpha03") // NEW in v2
+  implementation("dev.chrisbanes.haze:haze:<version>")
+  implementation("dev.chrisbanes.haze:haze-blur:<version>")
+  implementation("dev.chrisbanes.haze:haze-blur-materials:<version>")
 }
 ```
 
-### Rename the Materials Artifact
-
-If you use the pre-built Material, Cupertino, or Fluent blur styles, replace the v1 materials artifact with the renamed v2 artifact:
-
 ```kotlin
-dependencies {
-  // v1
-  implementation("dev.chrisbanes.haze:haze-materials:1.7.2")
-
-  // v2
-  implementation("dev.chrisbanes.haze:haze-blur-materials:2.0.0-alpha03")
-}
-```
-
-`haze-materials` is the old 1.x artifact. It does not publish 2.0 versions.
-
-### Update Imports
-
-Several blur-related classes have moved to the `dev.chrisbanes.haze.blur` package:
-
-**V1 imports:**
-```kotlin
-import dev.chrisbanes.haze.HazeStyle
-import dev.chrisbanes.haze.HazeTint
-import dev.chrisbanes.haze.HazeProgressive
-import dev.chrisbanes.haze.LocalHazeStyle
-import dev.chrisbanes.haze.materials.HazeMaterials
-```
-
-**V2 imports:**
-```kotlin
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.HazeColorEffect
-import dev.chrisbanes.haze.HazeProgressive
-import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
-import dev.chrisbanes.haze.blur.blurEffect // NEW: extension function
-import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.blur.hazeBlur
 ```
 
-Blur-specific defaults from `HazeDefaults` are now in `HazeBlurDefaults`. `HazeDefaults.drawContentBehind` has no direct replacement; leave `drawContentBehind` unset or set it directly on `HazeEffectScope`.
+`HazeProgressive` remains in the core `dev.chrisbanes.haze` package.
 
-### HazeProgressive moved to core
+## Migrate source-backed Blur
 
-`HazeProgressive` now lives in `dev.chrisbanes.haze.HazeProgressive` because progressive masks are shared by blur and Glass. The old `dev.chrisbanes.haze.blur.HazeProgressive` name remains as a deprecated typealias for source compatibility during the v2 alpha cycle.
-
-## API Migration
-
-### Basic Blur Configuration
-
-All blur-related properties that were previously set directly on `HazeEffectScope` now need to be wrapped in a `blurEffect {}` block.
-
-=== "v1"
-
-    ```kotlin
-    Modifier.hazeEffect(state = hazeState) {
-      blurRadius = 20.dp
-      tints = listOf(HazeTint(Color.Black.copy(alpha = 0.7f)))
-      noiseFactor = 0.15f
-    }
-    ```
-
-=== "v2"
-
-    ```kotlin
-    Modifier.hazeEffect(state = hazeState) {
-      blurEffect {  // NEW: wrap blur properties
-        blurRadius = 20.dp
-        colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.7f)))
-        noiseFactor = 0.15f
-      }
-    }
-    ```
-
-### Using Material Styles
-
-=== "v1"
-
-    ```kotlin
-    Modifier.hazeEffect(state = hazeState, style = HazeMaterials.ultraThin())
-    ```
-
-=== "v2"
-
-    ```kotlin
-    val style = HazeMaterials.ultraThin()
-
-    Modifier.hazeEffect(state = hazeState) {
-      blurEffect {
-        this.style = style
-      }
-    }
-    ```
-
-### Glass Style Grouping
-
-Flat `GlassStyle` construction has been grouped by concept.
+Before:
 
 ```kotlin
-// Before
-GlassStyle(
-  tint = Color.White.copy(alpha = 0.12f),
-  refractionStrength = 0.7f,
-  specularIntensity = 0.4f,
-  depth = 0.4f,
-  edgeSoftness = 12.dp,
-)
-
-// After
-GlassStyle(
-  tint = Color.White.copy(alpha = 0.12f),
-  optics = GlassOptics.Absolute(
-    refractionStrength = 0.7f,
-    depth = 0.4f,
-  ),
-  lighting = GlassLighting(
-    specularIntensity = 0.4f,
-  ),
-  rendering = GlassRendering(
-    edgeSoftness = 12.dp,
-  ),
-)
-```
-
-### Progressive Blurs
-
-=== "v1"
-
-    ```kotlin
-    Modifier.hazeEffect(state = hazeState) {
-      progressive = HazeProgressive.verticalGradient(startIntensity = 1f, endIntensity = 0f)
-    }
-    ```
-
-=== "v2"
-
-    ```kotlin
-    Modifier.hazeEffect(state = hazeState) {
-      blurEffect {
-        progressive = HazeProgressive.verticalGradient(startIntensity = 1f, endIntensity = 0f)
-      }
-    }
-    ```
-
-### Masking
-
-=== "v1"
-
-    ```kotlin
-    Modifier.hazeEffect(state = hazeState) {
-      mask = Brush.verticalGradient(...)
-    }
-    ```
-
-=== "v2"
-
-    ```kotlin
-    Modifier.hazeEffect(state = hazeState) {
-      blurEffect {
-        mask = Brush.verticalGradient(...)
-      }
-    }
-    ```
-
-### Enabling/Disabling Blur
-
-=== "v1"
-
-    ```kotlin
-    // At the state level (REMOVED in v2)
-    val hazeState = rememberHazeState(blurEnabled = true)
-
-    // At the effect level
-    Modifier.hazeEffect(state = hazeState) {
-      blurEnabled = true
-    }
-    ```
-
-=== "v2"
-
-    ```kotlin
-    // At the state level - parameter removed
-    val hazeState = rememberHazeState()
-
-    // At the effect level - now inside blurEffect {}
-    Modifier.hazeEffect(state = hazeState) {
-      blurEffect {
-        blurEnabled = true
-      }
-    }
-    ```
-
-### Foreground Blurring
-
-=== "v1"
-
-    ``` kotlin
-    Modifier.hazeEffect {
-      tints = listOf(HazeTint(Color.Black.copy(alpha = 0.5f)))
-      progressive = HazeProgressive.verticalGradient(...)
-    }
-    ```
-
-=== "v2"
-
-    ``` kotlin
-    Modifier.hazeEffect {
-      blurEffect {
-        colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.5f)))
-        progressive = HazeProgressive.verticalGradient(...)
-      }
-    }
-    ```
-
-### Adopt Explicit Inputs and Rendering Policies
-
-The nullable-state overloads remain available during the staged Haze 2 migration. New code can
-make foreground versus source-backed input explicit without waiting for the later effect-specific
-modifier APIs:
-
-```kotlin
-// Source-backed input
-Modifier.hazeEffect(
-    input = HazeInput.Sources(hazeState),
-) {
-    blurEffect { /* ... */ }
-}
-
-// The modifier's own content
-Modifier.hazeEffect(input = HazeInput.Content) {
-    blurEffect { /* ... */ }
+Modifier.hazeEffect(hazeState) {
+  blurEffect {
+    blurRadius = 20.dp
+    colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.7f)))
+  }
 }
 ```
 
-Map legacy scope policies to structural values as follows:
+After:
 
 ```kotlin
-Modifier.hazeEffect(
-    input = HazeInput.Sources(
-        state = hazeState,
-        selection = HazeSourceSelection.Behind
-            .where { source -> source.key != "excluded" },
-        retention = HazeSourceRetention.ClearWhenUnavailable,
+Modifier.hazeBlur(
+  input = HazeInput.Sources(hazeState),
+  style = HazeBlurStyle {
+    blurRadius(20.dp)
+    colorEffects(
+      listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.7f))),
+    )
+  },
+)
+```
+
+Use `HazeInput.Content` for foreground or own-content Blur.
+
+## Migrate Styles
+
+`HazeBlurStyle` is no longer a readable value patch with `copy`. It records Blur-specific writes:
+
+```kotlin
+val base = HazeBlurStyle {
+  blurRadius(20.dp)
+  noiseFactor(0.15f)
+}
+
+val compact = base.then {
+  blurRadius(12.dp)
+}
+```
+
+Resolution is defaults, then `LocalHazeBlurStyle`, then the explicit modifier Style. The last write
+wins. Replacing `compact` with `base` removes the 12 dp write immediately; no previous resolved
+value is retained.
+
+An explicit `colorEffects(emptyList())` clears inherited effects. Caller-owned lists are
+snapshotted before replay.
+
+## Migrate material presets
+
+Before:
+
+```kotlin
+Modifier.hazeEffect(hazeState) {
+  blurEffect {
+    style = HazeMaterials.thin()
+  }
+}
+```
+
+After:
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Sources(hazeState),
+  style = HazeMaterials.thin(),
+)
+```
+
+Customize a preset with `then`, not `copy`.
+
+## Migrate input and rendering policy
+
+These values are modifier structure, not Style:
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Sources(
+    state = hazeState,
+    retention = HazeSourceRetention.ClearWhenUnavailable,
+  ),
+  style = style,
+  sampling = HazeSampling.FullResolution,
+  expandLayerBounds = false,
+)
+```
+
+`HazeSampling.Default` preserves Blur's adaptive default. Use `FullResolution`, `Adaptive`, or
+`Fixed(scale)` when the policy must be explicit.
+
+## Lifecycle and sharing
+
+A Style can be shared by any number of modifiers. Each modifier creates its own Blur runtime,
+delegate, cache, retained layers, platform resources, and adaptive-sampling history. Recomposition
+replaces the complete Style on the existing runtime; detachment releases only that node's
+resources.
+
+## Other Haze 2 migrations
+
+The typed Blur API does not change the other Haze 2 migrations.
+
+### Glass Style
+
+`GlassStyle` is also a replayable Style. Write each property through its Style scope:
+
+```kotlin
+GlassStyle {
+  tint(Color.White.copy(alpha = 0.12f))
+  optics(
+    GlassOptics.Absolute(
+      refractionStrength = 0.7f,
+      depth = 0.4f,
     ),
-    sampling = HazeSampling.FullResolution,
-    expandLayerBounds = false,
-) {
-    blurEffect { /* ... */ }
+  )
+  specularIntensity(0.4f)
+  edgeSoftness(12.dp)
 }
 ```
 
-- Nullable `state` mode selection becomes `HazeInput.Sources(state)` or `HazeInput.Content`.
-- `canDrawArea` becomes `HazeSourceSelection.Behind.where { ... }` or
-  `HazeSourceSelection.All.where { ... }`. Predicates receive only `key` and `zIndex`, and
-  repeated `where` calls combine with logical AND.
-- `retainOutputWhenSourceUnavailable = true` maps to `KeepLastFrame`; `false` maps to
-  `ClearWhenUnavailable`. Prefer the clearing policy for privacy-sensitive surfaces.
-- `HazeInputScale.Default`, `None`, `Auto`, and `Fixed(scale)` map to `HazeSampling.Default`,
-  `FullResolution`, `Adaptive`, and `Fixed(scale)` respectively.
-- Nullable scope `expandLayerBounds` becomes a non-null modifier argument that defaults to `true`.
+### Position and geometry
 
-The structural `input`, `sampling`, and `expandLayerBounds` arguments are authoritative on this
-overload. Existing nullable `hazeEffect` overloads and `HazeEffectScope` properties are not
-deprecated by this migration step.
+`HazeArea.positionOnScreen` is replaced by `HazeArea.coordinates`. Read
+`coordinates.localPosition` or `coordinates.screenPosition` for the coordinate space you need.
+Custom `VisualEffect` implementations use `VisualEffectContext.position`, `rootBounds`,
+`positionOf(area)`, and `boundsOf(area)`.
 
-## Complete API Mapping
+`HazeState.positionStrategy` defaults to `HazePositionStrategy.Auto`. Override it with `Local` or
+`Screen` only when the host window arrangement requires a fixed coordinate space.
 
-| V1 Location | V2 Location | Notes |
-|-------------|-------------|-------|
-| `Modifier.haze(state)` | `Modifier.hazeSource(state)` | `haze` was a deprecated alias in v1 and is removed in v2 |
-| `Modifier.hazeChild(...)` | `Modifier.hazeEffect(...)` | `hazeChild` was a deprecated alias in v1 and is removed in v2 |
-| `Modifier.hazeEffect(state, style = style)` | `Modifier.hazeEffect(state) { blurEffect { this.style = style } }` | Style parameter removed from the core effect modifier |
-| `HazeEffectScope.blurRadius` | `BlurVisualEffect.blurRadius` | Inside `blurEffect {}` |
-| `HazeEffectScope.tints` | `BlurVisualEffect.colorEffects` | Inside `blurEffect {}` |
-| `HazeEffectScope.noiseFactor` | `BlurVisualEffect.noiseFactor` | Inside `blurEffect {}` |
-| `HazeEffectScope.progressive` | `BlurVisualEffect.progressive` | Inside `blurEffect {}` |
-| `HazeEffectScope.mask` | `BlurVisualEffect.mask` | Inside `blurEffect {}` |
-| `HazeEffectScope.style` | `BlurVisualEffect.style` | Inside `blurEffect {}` |
-| `HazeEffectScope.backgroundColor` | `BlurVisualEffect.backgroundColor` | Inside `blurEffect {}` |
-| `HazeEffectScope.blurredEdgeTreatment` | `BlurVisualEffect.blurredEdgeTreatment` | Inside `blurEffect {}` |
-| `HazeEffectScope.fallbackTint` | `BlurVisualEffect.fallbackTint` | Inside `blurEffect {}` |
-| `HazeEffectScope.alpha` | `BlurVisualEffect.alpha` | Inside `blurEffect {}` |
-| `HazeEffectScope.blurEnabled` | `BlurVisualEffect.blurEnabled` | Inside `blurEffect {}` |
-| `HazeEffectScope.inputScale` | `HazeSampling` | Structural on the explicit-input overload; the scope property remains on legacy overloads |
-| `HazeEffectScope.drawContentBehind` | `HazeEffectScope.drawContentBehind` | **Unchanged** - still on scope |
-| `HazeEffectScope.clipToAreasBounds` | `HazeEffectScope.clipToAreasBounds` | **Unchanged** - still on scope |
-| `HazeEffectScope.expandLayerBounds` | `Modifier.hazeEffect(expandLayerBounds = ...)` | Non-null and defaults to `true` on the explicit-input overload |
-| `HazeEffectScope.forceInvalidateOnPreDraw` | `HazeEffectScope.forceInvalidateOnPreDraw` | **Unchanged** - still on scope |
-| `HazeEffectScope.canDrawArea` | `HazeSourceSelection.where { ... }` | Metadata-only (`key`, `zIndex`) on the explicit-input overload; the scope property remains on legacy overloads |
-| `HazeEffectScope.retainOutputWhenSourceUnavailable` | `HazeSourceRetention` | `KeepLastFrame` or privacy-sensitive `ClearWhenUnavailable` on source-backed explicit input |
-| `rememberHazeState(blurEnabled)` | *Removed* | Use `blurEffect { blurEnabled = ... }` |
-| `HazeState.blurEnabled` | *Removed* | Use `blurEffect { blurEnabled = ... }` on each effect |
-| `HazeState.contentLayer` | *Removed* | Internal implementation detail from old single-source model |
-| `HazeState.positionOnScreen` | *Removed* | Internal/deprecated geometry property from old model |
-| `HazeArea.positionOnScreen` | `HazeArea.coordinates.localPosition` or `HazeArea.coordinates.screenPosition` | Coordinate model now stores both spaces |
-| `VisualEffectContext.positionOnScreen` | `VisualEffectContext.position` | Renamed |
-| `VisualEffectContext.rootBoundsOnScreen` | `VisualEffectContext.rootBounds` | Renamed |
-| `VisualEffectContext.visualEffect` | *Removed* | Custom effects should read their own properties directly |
-| `VisualEffect.calculateInputScaleFactor()` | *Removed* | Use `VisualEffect.shouldDrawContentBehind(context)`, `HazeEffectScope.inputScale`, or effect-specific logic as needed |
-| `VisualEffect.requireInvalidation()` | *Removed* | Call `VisualEffectContext.invalidateDraw()` from `update` or other lifecycle paths |
-| `VisualEffect.detach()` | `VisualEffect.detach(context)` | Detach now receives the attached context |
-| *N/A* | `HazeState.positionStrategy` | New — configurable position calculation |
-| *N/A* | `rememberHazeState(positionStrategy)` | New parameter, defaults to `Auto` |
-| *N/A* | `HazeCoordinates` | New value storing local and screen positions for each area |
-| *N/A* | `VisualEffectContext.positionOf(area)` / `boundsOf(area)` | Preferred helpers for custom effects |
-| `dev.chrisbanes.haze.HazeDefaults` blur defaults | `dev.chrisbanes.haze.blur.HazeBlurDefaults` | Blur-specific defaults moved to the blur module |
-| `dev.chrisbanes.haze.HazeDefaults.drawContentBehind` | `HazeEffectScope.drawContentBehind` | Set directly in the `hazeEffect` block if needed |
-| `dev.chrisbanes.haze.HazeStyle` | `dev.chrisbanes.haze.blur.HazeBlurStyle` | Renamed + package change |
-| `dev.chrisbanes.haze.HazeTint` | `dev.chrisbanes.haze.blur.HazeColorEffect` | Renamed + package change |
-| `dev.chrisbanes.haze.HazeProgressive` | `dev.chrisbanes.haze.HazeProgressive` | Unchanged core location; `dev.chrisbanes.haze.blur.HazeProgressive` remains as a deprecated typealias during the v2 alpha cycle |
-| `dev.chrisbanes.haze.LocalHazeStyle` | `dev.chrisbanes.haze.blur.LocalHazeBlurStyle` | Renamed + package change |
-| `dev.chrisbanes.haze.materials.*` | `dev.chrisbanes.haze.blur.materials.*` | Package moved; artifact also renamed to `haze-blur-materials` |
-| `dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi` | *Removed* | Materials APIs are no longer annotated with this opt-in |
-| `HazeDialog` | *Removed* | Use regular Compose dialogs with `hazeSource` / `hazeEffect` where needed |
+The `VisualEffect.detach` lifecycle method now receives its attached `VisualEffectContext`.
 
-## Step-by-Step Migration
+## Temporary compatibility boundary
 
-**Update dependencies** in your `build.gradle.kts`:
+`BlurVisualEffect`, `HazeEffectScope.blurEffect`, and legacy lambda-based `hazeEffect` overloads
+remain temporarily available so migration can be staged. They are compatibility APIs, not the
+recommended 2.0 Blur interface, and are scheduled for contraction separately. The sentinel-based
+`HazeBlurStyle(...)` constructors and `HazeBlurDefaults.style(...)` builder are deprecated.
+`HazeBlurStyle.copy` and readable patch properties are removed; use replayable Style blocks and
+`then`.
 
-   ```kotlin
-    implementation("dev.chrisbanes.haze:haze:2.0.0-alpha03")
-    implementation("dev.chrisbanes.haze:haze-blur:2.0.0-alpha03") // Add this for blur effects
-    implementation("dev.chrisbanes.haze:haze-blur-materials:2.0.0-alpha03") // Add this for material presets
-   ```
+## Complete API mapping
 
-**Update imports** for blur-related classes:
+| Haze 1 API | Haze 2 API | Notes |
+| --- | --- | --- |
+| `Modifier.haze(state)` | `Modifier.hazeSource(state)` | The deprecated `haze` alias is removed. |
+| `Modifier.hazeChild(...)` | `Modifier.hazeBlur(input = HazeInput.Sources(state), ...)` | Use `HazeInput.Content` for own-content Blur. |
+| `Modifier.hazeEffect(state, style = style)` | `Modifier.hazeBlur(input = HazeInput.Sources(state), style = style)` | Blur now has a typed modifier. |
+| `HazeEffectScope.blurRadius` | `HazeBlurStyle { blurRadius(...) }` | Style properties are write functions. |
+| `HazeEffectScope.tints` | `HazeBlurStyle { colorEffects(...) }` | `HazeTint` is renamed to `HazeColorEffect`. |
+| `HazeEffectScope.noiseFactor` | `HazeBlurStyle { noiseFactor(...) }` | Values are canonicalized during resolution. |
+| `HazeEffectScope.progressive` | `HazeBlurStyle { progressive(...) }` | `HazeProgressive` remains in the core package. |
+| `HazeEffectScope.mask` | `HazeBlurStyle { mask(...) }` | Write `null` to clear an inherited mask. |
+| `HazeEffectScope.backgroundColor` | `HazeBlurStyle { backgroundColor(...) }` | `Color.Unspecified` is not an inheritance sentinel in the new Style API. |
+| `HazeEffectScope.blurredEdgeTreatment` | `HazeBlurStyle { blurredEdgeTreatment(...) }` | Layer expansion remains structural. |
+| `HazeEffectScope.fallbackTint` | `HazeBlurStyle { fallbackColorEffect(...) }` | The effect type is unchanged. |
+| `HazeEffectScope.alpha` | `HazeBlurStyle { alpha(...) }` | Values are clamped to `0f..1f`. |
+| `HazeEffectScope.blurEnabled` | `HazeBlurStyle { blurEnabled(...) }` | State-level Blur enablement is removed. |
+| `HazeEffectScope.inputScale` | `Modifier.hazeBlur(sampling = ...)` | Map `Default`, `None`, `Auto`, and `Fixed` to `Default`, `FullResolution`, `Adaptive`, and `Fixed`. |
+| `HazeEffectScope.drawContentBehind` | `HazeEffectScope.drawContentBehind` | Unchanged on the temporary lambda-based compatibility API. |
+| `HazeEffectScope.clipToAreasBounds` | `HazeEffectScope.clipToAreasBounds` | Unchanged on the temporary lambda-based compatibility API. |
+| `HazeEffectScope.expandLayerBounds` | `Modifier.hazeBlur(expandLayerBounds = ...)` | Non-null and `true` by default. |
+| `HazeEffectScope.forceInvalidateOnPreDraw` | `HazeEffectScope.forceInvalidateOnPreDraw` | Unchanged on the temporary lambda-based compatibility API. |
+| `HazeEffectScope.canDrawArea` | `HazeSourceSelection.where { ... }` | Typed selection exposes immutable `key` and `zIndex` metadata. |
+| `HazeEffectScope.retainOutputWhenSourceUnavailable` | `HazeSourceRetention` | Choose `KeepLastFrame` or `ClearWhenUnavailable`. |
+| `rememberHazeState(blurEnabled)` | `rememberHazeState()` | Put `blurEnabled(...)` in the Style. |
+| `HazeState.blurEnabled` | `HazeBlurStyle { blurEnabled(...) }` | Configure each effect explicitly. |
+| `HazeState.contentLayer` | Removed | This was an internal detail of the old single-source model. |
+| `HazeState.positionOnScreen` | Removed | Use the position-strategy and coordinate APIs instead. |
+| `HazeArea.positionOnScreen` | `HazeArea.coordinates.localPosition` or `.screenPosition` | Choose the coordinate space required by the caller. |
+| `VisualEffectContext.positionOnScreen` | `VisualEffectContext.position` | Renamed for the selected position strategy. |
+| `VisualEffectContext.rootBoundsOnScreen` | `VisualEffectContext.rootBounds` | Renamed. |
+| `VisualEffectContext.visualEffect` | Removed | Custom effects read their own properties directly. |
+| `VisualEffect.calculateInputScaleFactor()` | Removed | Use sampling and effect-specific policy. |
+| `VisualEffect.requireInvalidation()` | Removed | Call `VisualEffectContext.invalidateDraw()`. |
+| `VisualEffect.detach()` | `VisualEffect.detach(context)` | Detach receives the attached context. |
+| N/A | `HazeState.positionStrategy` | New; defaults to `HazePositionStrategy.Auto`. |
+| N/A | `rememberHazeState(positionStrategy)` | New optional state-construction parameter. |
+| N/A | `HazeCoordinates` | Stores local and screen positions for each source area. |
+| N/A | `VisualEffectContext.positionOf(area)` / `boundsOf(area)` | Preferred geometry helpers for custom effects. |
+| `HazeDefaults` Blur values | `HazeBlurDefaults` | Blur defaults moved to `haze-blur`. |
+| `HazeDefaults.drawContentBehind` | `HazeEffectScope.drawContentBehind` | Set directly in the temporary `hazeEffect` compatibility block when needed. |
+| `HazeStyle` | `HazeBlurStyle` | Renamed, moved, and changed to a replayable Style. |
+| `HazeTint` | `HazeColorEffect` | Renamed and moved to `dev.chrisbanes.haze.blur`. |
+| `dev.chrisbanes.haze.blur.HazeProgressive` | `dev.chrisbanes.haze.HazeProgressive` | The old Blur-package name remains as a deprecated typealias during the v2 alpha cycle. |
+| `LocalHazeStyle` | `LocalHazeBlurStyle` | The local contains replayable Style writes. |
+| `dev.chrisbanes.haze.materials.*` | `dev.chrisbanes.haze.blur.materials.*` | The artifact is now `haze-blur-materials`. |
+| `ExperimentalHazeMaterialsApi` | Removed | Materials APIs no longer require this opt-in. |
+| `HazeDialog` | Regular Compose dialogs | Share one `HazeState` between the source and dialog effect. |
 
-  - Change blur-specific `dev.chrisbanes.haze.HazeDefaults` usage → `dev.chrisbanes.haze.blur.HazeBlurDefaults`
-  - Change `HazeDefaults.drawContentBehind` usage → direct `drawContentBehind` assignment in the `hazeEffect` block
-  - Change `dev.chrisbanes.haze.HazeStyle` → `dev.chrisbanes.haze.blur.HazeBlurStyle`
-  - Change `dev.chrisbanes.haze.HazeTint` → `dev.chrisbanes.haze.blur.HazeColorEffect`
-  - Keep `dev.chrisbanes.haze.HazeProgressive`; `dev.chrisbanes.haze.blur.HazeProgressive` remains as a deprecated typealias during the v2 alpha cycle
-  - Change `dev.chrisbanes.haze.LocalHazeStyle` → `dev.chrisbanes.haze.blur.LocalHazeBlurStyle`
-  - Change `dev.chrisbanes.haze.materials.HazeMaterials` → `dev.chrisbanes.haze.blur.materials.HazeMaterials`
-  - Add `import dev.chrisbanes.haze.blur.blurEffect`
+Legacy `HazeEffectScope` properties that are not represented above remain available only through
+the temporary lambda-based compatibility API.
 
-**Wrap blur properties** in `blurEffect {}`:
+## Step-by-step migration
 
-   - Find all `Modifier.hazeEffect { ... }` blocks
-   - Wrap blur-related properties in `blurEffect { ... }`
-   - Leave `inputScale`, `drawContentBehind`, `clipToAreasBounds`, `canDrawArea` outside the `blurEffect {}` block
+1. Add `haze-blur`, and replace `haze-materials` with `haze-blur-materials` if presets are used.
+2. Update imports from `HazeStyle`, `HazeTint`, `LocalHazeStyle`, and the old materials package to
+   `HazeBlurStyle`, `HazeColorEffect`, `LocalHazeBlurStyle`, and
+   `dev.chrisbanes.haze.blur.materials`.
+3. Replace `Modifier.haze(...)` with `Modifier.hazeSource(...)`.
+4. Replace Blur-configuring `hazeEffect` blocks with `hazeBlur`, choosing
+   `HazeInput.Sources(state)` or `HazeInput.Content`.
+5. Move Blur properties into `HazeBlurStyle { ... }`, changing property assignments into Style
+   functions. Use `then` instead of `copy` when customizing a preset.
+6. Move input scale, retention, source selection, and layer expansion to `HazeSampling`,
+   `HazeSourceRetention`, `HazeSourceSelection`, and `expandLayerBounds`.
+7. Remove `blurEnabled` from `rememberHazeState`; write it in the Style for each effect instead.
+8. Update custom-effect geometry and `detach` overrides using the mappings above.
 
-**Update `rememberHazeState()` calls**:
-
-   - Remove `blurEnabled` parameter if present
-   - Move blur enabling logic to `blurEffect { blurEnabled = ... }` if needed
-
-**Update Material style usage**:
-
-   - Change `hazeEffect(state, style = style)` to `val style = ...` followed by `hazeEffect(state) { blurEffect { this.style = style } }`
-   - Change the dependency from `haze-materials` to `haze-blur-materials`
-
-**Replace removed aliases**:
-
-   - Change `Modifier.haze(state)` to `Modifier.hazeSource(state)`
-   - Change `Modifier.hazeChild(...)` to `Modifier.hazeEffect(...)`
-   - Remove `HazeDialog` usage and compose dialogs directly
-
-## Position Strategy
-
-V2 introduces a configurable position calculation strategy that fixes blur misalignment in split-window modes (e.g. Huawei Parallel Space). In most cases, no action is needed — the default `Auto` strategy handles everything.
-
-**If you use `HazeArea.positionOnScreen`** in custom effects, read the coordinate space you need:
+For example:
 
 ```kotlin
-// v1
-val pos = area.positionOnScreen
+val style = HazeMaterials.thin().then {
+  blurRadius(24.dp)
+}
 
-// v2
-val localPos = area.coordinates.localPosition
-val screenPos = area.coordinates.screenPosition
+Modifier.hazeBlur(
+  input = HazeInput.Sources(
+    state = hazeState,
+    selection = HazeSourceSelection.Behind
+      .where { source -> source.key != "sensitive" },
+    retention = HazeSourceRetention.ClearWhenUnavailable,
+  ),
+  style = style,
+  sampling = HazeSampling.FullResolution,
+  expandLayerBounds = false,
+)
 ```
 
-**If you implement custom `VisualEffect`s**, update `VisualEffectContext` references:
+## Custom effects and architecture
+
+Haze 2 separates typed, shareable configuration from node-owned rendering resources:
+
+- `HazeEffectFactory<Style>` is stateless and may be shared.
+- Every modifier node creates its own `HazeEffectRenderer<Style>`.
+- Replacing a Style reuses that renderer.
+- Replacing the factory or detaching the node disposes its renderer exactly once.
+- `VisualEffect` remains temporarily available for compatibility and built-in adapter plumbing.
+
+Custom typed effects use the generic modifier rather than `hazeBlur`:
 
 ```kotlin
-// v1
-context.positionOnScreen
-context.rootBoundsOnScreen
-
-// v2
-context.position
-context.rootBounds
+Modifier.hazeEffect(
+  factory = myFactory,
+  input = HazeInput.Content,
+  style = myStyle,
+)
 ```
 
-Prefer the context helpers when working with source areas, because they respect `HazePositionStrategy`:
+## Getting help
 
-```kotlin
-val areaPosition = context.positionOf(area)
-val areaBounds = context.boundsOf(area)
-```
-
-Also update lifecycle overrides:
-
-```kotlin
-// v1
-override fun detach() = Unit
-
-// v2
-override fun detach(context: VisualEffectContext) = Unit
-```
-
-**If you need to force screen coordinates** (e.g. for a custom cross-window setup):
-
-```kotlin
-val state = rememberHazeState(positionStrategy = HazePositionStrategy.Screen)
-```
-
-## Understanding the New Architecture
-
-The v2 architecture introduces the `VisualEffect` interface, which allows Haze to support different types of visual effects:
-
-- **`VisualEffect`** - Core interface for all visual effects (in `haze` module)
-- **`BlurVisualEffect`** - Implementation for blur effects (in `haze-blur` module)
-- **`HazeEffectScope.visualEffect`** - Property that holds the current effect
-
-The `blurEffect {}` extension function is a convenience API that creates and configures a `BlurVisualEffect` instance. Under the hood, it sets the `visualEffect` property on `HazeEffectScope`.
-
-This architecture enables:
-
-- Better separation of concerns
-- Potential for custom visual effects in the future
-- Smaller core module for users who don't need blur
-- More maintainable and testable code
-
-## Getting Help
-
-If you encounter issues during migration:
-
-- Check the [GitHub Discussions](https://github.com/chrisbanes/haze/discussions)
-- Review the [updated usage documentation](blur/usage.md)
-- See working examples in the [sample app](https://github.com/chrisbanes/haze/tree/main/sample)
-- File an issue on [GitHub](https://github.com/chrisbanes/haze/issues)
+- Read the [Blur usage guide](blur/usage.md).
+- See the [sample applications](https://github.com/chrisbanes/haze/tree/main/sample).
+- Ask in [GitHub Discussions](https://github.com/chrisbanes/haze/discussions).
+- Report reproducible problems in [GitHub Issues](https://github.com/chrisbanes/haze/issues).

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -8,8 +8,8 @@ Blur effects use adaptive input scaling by default. The common cross-platform po
 resolved blur radius in physical pixels and expanded capture-layer pixel area to choose `1.0`,
 `0.8`, or `0.5`. Stronger blur can hide more downsampling, while the area gate avoids reallocating
 small layers for negligible savings. Progressive blur is capped at `0.8`; Glass remains unscaled by
-default. Explicit `None`, `Auto`, and `Fixed` values always win. You can find configuration details
-[here](blur/usage.md#input-scale).
+default. Explicit `HazeSampling.FullResolution`, `Adaptive`, and `Fixed` values always win. You can
+find configuration details [here](blur/usage.md#input-scale).
 
 In terms of the performance benefit which scaling provides, it's fairly small. In our Android benchmark tests, using an `inputScale` set to `0.5` reduced the _cost of Haze_ by **5-20%**. You can read more about this below.
 
@@ -26,8 +26,12 @@ We currently have 4 benchmark scenarios, each of them is one of the samples in t
 
 - **Scaffold**. The simple example, where the app bar and bottom navigation bar are blurred, with a scrollable list. This example uses rectangular haze areas.
 - **Scaffold, with progressive**. Same as Scaffold, but using a progressive blur.
-- **Images List**. Each item in the list has it's own `hazeSource` and `hazeEffect`. As each item has it's own `hazeSource`, the internal haze state does not change all that much (the list item content moves, but the `hazeEffect` doesn't in terms of local coordinates). This is more about multiple testing `RenderNode`s. This example uses rounded rectangle haze areas (i.e. we use `clipPath`).
-- **Credit Card**. A simple example, where the user can drag the `hazeEffect`. This tests how fast Haze's internal state invalidates and propogates to the `RenderNode`s. This example uses rounded rectangle haze areas like 'Images List'.
+- **Images List**. Each item has its own `hazeSource` and `hazeBlur`. The list item content moves,
+  but its effect does not move in local coordinates, so this primarily exercises multiple
+  `RenderNode`s. This example uses rounded rectangle haze areas (that is, `clipPath`).
+- **Credit Card**. A simple example where the user can drag the `hazeBlur` modifier. This tests how
+  quickly Haze invalidates state and propagates it to the `RenderNode`s. This example uses rounded
+  rectangle haze areas like Images List.
 
 !!! abstract "Test setup"
     All of the tests were ran with 16 iterations on a Pixel 6, running the latest version of Android available.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,43 +1,32 @@
+# Recipes
 
-## Scaffold
+## Scaffold chrome
 
-Blurring the content behind app bars is a common use case, so how can we use Haze with `Scaffold`? It's pretty much the same as above:
+Place `hazeSource` on the scrolling content and use the same state for each app bar:
 
-!!! tip "Multiple hazeEffects"
-    Note: We are using multiple `hazeEffect`s in this example. You can actually use an abitrary number of `hazeEffect`s.
-
-``` kotlin
+```kotlin
 val hazeState = rememberHazeState()
 val style = HazeMaterials.thin()
 
 Scaffold(
   topBar = {
     TopAppBar(
-      // Need to make app bar transparent to see the content behind
-      colors = TopAppBarDefaults.largeTopAppBarColors(Color.Transparent),
-      modifier = Modifier
-        .hazeEffect(state = hazeState) {
-          blurEffect {
-            this.style = style
-          }
-        }
-        .fillMaxWidth(),
-    ) {
-      /* todo */
-    }
+      colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
+      modifier = Modifier.hazeBlur(
+        input = HazeInput.Sources(hazeState),
+        style = style,
+      ),
+    )
   },
   bottomBar = {
     NavigationBar(
       containerColor = Color.Transparent,
-      modifier = Modifier
-        .hazeEffect(state = hazeState) {
-          blurEffect {
-            this.style = style
-          }
-        }
-        .fillMaxWidth(),
+      modifier = Modifier.hazeBlur(
+        input = HazeInput.Sources(hazeState),
+        style = style,
+      ),
     ) {
-      /* todo */
+      // Items
     }
   },
 ) { contentPadding ->
@@ -45,58 +34,73 @@ Scaffold(
     contentPadding = contentPadding,
     modifier = Modifier
       .fillMaxSize()
-      .hazeSource(
-        state = hazeState,
-      ),
+      .hazeSource(hazeState),
   ) {
-    // todo
+    // Items
   }
 }
 ```
 
-Common scaffold composables include:
+Pass scaffold padding to the scrollable content rather than applying it outside the source. That
+keeps interactive content clear of chrome while preserving source pixels behind translucent bars.
 
-- [`Scaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/Scaffold.composable), which provides content padding for app bars and other chrome.
-- [`BottomSheetScaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/BottomSheetScaffold.composable), which provides content padding for its top bar and bottom sheet.
-- [`NavigationSuiteScaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/adaptive/navigationsuite/NavigationSuiteScaffold.composable), which places adaptive navigation beside or below its content.
-- [`ListDetailPaneScaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/adaptive/layout/ListDetailPaneScaffold.composable), which arranges list, detail, and optional extra panes.
-- [`SupportingPaneScaffold`](https://developer.android.com/reference/kotlin/androidx/compose/material3/adaptive/layout/SupportingPaneScaffold.composable), which arranges main, supporting, and optional extra panes.
+## Sticky headers
 
-For scaffold composables that provide content padding, pass that padding to the scrollable content rather than applying it as an outer modifier. This keeps interactive items clear of the chrome while preserving a full-size Haze source with pixels behind translucent bars. Scaffold-like layouts that measure content beside or above their chrome require an application-level overlay or custom layout to achieve an edge-to-edge translucent effect.
-
-## Sticky Headers
-
-The `stickyHeader` functionality on `LazyColumn` and friends is very useful, but unfortunately the limitations of Haze means that blurring the list contents for the header background is tricky.
-
-Since we can not use `Modifier.hazeSource` on the `LazyColumn` and `Modifier.hazeEffect` on items, as we would get into recursive drawing, we need to get a bit more creative.
-
-Since we can have multiple nodes using `Modifier.hazeSource`, we can use the modifier on all non-header items, and then use `hazeEffect` as normal on the `stickyHeader`:
+Avoid making a `LazyColumn` both a source and a descendant effect. Mark non-header items as sources:
 
 ```kotlin
 val hazeState = rememberHazeState()
 val style = HazeMaterials.thin()
 
-LazyColumn(...) {
+LazyColumn {
   stickyHeader {
     Header(
-      modifier = Modifier
-        .hazeEffect(state = hazeState) {
-          blurEffect {
-            this.style = style
-          }
-        },
+      modifier = Modifier.hazeBlur(
+        input = HazeInput.Sources(hazeState),
+        style = style,
+        sampling = HazeSampling.Adaptive,
+      ),
     )
   }
 
-  items(list) { item ->
-    Foo(
-      modifier = Modifier
-        .hazeSource(hazeState),
+  items(items) { item ->
+    Item(
+      item,
+      modifier = Modifier.hazeSource(hazeState),
     )
   }
 }
 ```
 
-A more complete example can be found here: [ListWithStickyHeaders](https://github.com/chrisbanes/haze/blob/main/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt).
+## Privacy-sensitive source transitions
 
-![type:video](./media/sticky.mp4)
+Clear retained Blur output when no source is available:
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Sources(
+    state = hazeState,
+    retention = HazeSourceRetention.ClearWhenUnavailable,
+  ),
+  style = style,
+)
+```
+
+## Reusing and customizing a Style
+
+```kotlin
+val base = HazeMaterials.regular()
+val quiet = base.then {
+  noiseFactor(0f)
+  colorEffects(emptyList())
+}
+
+TopAppBar(
+  modifier = Modifier.hazeBlur(HazeInput.Sources(hazeState), quiet),
+)
+BottomAppBar(
+  modifier = Modifier.hazeBlur(HazeInput.Sources(hazeState), quiet),
+)
+```
+
+Both modifiers evaluate the shared Style into independent node-owned runtimes.

--- a/haze-blur/api/api.txt
+++ b/haze-blur/api/api.txt
@@ -39,46 +39,53 @@ package dev.chrisbanes.haze.blur {
 
   public final class HazeBlurDefaults {
     method public boolean blurEnabled();
-    method @KotlinOnly public dev.chrisbanes.haze.blur.HazeBlurStyle style(androidx.compose.ui.graphics.Color backgroundColor, optional dev.chrisbanes.haze.blur.HazeColorEffect tint, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor);
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.blur.HazeBlurStyle getStyle();
+    method @KotlinOnly @Deprecated public dev.chrisbanes.haze.blur.HazeBlurStyle style(androidx.compose.ui.graphics.Color backgroundColor, optional dev.chrisbanes.haze.blur.HazeColorEffect tint, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor);
     method @KotlinOnly public dev.chrisbanes.haze.blur.HazeColorEffect tint(androidx.compose.ui.graphics.Color color);
     property public androidx.compose.ui.unit.Dp blurRadius;
     property public androidx.compose.ui.draw.BlurredEdgeTreatment blurredEdgeTreatment;
     property public static float noiseFactor;
+    property public dev.chrisbanes.haze.blur.HazeBlurStyle style;
     property public static float tintAlpha;
     field public static final dev.chrisbanes.haze.blur.HazeBlurDefaults INSTANCE;
     field public static final float noiseFactor = 0.15f;
     field public static final float tintAlpha = 0.7f;
   }
 
-  @androidx.compose.runtime.Immutable public final class HazeBlurStyle {
-    ctor public HazeBlurStyle();
-    ctor @KotlinOnly public HazeBlurStyle(optional androidx.compose.ui.graphics.Color backgroundColor, optional dev.chrisbanes.haze.blur.HazeColorEffect? colorEffect, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor, optional dev.chrisbanes.haze.blur.HazeColorEffect fallbackColorEffect);
-    ctor @KotlinOnly public HazeBlurStyle(optional androidx.compose.ui.graphics.Color backgroundColor, optional java.util.List<dev.chrisbanes.haze.blur.HazeColorEffect>? colorEffects, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor, optional dev.chrisbanes.haze.blur.HazeColorEffect fallbackColorEffect);
-    method @KotlinOnly public operator androidx.compose.ui.graphics.Color component1();
-    method public operator java.util.List<dev.chrisbanes.haze.blur.HazeColorEffect> component2();
-    method @KotlinOnly public operator androidx.compose.ui.unit.Dp component3();
-    method public operator float component4();
-    method public operator dev.chrisbanes.haze.blur.HazeColorEffect component5();
-    method @KotlinOnly public dev.chrisbanes.haze.blur.HazeBlurStyle copy(optional androidx.compose.ui.graphics.Color backgroundColor, optional java.util.List<dev.chrisbanes.haze.blur.HazeColorEffect>? colorEffects, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor, optional dev.chrisbanes.haze.blur.HazeColorEffect fallbackColorEffect);
-    method @InaccessibleFromKotlin public java.util.List<dev.chrisbanes.haze.blur.HazeColorEffect> getColorEffects();
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.blur.HazeColorEffect getFallbackColorEffect();
-    method @InaccessibleFromKotlin public float getNoiseFactor();
-    property public androidx.compose.ui.graphics.Color backgroundColor;
-    property public androidx.compose.ui.unit.Dp blurRadius;
-    property public java.util.List<dev.chrisbanes.haze.blur.HazeColorEffect> colorEffects;
-    property public dev.chrisbanes.haze.blur.HazeColorEffect fallbackColorEffect;
-    property public float noiseFactor;
+  public final class HazeBlurKt {
+    method @androidx.compose.runtime.Stable public static androidx.compose.ui.Modifier hazeBlur(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeInput input, optional dev.chrisbanes.haze.blur.HazeBlurStyle style, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds);
+  }
+
+  @androidx.compose.runtime.Immutable public sealed nonexhaustive interface HazeBlurStyle {
+    method public default dev.chrisbanes.haze.blur.HazeBlurStyle then(dev.chrisbanes.haze.blur.HazeBlurStyle other);
+    method public default dev.chrisbanes.haze.blur.HazeBlurStyle then(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.blur.HazeBlurStyleScope,kotlin.Unit> block);
     field public static final dev.chrisbanes.haze.blur.HazeBlurStyle.Companion Companion;
   }
 
-  public static final class HazeBlurStyle.Companion {
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.blur.HazeBlurStyle getUnspecified();
-    property public dev.chrisbanes.haze.blur.HazeBlurStyle Unspecified;
+  public static final class HazeBlurStyle.Companion implements dev.chrisbanes.haze.blur.HazeBlurStyle {
+    method @InaccessibleFromKotlin @Deprecated public dev.chrisbanes.haze.blur.HazeBlurStyle getUnspecified();
+    property @Deprecated public dev.chrisbanes.haze.blur.HazeBlurStyle Unspecified;
   }
 
   public final class HazeBlurStyleKt {
+    method @KotlinOnly @Deprecated public static dev.chrisbanes.haze.blur.HazeBlurStyle HazeBlurStyle(optional androidx.compose.ui.graphics.Color backgroundColor, dev.chrisbanes.haze.blur.HazeColorEffect? colorEffect, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor, optional dev.chrisbanes.haze.blur.HazeColorEffect fallbackColorEffect);
+    method @KotlinOnly @Deprecated public static dev.chrisbanes.haze.blur.HazeBlurStyle HazeBlurStyle(optional androidx.compose.ui.graphics.Color backgroundColor, optional java.util.List<dev.chrisbanes.haze.blur.HazeColorEffect>? colorEffects, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor, optional dev.chrisbanes.haze.blur.HazeColorEffect fallbackColorEffect);
+    method public static dev.chrisbanes.haze.blur.HazeBlurStyle HazeBlurStyle(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.blur.HazeBlurStyleScope,kotlin.Unit> block);
     method @InaccessibleFromKotlin public static androidx.compose.runtime.ProvidableCompositionLocal<dev.chrisbanes.haze.blur.HazeBlurStyle> getLocalHazeBlurStyle();
     property public static androidx.compose.runtime.ProvidableCompositionLocal<dev.chrisbanes.haze.blur.HazeBlurStyle> LocalHazeBlurStyle;
+  }
+
+  public sealed nonexhaustive interface HazeBlurStyleScope {
+    method public void alpha(float alpha);
+    method @KotlinOnly public void backgroundColor(androidx.compose.ui.graphics.Color color);
+    method public void blurEnabled(boolean enabled);
+    method @KotlinOnly public void blurRadius(androidx.compose.ui.unit.Dp radius);
+    method @KotlinOnly public void blurredEdgeTreatment(androidx.compose.ui.draw.BlurredEdgeTreatment treatment);
+    method public void colorEffects(java.util.List<? extends dev.chrisbanes.haze.blur.HazeColorEffect> effects);
+    method public void fallbackColorEffect(dev.chrisbanes.haze.blur.HazeColorEffect effect);
+    method public void mask(androidx.compose.ui.graphics.Brush? mask);
+    method public void noiseFactor(float factor);
+    method public void progressive(dev.chrisbanes.haze.HazeProgressive? progressive);
   }
 
   @androidx.compose.runtime.Stable public sealed exhaustive interface HazeColorEffect {

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectRecompositionCountInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectRecompositionCountInstrumentationTest.kt
@@ -18,9 +18,9 @@ import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isLessThanOrEqualTo
+import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.test.RecompositionCounter
 import org.junit.Rule
@@ -43,7 +43,7 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val blurRadius = mutableStateOf(10.dp)
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.blurRadius = blurRadius.value
+      blurRadius(blurRadius.value)
     }
     composeTestRule.waitForIdle()
 
@@ -65,7 +65,7 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     )
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.colorEffects = colorEffects.value
+      colorEffects(colorEffects.value)
     }
     composeTestRule.waitForIdle()
 
@@ -83,23 +83,21 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val hazeState = HazeState()
     val effectCounter = mutableIntStateOf(0)
     val style = mutableStateOf(
-      HazeBlurStyle(
-        colorEffects = emptyList(),
-        blurRadius = 10.dp,
-      ),
+      HazeBlurStyle {
+        colorEffects(emptyList())
+        blurRadius(10.dp)
+      },
     )
 
-    composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.style = style.value
-    }
+    composeTestRule.setBlurEffectStyleContent(hazeState, effectCounter) { style.value }
     composeTestRule.waitForIdle()
 
     effectCounter.intValue = 0
 
-    style.value = HazeBlurStyle(
-      colorEffects = emptyList(),
-      blurRadius = 20.dp,
-    )
+    style.value = HazeBlurStyle {
+      colorEffects(emptyList())
+      blurRadius(20.dp)
+    }
     composeTestRule.waitForIdle()
 
     assertThat(effectCounter.intValue, "effect recompositions after style change")
@@ -113,7 +111,7 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val blurEnabled = mutableStateOf(true)
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.blurEnabled = blurEnabled.value
+      blurEnabled(blurEnabled.value)
     }
     composeTestRule.waitForIdle()
 
@@ -133,7 +131,7 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val progressive = mutableStateOf<HazeProgressive?>(null)
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.progressive = progressive.value
+      progressive(progressive.value)
     }
     composeTestRule.waitForIdle()
 
@@ -156,7 +154,7 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val noiseFactor = mutableStateOf(0f)
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.noiseFactor = noiseFactor.value
+      noiseFactor(noiseFactor.value)
     }
     composeTestRule.waitForIdle()
 
@@ -173,10 +171,10 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
   fun backgroundColorChange_causesBoundedRecompositions() {
     val hazeState = HazeState()
     val effectCounter = mutableIntStateOf(0)
-    val backgroundColor = mutableStateOf(Color.Unspecified)
+    val backgroundColor = mutableStateOf(Color.White)
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.backgroundColor = backgroundColor.value
+      backgroundColor(backgroundColor.value)
     }
     composeTestRule.waitForIdle()
 
@@ -196,7 +194,7 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val alpha = mutableStateOf(1f)
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.alpha = alpha.value
+      alpha(alpha.value)
     }
     composeTestRule.waitForIdle()
 
@@ -216,7 +214,7 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val mask = mutableStateOf<Brush?>(null)
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.mask = mask.value
+      mask(mask.value)
     }
     composeTestRule.waitForIdle()
 
@@ -235,10 +233,10 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
   fun fallbackTintChange_causesBoundedRecompositions() {
     val hazeState = HazeState()
     val effectCounter = mutableIntStateOf(0)
-    val fallbackTint = mutableStateOf<HazeColorEffect>(HazeColorEffect.Unspecified)
+    val fallbackTint = mutableStateOf<HazeColorEffect>(HazeColorEffect.tint(Color.White))
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.fallbackTint = fallbackTint.value
+      fallbackColorEffect(fallbackTint.value)
     }
     composeTestRule.waitForIdle()
 
@@ -258,7 +256,7 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val blurredEdgeTreatment = mutableStateOf(HazeBlurDefaults.blurredEdgeTreatment)
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.blurredEdgeTreatment = blurredEdgeTreatment.value
+      blurredEdgeTreatment(blurredEdgeTreatment.value)
     }
     composeTestRule.waitForIdle()
 
@@ -290,11 +288,10 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
       RecompositionCounter(effectCounter) {
         BlurTestGradientBox(
           Modifier
-            .hazeEffect(hazeState) {
-              blurEffect {
-                this.blurRadius = blurRadius.value
-              }
-            }
+            .hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = HazeBlurStyle { blurRadius(blurRadius.value) },
+            )
             .size(100.dp),
         )
       }
@@ -322,10 +319,10 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val effectCounter = mutableIntStateOf(0)
     val showSource = mutableStateOf(true)
     val style = mutableStateOf(
-      HazeBlurStyle(
-        blurRadius = 10.dp,
-        colorEffects = emptyList(),
-      ),
+      HazeBlurStyle {
+        blurRadius(10.dp)
+        colorEffects(emptyList())
+      },
     )
 
     composeTestRule.setContent {
@@ -336,11 +333,10 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
       RecompositionCounter(effectCounter) {
         BlurTestGradientBox(
           Modifier
-            .hazeEffect(hazeState) {
-              blurEffect {
-                this.style = style.value
-              }
-            }
+            .hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = style.value,
+            )
             .size(100.dp),
         )
       }
@@ -351,10 +347,10 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
 
     composeTestRule.runOnIdle {
       showSource.value = false
-      style.value = HazeBlurStyle(
-        blurRadius = 22.dp,
-        colorEffects = listOf(HazeColorEffect.tint(Color.Cyan.copy(alpha = 0.3f))),
-      )
+      style.value = HazeBlurStyle {
+        blurRadius(22.dp)
+        colorEffects(listOf(HazeColorEffect.tint(Color.Cyan.copy(alpha = 0.3f))))
+      }
     }
     composeTestRule.waitForIdle()
 
@@ -371,9 +367,9 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
     val noiseFactor = mutableStateOf(0f)
 
     composeTestRule.setBlurEffectContent(hazeState, effectCounter) {
-      this.blurRadius = blurRadius.value
-      this.alpha = alpha.value
-      this.noiseFactor = noiseFactor.value
+      blurRadius(blurRadius.value)
+      alpha(alpha.value)
+      noiseFactor(noiseFactor.value)
     }
     composeTestRule.waitForIdle()
 
@@ -397,16 +393,38 @@ class BlurVisualEffectRecompositionCountInstrumentationTest {
   private fun ComposeContentTestRule.setBlurEffectContent(
     hazeState: HazeState,
     effectCounter: MutableIntState,
-    configure: BlurVisualEffect.() -> Unit,
+    configure: HazeBlurStyleScope.() -> Unit,
   ) {
     setContent {
       Box(Modifier.hazeSource(hazeState).size(100.dp)) {
         RecompositionCounter(effectCounter) {
           BlurTestGradientBox(
             Modifier
-              .hazeEffect(hazeState) {
-                blurEffect(configure)
-              }
+              .hazeBlur(
+                input = HazeInput.Sources(hazeState),
+                style = HazeBlurStyle(configure),
+              )
+              .size(100.dp),
+          )
+        }
+      }
+    }
+  }
+
+  private fun ComposeContentTestRule.setBlurEffectStyleContent(
+    hazeState: HazeState,
+    effectCounter: MutableIntState,
+    style: () -> HazeBlurStyle,
+  ) {
+    setContent {
+      Box(Modifier.hazeSource(hazeState).size(100.dp)) {
+        RecompositionCounter(effectCounter) {
+          BlurTestGradientBox(
+            Modifier
+              .hazeBlur(
+                input = HazeInput.Sources(hazeState),
+                style = style(),
+              )
               .size(100.dp),
           )
         }

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectRecompositionLoopInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectRecompositionLoopInstrumentationTest.kt
@@ -14,9 +14,9 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import org.junit.Rule
 import org.junit.Test
@@ -29,15 +29,16 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
 
   private fun ComposeContentTestRule.setBlurEffectContent(
     hazeState: HazeState,
-    configure: BlurVisualEffect.() -> Unit,
+    configure: HazeBlurStyleScope.() -> Unit,
   ) {
     setContent {
       Box(Modifier.hazeSource(hazeState).size(100.dp)) {
         BlurTestGradientBox(
           Modifier
-            .hazeEffect(hazeState) {
-              blurEffect(configure)
-            }
+            .hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = HazeBlurStyle(configure),
+            )
             .size(100.dp),
         )
       }
@@ -50,7 +51,7 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     val blurRadius = mutableStateOf(10.dp)
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.blurRadius = blurRadius.value
+      blurRadius(blurRadius.value)
     }
     composeTestRule.waitForIdle()
 
@@ -66,7 +67,7 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     )
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.colorEffects = colorEffects.value
+      colorEffects(colorEffects.value)
     }
     composeTestRule.waitForIdle()
 
@@ -78,21 +79,19 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
   fun styleMutation_doesNotInfiniteLoop() {
     val hazeState = HazeState()
     val style = mutableStateOf(
-      HazeBlurStyle(
-        colorEffects = emptyList(),
-        blurRadius = 10.dp,
-      ),
+      HazeBlurStyle {
+        colorEffects(emptyList())
+        blurRadius(10.dp)
+      },
     )
 
-    composeTestRule.setBlurEffectContent(hazeState) {
-      this.style = style.value
-    }
+    composeTestRule.setBlurEffectStyleContent(hazeState) { style.value }
     composeTestRule.waitForIdle()
 
-    style.value = HazeBlurStyle(
-      colorEffects = emptyList(),
-      blurRadius = 20.dp,
-    )
+    style.value = HazeBlurStyle {
+      colorEffects(emptyList())
+      blurRadius(20.dp)
+    }
     composeTestRule.awaitIdleWithTimeout("after style mutation")
   }
 
@@ -102,7 +101,7 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     val blurEnabled = mutableStateOf(true)
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.blurEnabled = blurEnabled.value
+      blurEnabled(blurEnabled.value)
     }
     composeTestRule.waitForIdle()
 
@@ -116,7 +115,7 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     val progressive = mutableStateOf<HazeProgressive?>(null)
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.progressive = progressive.value
+      progressive(progressive.value)
     }
     composeTestRule.waitForIdle()
 
@@ -133,7 +132,7 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     val noiseFactor = mutableStateOf(0f)
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.noiseFactor = noiseFactor.value
+      noiseFactor(noiseFactor.value)
     }
     composeTestRule.waitForIdle()
 
@@ -144,10 +143,10 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
   @Test
   fun backgroundColorMutation_doesNotInfiniteLoop() {
     val hazeState = HazeState()
-    val backgroundColor = mutableStateOf(Color.Unspecified)
+    val backgroundColor = mutableStateOf(Color.White)
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.backgroundColor = backgroundColor.value
+      backgroundColor(backgroundColor.value)
     }
     composeTestRule.waitForIdle()
 
@@ -161,7 +160,7 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     val alpha = mutableStateOf(1f)
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.alpha = alpha.value
+      alpha(alpha.value)
     }
     composeTestRule.waitForIdle()
 
@@ -175,7 +174,7 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     val mask = mutableStateOf<Brush?>(null)
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.mask = mask.value
+      mask(mask.value)
     }
     composeTestRule.waitForIdle()
 
@@ -188,10 +187,10 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
   @Test
   fun fallbackTintMutation_doesNotInfiniteLoop() {
     val hazeState = HazeState()
-    val fallbackTint = mutableStateOf<HazeColorEffect>(HazeColorEffect.Unspecified)
+    val fallbackTint = mutableStateOf<HazeColorEffect>(HazeColorEffect.tint(Color.White))
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.fallbackTint = fallbackTint.value
+      fallbackColorEffect(fallbackTint.value)
     }
     composeTestRule.waitForIdle()
 
@@ -205,7 +204,7 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     val blurredEdgeTreatment = mutableStateOf(HazeBlurDefaults.blurredEdgeTreatment)
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.blurredEdgeTreatment = blurredEdgeTreatment.value
+      blurredEdgeTreatment(blurredEdgeTreatment.value)
     }
     composeTestRule.waitForIdle()
 
@@ -222,8 +221,8 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     )
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.blurRadius = blurRadius.value
-      this.colorEffects = colorEffects.value
+      blurRadius(blurRadius.value)
+      colorEffects(colorEffects.value)
     }
     composeTestRule.waitForIdle()
 
@@ -256,11 +255,10 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
 
       BlurTestGradientBox(
         Modifier
-          .hazeEffect(hazeState) {
-            blurEffect {
-              this.blurRadius = blurRadius.value
-            }
-          }
+          .hazeBlur(
+            input = HazeInput.Sources(hazeState),
+            style = HazeBlurStyle { blurRadius(blurRadius.value) },
+          )
           .size(100.dp),
       )
     }
@@ -280,10 +278,10 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     val hazeState = HazeState()
     val showSource = mutableStateOf(true)
     val style = mutableStateOf(
-      HazeBlurStyle(
-        blurRadius = 10.dp,
-        colorEffects = emptyList(),
-      ),
+      HazeBlurStyle {
+        blurRadius(10.dp)
+        colorEffects(emptyList())
+      },
     )
 
     composeTestRule.setContent {
@@ -293,11 +291,10 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
 
       BlurTestGradientBox(
         Modifier
-          .hazeEffect(hazeState) {
-            blurEffect {
-              this.style = style.value
-            }
-          }
+          .hazeBlur(
+            input = HazeInput.Sources(hazeState),
+            style = style.value,
+          )
           .size(100.dp),
       )
     }
@@ -305,10 +302,10 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
 
     composeTestRule.runOnIdle {
       showSource.value = false
-      style.value = HazeBlurStyle(
-        blurRadius = 22.dp,
-        colorEffects = listOf(HazeColorEffect.tint(Color.Cyan.copy(alpha = 0.3f))),
-      )
+      style.value = HazeBlurStyle {
+        blurRadius(22.dp)
+        colorEffects(listOf(HazeColorEffect.tint(Color.Cyan.copy(alpha = 0.3f))))
+      }
     }
     composeTestRule.awaitIdleWithTimeout("after combined source and style mutation")
   }
@@ -321,9 +318,9 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
     val noiseFactor = mutableStateOf(0f)
 
     composeTestRule.setBlurEffectContent(hazeState) {
-      this.blurRadius = blurRadius.value
-      this.alpha = alpha.value
-      this.noiseFactor = noiseFactor.value
+      blurRadius(blurRadius.value)
+      alpha(alpha.value)
+      noiseFactor(noiseFactor.value)
     }
     composeTestRule.waitForIdle()
 
@@ -335,6 +332,24 @@ class BlurVisualEffectRecompositionLoopInstrumentationTest {
         noiseFactor.value = if (toggled) 0.4f else 0f
       }
       composeTestRule.awaitIdleWithTimeout("after rapid combined mutation #$index")
+    }
+  }
+
+  private fun ComposeContentTestRule.setBlurEffectStyleContent(
+    hazeState: HazeState,
+    style: () -> HazeBlurStyle,
+  ) {
+    setContent {
+      Box(Modifier.hazeSource(hazeState).size(100.dp)) {
+        BlurTestGradientBox(
+          Modifier
+            .hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = style(),
+            )
+            .size(100.dp),
+        )
+      }
     }
   }
 }

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -145,7 +145,7 @@ public class BlurVisualEffect private constructor(
     (delegate as? RetainedOutputDelegate)?.clearRetainedOutput()
   }
 
-  override fun shouldClipToNodeBounds(): Boolean = blurredEdgeTreatment.shape != null
+  override fun shouldClipToNodeBounds(): Boolean = blurredEdgeTreatment.isBounded()
 
   private fun resetDirtyTracker() {
     dirtyTracker = Bitmask()
@@ -317,7 +317,9 @@ public class BlurVisualEffect private constructor(
         blurredEdgeTreatmentOverride = value
         if (old != blurredEdgeTreatment) {
           dirtyTracker += BlurDirtyFields.BlurredEdgeTreatment
-          needsLayerBoundsInvalidation = true
+          if (old.isBounded() != blurredEdgeTreatment.isBounded()) {
+            needsLayerBoundsInvalidation = true
+          }
         }
       }
     }
@@ -403,7 +405,9 @@ public class BlurVisualEffect private constructor(
     val newEdgeTreatment = blurredEdgeTreatmentOverride ?: new.blurredEdgeTreatment
     if (oldEdgeTreatment != newEdgeTreatment) {
       dirtyTracker += BlurDirtyFields.BlurredEdgeTreatment
-      needsLayerBoundsInvalidation = true
+      if (oldEdgeTreatment.isBounded() != newEdgeTreatment.isBounded()) {
+        needsLayerBoundsInvalidation = true
+      }
     }
   }
 
@@ -422,6 +426,8 @@ public class BlurVisualEffect private constructor(
 private fun Color.prefersClipToAreaBounds(): Boolean {
   return isSpecified && alpha > 0f && alpha < 0.9f
 }
+
+private fun BlurredEdgeTreatment.isBounded(): Boolean = shape != null
 
 internal interface RetainedOutputDelegate {
   fun canDrawRetainedOutput(): Boolean

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -35,19 +35,22 @@ import dev.chrisbanes.haze.VisualEffectContext
 @Stable
 public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
 
-  /** Creates a new [BlurVisualEffect] copying all effective properties from [other]. */
+  /** Creates a new [BlurVisualEffect] copying Styles and direct property overrides from [other]. */
   public constructor(other: BlurVisualEffect) : this() {
+    compositionLocalStyle = other.compositionLocalStyle
     style = other.style
-    blurEnabled = other.blurEnabled
-    blurRadius = other.blurRadius
-    noiseFactor = other.noiseFactor
-    mask = other.mask
-    backgroundColor = other.backgroundColor
-    colorEffects = other.colorEffects
-    fallbackTint = other.fallbackTint
-    alpha = other.alpha
-    progressive = other.progressive
-    blurredEdgeTreatment = other.blurredEdgeTreatment
+    blurEnabledOverride = other.blurEnabledOverride
+    blurRadiusOverride = other.blurRadiusOverride
+    noiseFactorOverride = other.noiseFactorOverride
+    maskOverrideSet = other.maskOverrideSet
+    maskOverride = other.maskOverride
+    backgroundColorOverride = other.backgroundColorOverride
+    colorEffectsOverride = other.colorEffectsOverride?.toList()
+    fallbackTintOverride = other.fallbackTintOverride
+    alphaOverride = other.alphaOverride
+    progressiveOverrideSet = other.progressiveOverrideSet
+    progressiveOverride = other.progressiveOverride
+    blurredEdgeTreatmentOverride = other.blurredEdgeTreatmentOverride
   }
 
   private var isAttached: Boolean = false

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -33,12 +33,16 @@ import dev.chrisbanes.haze.VisualEffectContext
  * runtime, including its delegate, retained layers, input-scale history, and render-effect cache.
  */
 @Stable
-public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
+public class BlurVisualEffect private constructor(
+  initialCompositionLocalStyle: HazeBlurStyle,
+  initialStyle: HazeBlurStyle,
+) : VisualEffect, RetainedOutputVisualEffect {
+
+  public constructor() : this(HazeBlurStyle, HazeBlurStyle)
 
   /** Creates a new [BlurVisualEffect] copying Styles and direct property overrides from [other]. */
-  public constructor(other: BlurVisualEffect) : this() {
-    compositionLocalStyle = other.compositionLocalStyle
-    style = other.style
+  public constructor(other: BlurVisualEffect) :
+    this(other.compositionLocalStyle, other.style) {
     blurEnabledOverride = other.blurEnabledOverride
     blurRadiusOverride = other.blurRadiusOverride
     noiseFactorOverride = other.noiseFactorOverride
@@ -55,6 +59,7 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
 
   private var isAttached: Boolean = false
   private var needsDelegateSelection: Boolean = true
+  private var needsLayerBoundsInvalidation: Boolean = false
   private val inputScalePolicy = BlurInputScalePolicy()
   internal val renderEffectCache = LruCache<RenderEffectCacheKey, RenderEffect>(maxSize = 50)
 
@@ -62,7 +67,7 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     private set
 
   private var resolvedStyle: ResolvedHazeBlurStyle =
-    resolveHazeBlurStyle(HazeBlurStyle, HazeBlurStyle)
+    resolveHazeBlurStyle(initialCompositionLocalStyle, initialStyle)
 
   internal var delegate: Delegate = ScrimBlurVisualEffectDelegate(this)
     set(value) {
@@ -97,7 +102,12 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     compositionLocalStyle = context.currentValueOf(LocalHazeBlurStyle)
     if (dirtyTracker.any(BlurDirtyFields.InvalidateFlags)) {
       needsDelegateSelection = true
-      context.invalidateDraw()
+      if (needsLayerBoundsInvalidation) {
+        needsLayerBoundsInvalidation = false
+        context.invalidateLayerBounds()
+      } else {
+        context.invalidateDraw()
+      }
     }
   }
 
@@ -174,7 +184,10 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
         HazeLogger.d(TAG) { "blurRadius changed. Current: $blurRadius. New: $value" }
         val old = blurRadius
         blurRadiusOverride = normalized
-        if (old != blurRadius) dirtyTracker += BlurDirtyFields.BlurRadius
+        if (old != blurRadius) {
+          dirtyTracker += BlurDirtyFields.BlurRadius
+          needsLayerBoundsInvalidation = true
+        }
       }
     }
 
@@ -220,7 +233,12 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
         HazeLogger.d(TAG) { "backgroundColor changed. Current: $backgroundColor. New: $value" }
         val old = backgroundColor
         backgroundColorOverride = normalized
-        if (old != backgroundColor) dirtyTracker += BlurDirtyFields.BackgroundColor
+        if (old != backgroundColor) {
+          dirtyTracker += BlurDirtyFields.BackgroundColor
+          if (old.prefersClipToAreaBounds() != backgroundColor.prefersClipToAreaBounds()) {
+            needsLayerBoundsInvalidation = true
+          }
+        }
       }
     }
 
@@ -297,7 +315,10 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
         }
         val old = blurredEdgeTreatment
         blurredEdgeTreatmentOverride = value
-        if (old != blurredEdgeTreatment) dirtyTracker += BlurDirtyFields.BlurredEdgeTreatment
+        if (old != blurredEdgeTreatment) {
+          dirtyTracker += BlurDirtyFields.BlurredEdgeTreatment
+          needsLayerBoundsInvalidation = true
+        }
       }
     }
 
@@ -311,7 +332,7 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     )
   }
 
-  internal var compositionLocalStyle: HazeBlurStyle = HazeBlurStyle
+  internal var compositionLocalStyle: HazeBlurStyle = initialCompositionLocalStyle
     set(value) {
       if (field !== value) {
         HazeLogger.d(TAG) { "LocalHazeBlurStyle changed. Current: $field. New: $value" }
@@ -321,7 +342,7 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     }
 
   /** Explicit Style replayed after [LocalHazeBlurStyle]. */
-  public var style: HazeBlurStyle = HazeBlurStyle
+  public var style: HazeBlurStyle = initialStyle
     set(value) {
       if (field !== value) {
         HazeLogger.d(TAG) { "style changed. Current: $field. New: $value" }
@@ -340,7 +361,7 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
   }
 
   override fun shouldPreferClipToAreaBounds(): Boolean {
-    return backgroundColor.isSpecified && backgroundColor.alpha > 0f && backgroundColor.alpha < 0.9f
+    return backgroundColor.prefersClipToAreaBounds()
   }
 
   override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
@@ -353,18 +374,36 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     new: ResolvedHazeBlurStyle,
   ) {
     if (old.blurEnabled != new.blurEnabled) dirtyTracker += BlurDirtyFields.BlurEnabled
-    if (old.blurRadius != new.blurRadius) dirtyTracker += BlurDirtyFields.BlurRadius
+    val oldBlurRadius = blurRadiusOverride ?: old.blurRadius
+    val newBlurRadius = blurRadiusOverride ?: new.blurRadius
+    if (oldBlurRadius != newBlurRadius) {
+      dirtyTracker += BlurDirtyFields.BlurRadius
+      needsLayerBoundsInvalidation = true
+    }
     if (old.noiseFactor != new.noiseFactor) dirtyTracker += BlurDirtyFields.NoiseFactor
     if (old.mask != new.mask) dirtyTracker += BlurDirtyFields.Mask
-    if (old.backgroundColor != new.backgroundColor) dirtyTracker += BlurDirtyFields.BackgroundColor
+    val oldBackgroundColor = backgroundColorOverride ?: old.backgroundColor
+    val newBackgroundColor = backgroundColorOverride ?: new.backgroundColor
+    if (oldBackgroundColor != newBackgroundColor) {
+      dirtyTracker += BlurDirtyFields.BackgroundColor
+      if (
+        oldBackgroundColor.prefersClipToAreaBounds() !=
+        newBackgroundColor.prefersClipToAreaBounds()
+      ) {
+        needsLayerBoundsInvalidation = true
+      }
+    }
     if (old.colorEffects != new.colorEffects) dirtyTracker += BlurDirtyFields.ColorEffects
     if (old.fallbackColorEffect != new.fallbackColorEffect) {
       dirtyTracker += BlurDirtyFields.FallbackColorEffect
     }
     if (old.alpha != new.alpha) dirtyTracker += BlurDirtyFields.Alpha
     if (old.progressive != new.progressive) dirtyTracker += BlurDirtyFields.Progressive
-    if (old.blurredEdgeTreatment != new.blurredEdgeTreatment) {
+    val oldEdgeTreatment = blurredEdgeTreatmentOverride ?: old.blurredEdgeTreatment
+    val newEdgeTreatment = blurredEdgeTreatmentOverride ?: new.blurredEdgeTreatment
+    if (oldEdgeTreatment != newEdgeTreatment) {
       dirtyTracker += BlurDirtyFields.BlurredEdgeTreatment
+      needsLayerBoundsInvalidation = true
     }
   }
 
@@ -378,6 +417,10 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
   internal companion object {
     const val TAG = "BlurVisualEffect"
   }
+}
+
+private fun Color.prefersClipToAreaBounds(): Boolean {
+  return isSpecified && alpha > 0f && alpha < 0.9f
 }
 
 internal interface RetainedOutputDelegate {

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.blur
 
+import androidx.collection.LruCache
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -11,13 +12,12 @@ import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.isSpecified
-import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.takeOrElse
+import androidx.compose.ui.unit.isSpecified
 import dev.chrisbanes.haze.Bitmask
 import dev.chrisbanes.haze.HazeLogger
 import dev.chrisbanes.haze.HazeProgressive
@@ -27,31 +27,17 @@ import dev.chrisbanes.haze.VisualEffect
 import dev.chrisbanes.haze.VisualEffectContext
 
 /**
- * A [VisualEffect] implementation that applies blur effects to content.
+ * Legacy mutable Blur runtime retained while callers migrate to [hazeBlur].
  *
- * This effect supports various blur-related features including:
- * - Configurable blur radius
- * - Tinting with multiple colors
- * - Progressive (gradient) blur
- * - Noise overlays
- * - Background color
- * - Alpha masking
- *
- * Example usage:
- * ```
- * Modifier.hazeEffect {
- *   blurEffect {
- *     blurRadius = 20.dp
- *     colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.5f)))
- *   }
- * }
- * ```
+ * New code should configure Blur with [HazeBlurStyle]. A modifier node owns each instance of this
+ * runtime, including its delegate, retained layers, input-scale history, and render-effect cache.
  */
 @Stable
 public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
 
-  /** Creates a new [BlurVisualEffect] copying all properties from [other]. */
+  /** Creates a new [BlurVisualEffect] copying all effective properties from [other]. */
   public constructor(other: BlurVisualEffect) : this() {
+    style = other.style
     blurEnabled = other.blurEnabled
     blurRadius = other.blurRadius
     noiseFactor = other.noiseFactor
@@ -62,25 +48,25 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     alpha = other.alpha
     progressive = other.progressive
     blurredEdgeTreatment = other.blurredEdgeTreatment
-    style = other.style
   }
 
   private var isAttached: Boolean = false
-
   private var needsDelegateSelection: Boolean = true
   private val inputScalePolicy = BlurInputScalePolicy()
+  internal val renderEffectCache = LruCache<RenderEffectCacheKey, RenderEffect>(maxSize = 50)
 
   internal var dirtyTracker: Bitmask by mutableStateOf(Bitmask())
     private set
+
+  private var resolvedStyle: ResolvedHazeBlurStyle =
+    resolveHazeBlurStyle(HazeBlurStyle, HazeBlurStyle)
 
   internal var delegate: Delegate = ScrimBlurVisualEffectDelegate(this)
     set(value) {
       if (value != field) {
         HazeLogger.d(TAG) { "delegate changed. Current $field. New: $value" }
         if (isAttached) {
-          // attach new delegate
           value.attach()
-          // detach old delegate
           field.detach()
         }
         field = value
@@ -99,13 +85,13 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     if (isAttached) {
       isAttached = false
       delegate.detach()
+      clearRenderEffectCache()
       inputScalePolicy.reset()
     }
   }
 
   override fun update(context: VisualEffectContext) {
     compositionLocalStyle = context.currentValueOf(LocalHazeBlurStyle)
-
     if (dirtyTracker.any(BlurDirtyFields.InvalidateFlags)) {
       needsDelegateSelection = true
       context.invalidateDraw()
@@ -129,10 +115,10 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     return delegate is ScrimBlurVisualEffectDelegate
   }
 
-  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel): Unit =
-    delegate.onTrimMemory(context, level).also {
-      clearRenderEffectCache()
-    }
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    delegate.onTrimMemory(context, level)
+    clearRenderEffectCache()
+  }
 
   override fun canDrawRetainedOutput(context: VisualEffectContext): Boolean {
     return (delegate as? RetainedOutputDelegate)?.canDrawRetainedOutput() == true
@@ -159,221 +145,161 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     }
   }
 
-  private var _blurEnabled: Boolean? = null
+  private var blurEnabledOverride: Boolean? = null
 
-  /**
-   * Whether the blur effect is enabled or not, when running on platforms which support blurring.
-   *
-   * When set to `false` a scrim effect will be used. When set to `true`, and running on a platform
-   * which does not support blurring, a scrim effect will be used.
-   *
-   * Defaults to [HazeBlurDefaults.blurEnabled].
-   */
+  /** Whether Blur is enabled on supported platforms. */
   public var blurEnabled: Boolean
-    get() = _blurEnabled ?: HazeBlurDefaults.blurEnabled()
+    get() = blurEnabledOverride ?: resolvedStyle.blurEnabled
     set(value) {
-      if (_blurEnabled == null || value != _blurEnabled) {
-        HazeLogger.d(TAG) { "blurEnabled changed. Current: $_blurEnabled. New: $value" }
-        _blurEnabled = value
+      if (value != blurEnabled) {
+        HazeLogger.d(TAG) { "blurEnabled changed. Current: $blurEnabled. New: $value" }
+        blurEnabledOverride = value
         dirtyTracker += BlurDirtyFields.BlurEnabled
+      } else if (blurEnabledOverride == null) {
+        blurEnabledOverride = value
       }
     }
 
-  /**
-   * Radius of the blur.
-   *
-   * There are precedence rules to how this styling property is applied:
-   *
-   *  - This property value, if specified.
-   *  - [HazeBlurStyle.blurRadius] value set in [style], if specified.
-   *  - [HazeBlurStyle.blurRadius] value set in the [LocalHazeBlurStyle] composition local.
-   */
-  public var blurRadius: Dp = Dp.Unspecified
-    get() {
-      return field
-        .takeOrElse { style.blurRadius }
-        .takeOrElse { compositionLocalStyle.blurRadius }
-    }
+  private var blurRadiusOverride: Dp? = null
+
+  /** Radius of the blur. */
+  public var blurRadius: Dp
+    get() = blurRadiusOverride ?: resolvedStyle.blurRadius
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "blurRadius changed. Current: $field. New: $value" }
-        field = value
-        dirtyTracker += BlurDirtyFields.BlurRadius
+      val normalized = value.takeIf(Dp::isSpecified)
+      if (normalized != blurRadiusOverride) {
+        HazeLogger.d(TAG) { "blurRadius changed. Current: $blurRadius. New: $value" }
+        val old = blurRadius
+        blurRadiusOverride = normalized
+        if (old != blurRadius) dirtyTracker += BlurDirtyFields.BlurRadius
       }
     }
 
-  /**
-   * Amount of noise applied to the content, in the range `0f` to `1f`.
-   * Anything outside of that range will be clamped.
-   *
-   * There are precedence rules to how this styling property is applied:
-   *
-   *  - This property value, if in the range 0f..1f.
-   *  - [HazeBlurStyle.noiseFactor] value set in [style], if in the range 0f..1f.
-   *  - [HazeBlurStyle.noiseFactor] value set in the [LocalHazeBlurStyle] composition local.
-   */
-  public var noiseFactor: Float = -1f
-    get() {
-      return field
-        .takeOrElse { style.noiseFactor }
-        .takeOrElse { compositionLocalStyle.noiseFactor }
-    }
+  private var noiseFactorOverride: Float? = null
+
+  /** Amount of noise applied to the content, clamped to `0f..1f`. */
+  public var noiseFactor: Float
+    get() = noiseFactorOverride ?: resolvedStyle.noiseFactor
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "noiseFactor changed. Current: $field. New: $value" }
-        field = value.normalizeNoiseFactor()
-        dirtyTracker += BlurDirtyFields.NoiseFactor
+      val normalized = value.takeIf { it >= 0f }?.coerceAtMost(1f)
+      if (normalized != noiseFactorOverride) {
+        HazeLogger.d(TAG) { "noiseFactor changed. Current: $noiseFactor. New: $value" }
+        val old = noiseFactor
+        noiseFactorOverride = normalized
+        if (old != noiseFactor) dirtyTracker += BlurDirtyFields.NoiseFactor
       }
     }
 
-  /**
-   * Optional alpha mask which allows effects such as fading via a
-   * [Brush.verticalGradient] or similar. This is only applied when [progressive] is null.
-   *
-   * An alpha mask provides a similar effect as that provided as [HazeProgressive], in a more
-   * performant way, but may provide a less pleasing visual result.
-   */
-  public var mask: Brush? = null
+  private var maskOverrideSet: Boolean = false
+  private var maskOverride: Brush? = null
+
+  /** Optional alpha mask. */
+  public var mask: Brush?
+    get() = if (maskOverrideSet) maskOverride else resolvedStyle.mask
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "mask changed. Current: $field. New: $value" }
-        field = value
-        dirtyTracker += BlurDirtyFields.Mask
+      if (!maskOverrideSet || value != maskOverride) {
+        HazeLogger.d(TAG) { "mask changed. Current: $mask. New: $value" }
+        val old = mask
+        maskOverrideSet = true
+        maskOverride = value
+        if (old != mask) dirtyTracker += BlurDirtyFields.Mask
       }
     }
 
-  /**
-   * Color to draw behind the blurred content. Ideally should be opaque
-   * so that the original content is not visible behind. Typically this would be
-   * `MaterialTheme.colorScheme.surface` or similar.
-   *
-   * There are precedence rules to how this styling property is applied:
-   *
-   *  - This property value, if specified.
-   *  - [HazeBlurStyle.backgroundColor] value set in [style], if specified.
-   *  - [HazeBlurStyle.backgroundColor] value set in the [LocalHazeBlurStyle] composition local.
-   */
-  public var backgroundColor: Color = Color.Unspecified
-    get() {
-      return field
-        .takeOrElse { style.backgroundColor }
-        .takeOrElse { compositionLocalStyle.backgroundColor }
-    }
+  private var backgroundColorOverride: Color? = null
+
+  /** Color drawn behind the blurred content. */
+  public var backgroundColor: Color
+    get() = backgroundColorOverride ?: resolvedStyle.backgroundColor
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "backgroundColor changed. Current: $field. New: $value" }
-        field = value
-        dirtyTracker += BlurDirtyFields.BackgroundColor
+      val normalized = value.takeIf { it.isSpecified }
+      if (normalized != backgroundColorOverride) {
+        HazeLogger.d(TAG) { "backgroundColor changed. Current: $backgroundColor. New: $value" }
+        val old = backgroundColor
+        backgroundColorOverride = normalized
+        if (old != backgroundColor) dirtyTracker += BlurDirtyFields.BackgroundColor
       }
     }
 
-  /**
-   * The [HazeTint]s to apply to the blurred content.
-   *
-   * There are precedence rules to how this styling property is applied:
-   *
-   *  - This property value, if not empty.
-   *  - [HazeBlurStyle.colorEffects] value set in [style], if not empty.
-   *  - [HazeBlurStyle.colorEffects] value set in the [LocalHazeBlurStyle] composition local.
-   */
-  public var colorEffects: List<HazeColorEffect>? = null
-    get() {
-      return field
-        ?: style.specifiedColorEffects
-        ?: compositionLocalStyle.specifiedColorEffects
-        ?: emptyList()
-    }
+  private var colorEffectsOverride: List<HazeColorEffect>? = null
+
+  /** Color effects applied to the blurred content. */
+  public var colorEffects: List<HazeColorEffect>?
+    get() = colorEffectsOverride ?: resolvedStyle.colorEffects
     set(value) {
       val snapshot = value?.toList()
-      if (snapshot != field) {
-        HazeLogger.d(TAG) { "colorEffects changed. Current: $field. New: $snapshot" }
-        field = snapshot
-        dirtyTracker += BlurDirtyFields.ColorEffects
+      if (snapshot != colorEffectsOverride) {
+        HazeLogger.d(TAG) { "colorEffects changed. Current: $colorEffects. New: $snapshot" }
+        val old = colorEffects
+        colorEffectsOverride = snapshot
+        if (old != colorEffects) dirtyTracker += BlurDirtyFields.ColorEffects
       }
     }
 
-  /**
-   * The [HazeTint] to use when Haze uses the fallback scrim functionality.
-   *
-   * The scrim used whenever [blurEnabled] is resolved to false, either because the host
-   * platform does not support blurring, or it has been manually disabled.
-   *
-   * When the fallback tint is used, the tints provided in [colorEffects] are ignored.
-   *
-   * There are precedence rules to how this styling property is applied:
-   *
-   *  - This property value, if specified
-   *  - [HazeBlurStyle.fallbackColorEffect] value set in [style], if specified.
-   *  - [HazeBlurStyle.fallbackColorEffect] value set in the [LocalHazeBlurStyle] composition local.
-   */
-  public var fallbackTint: HazeColorEffect = HazeColorEffect.Unspecified
-    get() {
-      return field.takeIf { it.isSpecified }
-        ?: style.fallbackColorEffect.takeIf { it.isSpecified }
-        ?: compositionLocalStyle.fallbackColorEffect
-    }
+  private var fallbackTintOverride: HazeColorEffect? = null
+
+  /** Color effect used by the fallback scrim. */
+  public var fallbackTint: HazeColorEffect
+    get() = fallbackTintOverride ?: resolvedStyle.fallbackColorEffect
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "fallbackTint changed. Current: $field. New: $value" }
-        field = value
-        dirtyTracker += BlurDirtyFields.FallbackColorEffect
+      val normalized = value.takeIf { it.isSpecified }
+      if (normalized != fallbackTintOverride) {
+        HazeLogger.d(TAG) { "fallbackTint changed. Current: $fallbackTint. New: $value" }
+        val old = fallbackTint
+        fallbackTintOverride = normalized
+        if (old != fallbackTint) dirtyTracker += BlurDirtyFields.FallbackColorEffect
       }
     }
 
-  /**
-   * The opacity that the overall effect will drawn with, in the range of 0..1.
-   */
-  public var alpha: Float = 1f
+  private var alphaOverride: Float? = null
+
+  /** Opacity of the overall effect. */
+  public var alpha: Float
+    get() = alphaOverride ?: resolvedStyle.alpha
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "alpha changed. Current: $field. New: $value" }
-        field = value
-        dirtyTracker += BlurDirtyFields.Alpha
+      val normalized = value.coerceIn(0f, 1f)
+      if (normalized != alphaOverride) {
+        HazeLogger.d(TAG) { "alpha changed. Current: $alpha. New: $value" }
+        val old = alpha
+        alphaOverride = normalized
+        if (old != alpha) dirtyTracker += BlurDirtyFields.Alpha
       }
     }
 
-  /**
-   * Parameters for enabling a progressive (or gradient) blur effect, or null for a uniform
-   * blurring effect. Defaults to null.
-   *
-   * Please note: progressive blurring effects can be expensive, so you should test on a variety
-   * of devices to verify that performance is acceptable for your use case. An alternative and
-   * more performant way to achieve this effect is via the [mask] parameter, at the cost of
-   * visual finesse.
-   */
-  public var progressive: HazeProgressive? = null
+  private var progressiveOverrideSet: Boolean = false
+  private var progressiveOverride: HazeProgressive? = null
+
+  /** Progressive Blur parameters, or null for uniform Blur. */
+  public var progressive: HazeProgressive?
+    get() = if (progressiveOverrideSet) progressiveOverride else resolvedStyle.progressive
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "progressive changed. Current: $field. New: $value" }
-        field = value
-        dirtyTracker += BlurDirtyFields.Progressive
+      if (!progressiveOverrideSet || value != progressiveOverride) {
+        HazeLogger.d(TAG) { "progressive changed. Current: $progressive. New: $value" }
+        val old = progressive
+        progressiveOverrideSet = true
+        progressiveOverride = value
+        if (old != progressive) dirtyTracker += BlurDirtyFields.Progressive
       }
     }
 
-  /**
-   * The [BlurredEdgeTreatment] to use when blurring content.
-   *
-   * Defaults to [BlurredEdgeTreatment.Rectangle] (via [HazeBlurDefaults.blurredEdgeTreatment]), which
-   * is nearly always the correct value for when performing background blurring. If you're
-   * performing content (foreground) blurring, it depends on the effect which you're looking for.
-   *
-   * Please note: some platforms do not support all of the treatments available. This value is a
-   * best-effort attempt.
-   */
-  public var blurredEdgeTreatment: BlurredEdgeTreatment = HazeBlurDefaults.blurredEdgeTreatment
+  private var blurredEdgeTreatmentOverride: BlurredEdgeTreatment? = null
+
+  /** Edge treatment used while blurring. */
+  public var blurredEdgeTreatment: BlurredEdgeTreatment
+    get() = blurredEdgeTreatmentOverride ?: resolvedStyle.blurredEdgeTreatment
     set(value) {
-      if (value != field) {
-        HazeLogger.d(TAG) { "blurredEdgeTreatment changed. Current: $field. New: $value" }
-        field = value
-        dirtyTracker += BlurDirtyFields.BlurredEdgeTreatment
+      if (value != blurredEdgeTreatmentOverride) {
+        HazeLogger.d(TAG) {
+          "blurredEdgeTreatment changed. Current: $blurredEdgeTreatment. New: $value"
+        }
+        val old = blurredEdgeTreatment
+        blurredEdgeTreatmentOverride = value
+        if (old != blurredEdgeTreatment) dirtyTracker += BlurDirtyFields.BlurredEdgeTreatment
       }
     }
 
   internal fun resolveInputScaleFactor(context: VisualEffectContext): Float {
-    val density = context.requireDensity()
-    val blurRadiusPx = with(density) {
-      blurRadius.takeOrElse { 0.dp }.toPx()
-    }
+    val blurRadiusPx = with(context.requireDensity()) { blurRadius.toPx() }
     return inputScalePolicy.resolve(
       requestedScale = context.inputScale,
       blurRadiusPx = blurRadiusPx,
@@ -382,54 +308,61 @@ public class BlurVisualEffect() : VisualEffect, RetainedOutputVisualEffect {
     )
   }
 
-  internal var compositionLocalStyle: HazeBlurStyle = HazeBlurStyle.Unspecified
+  internal var compositionLocalStyle: HazeBlurStyle = HazeBlurStyle
     set(value) {
-      if (field != value) {
+      if (field !== value) {
         HazeLogger.d(TAG) { "LocalHazeBlurStyle changed. Current: $field. New: $value" }
-        onStyleChanged(field, value)
         field = value
+        resolveStyle()
       }
     }
 
-  /**
-   * Style set on this specific blur effect.
-   *
-   * There are precedence rules to how each styling property is applied. The order of precedence
-   * for each property are as follows:
-   *
-   *  - Property value set directly on this [BlurVisualEffect], if specified.
-   *  - Value set here in [style], if specified.
-   *  - Value set in the [LocalHazeBlurStyle] composition local.
-   */
-  public var style: HazeBlurStyle = HazeBlurStyle.Unspecified
+  /** Explicit Style replayed after [LocalHazeBlurStyle]. */
+  public var style: HazeBlurStyle = HazeBlurStyle
     set(value) {
-      if (field != value) {
+      if (field !== value) {
         HazeLogger.d(TAG) { "style changed. Current: $field. New: $value" }
-        onStyleChanged(field, value)
         field = value
+        resolveStyle()
       }
     }
+
+  private fun resolveStyle() {
+    val previous = resolvedStyle
+    val next = resolveHazeBlurStyle(compositionLocalStyle, style)
+    if (previous != next) {
+      resolvedStyle = next
+      onResolvedStyleChanged(previous, next)
+    }
+  }
 
   override fun shouldPreferClipToAreaBounds(): Boolean {
-    return backgroundColor.isSpecified && backgroundColor.alpha < 0.9f
+    return backgroundColor.isSpecified && backgroundColor.alpha > 0f && backgroundColor.alpha < 0.9f
   }
 
   override fun calculateLayerBounds(rect: Rect, density: Density): Rect {
-    val blurRadiusPx = with(density) {
-      blurRadius.takeOrElse { 0.dp }.toPx()
-    }
-    return when {
-      blurRadiusPx >= 1f -> rect.inflate(blurRadiusPx)
-      else -> rect
-    }
+    val blurRadiusPx = with(density) { blurRadius.toPx() }
+    return if (blurRadiusPx >= 1f) rect.inflate(blurRadiusPx) else rect
   }
 
-  private fun onStyleChanged(old: HazeBlurStyle?, new: HazeBlurStyle?) {
-    if (old?.specifiedColorEffects != new?.specifiedColorEffects) dirtyTracker += BlurDirtyFields.ColorEffects
-    if (old?.fallbackColorEffect != new?.fallbackColorEffect) dirtyTracker += BlurDirtyFields.FallbackColorEffect
-    if (old?.backgroundColor != new?.backgroundColor) dirtyTracker += BlurDirtyFields.BackgroundColor
-    if (old?.noiseFactor != new?.noiseFactor) dirtyTracker += BlurDirtyFields.NoiseFactor
-    if (old?.blurRadius != new?.blurRadius) dirtyTracker += BlurDirtyFields.BlurRadius
+  private fun onResolvedStyleChanged(
+    old: ResolvedHazeBlurStyle,
+    new: ResolvedHazeBlurStyle,
+  ) {
+    if (old.blurEnabled != new.blurEnabled) dirtyTracker += BlurDirtyFields.BlurEnabled
+    if (old.blurRadius != new.blurRadius) dirtyTracker += BlurDirtyFields.BlurRadius
+    if (old.noiseFactor != new.noiseFactor) dirtyTracker += BlurDirtyFields.NoiseFactor
+    if (old.mask != new.mask) dirtyTracker += BlurDirtyFields.Mask
+    if (old.backgroundColor != new.backgroundColor) dirtyTracker += BlurDirtyFields.BackgroundColor
+    if (old.colorEffects != new.colorEffects) dirtyTracker += BlurDirtyFields.ColorEffects
+    if (old.fallbackColorEffect != new.fallbackColorEffect) {
+      dirtyTracker += BlurDirtyFields.FallbackColorEffect
+    }
+    if (old.alpha != new.alpha) dirtyTracker += BlurDirtyFields.Alpha
+    if (old.progressive != new.progressive) dirtyTracker += BlurDirtyFields.Progressive
+    if (old.blurredEdgeTreatment != new.blurredEdgeTreatment) {
+      dirtyTracker += BlurDirtyFields.BlurredEdgeTreatment
+    }
   }
 
   internal interface Delegate {

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
@@ -5,7 +5,6 @@
 
 package dev.chrisbanes.haze.blur
 
-import androidx.collection.LruCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
@@ -62,14 +61,8 @@ internal fun BlurVisualEffect.getOrCreateRenderEffect(
   )
 }
 
-private val renderEffectCache = lazy(mode = LazyThreadSafetyMode.NONE) {
-  LruCache<RenderEffectCacheKey, RenderEffect>(maxSize = 50)
-}
-
-internal fun clearRenderEffectCache() {
-  if (renderEffectCache.isInitialized()) {
-    renderEffectCache.value.evictAll()
-  }
+internal fun BlurVisualEffect.clearRenderEffectCache() {
+  renderEffectCache.evictAll()
 }
 
 @Poko
@@ -126,11 +119,14 @@ internal fun RenderEffectParams.renderEffectCacheKey(density: Density): RenderEf
 }
 
 @OptIn(ExperimentalHazeApi::class)
-private fun getOrCreateRenderEffect(context: VisualEffectContext, params: RenderEffectParams): RenderEffect? {
+private fun BlurVisualEffect.getOrCreateRenderEffect(
+  context: VisualEffectContext,
+  params: RenderEffectParams,
+): RenderEffect? {
   HazeLogger.d(BlurVisualEffect.TAG) { "getOrCreateRenderEffect: $params" }
   val density = context.requireDensity()
   val cacheKey = params.renderEffectCacheKey(density)
-  val cached = renderEffectCache.value[cacheKey]
+  val cached = renderEffectCache[cacheKey]
   if (cached != null) {
     HazeLogger.d(BlurVisualEffect.TAG) { "getOrCreateRenderEffect. Returning cached: $params" }
     return cached
@@ -144,6 +140,6 @@ private fun getOrCreateRenderEffect(context: VisualEffectContext, params: Render
       params = params,
     )
   }.also { effect ->
-    renderEffectCache.value.put(cacheKey, effect)
+    renderEffectCache.put(cacheKey, effect)
   }
 }

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlur.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlur.kt
@@ -1,0 +1,76 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import dev.chrisbanes.haze.HazeEffectFactory
+import dev.chrisbanes.haze.HazeEffectFactoryVisualEffect
+import dev.chrisbanes.haze.HazeEffectRenderer
+import dev.chrisbanes.haze.HazeEffectVisualEffectFactory
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeSampling
+import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.RetainedOutputVisualEffect
+import dev.chrisbanes.haze.VisualEffect
+import dev.chrisbanes.haze.hazeEffect
+
+/**
+ * Applies Blur to an explicit [input].
+ *
+ * [style] is an opaque, shareable program. Resolution starts from [HazeBlurDefaults.style], then
+ * replays [LocalHazeBlurStyle], then [style]. Later writes win. Each modifier node owns its Blur
+ * runtime, delegate, retained output, input-scale history, cache, and lifecycle resources.
+ *
+ * @param input Source-backed content or this modifier's own content.
+ * @param style Explicit Blur Style replayed after [LocalHazeBlurStyle].
+ * @param sampling Input-sampling policy for the Blur runtime.
+ * @param expandLayerBounds Whether Blur may expand its capture layer by the resolved radius.
+ */
+@Stable
+public fun Modifier.hazeBlur(
+  input: HazeInput,
+  style: HazeBlurStyle = HazeBlurStyle,
+  sampling: HazeSampling = HazeSampling.Default,
+  expandLayerBounds: Boolean = true,
+): Modifier = hazeEffect(
+  factory = HazeBlurFactory,
+  input = input,
+  style = style,
+  sampling = sampling,
+  expandLayerBounds = expandLayerBounds,
+)
+
+@OptIn(InternalHazeApi::class)
+internal object HazeBlurFactory :
+  HazeEffectFactory<HazeBlurStyle>,
+  HazeEffectVisualEffectFactory<HazeBlurStyle> {
+
+  override fun createRenderer(): HazeEffectRenderer<HazeBlurStyle> {
+    error("Blur uses the built-in full VisualEffect adapter")
+  }
+
+  override fun createVisualEffect(
+    style: HazeBlurStyle,
+    sampling: HazeSampling,
+  ): HazeEffectFactoryVisualEffect<HazeBlurStyle> {
+    return BlurHazeEffectFactoryVisualEffect(
+      BlurVisualEffect().apply {
+        this.style = style
+      },
+    )
+  }
+}
+
+@OptIn(InternalHazeApi::class)
+internal class BlurHazeEffectFactoryVisualEffect(
+  internal val effect: BlurVisualEffect,
+) : HazeEffectFactoryVisualEffect<HazeBlurStyle>,
+  VisualEffect by effect,
+  RetainedOutputVisualEffect by effect {
+
+  override fun updateStyle(style: HazeBlurStyle, sampling: HazeSampling) {
+    effect.style = style
+  }
+}

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurDefaults.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurDefaults.kt
@@ -36,6 +36,24 @@ public object HazeBlurDefaults {
   public val blurredEdgeTreatment: BlurredEdgeTreatment = BlurredEdgeTreatment.Rectangle
 
   /**
+   * Complete default Blur Style.
+   *
+   * This Style is replayed before composition-local and explicit Styles.
+   */
+  public val style: HazeBlurStyle = HazeBlurStyle {
+    blurEnabled(blurEnabled())
+    blurRadius(blurRadius)
+    noiseFactor(noiseFactor)
+    backgroundColor(Color.Transparent)
+    colorEffects(emptyList())
+    fallbackColorEffect(HazeColorEffect.Unspecified)
+    alpha(1f)
+    mask(null)
+    progressive(null)
+    blurredEdgeTreatment(blurredEdgeTreatment)
+  }
+
+  /**
    * Default builder for the 'tint' color. Transforms the provided [color].
    */
   public fun tint(color: Color): HazeColorEffect = HazeColorEffect.tint(
@@ -57,12 +75,18 @@ public object HazeBlurDefaults {
    * @param noiseFactor Amount of noise applied to the content, in the range `0f` to `1f`.
    * Anything outside of that range will be clamped.
    */
+  @Deprecated("Use HazeBlurDefaults.style.then { ... }")
   public fun style(
     backgroundColor: Color,
     tint: HazeColorEffect = tint(backgroundColor),
     blurRadius: Dp = this.blurRadius,
     noiseFactor: Float = this.noiseFactor,
-  ): HazeBlurStyle = HazeBlurStyle(backgroundColor, tint, blurRadius, noiseFactor)
+  ): HazeBlurStyle = style.then {
+    if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+    if (tint.isSpecified) colorEffects(listOf(tint))
+    blurRadius(blurRadius)
+    noiseFactor(noiseFactor)
+  }
 
   /**
    * Default values for [BlurVisualEffect.blurEnabled]. This function only returns `true` on

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
@@ -7,125 +7,281 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.Poko
 
 /**
- * A [ProvidableCompositionLocal] which provides the default [HazeBlurStyle] for all [dev.chrisbanes.haze.hazeEffect]
- * layout nodes placed within this composition local's content.
+ * A [ProvidableCompositionLocal] which provides Blur Style writes inherited by all
+ * [hazeBlur] modifiers in its content.
  *
- * There are precedence rules to how each styling property is applied. The order of precedence
- * for each property are as follows:
- *
- *  - Value set in [dev.chrisbanes.haze.HazeEffectScope], if specified.
- *  - Value set in style provided to [dev.chrisbanes.haze.hazeEffect] (or [dev.chrisbanes.haze.HazeEffectScope.style]), if specified.
- *  - Value set in this composition local.
+ * Resolution applies [HazeBlurDefaults.style], this Style, and the modifier's explicit Style in
+ * order. Later writes replace earlier writes.
  */
 public val LocalHazeBlurStyle: ProvidableCompositionLocal<HazeBlurStyle> =
-  compositionLocalOf { HazeBlurDefaults.style(Color.Unspecified) }
+  compositionLocalOf { HazeBlurStyle }
 
 /**
- * A holder for the style properties used by Haze.
+ * An opaque, stateless, and shareable program of Blur Style writes.
  *
- * Can be set via [dev.chrisbanes.haze.hazeSource] and [dev.chrisbanes.haze.hazeEffect].
- *
- * @property backgroundColor Color to draw behind the blurred content. Ideally should be opaque
- * so that the original content is not visible behind. Typically this would be
- * `MaterialTheme.colorScheme.surface` or similar.
- * @property colorEffects The [HazeTint]s to apply to the blurred content.
- * @property blurRadius Radius of the blur.
- * @property noiseFactor Amount of noise applied to the content, in the range `0f` to `1f`.
- * Anything outside of that range will be clamped.
- * @property fallbackColorEffect The [HazeTint] to use when Haze uses the fallback scrim functionality.
- * The scrim used whenever blurring is disabled, either because the host platform does not
- * support blurring, or it has been manually disabled.
- * When the fallback tint is used, the tints provided in [colorEffects] are ignored.
+ * A Style never owns renderer or platform resources. Calling [then] creates a new Style whose
+ * writes replay after this one, so the last write to each property wins.
  */
 @Immutable
-public class HazeBlurStyle public constructor(
-  public val backgroundColor: Color = Color.Unspecified,
-  colorEffects: List<HazeColorEffect>? = null,
-  public val blurRadius: Dp = Dp.Unspecified,
-  noiseFactor: Float = -1f,
-  public val fallbackColorEffect: HazeColorEffect = HazeColorEffect.Unspecified,
-) {
-  public constructor(
-    backgroundColor: Color = Color.Unspecified,
-    colorEffect: HazeColorEffect? = null,
-    blurRadius: Dp = Dp.Unspecified,
-    noiseFactor: Float = -1f,
-    fallbackColorEffect: HazeColorEffect = HazeColorEffect.Unspecified,
-  ) : this(
-    backgroundColor = backgroundColor,
-    colorEffects = colorEffect?.let(::listOf),
-    blurRadius = blurRadius,
-    noiseFactor = noiseFactor,
-    fallbackColorEffect = fallbackColorEffect,
-  )
+public sealed interface HazeBlurStyle {
+  /** Returns a Style that replays [other] after this Style. */
+  public fun then(other: HazeBlurStyle): HazeBlurStyle = combineHazeBlurStyles(this, other)
 
-  internal val specifiedColorEffects: List<HazeColorEffect>? = colorEffects?.toList()
+  /** Returns a Style that replays [block] after this Style. */
+  public fun then(block: HazeBlurStyleScope.() -> Unit): HazeBlurStyle =
+    then(HazeBlurStyle(block))
 
-  public val noiseFactor: Float = noiseFactor.normalizeNoiseFactor()
-
-  public val colorEffects: List<HazeColorEffect>
-    get() = specifiedColorEffects.orEmpty()
-
-  public operator fun component1(): Color = backgroundColor
-  public operator fun component2(): List<HazeColorEffect> = colorEffects
-  public operator fun component3(): Dp = blurRadius
-  public operator fun component4(): Float = noiseFactor
-  public operator fun component5(): HazeColorEffect = fallbackColorEffect
-
-  public fun copy(
-    backgroundColor: Color = this.backgroundColor,
-    colorEffects: List<HazeColorEffect>? = this.specifiedColorEffects,
-    blurRadius: Dp = this.blurRadius,
-    noiseFactor: Float = this.noiseFactor,
-    fallbackColorEffect: HazeColorEffect = this.fallbackColorEffect,
-  ): HazeBlurStyle = HazeBlurStyle(
-    backgroundColor = backgroundColor,
-    colorEffects = colorEffects,
-    blurRadius = blurRadius,
-    noiseFactor = noiseFactor,
-    fallbackColorEffect = fallbackColorEffect,
-  )
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other !is HazeBlurStyle) return false
-    return backgroundColor == other.backgroundColor &&
-      specifiedColorEffects == other.specifiedColorEffects &&
-      blurRadius == other.blurRadius &&
-      noiseFactor == other.noiseFactor &&
-      fallbackColorEffect == other.fallbackColorEffect
-  }
-
-  override fun hashCode(): Int {
-    var result = backgroundColor.hashCode()
-    result = 31 * result + specifiedColorEffects.hashCode()
-    result = 31 * result + blurRadius.hashCode()
-    result = 31 * result + noiseFactor.hashCode()
-    result = 31 * result + fallbackColorEffect.hashCode()
-    return result
-  }
-
-  override fun toString(): String {
-    return "HazeBlurStyle(" +
-      "backgroundColor=$backgroundColor, " +
-      "colorEffects=$specifiedColorEffects, " +
-      "blurRadius=$blurRadius, " +
-      "noiseFactor=$noiseFactor, " +
-      "fallbackColorEffect=$fallbackColorEffect" +
-      ")"
-  }
-
-  public companion object {
-    public val Unspecified: HazeBlurStyle = HazeBlurStyle(colorEffects = null)
+  public companion object : HazeBlurStyle {
+    /** Compatibility name for the empty Style. */
+    @Deprecated("Use HazeBlurStyle")
+    public val Unspecified: HazeBlurStyle get() = this
   }
 }
+
+@Immutable
+private class RecordedHazeBlurStyle(
+  private val writes: List<HazeBlurStyleScope.() -> Unit>,
+) : HazeBlurStyle {
+  fun replay(scope: HazeBlurStyleScope) {
+    for (write in writes) {
+      scope.write()
+    }
+  }
+
+  fun then(other: RecordedHazeBlurStyle): HazeBlurStyle =
+    RecordedHazeBlurStyle(writes + other.writes)
+}
+
+/** Creates an opaque, replayable Blur Style from [block]. */
+public fun HazeBlurStyle(block: HazeBlurStyleScope.() -> Unit): HazeBlurStyle =
+  RecordedHazeBlurStyle(recordWrites(block))
+
+/**
+ * Compatibility adapter for the pre-2.0 value Style.
+ *
+ * Sentinel interpretation is deliberately isolated here. New code should use the Style block.
+ */
+@Deprecated("Use HazeBlurStyle { ... }")
+public fun HazeBlurStyle(
+  backgroundColor: Color = Color.Unspecified,
+  colorEffects: List<HazeColorEffect>? = null,
+  blurRadius: Dp = Dp.Unspecified,
+  noiseFactor: Float = -1f,
+  fallbackColorEffect: HazeColorEffect = HazeColorEffect.Unspecified,
+): HazeBlurStyle = HazeBlurStyle {
+  if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+  if (colorEffects != null) colorEffects(colorEffects)
+  if (blurRadius.isSpecified) blurRadius(blurRadius)
+  if (noiseFactor >= 0f) noiseFactor(noiseFactor)
+  if (fallbackColorEffect.isSpecified) fallbackColorEffect(fallbackColorEffect)
+}
+
+/** Compatibility adapter for the singular pre-2.0 color effect constructor. */
+@Deprecated("Use HazeBlurStyle { ... }")
+@Suppress("DEPRECATION")
+public fun HazeBlurStyle(
+  backgroundColor: Color = Color.Unspecified,
+  colorEffect: HazeColorEffect?,
+  blurRadius: Dp = Dp.Unspecified,
+  noiseFactor: Float = -1f,
+  fallbackColorEffect: HazeColorEffect = HazeColorEffect.Unspecified,
+): HazeBlurStyle = HazeBlurStyle(
+  backgroundColor = backgroundColor,
+  colorEffects = colorEffect?.let(::listOf),
+  blurRadius = blurRadius,
+  noiseFactor = noiseFactor,
+  fallbackColorEffect = fallbackColorEffect,
+)
+
+private fun combineHazeBlurStyles(
+  first: HazeBlurStyle,
+  second: HazeBlurStyle,
+): HazeBlurStyle = when (first) {
+  HazeBlurStyle -> second
+  is RecordedHazeBlurStyle -> when (second) {
+    HazeBlurStyle -> first
+    is RecordedHazeBlurStyle -> first.then(second)
+  }
+}
+
+internal fun HazeBlurStyle.replay(scope: HazeBlurStyleScope) {
+  when (this) {
+    HazeBlurStyle -> Unit
+    is RecordedHazeBlurStyle -> replay(scope)
+  }
+}
+
+/**
+ * Blur-specific property functions available while constructing a [HazeBlurStyle].
+ */
+public sealed interface HazeBlurStyleScope {
+  public fun blurEnabled(enabled: Boolean)
+  public fun blurRadius(radius: Dp)
+  public fun noiseFactor(factor: Float)
+  public fun backgroundColor(color: Color)
+  public fun colorEffects(effects: List<HazeColorEffect>)
+  public fun fallbackColorEffect(effect: HazeColorEffect)
+  public fun alpha(alpha: Float)
+  public fun mask(mask: Brush?)
+  public fun progressive(progressive: HazeProgressive?)
+  public fun blurredEdgeTreatment(treatment: BlurredEdgeTreatment)
+}
+
+private fun recordWrites(
+  block: HazeBlurStyleScope.() -> Unit,
+): List<HazeBlurStyleScope.() -> Unit> = buildList {
+  RecordingHazeBlurStyleScope(this).block()
+}
+
+private class RecordingHazeBlurStyleScope(
+  private val writes: MutableList<HazeBlurStyleScope.() -> Unit>,
+) : HazeBlurStyleScope {
+  override fun blurEnabled(enabled: Boolean) {
+    writes += { blurEnabled(enabled) }
+  }
+
+  override fun blurRadius(radius: Dp) {
+    writes += { blurRadius(radius) }
+  }
+
+  override fun noiseFactor(factor: Float) {
+    writes += { noiseFactor(factor) }
+  }
+
+  override fun backgroundColor(color: Color) {
+    writes += { backgroundColor(color) }
+  }
+
+  override fun colorEffects(effects: List<HazeColorEffect>) {
+    val snapshot = effects.toList()
+    writes += { colorEffects(snapshot) }
+  }
+
+  override fun fallbackColorEffect(effect: HazeColorEffect) {
+    writes += { fallbackColorEffect(effect) }
+  }
+
+  override fun alpha(alpha: Float) {
+    writes += { alpha(alpha) }
+  }
+
+  override fun mask(mask: Brush?) {
+    writes += { mask(mask) }
+  }
+
+  override fun progressive(progressive: HazeProgressive?) {
+    writes += { progressive(progressive) }
+  }
+
+  override fun blurredEdgeTreatment(treatment: BlurredEdgeTreatment) {
+    writes += { blurredEdgeTreatment(treatment) }
+  }
+}
+
+@Poko
+internal class ResolvedHazeBlurStyle(
+  val blurEnabled: Boolean,
+  val blurRadius: Dp,
+  val noiseFactor: Float,
+  val backgroundColor: Color,
+  val colorEffects: List<HazeColorEffect>,
+  val fallbackColorEffect: HazeColorEffect,
+  val alpha: Float,
+  val mask: Brush?,
+  val progressive: HazeProgressive?,
+  val blurredEdgeTreatment: BlurredEdgeTreatment,
+)
+
+private class HazeBlurStyleAccumulator : HazeBlurStyleScope {
+  private var blurEnabled: Boolean = HazeBlurDefaults.blurEnabled()
+  private var blurRadius: Dp = HazeBlurDefaults.blurRadius
+  private var noiseFactor: Float = HazeBlurDefaults.noiseFactor
+  private var backgroundColor: Color = Color.Transparent
+  private var colorEffects: List<HazeColorEffect> = emptyList()
+  private var fallbackColorEffect: HazeColorEffect = HazeColorEffect.Unspecified
+  private var alpha: Float = 1f
+  private var mask: Brush? = null
+  private var progressive: HazeProgressive? = null
+  private var blurredEdgeTreatment: BlurredEdgeTreatment = HazeBlurDefaults.blurredEdgeTreatment
+
+  override fun blurEnabled(enabled: Boolean) {
+    blurEnabled = enabled
+  }
+
+  override fun blurRadius(radius: Dp) {
+    require(radius.isSpecified && radius >= 0.dp) { "blurRadius must be specified and non-negative" }
+    blurRadius = radius
+  }
+
+  override fun noiseFactor(factor: Float) {
+    require(!factor.isNaN()) { "noiseFactor must not be NaN" }
+    noiseFactor = factor.coerceIn(0f, 1f)
+  }
+
+  override fun backgroundColor(color: Color) {
+    require(color.isSpecified) { "backgroundColor must be specified" }
+    backgroundColor = color
+  }
+
+  override fun colorEffects(effects: List<HazeColorEffect>) {
+    colorEffects = effects.toList()
+  }
+
+  override fun fallbackColorEffect(effect: HazeColorEffect) {
+    fallbackColorEffect = effect
+  }
+
+  override fun alpha(alpha: Float) {
+    require(!alpha.isNaN()) { "alpha must not be NaN" }
+    this.alpha = alpha.coerceIn(0f, 1f)
+  }
+
+  override fun mask(mask: Brush?) {
+    this.mask = mask
+  }
+
+  override fun progressive(progressive: HazeProgressive?) {
+    this.progressive = progressive
+  }
+
+  override fun blurredEdgeTreatment(treatment: BlurredEdgeTreatment) {
+    blurredEdgeTreatment = treatment
+  }
+
+  fun snapshot(): ResolvedHazeBlurStyle = ResolvedHazeBlurStyle(
+    blurEnabled = blurEnabled,
+    blurRadius = blurRadius,
+    noiseFactor = noiseFactor,
+    backgroundColor = backgroundColor,
+    colorEffects = colorEffects.toList(),
+    fallbackColorEffect = fallbackColorEffect,
+    alpha = alpha,
+    mask = mask,
+    progressive = progressive,
+    blurredEdgeTreatment = blurredEdgeTreatment,
+  )
+}
+
+internal fun resolveHazeBlurStyle(
+  localStyle: HazeBlurStyle,
+  explicitStyle: HazeBlurStyle,
+): ResolvedHazeBlurStyle = HazeBlurStyleAccumulator().also { accumulator ->
+  HazeBlurDefaults.style.replay(accumulator)
+  localStyle.replay(accumulator)
+  explicitStyle.replay(accumulator)
+}.snapshot()
 
 /**
  * Describes a color effect applied by the haze effect.

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
@@ -374,12 +374,3 @@ public sealed interface HazeColorEffect {
     ): HazeColorEffect = TintBrush(brush, blendMode)
   }
 }
-
-internal inline fun Float.takeOrElse(block: () -> Float): Float =
-  if (this in 0f..1f) this else block()
-
-internal fun Float.normalizeNoiseFactor(): Float = when {
-  this > 1f -> 1f
-  this in 0f..1f -> this
-  else -> -1f
-}

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
@@ -121,16 +121,16 @@ class BlurVisualEffectLifecycleTest {
   fun blurRadius_prefersDirectThenStyleThenCompositionLocal() {
     val effect = BlurVisualEffect()
 
-    effect.compositionLocalStyle = HazeBlurStyle(
-      colorEffects = emptyList(),
-      blurRadius = HazeBlurDefaults.blurRadius,
-    )
+    effect.compositionLocalStyle = HazeBlurStyle {
+      colorEffects(emptyList())
+      blurRadius(HazeBlurDefaults.blurRadius)
+    }
     assertThat(effect.blurRadius).isEqualTo(HazeBlurDefaults.blurRadius)
 
-    effect.style = HazeBlurStyle(
-      colorEffects = emptyList(),
-      blurRadius = HazeBlurDefaults.blurRadius * 2,
-    )
+    effect.style = HazeBlurStyle {
+      colorEffects(emptyList())
+      blurRadius(HazeBlurDefaults.blurRadius * 2)
+    }
     assertThat(effect.blurRadius).isEqualTo(HazeBlurDefaults.blurRadius * 2)
 
     effect.blurRadius = HazeBlurDefaults.blurRadius * 3

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
@@ -145,12 +145,22 @@ class BlurVisualEffectLifecycleTest {
 
   @Test
   fun copy_preservesStyleAndCompositionLocalInheritance() {
+    val inheritedMask = Brush.verticalGradient(listOf(Color.White, Color.Transparent))
+    val inheritedColorEffect = HazeColorEffect.tint(Color.Magenta)
+    val inheritedFallback = HazeColorEffect.tint(Color.Gray)
+    val inheritedProgressive = HazeProgressive.verticalGradient()
     val original = BlurVisualEffect().apply {
       compositionLocalStyle = fullStyle(
         blurEnabled = false,
         blurRadius = 12.dp,
         noiseFactor = 0.2f,
         backgroundColor = Color.Red,
+        mask = inheritedMask,
+        colorEffect = inheritedColorEffect,
+        fallback = inheritedFallback,
+        alpha = 0.7f,
+        progressive = inheritedProgressive,
+        blurredEdgeTreatment = BlurredEdgeTreatment.Unbounded,
       )
       style = HazeBlurStyle {
         blurRadius(16.dp)
@@ -161,6 +171,17 @@ class BlurVisualEffectLifecycleTest {
     val localColorEffect = HazeColorEffect.tint(Color.Blue)
     val localFallback = HazeColorEffect.tint(Color.Green)
     val localProgressive = HazeProgressive.verticalGradient()
+
+    assertThat(copy.blurEnabled).isFalse()
+    assertThat(copy.blurRadius).isEqualTo(16.dp)
+    assertThat(copy.noiseFactor).isEqualTo(0.2f)
+    assertThat(copy.backgroundColor).isEqualTo(Color.Red)
+    assertThat(copy.mask).isEqualTo(inheritedMask)
+    assertThat(copy.colorEffects).isEqualTo(listOf(inheritedColorEffect))
+    assertThat(copy.fallbackTint).isEqualTo(inheritedFallback)
+    assertThat(copy.alpha).isEqualTo(0.7f)
+    assertThat(copy.progressive).isEqualTo(inheritedProgressive)
+    assertThat(copy.blurredEdgeTreatment).isEqualTo(BlurredEdgeTreatment.Unbounded)
 
     copy.compositionLocalStyle = fullStyle(
       blurEnabled = true,
@@ -241,6 +262,64 @@ class BlurVisualEffectLifecycleTest {
   }
 
   @Test
+  fun inheritedStructuralStyleChanges_invalidateLayerBoundsOnlyWhenRequired() {
+    val effect = BlurVisualEffect()
+    val context = TrackingInvalidationContext()
+
+    context.localStyle = HazeBlurStyle {
+      blurRadius(24.dp)
+    }
+    effect.update(context)
+
+    assertThat(context.invalidateLayerBoundsCount).isEqualTo(1)
+    assertThat(context.invalidateDrawCount).isEqualTo(0)
+
+    context.resetInvalidations()
+    context.localStyle = HazeBlurStyle {
+      blurRadius(24.dp)
+      noiseFactor(0.5f)
+    }
+    effect.update(context)
+
+    assertThat(context.invalidateLayerBoundsCount).isEqualTo(0)
+    assertThat(context.invalidateDrawCount).isEqualTo(1)
+
+    context.resetInvalidations()
+    context.localStyle = HazeBlurStyle {
+      blurRadius(24.dp)
+      noiseFactor(0.5f)
+      backgroundColor(Color.Red.copy(alpha = 0.5f))
+    }
+    effect.update(context)
+
+    assertThat(context.invalidateLayerBoundsCount).isEqualTo(1)
+    assertThat(context.invalidateDrawCount).isEqualTo(0)
+
+    context.resetInvalidations()
+    context.localStyle = HazeBlurStyle {
+      blurRadius(24.dp)
+      noiseFactor(0.5f)
+      backgroundColor(Color.Blue.copy(alpha = 0.5f))
+    }
+    effect.update(context)
+
+    assertThat(context.invalidateLayerBoundsCount).isEqualTo(0)
+    assertThat(context.invalidateDrawCount).isEqualTo(1)
+
+    context.resetInvalidations()
+    context.localStyle = HazeBlurStyle {
+      blurRadius(24.dp)
+      noiseFactor(0.5f)
+      backgroundColor(Color.Blue.copy(alpha = 0.5f))
+      blurredEdgeTreatment(BlurredEdgeTreatment.Unbounded)
+    }
+    effect.update(context)
+
+    assertThat(context.invalidateLayerBoundsCount).isEqualTo(1)
+    assertThat(context.invalidateDrawCount).isEqualTo(0)
+  }
+
+  @Test
   fun retainedOutputAvailabilityReflectsDelegate() {
     val effect = BlurVisualEffect()
     val delegate = RetainedTrackingBlurDelegate()
@@ -317,6 +396,33 @@ private data object FakeVisualEffectContext : VisualEffectContext {
   override fun <T> currentValueOf(local: CompositionLocal<T>): T = error("Unused in lifecycle tests")
   override fun requireGraphicsContext(): GraphicsContext = error("Unused in lifecycle tests")
   override fun invalidateDraw() = Unit
+}
+
+private class TrackingInvalidationContext : VisualEffectContext by FakeVisualEffectContext {
+  var localStyle: HazeBlurStyle = HazeBlurStyle
+  var invalidateDrawCount: Int = 0
+    private set
+  var invalidateLayerBoundsCount: Int = 0
+    private set
+
+  @Suppress("UNCHECKED_CAST")
+  override fun <T> currentValueOf(local: CompositionLocal<T>): T {
+    check(local === LocalHazeBlurStyle)
+    return localStyle as T
+  }
+
+  override fun invalidateDraw() {
+    invalidateDrawCount++
+  }
+
+  override fun invalidateLayerBounds() {
+    invalidateLayerBoundsCount++
+  }
+
+  fun resetInvalidations() {
+    invalidateDrawCount = 0
+    invalidateLayerBoundsCount = 0
+  }
 }
 
 @Poko

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.blur
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.CompositionLocal
 import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.geometry.Offset
@@ -311,12 +312,36 @@ class BlurVisualEffectLifecycleTest {
       blurRadius(24.dp)
       noiseFactor(0.5f)
       backgroundColor(Color.Blue.copy(alpha = 0.5f))
+      blurredEdgeTreatment(BlurredEdgeTreatment(RoundedCornerShape(8.dp)))
+    }
+    effect.update(context)
+
+    assertThat(context.invalidateLayerBoundsCount).isEqualTo(0)
+    assertThat(context.invalidateDrawCount).isEqualTo(1)
+
+    context.resetInvalidations()
+    context.localStyle = HazeBlurStyle {
+      blurRadius(24.dp)
+      noiseFactor(0.5f)
+      backgroundColor(Color.Blue.copy(alpha = 0.5f))
       blurredEdgeTreatment(BlurredEdgeTreatment.Unbounded)
     }
     effect.update(context)
 
     assertThat(context.invalidateLayerBoundsCount).isEqualTo(1)
     assertThat(context.invalidateDrawCount).isEqualTo(0)
+  }
+
+  @Test
+  fun directBoundedEdgeTreatmentChange_doesNotInvalidateLayerBounds() {
+    val effect = BlurVisualEffect()
+    val context = TrackingInvalidationContext()
+
+    effect.blurredEdgeTreatment = BlurredEdgeTreatment(RoundedCornerShape(8.dp))
+    effect.update(context)
+
+    assertThat(context.invalidateLayerBoundsCount).isEqualTo(0)
+    assertThat(context.invalidateDrawCount).isEqualTo(1)
   }
 
   @Test

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectLifecycleTest.kt
@@ -4,21 +4,27 @@
 package dev.chrisbanes.haze.blur
 
 import androidx.compose.runtime.CompositionLocal
+import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeArea
 import dev.chrisbanes.haze.HazeInputScale
+import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.PlatformContext
 import dev.chrisbanes.haze.Poko
@@ -138,6 +144,103 @@ class BlurVisualEffectLifecycleTest {
   }
 
   @Test
+  fun copy_preservesStyleAndCompositionLocalInheritance() {
+    val original = BlurVisualEffect().apply {
+      compositionLocalStyle = fullStyle(
+        blurEnabled = false,
+        blurRadius = 12.dp,
+        noiseFactor = 0.2f,
+        backgroundColor = Color.Red,
+      )
+      style = HazeBlurStyle {
+        blurRadius(16.dp)
+      }
+    }
+    val copy = BlurVisualEffect(original)
+    val localMask = Brush.verticalGradient(listOf(Color.Black, Color.Transparent))
+    val localColorEffect = HazeColorEffect.tint(Color.Blue)
+    val localFallback = HazeColorEffect.tint(Color.Green)
+    val localProgressive = HazeProgressive.verticalGradient()
+
+    copy.compositionLocalStyle = fullStyle(
+      blurEnabled = true,
+      blurRadius = 20.dp,
+      noiseFactor = 0.6f,
+      backgroundColor = Color.Cyan,
+      mask = localMask,
+      colorEffect = localColorEffect,
+      fallback = localFallback,
+      alpha = 0.4f,
+      progressive = localProgressive,
+      blurredEdgeTreatment = BlurredEdgeTreatment.Unbounded,
+    )
+    copy.style = HazeBlurStyle {
+      blurRadius(24.dp)
+    }
+
+    assertThat(copy.blurEnabled).isTrue()
+    assertThat(copy.blurRadius).isEqualTo(24.dp)
+    assertThat(copy.noiseFactor).isEqualTo(0.6f)
+    assertThat(copy.backgroundColor).isEqualTo(Color.Cyan)
+    assertThat(copy.mask).isEqualTo(localMask)
+    assertThat(copy.colorEffects).isEqualTo(listOf(localColorEffect))
+    assertThat(copy.fallbackTint).isEqualTo(localFallback)
+    assertThat(copy.alpha).isEqualTo(0.4f)
+    assertThat(copy.progressive).isEqualTo(localProgressive)
+    assertThat(copy.blurredEdgeTreatment).isEqualTo(BlurredEdgeTreatment.Unbounded)
+  }
+
+  @Test
+  fun copy_preservesDirectOverrides() {
+    val inheritedMask = Brush.verticalGradient(listOf(Color.Black, Color.Transparent))
+    val inheritedProgressive = HazeProgressive.verticalGradient()
+    val directFallback = HazeColorEffect.tint(Color.Green)
+    val original = BlurVisualEffect().apply {
+      style = fullStyle(
+        blurEnabled = false,
+        blurRadius = 12.dp,
+        noiseFactor = 0.2f,
+        backgroundColor = Color.Red,
+        mask = inheritedMask,
+        progressive = inheritedProgressive,
+        blurredEdgeTreatment = BlurredEdgeTreatment.Unbounded,
+      )
+      blurEnabled = true
+      blurRadius = 32.dp
+      noiseFactor = 0.9f
+      backgroundColor = Color.Yellow
+      mask = null
+      colorEffects = emptyList()
+      fallbackTint = directFallback
+      alpha = 0.8f
+      progressive = null
+      blurredEdgeTreatment = BlurredEdgeTreatment.Rectangle
+    }
+    val copy = BlurVisualEffect(original)
+
+    copy.style = fullStyle(
+      blurEnabled = false,
+      blurRadius = 20.dp,
+      noiseFactor = 0.4f,
+      backgroundColor = Color.Cyan,
+      mask = inheritedMask,
+      progressive = inheritedProgressive,
+      blurredEdgeTreatment = BlurredEdgeTreatment.Unbounded,
+    )
+
+    assertThat(copy.blurEnabled).isTrue()
+    assertThat(copy.blurRadius).isEqualTo(32.dp)
+    assertThat(copy.noiseFactor).isEqualTo(0.9f)
+    assertThat(copy.backgroundColor).isEqualTo(Color.Yellow)
+    assertThat(copy.mask).isNull()
+    assertThat(copy.colorEffects).isEqualTo(emptyList())
+    assertThat(copy.fallbackTint).isEqualTo(directFallback)
+    assertThat(copy.alpha).isEqualTo(0.8f)
+    assertThat(copy.progressive).isNull()
+    assertThat(copy.blurredEdgeTreatment).isEqualTo(BlurredEdgeTreatment.Rectangle)
+  }
+
+  @Test
   fun retainedOutputAvailabilityReflectsDelegate() {
     val effect = BlurVisualEffect()
     val delegate = RetainedTrackingBlurDelegate()
@@ -163,6 +266,30 @@ class BlurVisualEffectLifecycleTest {
     assertThat(effect.canDrawRetainedOutput(FakeVisualEffectContext)).isFalse()
     assertThat(effect.shouldDrawRetainedOutput(FakeVisualEffectContext)).isFalse()
   }
+}
+
+private fun fullStyle(
+  blurEnabled: Boolean,
+  blurRadius: Dp,
+  noiseFactor: Float,
+  backgroundColor: Color,
+  mask: Brush? = null,
+  colorEffect: HazeColorEffect = HazeColorEffect.tint(Color.Magenta),
+  fallback: HazeColorEffect = HazeColorEffect.tint(Color.Gray),
+  alpha: Float = 0.7f,
+  progressive: HazeProgressive? = null,
+  blurredEdgeTreatment: BlurredEdgeTreatment = BlurredEdgeTreatment.Rectangle,
+): HazeBlurStyle = HazeBlurStyle {
+  blurEnabled(blurEnabled)
+  blurRadius(blurRadius)
+  noiseFactor(noiseFactor)
+  backgroundColor(backgroundColor)
+  mask(mask)
+  colorEffects(listOf(colorEffect))
+  fallbackColorEffect(fallback)
+  alpha(alpha)
+  progressive(progressive)
+  blurredEdgeTreatment(blurredEdgeTreatment)
 }
 
 private data object FakeVisualEffectContext : VisualEffectContext {

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectRecompositionCountTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectRecompositionCountTest.kt
@@ -11,15 +11,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isLessThanOrEqualTo
+import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.test.ContextTest
 import dev.chrisbanes.haze.test.RecompositionCounter
@@ -39,7 +40,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val blurRadius = mutableStateOf(10.dp)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.blurRadius = blurRadius.value
+      blurRadius(blurRadius.value)
     }
     waitForIdle()
 
@@ -61,7 +62,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     )
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.colorEffects = colorEffects.value
+      colorEffects(colorEffects.value)
     }
     waitForIdle()
 
@@ -79,23 +80,23 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val hazeState = HazeState()
     val effectCounter = mutableIntStateOf(0)
     val style = mutableStateOf(
-      HazeBlurStyle(
-        colorEffects = emptyList(),
-        blurRadius = 10.dp,
-      ),
+      HazeBlurStyle {
+        colorEffects(emptyList())
+        blurRadius(10.dp)
+      },
     )
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.style = style.value
+      style.value.replay(this)
     }
     waitForIdle()
 
     effectCounter.intValue = 0
 
-    style.value = HazeBlurStyle(
-      colorEffects = emptyList(),
-      blurRadius = 20.dp,
-    )
+    style.value = HazeBlurStyle {
+      colorEffects(emptyList())
+      blurRadius(20.dp)
+    }
     waitForIdle()
 
     assertThat(effectCounter.intValue, "effect recompositions after style change")
@@ -109,7 +110,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val blurEnabled = mutableStateOf(true)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.blurEnabled = blurEnabled.value
+      blurEnabled(blurEnabled.value)
     }
     waitForIdle()
 
@@ -129,7 +130,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val progressive = mutableStateOf<HazeProgressive?>(null)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.progressive = progressive.value
+      progressive(progressive.value)
     }
     waitForIdle()
 
@@ -152,7 +153,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val noiseFactor = mutableStateOf(0f)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.noiseFactor = noiseFactor.value
+      noiseFactor(noiseFactor.value)
     }
     waitForIdle()
 
@@ -172,7 +173,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val backgroundColor = mutableStateOf(Color.Unspecified)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.backgroundColor = backgroundColor.value
+      if (backgroundColor.value.isSpecified) backgroundColor(backgroundColor.value)
     }
     waitForIdle()
 
@@ -192,7 +193,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val alpha = mutableStateOf(1f)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.alpha = alpha.value
+      alpha(alpha.value)
     }
     waitForIdle()
 
@@ -212,7 +213,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val mask = mutableStateOf<Brush?>(null)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.mask = mask.value
+      mask(mask.value)
     }
     waitForIdle()
 
@@ -234,7 +235,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val fallbackTint = mutableStateOf<HazeColorEffect>(HazeColorEffect.Unspecified)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.fallbackTint = fallbackTint.value
+      fallbackColorEffect(fallbackTint.value)
     }
     waitForIdle()
 
@@ -254,7 +255,7 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val blurredEdgeTreatment = mutableStateOf(HazeBlurDefaults.blurredEdgeTreatment)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.blurredEdgeTreatment = blurredEdgeTreatment.value
+      blurredEdgeTreatment(blurredEdgeTreatment.value)
     }
     waitForIdle()
 
@@ -286,11 +287,10 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
       RecompositionCounter(effectCounter) {
         BlurTestGradientBox(
           Modifier
-            .hazeEffect(hazeState) {
-              blurEffect {
-                this.blurRadius = blurRadius.value
-              }
-            }
+            .hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = HazeBlurStyle { blurRadius(blurRadius.value) },
+            )
             .size(100.dp),
         )
       }
@@ -318,10 +318,10 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val effectCounter = mutableIntStateOf(0)
     val showSource = mutableStateOf(true)
     val style = mutableStateOf(
-      HazeBlurStyle(
-        blurRadius = 10.dp,
-        colorEffects = emptyList(),
-      ),
+      HazeBlurStyle {
+        blurRadius(10.dp)
+        colorEffects(emptyList())
+      },
     )
 
     setContent {
@@ -332,11 +332,10 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
       RecompositionCounter(effectCounter) {
         BlurTestGradientBox(
           Modifier
-            .hazeEffect(hazeState) {
-              blurEffect {
-                this.style = style.value
-              }
-            }
+            .hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = style.value,
+            )
             .size(100.dp),
         )
       }
@@ -348,10 +347,10 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     // Trigger both source lifecycle and full style replacement in the same frame.
     runOnIdle {
       showSource.value = false
-      style.value = HazeBlurStyle(
-        blurRadius = 22.dp,
-        colorEffects = listOf(HazeColorEffect.tint(Color.Cyan.copy(alpha = 0.3f))),
-      )
+      style.value = HazeBlurStyle {
+        blurRadius(22.dp)
+        colorEffects(listOf(HazeColorEffect.tint(Color.Cyan.copy(alpha = 0.3f))))
+      }
     }
     waitForIdle()
 
@@ -368,9 +367,9 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
     val noiseFactor = mutableStateOf(0f)
 
     setBlurEffectContent(hazeState, effectCounter) {
-      this.blurRadius = blurRadius.value
-      this.alpha = alpha.value
-      this.noiseFactor = noiseFactor.value
+      blurRadius(blurRadius.value)
+      alpha(alpha.value)
+      noiseFactor(noiseFactor.value)
     }
     waitForIdle()
 
@@ -394,16 +393,17 @@ class BlurVisualEffectRecompositionCountTest : ContextTest() {
   private fun ComposeUiTest.setBlurEffectContent(
     hazeState: HazeState,
     effectCounter: MutableIntState,
-    configure: BlurVisualEffect.() -> Unit,
+    configure: HazeBlurStyleScope.() -> Unit,
   ) {
     setContent {
       Box(Modifier.hazeSource(hazeState).size(100.dp)) {
         RecompositionCounter(effectCounter) {
           BlurTestGradientBox(
             Modifier
-              .hazeEffect(hazeState) {
-                blurEffect(configure)
-              }
+              .hazeBlur(
+                input = HazeInput.Sources(hazeState),
+                style = HazeBlurStyle(configure),
+              )
               .size(100.dp),
           )
         }

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectRecompositionLoopTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectRecompositionLoopTest.kt
@@ -9,13 +9,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
@@ -29,7 +30,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val blurRadius = mutableStateOf(10.dp)
 
     setBlurEffectContent(hazeState) {
-      this.blurRadius = blurRadius.value
+      blurRadius(blurRadius.value)
     }
     waitForIdle()
 
@@ -46,7 +47,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     )
 
     setBlurEffectContent(hazeState) {
-      this.colorEffects = colorEffects.value
+      colorEffects(colorEffects.value)
     }
     waitForIdle()
 
@@ -59,21 +60,21 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
   fun styleMutation_doesNotInfiniteLoop() = runComposeUiTest {
     val hazeState = HazeState()
     val style = mutableStateOf(
-      HazeBlurStyle(
-        colorEffects = emptyList(),
-        blurRadius = 10.dp,
-      ),
+      HazeBlurStyle {
+        colorEffects(emptyList())
+        blurRadius(10.dp)
+      },
     )
 
     setBlurEffectContent(hazeState) {
-      this.style = style.value
+      style.value.replay(this)
     }
     waitForIdle()
 
-    style.value = HazeBlurStyle(
-      colorEffects = emptyList(),
-      blurRadius = 20.dp,
-    )
+    style.value = HazeBlurStyle {
+      colorEffects(emptyList())
+      blurRadius(20.dp)
+    }
 
     awaitIdleWithTimeout("after style mutation")
   }
@@ -84,7 +85,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val blurEnabled = mutableStateOf(true)
 
     setBlurEffectContent(hazeState) {
-      this.blurEnabled = blurEnabled.value
+      blurEnabled(blurEnabled.value)
     }
     waitForIdle()
 
@@ -99,7 +100,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val progressive = mutableStateOf<HazeProgressive?>(null)
 
     setBlurEffectContent(hazeState) {
-      this.progressive = progressive.value
+      progressive(progressive.value)
     }
     waitForIdle()
 
@@ -117,7 +118,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val noiseFactor = mutableStateOf(0f)
 
     setBlurEffectContent(hazeState) {
-      this.noiseFactor = noiseFactor.value
+      noiseFactor(noiseFactor.value)
     }
     waitForIdle()
 
@@ -132,7 +133,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val backgroundColor = mutableStateOf(Color.Unspecified)
 
     setBlurEffectContent(hazeState) {
-      this.backgroundColor = backgroundColor.value
+      if (backgroundColor.value.isSpecified) backgroundColor(backgroundColor.value)
     }
     waitForIdle()
 
@@ -147,7 +148,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val alpha = mutableStateOf(1f)
 
     setBlurEffectContent(hazeState) {
-      this.alpha = alpha.value
+      alpha(alpha.value)
     }
     waitForIdle()
 
@@ -162,7 +163,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val mask = mutableStateOf<Brush?>(null)
 
     setBlurEffectContent(hazeState) {
-      this.mask = mask.value
+      mask(mask.value)
     }
     waitForIdle()
 
@@ -179,7 +180,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val fallbackTint = mutableStateOf<HazeColorEffect>(HazeColorEffect.Unspecified)
 
     setBlurEffectContent(hazeState) {
-      this.fallbackTint = fallbackTint.value
+      fallbackColorEffect(fallbackTint.value)
     }
     waitForIdle()
 
@@ -194,7 +195,7 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val blurredEdgeTreatment = mutableStateOf(HazeBlurDefaults.blurredEdgeTreatment)
 
     setBlurEffectContent(hazeState) {
-      this.blurredEdgeTreatment = blurredEdgeTreatment.value
+      blurredEdgeTreatment(blurredEdgeTreatment.value)
     }
     waitForIdle()
 
@@ -212,8 +213,8 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     )
 
     setBlurEffectContent(hazeState) {
-      this.blurRadius = blurRadius.value
-      this.colorEffects = colorEffects.value
+      blurRadius(blurRadius.value)
+      colorEffects(colorEffects.value)
     }
     waitForIdle()
 
@@ -246,11 +247,10 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
 
       BlurTestGradientBox(
         Modifier
-          .hazeEffect(hazeState) {
-            blurEffect {
-              this.blurRadius = blurRadius.value
-            }
-          }
+          .hazeBlur(
+            input = HazeInput.Sources(hazeState),
+            style = HazeBlurStyle { blurRadius(blurRadius.value) },
+          )
           .size(100.dp),
       )
     }
@@ -271,10 +271,10 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val hazeState = HazeState()
     val showSource = mutableStateOf(true)
     val style = mutableStateOf(
-      HazeBlurStyle(
-        blurRadius = 10.dp,
-        colorEffects = emptyList(),
-      ),
+      HazeBlurStyle {
+        blurRadius(10.dp)
+        colorEffects(emptyList())
+      },
     )
 
     setContent {
@@ -284,11 +284,10 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
 
       BlurTestGradientBox(
         Modifier
-          .hazeEffect(hazeState) {
-            blurEffect {
-              this.style = style.value
-            }
-          }
+          .hazeBlur(
+            input = HazeInput.Sources(hazeState),
+            style = style.value,
+          )
           .size(100.dp),
       )
     }
@@ -296,10 +295,10 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
 
     runOnIdle {
       showSource.value = false
-      style.value = HazeBlurStyle(
-        blurRadius = 22.dp,
-        colorEffects = listOf(HazeColorEffect.tint(Color.Cyan.copy(alpha = 0.3f))),
-      )
+      style.value = HazeBlurStyle {
+        blurRadius(22.dp)
+        colorEffects(listOf(HazeColorEffect.tint(Color.Cyan.copy(alpha = 0.3f))))
+      }
     }
     awaitIdleWithTimeout("after combined source and style mutation")
   }
@@ -312,9 +311,9 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
     val noiseFactor = mutableStateOf(0f)
 
     setBlurEffectContent(hazeState) {
-      this.blurRadius = blurRadius.value
-      this.alpha = alpha.value
-      this.noiseFactor = noiseFactor.value
+      blurRadius(blurRadius.value)
+      alpha(alpha.value)
+      noiseFactor(noiseFactor.value)
     }
     waitForIdle()
 
@@ -331,15 +330,16 @@ class BlurVisualEffectRecompositionLoopTest : ContextTest() {
 
   private fun ComposeUiTest.setBlurEffectContent(
     hazeState: HazeState,
-    configure: BlurVisualEffect.() -> Unit,
+    configure: HazeBlurStyleScope.() -> Unit,
   ) {
     setContent {
       Box(Modifier.hazeSource(hazeState).size(100.dp)) {
         BlurTestGradientBox(
           Modifier
-            .hazeEffect(hazeState) {
-              blurEffect(configure)
-            }
+            .hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = HazeBlurStyle(configure),
+            )
             .size(100.dp),
         )
       }

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyleTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyleTest.kt
@@ -3,98 +3,220 @@
 
 package dev.chrisbanes.haze.blur
 
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isSameInstanceAs
+import dev.chrisbanes.haze.HazeProgressive
 import kotlin.test.Test
 
 class HazeBlurStyleTest {
 
   @Test
-  fun hazeBlurStyle_colorEffectsSnapshotsMutableInput() {
+  fun defaultStyle_isShared() {
+    assertThat(HazeBlurDefaults.style).isSameInstanceAs(HazeBlurDefaults.style)
+  }
+
+  @Test
+  fun styleChain_appliesWritesInOrder() {
+    val style = HazeBlurStyle {
+      blurRadius(8.dp)
+      backgroundColor(Color.Red)
+    }.then {
+      blurRadius(24.dp)
+    }
+
+    val resolved = resolveHazeBlurStyle(
+      localStyle = HazeBlurStyle,
+      explicitStyle = style,
+    )
+
+    assertThat(resolved.blurRadius).isEqualTo(24.dp)
+    assertThat(resolved.backgroundColor).isEqualTo(Color.Red)
+  }
+
+  @Test
+  fun resolution_appliesDefaultsLocalAndExplicitStyle() {
+    val local = HazeBlurStyle {
+      blurRadius(12.dp)
+      noiseFactor(0.3f)
+    }
+    val explicit = HazeBlurStyle {
+      blurRadius(28.dp)
+    }
+
+    val resolved = resolveHazeBlurStyle(local, explicit)
+
+    assertThat(resolved.blurRadius).isEqualTo(28.dp)
+    assertThat(resolved.noiseFactor).isEqualTo(0.3f)
+    assertThat(resolved.backgroundColor).isEqualTo(Color.Transparent)
+    assertThat(resolved.alpha).isEqualTo(1f)
+    assertThat(resolved.blurredEdgeTreatment).isEqualTo(HazeBlurDefaults.blurredEdgeTreatment)
+  }
+
+  @Test
+  fun evaluation_startsFromFreshAccumulator() {
+    val style = HazeBlurStyle {
+      blurRadius(36.dp)
+    }
+
+    val first = resolveHazeBlurStyle(HazeBlurStyle, style)
+    val second = resolveHazeBlurStyle(HazeBlurStyle, HazeBlurStyle)
+
+    assertThat(first.blurRadius).isEqualTo(36.dp)
+    assertThat(second.blurRadius).isEqualTo(HazeBlurDefaults.blurRadius)
+  }
+
+  @Test
+  fun propertyRemoval_revealsLowerTier() {
+    val local = HazeBlurStyle {
+      blurRadius(16.dp)
+      noiseFactor(0.4f)
+    }
+    val withOverride = HazeBlurStyle {
+      blurRadius(32.dp)
+      noiseFactor(0.8f)
+    }
+    val withoutRadius = HazeBlurStyle {
+      noiseFactor(0.8f)
+    }
+
+    assertThat(resolveHazeBlurStyle(local, withOverride).blurRadius).isEqualTo(32.dp)
+    assertThat(resolveHazeBlurStyle(local, withoutRadius).blurRadius).isEqualTo(16.dp)
+  }
+
+  @Test
+  fun emptyColorEffects_clearsInheritedEffects() {
+    val inherited = HazeColorEffect.tint(Color.Red)
+    val local = HazeBlurStyle {
+      colorEffects(listOf(inherited))
+    }
+    val explicit = HazeBlurStyle {
+      colorEffects(emptyList())
+    }
+
+    assertThat(resolveHazeBlurStyle(local, explicit).colorEffects).isEmpty()
+  }
+
+  @Test
+  fun colorEffects_snapshotsCallerOwnedList() {
     val first = HazeColorEffect.tint(Color.Red)
     val second = HazeColorEffect.tint(Color.Blue)
     val input = mutableListOf(first)
-
-    val style = HazeBlurStyle(colorEffects = input)
+    val style = HazeBlurStyle {
+      colorEffects(input)
+    }
 
     input += second
 
-    assertThat(style.colorEffects).containsExactly(first)
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, style).colorEffects)
+      .containsExactly(first)
   }
 
   @Test
-  fun blurVisualEffect_emptyColorEffectsViaStyleAreExplicitlySpecified() {
-    val inherited = HazeBlurStyle(colorEffect = HazeColorEffect.tint(Color.Red))
-    val style = HazeBlurStyle(colorEffects = emptyList())
-    val effect = BlurVisualEffect().apply {
-      compositionLocalStyle = inherited
-      this.style = style
+  fun noiseFactor_clampsAtAccumulatorBoundary() {
+    val style = HazeBlurStyle {
+      noiseFactor(2f)
     }
 
-    assertThat(effect.colorEffects.orEmpty()).isEmpty()
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, style).noiseFactor).isEqualTo(1f)
   }
 
   @Test
-  fun blurVisualEffect_emptyColorEffectsClearsInheritedEffects() {
-    val inherited = HazeBlurStyle(colorEffect = HazeColorEffect.tint(Color.Red))
-    val effect = BlurVisualEffect().apply {
-      compositionLocalStyle = inherited
-      colorEffects = emptyList()
-    }
-
-    assertThat(effect.colorEffects.orEmpty()).isEmpty()
-  }
-
-  @Test
-  fun blurVisualEffect_nullColorEffectsFallsBackToInheritedStyle() {
-    val inherited = HazeBlurStyle(colorEffect = HazeColorEffect.tint(Color.Red))
-    val effect = BlurVisualEffect().apply {
-      compositionLocalStyle = inherited
-      colorEffects = listOf(HazeColorEffect.tint(Color.Blue))
-    }
-
-    // Verify the direct override is active
-    assertThat(effect.colorEffects.orEmpty()).containsExactly(HazeColorEffect.tint(Color.Blue))
-
-    // Clear the direct override
-    effect.colorEffects = null
-
-    // Should fall back to inherited style
-    assertThat(effect.colorEffects.orEmpty()).containsExactly(HazeColorEffect.tint(Color.Red))
-  }
-
-  @Test
-  fun blurVisualEffect_noiseFactorAboveRangeClampsInsteadOfFallingBack() {
-    val effect = BlurVisualEffect().apply {
-      compositionLocalStyle = HazeBlurStyle(
-        backgroundColor = Color.Unspecified,
-        colorEffects = null,
-        noiseFactor = 0.2f,
+  fun noiseFactor_rejectsNaN() {
+    assertFailure {
+      resolveHazeBlurStyle(
+        HazeBlurStyle,
+        HazeBlurStyle {
+          noiseFactor(Float.NaN)
+        },
       )
-      noiseFactor = 2f
-    }
-
-    assertThat(effect.noiseFactor).isEqualTo(1f)
+    }.isInstanceOf<IllegalArgumentException>()
   }
 
   @Test
-  fun hazeBlurStyle_noiseFactorAboveRangeClampsInsteadOfFallingBack() {
-    val effect = BlurVisualEffect().apply {
-      compositionLocalStyle = HazeBlurStyle(
-        backgroundColor = Color.Unspecified,
-        colorEffects = null,
-        noiseFactor = 0.2f,
+  fun blurRadius_rejectsNegativeValues() {
+    assertFailure {
+      resolveHazeBlurStyle(
+        HazeBlurStyle,
+        HazeBlurStyle {
+          blurRadius((-1).dp)
+        },
       )
-      style = HazeBlurStyle(
-        backgroundColor = Color.Unspecified,
-        colorEffects = null,
-        noiseFactor = 2f,
-      )
+    }.isInstanceOf<IllegalArgumentException>()
+  }
+
+  @Test
+  fun everyStyleFunction_isCapturedInTheResolvedSnapshot() {
+    val mask = Brush.verticalGradient(listOf(Color.Black, Color.Transparent))
+    val progressive = HazeProgressive.verticalGradient()
+    val effect = HazeColorEffect.tint(Color.Magenta)
+    val fallback = HazeColorEffect.tint(Color.Gray)
+    val style = HazeBlurStyle {
+      blurEnabled(false)
+      blurRadius(18.dp)
+      noiseFactor(0.25f)
+      backgroundColor(Color.Cyan)
+      colorEffects(listOf(effect))
+      fallbackColorEffect(fallback)
+      alpha(0.6f)
+      mask(mask)
+      progressive(progressive)
+      blurredEdgeTreatment(BlurredEdgeTreatment.Unbounded)
     }
 
-    assertThat(effect.noiseFactor).isEqualTo(1f)
+    val resolved = resolveHazeBlurStyle(HazeBlurStyle, style)
+
+    assertThat(resolved.blurEnabled).isFalse()
+    assertThat(resolved.blurRadius).isEqualTo(18.dp)
+    assertThat(resolved.noiseFactor).isEqualTo(0.25f)
+    assertThat(resolved.backgroundColor).isEqualTo(Color.Cyan)
+    assertThat(resolved.colorEffects).containsExactly(effect)
+    assertThat(resolved.fallbackColorEffect).isEqualTo(fallback)
+    assertThat(resolved.alpha).isEqualTo(0.6f)
+    assertThat(resolved.mask).isEqualTo(mask)
+    assertThat(resolved.progressive).isEqualTo(progressive)
+    assertThat(resolved.blurredEdgeTreatment).isEqualTo(BlurredEdgeTreatment.Unbounded)
+  }
+
+  @Test
+  fun alpha_clampsAtAccumulatorBoundary() {
+    val style = HazeBlurStyle {
+      alpha(-1f)
+    }
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, style).alpha).isEqualTo(0f)
+  }
+
+  @Test
+  fun alpha_rejectsNaN() {
+    assertFailure {
+      resolveHazeBlurStyle(
+        HazeBlurStyle,
+        HazeBlurStyle {
+          alpha(Float.NaN)
+        },
+      )
+    }.isInstanceOf<IllegalArgumentException>()
+  }
+
+  @Test
+  fun backgroundColor_rejectsUnspecifiedValues() {
+    assertFailure {
+      resolveHazeBlurStyle(
+        HazeBlurStyle,
+        HazeBlurStyle {
+          backgroundColor(Color.Unspecified)
+        },
+      )
+    }.isInstanceOf<IllegalArgumentException>()
   }
 }

--- a/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurModifierTest.kt
+++ b/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurModifierTest.kt
@@ -1,0 +1,254 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocal
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotSameInstanceAs
+import assertk.assertions.isSameInstanceAs
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeArea
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeInputScale
+import dev.chrisbanes.haze.HazeSampling
+import dev.chrisbanes.haze.HazeSourceRetention
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.PlatformContext
+import dev.chrisbanes.haze.VisualEffectContext
+import dev.chrisbanes.haze.hazeSource
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlinx.coroutines.CoroutineScope
+
+@OptIn(ExperimentalTestApi::class, InternalHazeApi::class)
+class HazeBlurModifierTest {
+
+  @Test
+  fun contentInput_resolvesDefaultsLocalAndExplicitStyles() = runComposeUiTest {
+    val localStyle = HazeBlurStyle {
+      blurEnabled(false)
+      fallbackColorEffect(HazeColorEffect.tint(Color.Red))
+    }
+    val explicitStyle = mutableStateOf(
+      HazeBlurStyle {
+        fallbackColorEffect(HazeColorEffect.tint(Color.Blue))
+      },
+    )
+
+    setContent {
+      CompositionLocalProvider(LocalHazeBlurStyle provides localStyle) {
+        Box(
+          Modifier
+            .size(100.dp)
+            .testTag("effect")
+            .hazeBlur(
+              input = HazeInput.Content,
+              style = explicitStyle.value,
+            )
+            .background(Color.White),
+        )
+      }
+    }
+
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Blue)
+
+    explicitStyle.value = HazeBlurStyle
+    waitForIdle()
+
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Red)
+  }
+
+  @Test
+  fun sourceInput_drawsTheSelectedSourceWithFallbackStyle() = runComposeUiTest {
+    val state = HazeState()
+    val style = HazeBlurStyle {
+      blurEnabled(false)
+      fallbackColorEffect(HazeColorEffect.tint(Color.Blue))
+    }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(state)
+            .background(Color.Red),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("effect")
+            .hazeBlur(
+              input = HazeInput.Sources(state),
+              style = style,
+              sampling = HazeSampling.FullResolution,
+              expandLayerBounds = false,
+            ),
+        )
+      }
+    }
+
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Blue)
+  }
+
+  @Test
+  fun sharedFactory_createsIsolatedRuntimesAndStyleReplacementReusesRuntime() {
+    val sharedStyle = HazeBlurStyle {
+      blurRadius(12.dp)
+    }
+    val first = HazeBlurFactory.createVisualEffect(
+      style = sharedStyle,
+      sampling = HazeSampling.Default,
+    ) as BlurHazeEffectFactoryVisualEffect
+    val second = HazeBlurFactory.createVisualEffect(
+      style = sharedStyle,
+      sampling = HazeSampling.Default,
+    ) as BlurHazeEffectFactoryVisualEffect
+
+    assertThat(first.effect).isNotSameInstanceAs(second.effect)
+
+    val firstRuntime = first.effect
+    first.updateStyle(
+      style = HazeBlurStyle {
+        blurRadius(24.dp)
+      },
+      sampling = HazeSampling.FullResolution,
+    )
+
+    assertThat(first.effect).isSameInstanceAs(firstRuntime)
+    assertThat(first.effect.blurRadius).isEqualTo(24.dp)
+    assertThat(second.effect.blurRadius).isEqualTo(12.dp)
+  }
+
+  @Test
+  fun detachingOneSharedFactoryRuntime_releasesOnlyThatRuntime() {
+    val style = HazeBlurStyle
+    val first = HazeBlurFactory.createVisualEffect(
+      style = style,
+      sampling = HazeSampling.Default,
+    ) as BlurHazeEffectFactoryVisualEffect
+    val second = HazeBlurFactory.createVisualEffect(
+      style = style,
+      sampling = HazeSampling.Default,
+    ) as BlurHazeEffectFactoryVisualEffect
+    val firstDelegate = ModifierTrackingDelegate()
+    val secondDelegate = ModifierTrackingDelegate()
+    first.effect.delegate = firstDelegate
+    second.effect.delegate = secondDelegate
+
+    first.attach(TestVisualEffectContext)
+    second.attach(TestVisualEffectContext)
+    first.detach(TestVisualEffectContext)
+
+    assertThat(firstDelegate.attachCount).isEqualTo(1)
+    assertThat(firstDelegate.detachCount).isEqualTo(1)
+    assertThat(secondDelegate.attachCount).isEqualTo(1)
+    assertThat(secondDelegate.detachCount).isEqualTo(0)
+
+    second.detach(TestVisualEffectContext)
+    assertThat(secondDelegate.detachCount).isEqualTo(1)
+  }
+}
+
+private class ModifierTrackingDelegate : BlurVisualEffect.Delegate {
+  var attachCount = 0
+    private set
+  var detachCount = 0
+    private set
+
+  override fun attach() {
+    attachCount++
+  }
+
+  override fun DrawScope.draw(context: VisualEffectContext) = Unit
+
+  override fun detach() {
+    detachCount++
+  }
+}
+
+@OptIn(ExperimentalHazeApi::class)
+private data object TestVisualEffectContext : VisualEffectContext {
+  override val position: Offset = Offset.Zero
+  override val size: Size = Size.Zero
+  override val layerSize: Size = Size.Zero
+  override val layerOffset: Offset = Offset.Zero
+  override val rootBounds: Rect = Rect.Zero
+  override val inputScale: HazeInputScale = HazeInputScale.None
+  override val windowId: Any? = null
+  override val areas: List<HazeArea> = emptyList()
+  override val state: HazeState? = null
+  override val coroutineScope: CoroutineScope = object : CoroutineScope {
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext
+  }
+
+  override fun positionOf(area: HazeArea): Offset = area.coordinates.localPosition
+
+  override fun boundsOf(area: HazeArea): Rect? {
+    val position = area.coordinates.localPosition
+    return if (position.isSpecified && area.size.isSpecified) Rect(position, area.size) else null
+  }
+
+  override fun requirePlatformContext(): PlatformContext = error("Unused in modifier tests")
+  override fun requireDensity(): Density = Density(1f)
+  override fun <T> currentValueOf(local: CompositionLocal<T>): T = error("Unused in modifier tests")
+  override fun requireGraphicsContext(): GraphicsContext = error("Unused in modifier tests")
+  override fun invalidateDraw() = Unit
+}
+
+@Suppress("unused")
+// HazeEffectInputTest behaviorally verifies these structural policies at the shared core seam.
+// This compile inventory verifies that the typed Blur entry point forwards every policy shape.
+private fun everyTypedBlurPolicyCompiles(
+  state: HazeState,
+  style: HazeBlurStyle,
+): Modifier = Modifier
+  .hazeBlur(
+    input = HazeInput.Sources(
+      state = state,
+      retention = HazeSourceRetention.KeepLastFrame,
+    ),
+    style = style,
+    sampling = HazeSampling.Default,
+    expandLayerBounds = true,
+  )
+  .hazeBlur(
+    input = HazeInput.Sources(
+      state = state,
+      retention = HazeSourceRetention.ClearWhenUnavailable,
+    ),
+    sampling = HazeSampling.Adaptive,
+  )
+  .hazeBlur(
+    input = HazeInput.Content,
+    sampling = HazeSampling.Fixed(0.6f),
+  )

--- a/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegateTrimMemoryTest.kt
+++ b/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegateTrimMemoryTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.Density
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeArea
@@ -28,6 +29,14 @@ import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalHazeApi::class)
 class RenderEffectBlurVisualEffectDelegateTrimMemoryTest {
+
+  @Test
+  fun renderEffectCache_isOwnedByEachBlurRuntime() {
+    val first = BlurVisualEffect()
+    val second = BlurVisualEffect()
+
+    assertThat(first.renderEffectCache).isNotSameInstanceAs(second.renderEffectCache)
+  }
 
   @Test
   fun onTrimMemory_backgroundKeepsRetainedOutputAvailability() {

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterials.kt
@@ -94,18 +94,37 @@ internal fun cupertinoMaterialStyle(
   lightForegroundColor: Color,
   darkBackgroundColor: Color,
   darkForegroundColor: Color,
-): HazeBlurStyle = HazeBlurStyle(
-  blurRadius = 24.dp,
-  backgroundColor = containerColor,
-  colorEffects = listOf(
-    HazeColorEffect.tint(
-      color = if (isDark) darkBackgroundColor else lightBackgroundColor,
-      blendMode = if (isDark) BlendMode.Overlay else BlendMode.ColorDodge,
-    ),
-    HazeColorEffect.tint(
-      color = if (isDark) darkForegroundColor else lightForegroundColor,
-      blendMode = HazeColorEffect.DefaultBlendMode,
-    ),
+): HazeBlurStyle {
+  val (backgroundColor, colorEffects) = cupertinoMaterialValues(
+    containerColor = containerColor,
+    isDark = isDark,
+    lightBackgroundColor = lightBackgroundColor,
+    lightForegroundColor = lightForegroundColor,
+    darkBackgroundColor = darkBackgroundColor,
+    darkForegroundColor = darkForegroundColor,
+  )
+  return HazeBlurStyle {
+    blurRadius(24.dp)
+    backgroundColor(backgroundColor)
+    colorEffects(colorEffects)
+  }
+}
+
+internal fun cupertinoMaterialValues(
+  containerColor: Color,
+  isDark: Boolean,
+  lightBackgroundColor: Color,
+  lightForegroundColor: Color,
+  darkBackgroundColor: Color,
+  darkForegroundColor: Color,
+): Pair<Color, List<HazeColorEffect>> = containerColor to listOf(
+  HazeColorEffect.tint(
+    color = if (isDark) darkBackgroundColor else lightBackgroundColor,
+    blendMode = if (isDark) BlendMode.Overlay else BlendMode.ColorDodge,
+  ),
+  HazeColorEffect.tint(
+    color = if (isDark) darkForegroundColor else lightForegroundColor,
+    blendMode = HazeColorEffect.DefaultBlendMode,
   ),
 )
 

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterials.kt
@@ -95,23 +95,24 @@ public object FluentMaterials {
 
   internal fun acrylicBaseStyle(
     isDark: Boolean,
-  ): HazeBlurStyle = hazeAcrylicMaterialStyle(
-    containerColor = if (isDark) {
-      Color(0xFF202020)
-    } else {
-      Color(0xFFF3F3F3)
-    },
-    fallbackColor = if (isDark) {
-      Color(0xFF1C1C1C)
-    } else {
-      Color(0xFFEEEEEE)
-    },
-    isDark = isDark,
-    lightTintOpacity = 0f,
-    lightLuminosityOpacity = 0.9f,
-    darkTintOpacity = 0.5f,
-    darkLuminosityOpacity = 0.96f,
-  )
+  ): HazeBlurStyle {
+    val (containerColor, fallbackColor) = acrylicBaseColors(isDark)
+    return hazeAcrylicMaterialStyle(
+      containerColor = containerColor,
+      fallbackColor = fallbackColor,
+      isDark = isDark,
+      lightTintOpacity = 0f,
+      lightLuminosityOpacity = 0.9f,
+      darkTintOpacity = 0.5f,
+      darkLuminosityOpacity = 0.96f,
+    )
+  }
+
+  internal fun acrylicBaseColors(isDark: Boolean): Pair<Color, Color> = if (isDark) {
+    Color(0xFF202020) to Color(0xFF1C1C1C)
+  } else {
+    Color(0xFFF3F3F3) to Color(0xFFEEEEEE)
+  }
 
   /**
    * A [HazeBlurStyle] which implements a translucent material used for the popup container background.
@@ -212,26 +213,28 @@ public object FluentMaterials {
     lightLuminosityOpacity: Float,
     darkTintOpacity: Float,
     darkLuminosityOpacity: Float,
-  ): HazeBlurStyle = HazeBlurStyle(
-    blurRadius = blurRadius,
-    noiseFactor = noiseFactor,
-    backgroundColor = containerColor,
-    colorEffects = listOf(
-      HazeColorEffect.tint(
-        color = containerColor.copy(
-          alpha = if (isDark) darkTintOpacity else lightTintOpacity,
+  ): HazeBlurStyle = HazeBlurStyle {
+    blurRadius(blurRadius)
+    noiseFactor(noiseFactor)
+    backgroundColor(containerColor)
+    colorEffects(
+      listOf(
+        HazeColorEffect.tint(
+          color = containerColor.copy(
+            alpha = if (isDark) darkTintOpacity else lightTintOpacity,
+          ),
+          blendMode = BlendMode.Color,
         ),
-        blendMode = BlendMode.Color,
-      ),
-      HazeColorEffect.tint(
-        color = containerColor.copy(
-          alpha = if (isDark) darkLuminosityOpacity else lightLuminosityOpacity,
+        HazeColorEffect.tint(
+          color = containerColor.copy(
+            alpha = if (isDark) darkLuminosityOpacity else lightLuminosityOpacity,
+          ),
+          blendMode = BlendMode.Luminosity,
         ),
-        blendMode = BlendMode.Luminosity,
       ),
-    ),
-    fallbackColorEffect = HazeColorEffect.tint(fallbackColor),
-  )
+    )
+    fallbackColorEffect(HazeColorEffect.tint(fallbackColor))
+  }
 
   @ReadOnlyComposable
   @Composable

--- a/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/HazeMaterials.kt
+++ b/haze-materials/src/commonMain/kotlin/dev/chrisbanes/haze/blur/materials/HazeMaterials.kt
@@ -96,12 +96,18 @@ public object HazeMaterials {
     containerColor: Color,
     lightAlpha: Float,
     darkAlpha: Float,
-  ): HazeBlurStyle = HazeBlurStyle(
-    blurRadius = 24.dp,
-    backgroundColor = containerColor,
-    colorEffect = HazeColorEffect.tint(
-      containerColor.copy(alpha = if (containerColor.luminance() >= 0.5) lightAlpha else darkAlpha),
-      HazeColorEffect.DefaultBlendMode,
-    ),
-  )
+  ): HazeBlurStyle = HazeBlurStyle {
+    blurRadius(24.dp)
+    backgroundColor(containerColor)
+    colorEffects(
+      listOf(
+        HazeColorEffect.tint(
+          containerColor.copy(
+            alpha = if (containerColor.luminance() >= 0.5) lightAlpha else darkAlpha,
+          ),
+          HazeColorEffect.DefaultBlendMode,
+        ),
+      ),
+    )
+  }
 }

--- a/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterialsTest.kt
+++ b/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/CupertinoMaterialsTest.kt
@@ -6,6 +6,7 @@ package dev.chrisbanes.haze.blur.materials
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import dev.chrisbanes.haze.blur.HazeColorEffect
 import kotlin.test.Test
@@ -13,59 +14,44 @@ import kotlin.test.Test
 class CupertinoMaterialsTest {
 
   @Test
-  fun cupertinoMaterialStyleUsesContainerColorAsBackground() {
-    val containerColor = Color(0xFF123456)
-
-    val style = cupertinoMaterialStyle(
-      containerColor = containerColor,
-      lightBackgroundColor = Color(0xFF111111),
-      lightForegroundColor = Color(0xFF222222),
-      darkBackgroundColor = Color(0xFF333333),
-      darkForegroundColor = Color(0xFF444444),
-    )
-
-    assertThat(style.backgroundColor).isEqualTo(containerColor)
-  }
-
-  @Test
-  fun cupertinoMaterialStyle_usesLightEffectsForLightContainer() {
+  fun cupertinoMaterialValues_useContainerColorAndLightEffects() {
+    val containerColor = Color.White
     val lightBackgroundColor = Color(0xFF111111)
     val lightForegroundColor = Color(0xFF222222)
 
-    val style = cupertinoMaterialStyle(
-      containerColor = Color.White,
+    val (backgroundColor, colorEffects) = cupertinoMaterialValues(
+      containerColor = containerColor,
+      isDark = false,
       lightBackgroundColor = lightBackgroundColor,
       lightForegroundColor = lightForegroundColor,
       darkBackgroundColor = Color(0xFF333333),
       darkForegroundColor = Color(0xFF444444),
     )
 
-    assertThat(style.colorEffects).isEqualTo(
-      listOf(
-        HazeColorEffect.tint(lightBackgroundColor, BlendMode.ColorDodge),
-        HazeColorEffect.tint(lightForegroundColor),
-      ),
+    assertThat(backgroundColor).isEqualTo(containerColor)
+    assertThat(colorEffects).containsExactly(
+      HazeColorEffect.tint(lightBackgroundColor, BlendMode.ColorDodge),
+      HazeColorEffect.tint(lightForegroundColor),
     )
   }
 
   @Test
-  fun cupertinoMaterialStyle_usesDarkEffectsForDarkContainer() {
+  fun cupertinoMaterialValues_useDarkEffects() {
     val darkBackgroundColor = Color(0xFF333333)
     val darkForegroundColor = Color(0xFF444444)
 
-    val style = cupertinoMaterialStyle(
+    val (_, colorEffects) = cupertinoMaterialValues(
       containerColor = Color.Black,
+      isDark = true,
       lightBackgroundColor = Color(0xFF111111),
       lightForegroundColor = Color(0xFF222222),
       darkBackgroundColor = darkBackgroundColor,
       darkForegroundColor = darkForegroundColor,
     )
 
-    assertThat(style.colorEffects).isEqualTo(
-      listOf(
-        HazeColorEffect.tint(darkBackgroundColor, BlendMode.Overlay),
-        HazeColorEffect.tint(darkForegroundColor),
-      ),
+    assertThat(colorEffects).containsExactly(
+      HazeColorEffect.tint(darkBackgroundColor, BlendMode.Overlay),
+      HazeColorEffect.tint(darkForegroundColor),
     )
   }
 }

--- a/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterialsTest.kt
+++ b/haze-materials/src/commonTest/kotlin/dev/chrisbanes/haze/blur/materials/FluentMaterialsTest.kt
@@ -3,7 +3,6 @@
 
 package dev.chrisbanes.haze.blur.materials
 
-import androidx.compose.ui.graphics.Color
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
@@ -12,15 +11,12 @@ class FluentMaterialsTest {
 
   @Test
   fun acrylicBaseUsesOpaqueContainerAndFallbackColors() {
-    val lightStyle = FluentMaterials.acrylicBaseStyle(isDark = false)
-    val darkStyle = FluentMaterials.acrylicBaseStyle(isDark = true)
+    val (lightContainer, lightFallback) = FluentMaterials.acrylicBaseColors(isDark = false)
+    val (darkContainer, darkFallback) = FluentMaterials.acrylicBaseColors(isDark = true)
 
-    assertThat(lightStyle.backgroundColor.alpha).isEqualTo(1f)
-    assertThat(darkStyle.backgroundColor.alpha).isEqualTo(1f)
-    assertThat(lightStyle.fallbackColorEffect.color.alpha).isEqualTo(1f)
-    assertThat(darkStyle.fallbackColorEffect.color.alpha).isEqualTo(1f)
+    assertThat(lightContainer.alpha).isEqualTo(1f)
+    assertThat(lightFallback.alpha).isEqualTo(1f)
+    assertThat(darkContainer.alpha).isEqualTo(1f)
+    assertThat(darkFallback.alpha).isEqualTo(1f)
   }
 }
-
-private val dev.chrisbanes.haze.blur.HazeColorEffect.color: Color
-  get() = (this as dev.chrisbanes.haze.blur.HazeColorEffect.TintColor).color

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeContentBlurringScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeContentBlurringScreenshotTest.kt
@@ -357,14 +357,16 @@ class HazeContentBlurringScreenshotTest : ScreenshotTest() {
       Color.White.copy(alpha = 0.1f),
       HazeColorEffect.DefaultBlendMode,
     )
-    val OverrideStyle = HazeBlurStyle(
-      colorEffects = listOf(
-        HazeColorEffect.tint(
-          Color.Red.copy(alpha = 0.5f),
-          HazeColorEffect.DefaultBlendMode,
+    val OverrideStyle = HazeBlurStyle {
+      colorEffects(
+        listOf(
+          HazeColorEffect.tint(
+            Color.Red.copy(alpha = 0.5f),
+            HazeColorEffect.DefaultBlendMode,
+          ),
         ),
-      ),
-    )
+      )
+    }
 
     val BrushTint = HazeColorEffect.tint(
       brush = Brush.radialGradient(

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeScreenshotTest.kt
@@ -36,7 +36,7 @@ import dev.chrisbanes.haze.blur.HazeBlurDefaults
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.HazeColorEffect
 import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest
@@ -642,15 +642,14 @@ class HazeScreenshotTest : ScreenshotTest() {
 
           Box(
             modifier = Modifier
-              .hazeEffect(state = outerHazeState) {
-                blurEffect {
-                  style = HazeBlurDefaults.style(
-                    backgroundColor = Color.Blue,
-                    tint = DefaultTint,
-                    blurRadius = 8.dp,
-                  )
-                }
-              }
+              .hazeBlur(
+                input = HazeInput.Sources(outerHazeState),
+                style = HazeBlurDefaults.style.then {
+                  backgroundColor(Color.Blue)
+                  colorEffects(listOf(DefaultTint))
+                  blurRadius(8.dp)
+                },
+              )
               .align(Alignment.TopStart)
               .fillMaxWidth()
               .height(56.dp),
@@ -858,14 +857,16 @@ class HazeScreenshotTest : ScreenshotTest() {
       Color.White.copy(alpha = 0.1f),
       HazeColorEffect.DefaultBlendMode,
     )
-    val OverrideStyle = HazeBlurStyle(
-      colorEffects = listOf(
-        HazeColorEffect.tint(
-          Color.Red.copy(alpha = 0.5f),
-          HazeColorEffect.DefaultBlendMode,
+    val OverrideStyle = HazeBlurStyle {
+      colorEffects(
+        listOf(
+          HazeColorEffect.tint(
+            Color.Red.copy(alpha = 0.5f),
+            HazeColorEffect.DefaultBlendMode,
+          ),
         ),
-      ),
-    )
+      )
+    }
 
     val BrushTint = HazeColorEffect.tint(
       brush = Brush.radialGradient(

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/NavDisplaySourceScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/NavDisplaySourceScreenshotTest.kt
@@ -46,8 +46,9 @@ import androidx.navigation3.scene.SceneDecoratorStrategy
 import androidx.navigation3.ui.NavDisplay
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.HazeColorEffect
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -200,12 +201,13 @@ private fun TestNavigationBar(
     modifier = modifier
       .fillMaxWidth()
       .height(220.dp)
-      .hazeEffect(hazeState) {
-        blurEffect {
-          blurRadius = 32.dp
-          colorEffects = listOf(HazeColorEffect.tint(Color.White.copy(alpha = 0.18f)))
-        }
-      },
+      .hazeBlur(
+        input = HazeInput.Sources(hazeState),
+        style = HazeBlurStyle {
+          blurRadius(32.dp)
+          colorEffects(listOf(HazeColorEffect.tint(Color.White.copy(alpha = 0.18f))))
+        },
+      ),
     contentAlignment = Alignment.Center,
   ) {
     Text(

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/ExoPlayerSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/ExoPlayerSample.kt
@@ -21,9 +21,9 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import dev.chrisbanes.haze.sample.shared.R
@@ -72,12 +72,10 @@ fun ExoPlayerSample(blurEnabled: Boolean) {
         .fillMaxSize(0.5f)
         .align(Alignment.Center)
         .clip(MaterialTheme.shapes.large)
-        .hazeEffect(hazeState) {
-          blurEffect {
-            this.blurEnabled = blurEnabled
-            this.style = style
-          }
-        },
+        .hazeBlur(
+          input = HazeInput.Sources(hazeState),
+          style = style.then { blurEnabled(blurEnabled) },
+        ),
     )
   }
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
@@ -35,9 +35,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
@@ -99,12 +99,10 @@ fun BottomSheet(navController: NavHostController, blurEnabled: Boolean) {
         val style = HazeMaterials.thin()
         Column(
           modifier = Modifier
-            .hazeEffect(state = hazeState) {
-              blurEffect {
-                this.blurEnabled = blurEnabled
-                this.style = style
-              }
-            }
+            .hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = style.then { blurEnabled(blurEnabled) },
+            )
             .height(400.dp)
             .fillMaxWidth(),
         ) {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
@@ -9,11 +9,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.blur.HazeBlurDefaults
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.HazeColorEffect
-import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.hazeSource
 
 @Composable
@@ -21,24 +21,23 @@ fun CreditCardSample(
   navController: NavHostController,
   blurEnabled: Boolean = HazeBlurDefaults.blurEnabled(),
 ) {
-  val cardStyle = HazeBlurStyle(
-    backgroundColor = Color.Black,
-    colorEffects = listOf(HazeColorEffect.tint(Color.Yellow.copy(alpha = 0.4f))),
-    blurRadius = 8.dp,
-    noiseFactor = HazeBlurDefaults.noiseFactor,
-  )
+  val cardStyle = HazeBlurStyle {
+    blurEnabled(blurEnabled)
+    backgroundColor(Color.Black)
+    colorEffects(listOf(HazeColorEffect.tint(Color.Yellow.copy(alpha = 0.4f))))
+    blurRadius(8.dp)
+    noiseFactor(HazeBlurDefaults.noiseFactor)
+  }
 
   CreditCardScene(onNavigateUp = navController::navigateUp) { hazeState, modifier, shape, zIndex ->
     Box(
       modifier = modifier
         .hazeSource(hazeState, zIndex = zIndex)
         .clip(shape)
-        .hazeEffect(state = hazeState) {
-          blurEffect {
-            this.blurEnabled = blurEnabled
-            style = cardStyle
-          }
-        },
+        .hazeBlur(
+          input = HazeInput.Sources(hazeState),
+          style = cardStyle,
+        ),
     ) {
       DefaultCreditCardContents()
     }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ContentBlurring.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ContentBlurring.kt
@@ -41,9 +41,9 @@ import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -76,7 +76,6 @@ fun ContentBlurring(
     modifier = Modifier.fillMaxSize(),
   ) {
     var clipEnabled by remember { mutableStateOf(true) }
-    var drawContentBehind by remember { mutableStateOf(false) }
 
     val style = HazeMaterials.ultraThin()
 
@@ -93,21 +92,20 @@ fun ContentBlurring(
         contentScale = ContentScale.Crop,
         contentDescription = null,
         modifier = Modifier
-          .hazeEffect {
-            this.drawContentBehind = drawContentBehind
-
-            blurEffect {
-              this.blurEnabled = blurEnabled
-              this.style = style
-              backgroundColor = Color.Transparent
-              this.blurEnabled = blurEnabled
-              this.blurredEdgeTreatment = when {
-                clipEnabled -> BlurredEdgeTreatment.Rectangle
-                else -> BlurredEdgeTreatment.Unbounded
-              }
-              this.blurRadius = 100.dp
-            }
-          }
+          .hazeBlur(
+            input = HazeInput.Content,
+            style = style.then {
+              blurEnabled(blurEnabled)
+              backgroundColor(Color.Transparent)
+              blurredEdgeTreatment(
+                when {
+                  clipEnabled -> BlurredEdgeTreatment.Rectangle
+                  else -> BlurredEdgeTreatment.Unbounded
+                },
+              )
+              blurRadius(100.dp)
+            },
+          )
           .align(Alignment.Center)
           .size(300.dp),
       )
@@ -119,11 +117,6 @@ fun ContentBlurring(
           .windowInsetsPadding(WindowInsets.navigationBars)
           .align(Alignment.BottomCenter),
       ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-          Text("Draw content behind:", modifier = Modifier.padding(end = 8.dp))
-          Switch(checked = drawContentBehind, onCheckedChange = { drawContentBehind = it })
-        }
-
         Row(verticalAlignment = Alignment.CenterVertically) {
           Text("Clipped:", modifier = Modifier.padding(end = 8.dp))
           Switch(checked = clipEnabled, onCheckedChange = { clipEnabled = it })

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
@@ -37,9 +37,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavHostController
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.time.Duration.Companion.seconds
@@ -80,12 +80,10 @@ fun DialogSample(navController: NavHostController, blurEnabled: Boolean) {
         ) {
           val style = HazeMaterials.regular()
           Box(
-            Modifier.hazeEffect(state = hazeState) {
-              blurEffect {
-                this.blurEnabled = blurEnabled
-                this.style = style
-              }
-            },
+            Modifier.hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = style.then { blurEnabled(blurEnabled) },
+            ),
           ) {
             // empty
           }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
@@ -29,9 +29,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
@@ -87,12 +87,10 @@ fun ImagesList(navController: NavHostController, blurEnabled: Boolean) {
                   .fillMaxSize(0.8f)
                   .align(Alignment.Center)
                   .clip(RoundedCornerShape(4.dp))
-                  .hazeEffect(state = hazeState) {
-                    blurEffect {
-                      this.blurEnabled = blurEnabled
-                      this.style = style
-                    }
-                  },
+                  .hazeBlur(
+                    input = HazeInput.Sources(hazeState),
+                    style = style.then { blurEnabled(blurEnabled) },
+                  ),
               ) {
                 Text(
                   "Image $index",

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/LayerTransformations.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/LayerTransformations.kt
@@ -29,8 +29,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
-import dev.chrisbanes.haze.blur.blurEffect
-import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.math.PI
@@ -100,12 +101,13 @@ fun LayerTransformations(
           translationY = (radiusPx * sin(theta)).toFloat()
         }
         .align(Alignment.Center)
-        .hazeEffect(state = hazeState) {
-          blurEffect {
-            this.blurEnabled = blurEnabled
-            blurRadius = 20.dp
-          }
-        }
+        .hazeBlur(
+          input = HazeInput.Sources(hazeState),
+          style = HazeBlurStyle {
+            blurEnabled(blurEnabled)
+            blurRadius(20.dp)
+          },
+        )
         .padding(16.dp),
     )
   }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
@@ -32,9 +32,9 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
@@ -96,12 +96,10 @@ fun ListOverImage(navController: NavHostController, blurEnabled: Boolean) {
                 modifier = Modifier
                   .fillMaxSize()
                   .padding(horizontal = 24.dp)
-                  .hazeEffect(state = hazeState) {
-                    blurEffect {
-                      this.blurEnabled = blurEnabled
-                      this.style = style
-                    }
-                  },
+                  .hazeBlur(
+                    input = HazeInput.Sources(hazeState),
+                    style = style.then { blurEnabled(blurEnabled) },
+                  ),
               ) {
                 Text(
                   "Item $index",

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
@@ -28,10 +28,10 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import dev.chrisbanes.haze.ExperimentalHazeApi
-import dev.chrisbanes.haze.HazeInputScale
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeSampling
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
@@ -74,13 +74,11 @@ fun ListWithStickyHeaders(navController: NavHostController, blurEnabled: Boolean
           Box(
             modifier = Modifier
               .fillMaxWidth()
-              .hazeEffect(state = hazeState) {
-                inputScale = HazeInputScale.Auto
-                blurEffect {
-                  this.blurEnabled = blurEnabled
-                  this.style = style
-                }
-              },
+              .hazeBlur(
+                input = HazeInput.Sources(hazeState),
+                style = style.then { blurEnabled(blurEnabled) },
+                sampling = HazeSampling.Adaptive,
+              ),
           ) {
             Text("Header: $group", modifier = Modifier.padding(16.dp))
           }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -28,13 +28,13 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
+import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.blur.HazeBlurStyle
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.CupertinoMaterials
 import dev.chrisbanes.haze.blur.materials.FluentMaterials
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
@@ -317,12 +317,10 @@ private fun MaterialsCard(
     Box(
       Modifier
         .fillMaxSize()
-        .hazeEffect(state = state) {
-          blurEffect {
-            this.blurEnabled = blurEnabled
-            this.style = style
-          }
-        }
+        .hazeBlur(
+          input = HazeInput.Sources(state),
+          style = style,
+        )
         .padding(16.dp),
     ) {
       Text(name)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/PopupSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/PopupSample.kt
@@ -37,9 +37,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.navigation.NavHostController
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.time.Duration.Companion.seconds
@@ -80,12 +80,10 @@ fun PopupSample(navController: NavHostController, blurEnabled: Boolean) {
         ) {
           val style = HazeMaterials.regular()
           Box(
-            Modifier.hazeEffect(state = hazeState) {
-              blurEffect {
-                this.blurEnabled = blurEnabled
-                this.style = style
-              }
-            },
+            Modifier.hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = style.then { blurEnabled(blurEnabled) },
+            ),
           ) {
             // empty
           }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -41,11 +41,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeInputScale
 import dev.chrisbanes.haze.HazeProgressive
-import dev.chrisbanes.haze.blur.blurEffect
+import dev.chrisbanes.haze.HazeSampling
+import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
@@ -91,28 +92,28 @@ fun ScaffoldSample(
           scrolledContainerColor = Color.Transparent,
         ),
         modifier = Modifier
-          .hazeEffect(state = hazeState) {
-            this.inputScale = inputScale
-
-            blurEffect {
-              this.blurEnabled = blurEnabled
-              this.style = style
-
+          .hazeBlur(
+            input = HazeInput.Sources(hazeState),
+            sampling = inputScale.toSampling(),
+            style = style.then {
+              blurEnabled(blurEnabled)
               when (mode) {
                 ScaffoldSampleMode.Default -> Unit
                 ScaffoldSampleMode.Progressive -> {
-                  progressive = HazeProgressive.verticalGradient(
-                    startIntensity = 1f,
-                    endIntensity = 0f,
+                  progressive(
+                    HazeProgressive.verticalGradient(
+                      startIntensity = 1f,
+                      endIntensity = 0f,
+                    ),
                   )
                 }
 
                 ScaffoldSampleMode.Mask -> {
-                  mask = Brush.easedVerticalGradient(EaseIn)
+                  mask(Brush.easedVerticalGradient(EaseIn))
                 }
               }
-            }
-          }
+            },
+          )
           .fillMaxWidth(),
       )
     },
@@ -127,13 +128,11 @@ fun ScaffoldSample(
           selectedIndex = selectedIndex,
           onItemClicked = { selectedIndex = it },
           modifier = Modifier
-            .hazeEffect(state = hazeState) {
-              this.inputScale = inputScale
-              blurEffect {
-                this.blurEnabled = blurEnabled
-                this.style = style
-              }
-            }
+            .hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              sampling = inputScale.toSampling(),
+              style = style.then { blurEnabled(blurEnabled) },
+            )
             .fillMaxWidth(),
         )
       }
@@ -162,6 +161,13 @@ fun ScaffoldSample(
       }
     }
   }
+}
+
+private fun HazeInputScale.toSampling(): HazeSampling = when (this) {
+  HazeInputScale.EffectDefault -> HazeSampling.Default
+  HazeInputScale.None -> HazeSampling.FullResolution
+  HazeInputScale.Auto -> HazeSampling.Adaptive
+  is HazeInputScale.Fixed -> HazeSampling.Fixed(scale)
 }
 
 @Composable


### PR DESCRIPTION
## Summary

- add a replayable, shareable `HazeBlurStyle` with defaults → local → explicit resolution
- add typed `Modifier.hazeBlur` while preserving legacy compatibility
- keep renderer/cache ownership per modifier node, including reuse, trim, and detach behavior
- migrate Blur materials, samples, tests, API signatures, and documentation

## Validation

- `:haze-blur:check` across supported targets
- shared sample JS/Wasm compilation
- Metalava compatibility
- Dokka and MkDocs documentation build
- repository-wide checks; only the known Gallery environment diffs reproduced from the base (15.21% portrait, 15.32% landscape)
- no screenshot baseline or image changes

Closes #1131
