### PR TITLE
Migrate Glass callers to typed styles

### DIFF
--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -40,23 +40,22 @@ Adaptive content behavior, interaction-driven deformation, and morphing are unsu
 
 ## GlassStyle
 
-Use a `GlassStyle` container to provide a shared `optics` configuration and grouped visual
-styling. The style supports a four-tier precedence chain for each property:
-
-1. Direct property value on the effect (highest priority)
-2. Value set via the `style` parameter
-3. Value from the `LocalGlassStyle` composition local
-4. Default from `GlassDefaults`
+`GlassStyle` is an opaque, replayable appearance program. Create it with a block and compose
+values with `then`; later writes win. A style can be shared by any number of `hazeGlass` nodes:
+each node evaluates defaults, `LocalGlassStyle`, and its explicit style into its own snapshot.
+Replacing a Style through recomposition also removes properties and interaction blocks omitted by
+the replacement.
 
 ```kotlin
-val myStyle = GlassStyle(
-  tint = Color.White.copy(alpha = 0.16f),
-  optics = GlassOptics.Absolute(refractionStrength = 0.8f),
-  shape = RoundedCornerShape(20.dp),
-)
+val baseStyle = GlassStyle {
+  tint(Color.White.copy(alpha = 0.16f))
+  optics(GlassOptics.Absolute(refractionStrength = 0.8f))
+  shape(RoundedCornerShape(20.dp))
+}
+val emphasizedStyle = baseStyle.then { specularIntensity(0.7f) }
 
-CompositionLocalProvider(LocalGlassStyle provides myStyle) {
-  // All Glass effects in this scope will use myStyle as their baseline
+CompositionLocalProvider(LocalGlassStyle provides baseStyle) {
+  // Each node gets a fresh snapshot; an explicit Style is applied last.
 }
 ```
 
@@ -69,9 +68,7 @@ applied automatically when no style or direct property overrides are provided.
 Box(
   Modifier
     .size(180.dp)
-    .hazeEffect(state = hazeState) {
-      glassEffect()
-    }
+    .hazeGlass(input = HazeInput.Sources(hazeState))
 )
 ```
 
@@ -82,20 +79,18 @@ material's size, aspect ratio, and roundness. Use `GlassOptics.Absolute` when yo
 complete literal configuration instead:
 
 ```kotlin
-glassEffect {
-  optics = GlassOptics.Adaptive
-}
+GlassStyle { optics(GlassOptics.Adaptive) }
 ```
 
 ```kotlin
-glassEffect {
-  optics = GlassOptics.Absolute(
+GlassStyle {
+  optics(GlassOptics.Absolute(
     blurRadius = 20.dp,
     refractionStrength = 0.8f,
     refractionHeightFraction = 0.3f,
     refractionDisplacement = 18.dp,
     depth = 0.5f,
-  )
+  ))
 }
 ```
 
@@ -111,30 +106,31 @@ content also needs clipping.
 
 Glass can retain and redraw its last captured output when all source areas disappear. This
 keeps source transitions smooth, but can briefly preserve stale pixels from removed source content.
-For privacy-sensitive surfaces, disable retained output on the shared effect scope:
+The typed modifier preserves Glass's default retained-output policy. Keep source ownership explicit
+with `HazeInput.Sources` so transitions are visible at the call site:
 
 ```kotlin
 Box(
   Modifier
     .size(180.dp)
-    .hazeEffect(state = hazeState) {
-      retainOutputWhenSourceUnavailable = false
-      glassEffect()
-    }
+    .hazeGlass(
+      input = HazeInput.Sources(hazeState),
+      style = GlassStyle,
+    )
 )
 ```
 
 You can select a literal optical configuration when the built-in material does not fit the design:
 
 ```kotlin
-glassEffect {
-  tint = Color.White.copy(alpha = 0.20f)
-  optics = GlassOptics.Absolute(
+GlassStyle {
+  tint(Color.White.copy(alpha = 0.20f))
+  optics(GlassOptics.Absolute(
     progressive = HazeProgressive.verticalGradient(
       startIntensity = 1f,
       endIntensity = 0.25f,
     ),
-  )
+  ))
 }
 ```
 
@@ -163,11 +159,10 @@ Glass interaction is default-disabled and entirely opt-in. It adds a visual resp
 not add click handling, focusability, semantics, or keyboard/D-pad activation.
 
 ```kotlin
-Modifier.hazeEffect(hazeState) {
-  glassEffect {
-    pressed()
-  }
-}
+Modifier.hazeGlass(
+  input = HazeInput.Sources(hazeState),
+  style = GlassStyle { pressed {} },
+)
 ```
 
 `hovered()`, `focused()`, and `pressed()` enable their respective default visual responses.
@@ -180,12 +175,15 @@ val interactionSource = remember { MutableInteractionSource() }
 Modifier
   .clickable(interactionSource = interactionSource, indication = null) { onClick() }
   .focusable(interactionSource = interactionSource)
-  .hazeEffect(hazeState) {
-    glassEffect {
-      this.interactionSource = interactionSource
-      interactable()
-    }
-  }
+  .hazeGlass(
+    input = HazeInput.Sources(hazeState),
+    interactionSource = interactionSource,
+    style = GlassStyle {
+      hovered {}
+      focused {}
+      pressed {}
+    },
+  )
 ```
 
 Custom blocks replace that state's preset from identity. Resolve each property with fixed
@@ -194,7 +192,7 @@ block to own the arrival and departure animation specs respectively; entering or
 `toSpec`, while departing uses `fromSpec`.
 
 ```kotlin
-glassEffect {
+GlassStyle {
   pressed {
     animate(
       toSpec = GlassDefaults.pressAnimationSpec,
@@ -206,10 +204,9 @@ glassEffect {
 }
 ```
 
-`interactionTransformTarget` selects whether a response transforms only the material or the
+The `interactionTransformTarget` argument selects whether a response transforms only the material or the
 material and content. `interactionTransformPivot` selects `Pointer` or `Center`. Use
-`clearHovered()`, `clearFocused()`, `clearPressed()`, or `clearInteractions()` to remove configured
-responses. `GlassReducedMotionPolicy.System` follows the available system duration scale,
+Omit a state block from a replacement Style to remove it. `GlassReducedMotionPolicy.System` follows the available system duration scale,
 `Reduced` snaps lighting and optics while suppressing transforms, and `Full` forces motion.
 
 ## Usage
@@ -218,22 +215,23 @@ responses. `GlassReducedMotionPolicy.System` follows the available system durati
 Box(
   Modifier
     .size(180.dp)
-    .hazeEffect(state = hazeState) {
-      glassEffect {
-        tint = Color.White.copy(alpha = 0.16f)
-        optics = GlassOptics.Absolute(
+    .hazeGlass(
+      input = HazeInput.Sources(hazeState),
+      style = GlassStyle {
+        tint(Color.White.copy(alpha = 0.16f))
+        optics(GlassOptics.Absolute(
           refractionStrength = 0.8f,
           refractionHeightFraction = 0.32f,
           depth = 0.5f,
-        )
-        specularIntensity = 0.7f
-        ambientResponse = 0.7f
-        edgeSoftness = 14.dp
-        shape = RoundedCornerShape(20.dp)
-        surfaceProfile = SurfaceProfile.Squircle
-        chromaticAberrationStrength = 0.2f
-      }
-    }
+        ))
+        specularIntensity(0.7f)
+        ambientResponse(0.7f)
+        edgeSoftness(14.dp)
+        shape(RoundedCornerShape(20.dp))
+        surfaceProfile(SurfaceProfile.Squircle)
+        chromaticAberrationStrength(0.2f)
+      },
+    )
 )
 ```
 

--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -120,6 +120,19 @@ Box(
 )
 ```
 
+The default is `HazeSourceRetention.KeepLastFrame`. For privacy-sensitive source content, opt out
+of retaining pixels when the source disappears:
+
+```kotlin
+Modifier.hazeGlass(
+  input = HazeInput.Sources(
+    state = hazeState,
+    retention = HazeSourceRetention.ClearWhenUnavailable,
+  ),
+  style = GlassStyle,
+)
+```
+
 You can select a literal optical configuration when the built-in material does not fit the design:
 
 ```kotlin

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -129,12 +129,26 @@ resources.
 
 The typed Blur API does not change the other Haze 2 migrations.
 
-### Glass Style
+### Glass migration
 
-`GlassStyle` is also a replayable Style. Write each property through its Style scope:
+Glass also has a typed modifier and an opaque, replayable `GlassStyle`. Replace the complete Style
+through recomposition; do not mutate an effect, use sentinel patches, `copy`, or `clear*` calls.
+
+| Legacy | Typed replacement |
+| --- | --- |
+| `hazeEffect { glassEffect { … } }` | `hazeGlass(input, style, sampling, expandLayerBounds, …)` |
+| mutable effect properties | replace `GlassStyle` through recomposition |
+| sentinel patches and `copy` | `GlassStyle { … }`, `then`, and `LocalGlassStyle` |
+| interaction mutation and `clear*` | declarative `hovered`, `focused`, and `pressed` blocks; omit blocks in a replacement Style |
+| effect-owned interaction controls | typed modifier arguments |
+| implicit source/content | explicit `HazeInput.Sources` or `HazeInput.Content` |
+| raw optical displacement/caps | semantic `GlassOptics` and `Dp` controls |
+
+Write each property through the Style scope, then pass the Style and structural policies to
+`hazeGlass`:
 
 ```kotlin
-GlassStyle {
+val glassStyle = GlassStyle {
   tint(Color.White.copy(alpha = 0.12f))
   optics(
     GlassOptics.Absolute(
@@ -144,7 +158,15 @@ GlassStyle {
   )
   specularIntensity(0.4f)
   edgeSoftness(12.dp)
+  pressed { scale(0.98f) }
 }
+
+Modifier.hazeGlass(
+  input = HazeInput.Sources(hazeState),
+  style = glassStyle,
+  sampling = HazeSampling.Default,
+  expandLayerBounds = true,
+)
 ```
 
 ### Position and geometry

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassDepthAndroidScreenshotTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassDepthAndroidScreenshotTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.glass.GlassOptics
-import dev.chrisbanes.haze.glass.GlassVisualEffect
+import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest
@@ -147,19 +147,19 @@ class GlassDepthAndroidScreenshotTest : ScreenshotTest() {
   @Test
   fun glass_depthZeroMasksShape() = runScreenshotTest {
     val shape = RoundedCornerShape(48.dp)
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.White.copy(alpha = 0.28f)
-      optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 0f, blurRadius = 32.dp)
-      specularIntensity = 0f
-      ambientResponse = 0f
-      edgeSoftness = 16.dp
-      this.shape = shape
+    val style = GlassStyle {
+      tint(Color.White.copy(alpha = 0.28f))
+      optics(GlassOptics.Absolute(refractionStrength = 0f, depth = 0f, blurRadius = 32.dp))
+      specularIntensity(0f)
+      ambientResponse(0f)
+      edgeSoftness(16.dp)
+      this.shape(shape)
     }
 
     setContent {
       ScreenshotTheme {
         GlassBlurRadiusSample(
-          visualEffect = visualEffect,
+          style = style,
           shape = shape,
           clipShape = false,
         )

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceTransitionAndroidScreenshotTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceTransitionAndroidScreenshotTest.kt
@@ -61,11 +61,13 @@ class SourceTransitionAndroidScreenshotTest : ScreenshotTest() {
   @Test
   @Config(sdk = [35], qualifiers = "w393dp-h698dp-440dpi")
   fun glass_sourceRemoved_reprocessesRetainedCapture() = runScreenshotTest {
-    var style by mutableStateOf(GlassStyle {
-      tint(Color.White.copy(alpha = 0.12f))
-      optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
-      specularIntensity(0.45f)
-    })
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(Color.White.copy(alpha = 0.12f))
+        optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
+        specularIntensity(0.45f)
+      },
+    )
     var showSource by mutableStateOf(true)
 
     setContent {

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceTransitionAndroidScreenshotTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceTransitionAndroidScreenshotTest.kt
@@ -17,7 +17,8 @@ import assertk.assertions.isLessThan
 import dev.chrisbanes.haze.blur.BlurVisualEffect
 import dev.chrisbanes.haze.blur.HazeColorEffect
 import dev.chrisbanes.haze.glass.GlassOptics
-import dev.chrisbanes.haze.glass.GlassVisualEffect
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest
@@ -60,17 +61,17 @@ class SourceTransitionAndroidScreenshotTest : ScreenshotTest() {
   @Test
   @Config(sdk = [35], qualifiers = "w393dp-h698dp-440dpi")
   fun glass_sourceRemoved_reprocessesRetainedCapture() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.White.copy(alpha = 0.12f)
-      optics = GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f)
-      specularIntensity = 0.45f
-    }
+    var style by mutableStateOf(GlassStyle {
+      tint(Color.White.copy(alpha = 0.12f))
+      optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
+      specularIntensity(0.45f)
+    })
     var showSource by mutableStateOf(true)
 
     setContent {
       ScreenshotTheme {
-        SourceTransitionSample(
-          visualEffect = visualEffect,
+        SourceTransitionGlassSample(
+          style = style,
           showSource = showSource,
         )
       }
@@ -80,7 +81,7 @@ class SourceTransitionAndroidScreenshotTest : ScreenshotTest() {
     showSource = false
     waitForIdle()
     val retained = captureRootPixels().snapshot()
-    visualEffect.tint = Color.Magenta.copy(alpha = 0.24f)
+    style = style.then { tint(Color.Magenta.copy(alpha = 0.24f)) }
     waitForIdle()
     val reprocessed = captureRootPixels().snapshot()
 

--- a/haze-screenshot-tests/src/commonMain/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
+++ b/haze-screenshot-tests/src/commonMain/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
@@ -219,6 +219,49 @@ internal fun SourceTransitionSample(
   }
 }
 
+@Composable
+internal fun SourceTransitionGlassSample(
+  style: GlassStyle,
+  showSource: Boolean,
+) {
+  val hazeState = rememberHazeState()
+
+  Box(
+    modifier = Modifier
+      .fillMaxSize()
+      .background(Color.Black),
+  ) {
+    if (showSource) {
+      CreditCardBackground(
+        backgroundColors = listOf(Color(0xFF1E88E5), Color(0xFFE91E63)),
+        modifier = Modifier
+          .fillMaxSize()
+          .hazeSource(state = hazeState, zIndex = 0f),
+      )
+    }
+
+    Box(
+      modifier = Modifier
+        .align(Alignment.TopCenter)
+        .fillMaxWidth()
+        .height(176.dp)
+        .hazeGlass(
+          input = HazeInput.Sources(hazeState),
+          style = style,
+        ),
+    ) {
+      Text(
+        text = "Transition",
+        color = Color.White,
+        style = MaterialTheme.typography.headlineSmall,
+        modifier = Modifier
+          .align(Alignment.CenterStart)
+          .padding(horizontal = 32.dp),
+      )
+    }
+  }
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun StickyHeaderListSample(

--- a/haze-screenshot-tests/src/commonMain/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
+++ b/haze-screenshot-tests/src/commonMain/kotlin/dev/chrisbanes/haze/ScreenshotTestContent.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.blur.BlurVisualEffect
 import dev.chrisbanes.haze.blur.HazeColorEffect
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import haze_root.haze_screenshot_tests.generated.resources.Res
 import haze_root.haze_screenshot_tests.generated.resources.photo
 import kotlin.math.roundToInt
@@ -88,6 +90,55 @@ internal fun CreditCardSample(
 }
 
 @Composable
+internal fun CreditCardGlassSample(
+  style: GlassStyle,
+  styles: List<GlassStyle> = listOf(style),
+  backgroundColors: List<Color> = listOf(Color.Blue, Color.Cyan),
+  shape: RoundedCornerShape = RoundedCornerShape(16.dp),
+  enabled: Boolean = true,
+  numberCards: Int = 1,
+) {
+  require(styles.size == numberCards)
+  val hazeState = remember { HazeState() }
+
+  Box {
+    CreditCardBackground(
+      backgroundColors = backgroundColors,
+      modifier = Modifier
+        .fillMaxSize()
+        .hazeSource(state = hazeState, zIndex = 0f),
+    )
+
+    repeat(numberCards) { index ->
+      val reverseIndex = numberCards - 1 - index
+      Box(
+        modifier = Modifier
+          .align(Alignment.Center)
+          .fillMaxWidth(.7f - (reverseIndex * 0.05f))
+          .aspectRatio(16 / 9f)
+          .offset { IntOffset(x = 0, y = reverseIndex * -100) }
+          .hazeSource(hazeState, zIndex = 1f + index)
+          .clip(shape)
+          .then(
+            if (enabled) {
+              Modifier.hazeGlass(
+                input = HazeInput.Sources(hazeState),
+                style = styles[index],
+              )
+            } else {
+              Modifier
+            },
+          ),
+      ) {
+        Column(Modifier.padding(32.dp)) {
+          Text("Bank of Haze")
+        }
+      }
+    }
+  }
+}
+
+@Composable
 internal fun CreditCardContentBlurring(
   visualEffect: VisualEffect,
   backgroundColors: List<Color> = listOf(Color.Blue, Color.Cyan),
@@ -106,6 +157,23 @@ internal fun CreditCardContentBlurring(
           this.visualEffect = visualEffect
         },
     )
+  }
+}
+
+@Composable
+internal fun CreditCardGlassContentBlurring(
+  style: GlassStyle,
+  backgroundColors: List<Color> = listOf(Color.Blue, Color.Cyan),
+) {
+  Box(
+    Modifier
+      .background(backgroundColors.first())
+      .hazeGlass(
+        input = HazeInput.Content,
+        style = style,
+      ),
+  ) {
+    CreditCardBackground(backgroundColors = backgroundColors, modifier = Modifier.fillMaxSize())
   }
 }
 

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
@@ -16,6 +16,7 @@ import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.glass.GlassVisualEffect
 import dev.chrisbanes.haze.glass.SurfaceProfile
+import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest
@@ -25,12 +26,10 @@ class GlassContentScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-    }
+    val style = GlassStyle { tint(DefaultTint) }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(visualEffect = visualEffect)
+        CreditCardGlassContentBlurring(style = style)
       }
     }
     captureRoot()
@@ -38,12 +37,10 @@ class GlassContentScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_noTint() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.Transparent
-    }
+    val style = GlassStyle { tint(Color.Transparent) }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(visualEffect = visualEffect)
+        CreditCardGlassContentBlurring(style = style)
       }
     }
     captureRoot()
@@ -51,12 +48,9 @@ class GlassContentScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_style() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      style = VibrantStyle
-    }
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(visualEffect = visualEffect)
+        CreditCardGlassContentBlurring(style = VibrantStyle)
       }
     }
     captureRoot()
@@ -81,63 +75,67 @@ class GlassContentScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_alpha() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      alpha = 0.7f
-      optics = GlassOptics.Absolute(refractionStrength = 0.45f)
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        alpha(0.7f)
+        optics(GlassOptics.Absolute(refractionStrength = 0.45f))
+      },
+    )
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(visualEffect = visualEffect)
+        CreditCardGlassContentBlurring(style = style)
       }
     }
 
     captureRoot("70")
 
-    visualEffect.alpha = 0.4f
+    style = style.then { alpha(0.4f) }
     waitForIdle()
     captureRoot("40")
 
-    visualEffect.alpha = 1f
+    style = style.then { alpha(1f) }
     waitForIdle()
     captureRoot("100")
   }
 
   @Test
   fun creditCard_lightPosition() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      specularIntensity = 0.65f
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        specularIntensity(0.65f)
+      },
+    )
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(visualEffect = visualEffect)
+        CreditCardGlassContentBlurring(style = style)
       }
     }
 
     captureRoot("center")
 
-    visualEffect.lightPosition = Offset(-96f, -64f)
+    style = style.then { lightPosition(Offset(-96f, -64f)) }
     waitForIdle()
     captureRoot("topLeft")
 
-    visualEffect.lightPosition = Offset(120f, 80f)
+    style = style.then { lightPosition(Offset(120f, 80f)) }
     waitForIdle()
     captureRoot("bottomRight")
   }
 
   @Test
   fun creditCard_backgroundChange() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      edgeSoftness = 12.dp
+    val style = GlassStyle {
+      tint(DefaultTint)
+      edgeSoftness(12.dp)
     }
     var backgroundColors by mutableStateOf(listOf(Color.Blue, Color.Cyan))
 
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(
-          visualEffect = visualEffect,
+        CreditCardGlassContentBlurring(
+          style = style,
           backgroundColors = backgroundColors,
         )
       }
@@ -156,18 +154,20 @@ class GlassContentScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_shape_refractionHeight() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionHeightFraction = 0.3f, depth = 0.45f)
-      specularIntensity = 0.6f
-      edgeSoftness = 10.dp
-      shape = androidx.compose.foundation.shape.RoundedCornerShape(22.dp)
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        optics(GlassOptics.Absolute(refractionHeightFraction = 0.3f, depth = 0.45f))
+        specularIntensity(0.6f)
+        edgeSoftness(10.dp)
+        shape(androidx.compose.foundation.shape.RoundedCornerShape(22.dp))
+      },
+    )
 
     setContent {
       ScreenshotTheme {
-        CreditCardContentBlurring(
-          visualEffect = visualEffect,
+        CreditCardGlassContentBlurring(
+          style = style,
           backgroundColors = listOf(Color(0xFF1E88E5), Color(0xFF00ACC1)),
         )
       }
@@ -175,7 +175,7 @@ class GlassContentScreenshotTest : ScreenshotTest() {
 
     captureRoot("rounded")
 
-    visualEffect.updateAbsoluteOptics { copy(refractionHeightFraction = 0.16f) }
+    style = style.then { optics(GlassOptics.Absolute(refractionHeightFraction = 0.16f, depth = 0.45f)) }
     waitForIdle()
     captureRoot("shallow")
   }

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassRoundedEdgeInvariant.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassRoundedEdgeInvariant.kt
@@ -21,7 +21,8 @@ import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isLessThanOrEqualTo
 import dev.chrisbanes.haze.glass.GlassOptics
-import dev.chrisbanes.haze.glass.GlassVisualEffect
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.test.ScreenshotUiTest
 import kotlin.math.abs
 
@@ -39,17 +40,19 @@ private enum class RoundedEdgeClipPlacement {
 
 internal fun ScreenshotUiTest.assertGlassRoundedEdgePixelsAreContinuous() {
   val shape = RoundedCornerShape(31.dp)
-  val effect = GlassVisualEffect().apply {
-    tint = Color.White.copy(alpha = 0.8f)
-    optics = GlassOptics.Absolute(
-      refractionStrength = 0f,
-      depth = 0f,
-      blurRadius = 0.dp,
+  val style = GlassStyle {
+    tint(Color.White.copy(alpha = 0.8f))
+    optics(
+      GlassOptics.Absolute(
+        refractionStrength = 0f,
+        depth = 0f,
+        blurRadius = 0.dp,
+      ),
     )
-    specularIntensity = 0f
-    ambientResponse = 0f
-    edgeSoftness = 0.dp
-    this.shape = shape
+    specularIntensity(0f)
+    ambientResponse(0f)
+    edgeSoftness(0.dp)
+    this.shape(shape)
   }
   var clipPlacement by mutableStateOf(RoundedEdgeClipPlacement.InternalMaskOnly)
 
@@ -80,18 +83,21 @@ internal fun ScreenshotUiTest.assertGlassRoundedEdgePixelsAreContinuous() {
 
       Box(
         when (clipPlacement) {
-          RoundedEdgeClipPlacement.InternalMaskOnly -> effectModifier.hazeEffect(hazeState) {
-            inputScale = HazeInputScale.None
-            visualEffect = effect
-          }
-          RoundedEdgeClipPlacement.AroundEffect -> effectModifier.clip(shape).hazeEffect(hazeState) {
-            inputScale = HazeInputScale.None
-            visualEffect = effect
-          }
-          RoundedEdgeClipPlacement.AroundContent -> effectModifier.hazeEffect(hazeState) {
-            inputScale = HazeInputScale.None
-            visualEffect = effect
-          }.clip(shape)
+          RoundedEdgeClipPlacement.InternalMaskOnly -> effectModifier.hazeGlass(
+            input = HazeInput.Sources(hazeState),
+            style = style,
+            sampling = HazeSampling.FullResolution,
+          )
+          RoundedEdgeClipPlacement.AroundEffect -> effectModifier.clip(shape).hazeGlass(
+            input = HazeInput.Sources(hazeState),
+            style = style,
+            sampling = HazeSampling.FullResolution,
+          )
+          RoundedEdgeClipPlacement.AroundContent -> effectModifier.hazeGlass(
+            input = HazeInput.Sources(hazeState),
+            style = style,
+            sampling = HazeSampling.FullResolution,
+          ).clip(shape)
         },
       )
     }

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
@@ -36,8 +36,9 @@ import assertk.assertions.isLessThanOrEqualTo
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
-import dev.chrisbanes.haze.glass.GlassVisualEffect
 import dev.chrisbanes.haze.glass.SurfaceProfile
+import dev.chrisbanes.haze.glass.hazeGlass
+import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest
@@ -53,13 +54,11 @@ class GlassScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-    }
+    val style = GlassStyle { tint(DefaultTint) }
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect)
+        CreditCardGlassSample(style = style)
       }
     }
     captureRoot()
@@ -67,13 +66,11 @@ class GlassScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_noTint() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.Transparent
-    }
+    val style = GlassStyle { tint(Color.Transparent) }
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect)
+        CreditCardGlassSample(style = style)
       }
     }
     captureRoot()
@@ -81,17 +78,17 @@ class GlassScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_multiple() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionStrength = 0.45f)
+    val style = GlassStyle {
+      tint(DefaultTint)
+      optics(GlassOptics.Absolute(refractionStrength = 0.45f))
     }
-    val visualEffects = List(3) { GlassVisualEffect(visualEffect) }
+    val styles = List(3) { style }
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(
-          visualEffect = visualEffects.first(),
-          visualEffects = visualEffects,
+        CreditCardGlassSample(
+          style = styles.first(),
+          styles = styles,
           numberCards = 3,
         )
       }
@@ -102,13 +99,9 @@ class GlassScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_style() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      style = VibrantStyle
-    }
-
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect)
+        CreditCardGlassSample(style = VibrantStyle)
       }
     }
     captureRoot()
@@ -116,25 +109,27 @@ class GlassScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_alpha() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      alpha = 0.85f
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        alpha(0.85f)
+      },
+    )
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect)
+        CreditCardGlassSample(style = style)
       }
     }
 
     captureRoot()
     val initialPixels = captureRootPixels().snapshot()
 
-    visualEffect.alpha = 0.45f
+    style = style.then { alpha(0.45f) }
     waitForIdle()
     captureRoot("45")
 
-    visualEffect.alpha = 0.15f
+    style = style.then { alpha(0.15f) }
     waitForIdle()
     val lowAlphaPixels = captureRootPixels().snapshot()
     captureRoot("15")
@@ -147,42 +142,48 @@ class GlassScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_edgeSoftness() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      edgeSoftness = 0.dp
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        edgeSoftness(0.dp)
+      },
+    )
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect)
+        CreditCardGlassSample(style = style)
       }
     }
 
     captureRoot("sharp")
 
-    visualEffect.edgeSoftness = 18.dp
+    style = style.then { edgeSoftness(18.dp) }
     waitForIdle()
     captureRoot("soft", unmatchedPixelThreshold = 0.01f)
   }
 
   @Test
   fun creditCard_refraction_depth() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionStrength = 0.25f, depth = 0.15f)
-      specularIntensity = 0.35f
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        optics(GlassOptics.Absolute(refractionStrength = 0.25f, depth = 0.15f))
+        specularIntensity(0.35f)
+      },
+    )
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect)
+        CreditCardGlassSample(style = style)
       }
     }
 
     captureRoot("low")
 
-    visualEffect.optics = GlassOptics.Absolute(refractionStrength = 0.6f, depth = 0.5f)
-    visualEffect.specularIntensity = 0.7f
+    style = style.then {
+      optics(GlassOptics.Absolute(refractionStrength = 0.6f, depth = 0.5f))
+      specularIntensity(0.7f)
+    }
     waitForIdle()
     captureRoot("high")
   }
@@ -190,19 +191,19 @@ class GlassScreenshotTest : ScreenshotTest() {
   @Test
   fun creditCard_blurRadius() = runScreenshotTest {
     val shape = RoundedCornerShape(28.dp)
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.White.copy(alpha = 0.08f)
-      optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 1f, blurRadius = 32.dp)
-      specularIntensity = 0f
-      ambientResponse = 0f
-      edgeSoftness = 0.dp
-      this.shape = shape
+    val style = GlassStyle {
+      tint(Color.White.copy(alpha = 0.08f))
+      optics(GlassOptics.Absolute(refractionStrength = 0f, depth = 1f, blurRadius = 32.dp))
+      specularIntensity(0f)
+      ambientResponse(0f)
+      edgeSoftness(0.dp)
+      this.shape(shape)
     }
 
     setContent {
       ScreenshotTheme {
         GlassBlurRadiusSample(
-          visualEffect = visualEffect,
+          style = style,
           shape = shape,
         )
       }
@@ -217,25 +218,29 @@ class GlassScreenshotTest : ScreenshotTest() {
     if (!isRuntimeShaderRenderEffectSupported()) return@runScreenshotTest
 
     val shape = RoundedCornerShape(0.dp)
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.White.copy(alpha = 0.08f)
-      optics = GlassOptics.Absolute(
-        refractionStrength = 0f,
-        depth = 1f,
-        blurRadius = 0.dp,
-      )
-      specularIntensity = 0f
-      ambientResponse = 0f
-      edgeSoftness = 0.dp
-      this.shape = shape
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(Color.White.copy(alpha = 0.08f))
+        optics(
+          GlassOptics.Absolute(
+            refractionStrength = 0f,
+            depth = 1f,
+            blurRadius = 0.dp,
+          ),
+        )
+        specularIntensity(0f)
+        ambientResponse(0f)
+        edgeSoftness(0.dp)
+        this.shape(shape)
+      },
+    )
     var density by mutableStateOf(Density(1f))
 
     setContent {
       CompositionLocalProvider(LocalDensity provides density) {
         ScreenshotTheme {
           GlassBlurRadiusSample(
-            visualEffect = visualEffect,
+            style = style,
             shape = shape,
             cardWidth = (520f / density.density).dp,
             cardHeight = (320f / density.density).dp,
@@ -247,11 +252,9 @@ class GlassScreenshotTest : ScreenshotTest() {
 
     val zeroBlurPixels = captureRootPixels().snapshot()
 
-    visualEffect.optics = GlassOptics.Absolute(
-      refractionStrength = 0f,
-      depth = 1f,
-      blurRadius = 100.dp,
-    )
+    style = style.then {
+      optics(GlassOptics.Absolute(refractionStrength = 0f, depth = 1f, blurRadius = 100.dp))
+    }
     waitForIdle()
     val densityOnePixels = captureRootPixels().snapshot()
 
@@ -273,18 +276,18 @@ class GlassScreenshotTest : ScreenshotTest() {
   @Test
   fun creditCard_fallbackTintAndEdge() = runScreenshotTest {
     val shape = RoundedCornerShape(28.dp)
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.White.copy(alpha = 0.18f)
-      edgeSoftness = 12.dp
-      specularIntensity = 0.4f
-      ambientResponse = 0.5f
-      this.shape = shape
+    val style = GlassStyle {
+      tint(Color.White.copy(alpha = 0.18f))
+      edgeSoftness(12.dp)
+      specularIntensity(0.4f)
+      ambientResponse(0.5f)
+      this.shape(shape)
     }
 
     setContent {
       ScreenshotTheme {
         GlassBlurRadiusSample(
-          visualEffect = visualEffect,
+          style = style,
           shape = shape,
           clipShape = false,
         )
@@ -297,19 +300,21 @@ class GlassScreenshotTest : ScreenshotTest() {
   @Test
   fun creditCard_blurRadiusWithRefraction() = runScreenshotTest {
     val shape = RoundedCornerShape(28.dp)
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.White.copy(alpha = 0.08f)
-      optics = GlassOptics.Absolute(refractionStrength = 0.85f, depth = 0.9f, blurRadius = 0.dp)
-      specularIntensity = 0f
-      ambientResponse = 0f
-      edgeSoftness = 0.dp
-      this.shape = shape
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(Color.White.copy(alpha = 0.08f))
+        optics(GlassOptics.Absolute(refractionStrength = 0.85f, depth = 0.9f, blurRadius = 0.dp))
+        specularIntensity(0f)
+        ambientResponse(0f)
+        edgeSoftness(0.dp)
+        this.shape(shape)
+      },
+    )
 
     setContent {
       ScreenshotTheme {
         GlassBlurRadiusSample(
-          visualEffect = visualEffect,
+          style = style,
           shape = shape,
         )
       }
@@ -317,32 +322,36 @@ class GlassScreenshotTest : ScreenshotTest() {
 
     captureRoot("zero")
 
-    visualEffect.optics = GlassOptics.Absolute(refractionStrength = 0.85f, depth = 0.9f, blurRadius = 32.dp)
+    style = style.then {
+      optics(GlassOptics.Absolute(refractionStrength = 0.85f, depth = 0.9f, blurRadius = 32.dp))
+    }
     waitForIdle()
     captureRoot("strong")
   }
 
   @Test
   fun creditCard_lightPosition() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      lightPosition = Offset.Unspecified
-      specularIntensity = 0.55f
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        lightPosition(Offset.Unspecified)
+        specularIntensity(0.55f)
+      },
+    )
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect)
+        CreditCardGlassSample(style = style)
       }
     }
 
     captureRoot("center")
 
-    visualEffect.lightPosition = Offset(-120f, -80f)
+    style = style.then { lightPosition(Offset(-120f, -80f)) }
     waitForIdle()
     captureRoot("topLeft")
 
-    visualEffect.lightPosition = Offset(140f, 120f)
+    style = style.then { lightPosition(Offset(140f, 120f)) }
     waitForIdle()
     captureRoot("bottomRight")
   }
@@ -359,22 +368,24 @@ class GlassScreenshotTest : ScreenshotTest() {
     setContent {
       ScreenshotTheme {
         key(effectGeneration) {
-          val visualEffect = remember {
-            GlassVisualEffect().apply {
-              tint = Color.Transparent
-              optics = GlassOptics.Absolute(
-                refractionStrength = 0.6f,
-                depth = 0.5f,
-                blurRadius = 0.dp,
+          val style = remember {
+            GlassStyle {
+              tint(Color.Transparent)
+              optics(
+                GlassOptics.Absolute(
+                  refractionStrength = 0.6f,
+                  depth = 0.5f,
+                  blurRadius = 0.dp,
+                ),
               )
-              specularIntensity = 0f
-              ambientResponse = 0f
-              edgeSoftness = 0.dp
-              this.shape = shape
+              specularIntensity(0f)
+              ambientResponse(0f)
+              edgeSoftness(0.dp)
+              this.shape(shape)
             }
           }
           GlassBlurRadiusSample(
-            visualEffect = visualEffect,
+            style = style,
             shape = shape,
             effectOffset = effectOffset,
             cardWidth = 320.dp,
@@ -405,14 +416,12 @@ class GlassScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_conditional_enabled() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-    }
+    val style = GlassStyle { tint(DefaultTint) }
     var enabled by mutableStateOf(true)
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect, enabled = enabled)
+        CreditCardGlassSample(style = style, enabled = enabled)
       }
     }
 
@@ -429,99 +438,106 @@ class GlassScreenshotTest : ScreenshotTest() {
 
   @Test
   fun creditCard_shape_refractionHeight() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionHeightFraction = 0.32f, depth = 0.45f)
-      specularIntensity = 0.6f
-      shape = RoundedCornerShape(24.dp)
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        optics(GlassOptics.Absolute(refractionHeightFraction = 0.32f, depth = 0.45f))
+        specularIntensity(0.6f)
+        shape(RoundedCornerShape(24.dp))
+      },
+    )
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect, shape = RoundedCornerShape(24.dp))
+        CreditCardGlassSample(style = style, shape = RoundedCornerShape(24.dp))
       }
     }
 
     captureRoot("rounded")
 
-    visualEffect.optics = GlassOptics.Absolute(
-      refractionHeightFraction = 0.18f,
-      depth = 0.45f,
-    )
+    style = style.then {
+      optics(GlassOptics.Absolute(refractionHeightFraction = 0.18f, depth = 0.45f))
+    }
     waitForIdle()
     captureRoot("shallow")
   }
 
   @Test
   fun creditCard_chromaticAberration() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionStrength = 0.8f, depth = 0.4f)
-      chromaticAberrationStrength = 0.0f
-      edgeSoftness = 14.dp
-      shape = RoundedCornerShape(20.dp)
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        optics(GlassOptics.Absolute(refractionStrength = 0.8f, depth = 0.4f))
+        chromaticAberrationStrength(0.0f)
+        edgeSoftness(14.dp)
+        shape(RoundedCornerShape(20.dp))
+      },
+    )
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect, shape = RoundedCornerShape(20.dp))
+        CreditCardGlassSample(style = style, shape = RoundedCornerShape(20.dp))
       }
     }
 
     captureRoot("off")
 
-    visualEffect.chromaticAberrationStrength = 0.24f
+    style = style.then { chromaticAberrationStrength(0.24f) }
     waitForIdle()
     captureRoot("on")
   }
 
   @Test
   fun creditCard_surfaceProfile() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionHeightFraction = 0.28f, depth = 0.4f)
-      specularIntensity = 0.5f
-      shape = RoundedCornerShape(24.dp)
-      surfaceProfile = SurfaceProfile.Squircle
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        optics(GlassOptics.Absolute(refractionHeightFraction = 0.28f, depth = 0.4f))
+        specularIntensity(0.5f)
+        shape(RoundedCornerShape(24.dp))
+        surfaceProfile(SurfaceProfile.Squircle)
+      },
+    )
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect, shape = RoundedCornerShape(24.dp))
+        CreditCardGlassSample(style = style, shape = RoundedCornerShape(24.dp))
       }
     }
 
     captureRoot("squircle")
 
-    visualEffect.surfaceProfile = SurfaceProfile.Concave
+    style = style.then { surfaceProfile(SurfaceProfile.Concave) }
     waitForIdle()
     captureRoot("concave")
 
-    visualEffect.surfaceProfile = SurfaceProfile.Lip
+    style = style.then { surfaceProfile(SurfaceProfile.Lip) }
     waitForIdle()
     captureRoot("lip")
   }
 
   @Test
   fun creditCard_chromaticAberrationMode() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionStrength = 0.8f, depth = 0.45f)
-      chromaticAberrationStrength = 0.3f
-      edgeSoftness = 14.dp
-      shape = RoundedCornerShape(20.dp)
-      chromaticAberrationMode = ChromaticAberrationMode.Simple
-    }
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(DefaultTint)
+        optics(GlassOptics.Absolute(refractionStrength = 0.8f, depth = 0.45f))
+        chromaticAberrationStrength(0.3f)
+        edgeSoftness(14.dp)
+        shape(RoundedCornerShape(20.dp))
+        chromaticAberrationMode(ChromaticAberrationMode.Simple)
+      },
+    )
 
     setContent {
       ScreenshotTheme {
-        CreditCardSample(visualEffect = visualEffect, shape = RoundedCornerShape(20.dp))
+        CreditCardGlassSample(style = style, shape = RoundedCornerShape(20.dp))
       }
     }
 
     captureRoot("simple")
 
-    visualEffect.chromaticAberrationMode = ChromaticAberrationMode.Full
+    style = style.then { chromaticAberrationMode(ChromaticAberrationMode.Full) }
     waitForIdle()
     captureRoot("full")
   }
@@ -547,7 +563,7 @@ class GlassScreenshotTest : ScreenshotTest() {
 
 @Composable
 internal fun GlassBlurRadiusSample(
-  visualEffect: GlassVisualEffect,
+  style: GlassStyle,
   shape: RoundedCornerShape,
   clipShape: Boolean = true,
   cardWidth: Dp = 520.dp,
@@ -598,9 +614,10 @@ internal fun GlassBlurRadiusSample(
         .offset { effectOffset }
         .size(width = cardWidth, height = cardHeight)
         .then(if (clipShape) Modifier.clip(shape) else Modifier)
-        .hazeEffect(state = hazeState) {
-          this.visualEffect = visualEffect
-        },
+        .hazeGlass(
+          input = HazeInput.Sources(hazeState),
+          style = style,
+        ),
     )
   }
 }

--- a/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/SourceTransitionScreenshotTest.kt
+++ b/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/SourceTransitionScreenshotTest.kt
@@ -17,7 +17,8 @@ import assertk.assertions.isLessThan
 import dev.chrisbanes.haze.blur.BlurVisualEffect
 import dev.chrisbanes.haze.blur.HazeColorEffect
 import dev.chrisbanes.haze.glass.GlassOptics
-import dev.chrisbanes.haze.glass.GlassVisualEffect
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest
@@ -57,17 +58,17 @@ class SourceTransitionScreenshotTest : ScreenshotTest() {
 
   @Test
   fun glass_sourceRemoved_retainsLastOutput() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.White.copy(alpha = 0.12f)
-      optics = GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f)
-      specularIntensity = 0.45f
+    val style = GlassStyle {
+      tint(Color.White.copy(alpha = 0.12f))
+      optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
+      specularIntensity(0.45f)
     }
     var showSource by mutableStateOf(true)
 
     setContent {
       ScreenshotTheme {
-        SourceTransitionSample(
-          visualEffect = visualEffect,
+        SourceTransitionGlassSample(
+          style = style,
           showSource = showSource,
         )
       }
@@ -83,17 +84,17 @@ class SourceTransitionScreenshotTest : ScreenshotTest() {
 
   @Test
   fun glass_sourceRemoved_reprocessesRetainedCapture() = runScreenshotTest {
-    val visualEffect = GlassVisualEffect().apply {
-      tint = Color.White.copy(alpha = 0.12f)
-      optics = GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f)
-      specularIntensity = 0.45f
-    }
+    var style by mutableStateOf(GlassStyle {
+      tint(Color.White.copy(alpha = 0.12f))
+      optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
+      specularIntensity(0.45f)
+    })
     var showSource by mutableStateOf(true)
 
     setContent {
       ScreenshotTheme {
-        SourceTransitionSample(
-          visualEffect = visualEffect,
+        SourceTransitionGlassSample(
+          style = style,
           showSource = showSource,
         )
       }
@@ -103,7 +104,7 @@ class SourceTransitionScreenshotTest : ScreenshotTest() {
     showSource = false
     waitForIdle()
     val retained = captureRootPixels().snapshot()
-    visualEffect.tint = Color.Magenta.copy(alpha = 0.24f)
+    style = style.then { tint(Color.Magenta.copy(alpha = 0.24f)) }
     waitForIdle()
     val reprocessed = captureRootPixels().snapshot()
 

--- a/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/SourceTransitionScreenshotTest.kt
+++ b/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/SourceTransitionScreenshotTest.kt
@@ -84,11 +84,13 @@ class SourceTransitionScreenshotTest : ScreenshotTest() {
 
   @Test
   fun glass_sourceRemoved_reprocessesRetainedCapture() = runScreenshotTest {
-    var style by mutableStateOf(GlassStyle {
-      tint(Color.White.copy(alpha = 0.12f))
-      optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
-      specularIntensity(0.45f)
-    })
+    var style by mutableStateOf(
+      GlassStyle {
+        tint(Color.White.copy(alpha = 0.12f))
+        optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
+        specularIntensity(0.45f)
+      },
+    )
     var showSource by mutableStateOf(true)
 
     setContent {

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenarioTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenarioTest.kt
@@ -5,7 +5,6 @@
 
 package dev.chrisbanes.haze.sample
 
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.dp
 import assertk.assertFailure
 import assertk.assertThat
@@ -15,10 +14,7 @@ import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
-import dev.chrisbanes.haze.glass.ChromaticAberrationMode
-import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassOptics
-import dev.chrisbanes.haze.glass.GlassVisualEffect
 import kotlin.test.Test
 
 class GlassProfilingScenarioTest {
@@ -104,13 +100,6 @@ class GlassProfilingScenarioTest {
       GlassProfilingScenario.SteadyFull3,
       GlassProfilingScenario.SteadyFull9,
     ).forEach { scenario ->
-      val effect = GlassVisualEffect().apply {
-        applyProfilingScenarioBase(scenario)
-      }
-
-      assertThat(effect.style, name = scenario.id).isEqualTo(GlassDefaults.style)
-      assertThat(effect.optics, name = scenario.id).isEqualTo(GlassDefaults.optics)
-      assertThat(effect.shape, name = scenario.id).isEqualTo(GlassDefaults.shape)
       assertThat(scenario.opticsOverride, name = scenario.id).isNull()
     }
   }
@@ -134,9 +123,7 @@ class GlassProfilingScenarioTest {
       GlassProfilingScenario.SteadyProgressive,
       GlassProfilingScenario.SteadyProgressive9,
     ).forEach { scenario ->
-      val effect = GlassVisualEffect().apply { applyProfilingScenarioBase(scenario) }
-      assertThat(effect.style, name = scenario.id).isEqualTo(GlassDefaults.style)
-      assertThat(effect.optics, name = scenario.id).isEqualTo(
+      assertThat(scenario.opticsOverride, name = scenario.id).isEqualTo(
         scenario.opticsOverride,
       )
     }
@@ -144,35 +131,7 @@ class GlassProfilingScenarioTest {
       GlassProfilingScenario.SteadyFullChroma,
       GlassProfilingScenario.SteadyFullChroma9,
     ).forEach { scenario ->
-      val effect = GlassVisualEffect().apply { applyProfilingScenarioBase(scenario) }
-      assertThat(effect.style, name = scenario.id).isEqualTo(GlassDefaults.style)
-      assertThat(effect.optics, name = scenario.id).isEqualTo(GlassDefaults.optics)
-      assertThat(effect.chromaticAberrationMode, name = scenario.id)
-        .isEqualTo(ChromaticAberrationMode.Full)
-      assertThat(effect.chromaticAberrationStrength, name = scenario.id).isEqualTo(0.3f)
-    }
-  }
-
-  @Test
-  fun opticalUpdateScenarios_changeOnlyTheirNamedAbsoluteValue() {
-    val baseline = GlassOptics.Absolute()
-    listOf(
-      GlassProfilingScenario.DepthUpdate,
-      GlassProfilingScenario.BlurUpdate,
-    ).forEach { scenario ->
-      val frame = glassProfilingFrame(scenario, progress = 0.75f)
-      val effect = GlassVisualEffect().apply {
-        applyProfilingScenarioBase(scenario)
-        applyProfilingFrame(scenario, frame, Size(240f, 160f))
-      }
-
-      val expected = when (scenario) {
-        GlassProfilingScenario.DepthUpdate -> baseline.copy(depth = frame.depth)
-        GlassProfilingScenario.BlurUpdate -> baseline.copy(blurRadius = frame.blurRadius)
-        else -> error("Unexpected scenario: $scenario")
-      }
-      assertThat(effect.style, name = scenario.id).isEqualTo(GlassDefaults.style)
-      assertThat(effect.optics, name = scenario.id).isEqualTo(expected)
+      assertThat(scenario.fullChroma, name = scenario.id).isTrue()
     }
   }
 

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenarioTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenarioTest.kt
@@ -94,6 +94,17 @@ class GlassProfilingScenarioTest {
   }
 
   @Test
+  fun styles_changeOnlyForOpticalDepthAndBlurScenarios() {
+    GlassProfilingScenario.entries.forEach { scenario ->
+      assertThat(profilingStyleUsesFrame(scenario), name = scenario.id).isEqualTo(
+        scenario == GlassProfilingScenario.OpticalUpdate ||
+          scenario == GlassProfilingScenario.DepthUpdate ||
+          scenario == GlassProfilingScenario.BlurUpdate,
+      )
+    }
+  }
+
+  @Test
   fun fullScenarios_useDefaultGlassStyleWithoutOpticsOverrides() {
     listOf(
       GlassProfilingScenario.SteadyFull,

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
@@ -318,7 +318,7 @@ internal fun profilingGlassStyle(
   scenario: GlassProfilingScenario,
   frame: GlassProfilingFrame,
   surfaceSize: Size,
-) : GlassStyle = GlassDefaults.style.then {
+): GlassStyle = GlassDefaults.style.then {
   scenario.opticsOverride?.let(::optics)
   if (scenario.fullChroma) {
     chromaticAberrationMode(ChromaticAberrationMode.Full)
@@ -327,18 +327,22 @@ internal fun profilingGlassStyle(
   if (!scenario.rimEnabled) specularIntensity(0f)
   when (scenario) {
     GlassProfilingScenario.OpticalUpdate -> {
-      lightPosition(Offset(
-        x = surfaceSize.width * frame.lightPosition.x,
-        y = surfaceSize.height * frame.lightPosition.y,
-      ))
+      lightPosition(
+        Offset(
+          x = surfaceSize.width * frame.lightPosition.x,
+          y = surfaceSize.height * frame.lightPosition.y,
+        ),
+      )
     }
     GlassProfilingScenario.DepthUpdate,
     GlassProfilingScenario.BlurUpdate,
     -> {
-      optics((scenario.opticsOverride ?: GlassOptics.Absolute()).copy(
-        depth = frame.depth,
-        blurRadius = frame.blurRadius,
-      ))
+      optics(
+        (scenario.opticsOverride ?: GlassOptics.Absolute()).copy(
+          depth = frame.depth,
+          blurRadius = frame.blurRadius,
+        ),
+      )
     }
     GlassProfilingScenario.EffectAttach,
     GlassProfilingScenario.EffectAttach3,

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
@@ -123,9 +123,14 @@ private fun GlassProfilingScene(
   var effectFrame by remember(scenario) {
     mutableStateOf(glassProfilingFrame(scenario, progress = 0f))
   }
-  val styles = remember(scenario, effectFrame, effectSurfaceSizePx) {
+  val styleFrame = if (profilingStyleUsesFrame(scenario)) effectFrame else null
+  val styles = remember(scenario, styleFrame, effectSurfaceSizePx) {
     List(scenario.effectCount) {
-      profilingGlassStyle(scenario, effectFrame, effectSurfaceSizePx)
+      profilingGlassStyle(
+        scenario,
+        styleFrame ?: glassProfilingFrame(scenario, progress = 0f),
+        effectSurfaceSizePx,
+      )
     }
   }
 
@@ -385,6 +390,14 @@ internal fun profilingGlassStyle(
       scale(0.98f)
     }
   }
+}
+
+internal fun profilingStyleUsesFrame(scenario: GlassProfilingScenario): Boolean = when (scenario) {
+  GlassProfilingScenario.OpticalUpdate,
+  GlassProfilingScenario.DepthUpdate,
+  GlassProfilingScenario.BlurUpdate,
+  -> true
+  else -> false
 }
 
 private fun profilingEffectSize(surfaceSize: Size, effectCount: Int): Size {

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
@@ -27,7 +27,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
@@ -39,13 +42,15 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.ExperimentalHazeApi
-import dev.chrisbanes.haze.HazeInputScale
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
 import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassReducedMotionPolicy
-import dev.chrisbanes.haze.glass.GlassVisualEffect
-import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
+import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.delay
@@ -114,31 +119,17 @@ private fun GlassProfilingScene(
   val surfaceSizePx = with(density) {
     Size(ProfilingSurfaceSize.width.toPx(), ProfilingSurfaceSize.height.toPx())
   }
-  val coldAttachGeneration = scenario.attachesDuringMeasurement &&
-    !scenario.prewarmsBeforeMeasurement &&
-    (state.phase == GlassProfilingPhase.Running || state.phase == GlassProfilingPhase.Complete)
-  val effects = remember(scenario, interactionSource, coldAttachGeneration) {
+  val effectSurfaceSizePx = profilingEffectSize(surfaceSizePx, scenario.effectCount)
+  var effectFrame by remember(scenario) {
+    mutableStateOf(glassProfilingFrame(scenario, progress = 0f))
+  }
+  val styles = remember(scenario, effectFrame, effectSurfaceSizePx) {
     List(scenario.effectCount) {
-      GlassVisualEffect().apply {
-        applyProfilingScenarioBase(scenario)
-        this.interactionSource = interactionSource
-        interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
-        pressed {
-          animate(
-            toSpec = GlassDefaults.pressAnimationSpec,
-            fromSpec = GlassDefaults.releaseAnimationSpec,
-          ) {
-            lightingIntensity(1f)
-            refractionMultiplier(1.08f)
-            scale(0.98f)
-          }
-        }
-      }
+      profilingGlassStyle(scenario, effectFrame, effectSurfaceSizePx)
     }
   }
-  val effectSurfaceSizePx = profilingEffectSize(surfaceSizePx, scenario.effectCount)
 
-  LaunchedEffect(state.phase, scenario, effects, interactionSource, surfaceSizePx) {
+  LaunchedEffect(state.phase, scenario, interactionSource, surfaceSizePx) {
     if (state.phase == GlassProfilingPhase.Settling) {
       repeat(GLASS_PROFILING_SETTLING_FRAMES) {
         androidx.compose.runtime.withFrameNanos {}
@@ -182,13 +173,7 @@ private fun GlassProfilingScene(
           ),
         ) {
           state.updateProgress(value)
-          effects.forEach { currentEffect ->
-            currentEffect.applyProfilingFrame(
-              scenario = scenario,
-              frame = glassProfilingFrame(scenario, value),
-              surfaceSize = effectSurfaceSizePx,
-            )
-          }
+          effectFrame = glassProfilingFrame(scenario, value)
         }
       }
     }
@@ -227,8 +212,9 @@ private fun GlassProfilingScene(
     if (scenario.glassEnabled && attachGlass) {
       GlassProfilingEffectGrid(
         hazeState = hazeState,
-        effects = effects,
-        inputScale = scenario.fixedInputScale?.let(HazeInputScale::Fixed) ?: HazeInputScale.Auto,
+        styles = styles,
+        sampling = scenario.fixedInputScale?.let(HazeSampling::Fixed) ?: HazeSampling.Adaptive,
+        interactionSource = interactionSource,
         drawProgress = if (scenario.steadyDraw) {
           { state.progress }
         } else {
@@ -292,13 +278,14 @@ private fun GlassProfilingScene(
 @Composable
 private fun GlassProfilingEffectGrid(
   hazeState: dev.chrisbanes.haze.HazeState,
-  effects: List<GlassVisualEffect>,
-  inputScale: HazeInputScale,
+  styles: List<GlassStyle>,
+  sampling: HazeSampling,
+  interactionSource: MutableInteractionSource,
   drawProgress: (() -> Float)?,
   modifier: Modifier = Modifier,
 ) {
-  val rowCount = if (effects.size <= 3) 1 else 3
-  val columnCount = effects.size / rowCount
+  val rowCount = if (styles.size <= 3) 1 else 3
+  val columnCount = styles.size / rowCount
   Column(modifier) {
     repeat(rowCount) { rowIndex ->
       Row(Modifier.fillMaxWidth().weight(1f)) {
@@ -312,10 +299,13 @@ private fun GlassProfilingEffectGrid(
                 drawProgress?.invoke()
                 drawContent()
               }
-              .hazeEffect(hazeState) {
-                this.inputScale = inputScale
-                visualEffect = effects[effectIndex]
-              }
+              .hazeGlass(
+                input = HazeInput.Sources(hazeState),
+                style = styles[effectIndex],
+                sampling = sampling,
+                interactionSource = interactionSource,
+                interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full,
+              )
               .testTag("glass_profiling_surface_$effectIndex"),
           )
         }
@@ -324,37 +314,31 @@ private fun GlassProfilingEffectGrid(
   }
 }
 
-internal fun GlassVisualEffect.applyProfilingScenarioBase(scenario: GlassProfilingScenario) {
-  style = GlassDefaults.style
-  scenario.opticsOverride?.let { optics = it }
-  if (scenario.fullChroma) {
-    chromaticAberrationMode = ChromaticAberrationMode.Full
-    chromaticAberrationStrength = 0.3f
-  }
-  if (!scenario.rimEnabled) {
-    specularIntensity = 0f
-  }
-}
-
-internal fun GlassVisualEffect.applyProfilingFrame(
+internal fun profilingGlassStyle(
   scenario: GlassProfilingScenario,
   frame: GlassProfilingFrame,
   surfaceSize: Size,
-) {
+) : GlassStyle = GlassDefaults.style.then {
+  scenario.opticsOverride?.let(::optics)
+  if (scenario.fullChroma) {
+    chromaticAberrationMode(ChromaticAberrationMode.Full)
+    chromaticAberrationStrength(0.3f)
+  }
+  if (!scenario.rimEnabled) specularIntensity(0f)
   when (scenario) {
     GlassProfilingScenario.OpticalUpdate -> {
-      lightPosition = Offset(
+      lightPosition(Offset(
         x = surfaceSize.width * frame.lightPosition.x,
         y = surfaceSize.height * frame.lightPosition.y,
-      )
+      ))
     }
     GlassProfilingScenario.DepthUpdate,
     GlassProfilingScenario.BlurUpdate,
     -> {
-      optics = (optics as GlassOptics.Absolute).copy(
+      optics((scenario.opticsOverride ?: GlassOptics.Absolute()).copy(
         depth = frame.depth,
         blurRadius = frame.blurRadius,
-      )
+      ))
     }
     GlassProfilingScenario.EffectAttach,
     GlassProfilingScenario.EffectAttach3,
@@ -385,6 +369,17 @@ internal fun GlassVisualEffect.applyProfilingFrame(
     GlassProfilingScenario.SourceUpdate9,
     GlassProfilingScenario.SourceUpdateNoGlass,
     -> Unit
+  }
+}.then {
+  pressed {
+    animate(
+      toSpec = GlassDefaults.pressAnimationSpec,
+      fromSpec = GlassDefaults.releaseAnimationSpec,
+    ) {
+      lightingIntensity(1f)
+      refractionMultiplier(1.08f)
+      scale(0.98f)
+    }
   }
 }
 

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
@@ -13,7 +13,6 @@ import dev.chrisbanes.haze.glass.ChromaticAberrationMode
 import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
-import dev.chrisbanes.haze.glass.GlassVisualEffect
 import dev.chrisbanes.haze.glass.SurfaceProfile
 
 @Immutable
@@ -113,7 +112,7 @@ internal data class GlassLabStyleValues(
   }
 }
 
-private fun glassLabPresetValues(id: GlassLabPresetId): GlassLabStyleValues = when (id) {
+internal fun glassLabPresetValues(id: GlassLabPresetId): GlassLabStyleValues = when (id) {
   GlassLabPresetId.Adaptive -> GlassLabStyleValues()
   GlassLabPresetId.Clear -> GlassLabStyleValues(
     tint = Color.White.copy(alpha = 0.06f),
@@ -197,14 +196,15 @@ internal enum class GlassLabInteractionMode {
   All,
   ;
 
-  fun applyTo(effect: GlassVisualEffect) {
-    effect.clearInteractions()
-    when (this) {
-      Off -> Unit
-      Pressed -> effect.pressed()
-      All -> effect.interactable()
+  val style: GlassStyle
+    get() = when (this) {
+      Off -> GlassStyle
+      Pressed -> GlassStyle { pressed {} }
+      All -> GlassStyle {
+        hovered {}
+        pressed {}
+      }
     }
-  }
 }
 
 @Immutable

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
@@ -202,13 +202,31 @@ internal enum class GlassLabInteractionMode {
   val style: GlassStyle
     get() = when (this) {
       Off -> GlassStyle
-      Pressed -> GlassStyle { pressed {} }
+      Pressed -> GlassStyle { pressed { defaultPressResponse() } }
       All -> GlassStyle {
-        hovered {}
-        if (includesFocusedResponse) focused {}
-        pressed {}
+        hovered { defaultHoverResponse() }
+        if (includesFocusedResponse) focused { defaultHoverResponse() }
+        pressed { defaultPressResponse() }
       }
     }
+}
+
+private fun dev.chrisbanes.haze.glass.GlassInteractionScope.defaultHoverResponse() {
+  animate(GlassDefaults.hoverAnimationSpec, GlassDefaults.releaseAnimationSpec) {
+    lightingIntensity(0.35f)
+    refractionMultiplier(1.02f)
+    whitePointDelta(0.01f)
+    scale(1f)
+  }
+}
+
+private fun dev.chrisbanes.haze.glass.GlassInteractionScope.defaultPressResponse() {
+  animate(GlassDefaults.pressAnimationSpec, GlassDefaults.releaseAnimationSpec) {
+    lightingIntensity(1f)
+    refractionMultiplier(1.08f)
+    whitePointDelta(0.04f)
+    scale(0.98f)
+  }
 }
 
 @Immutable

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
@@ -196,12 +196,16 @@ internal enum class GlassLabInteractionMode {
   All,
   ;
 
+  val includesFocusedResponse: Boolean
+    get() = this == All
+
   val style: GlassStyle
     get() = when (this) {
       Off -> GlassStyle
       Pressed -> GlassStyle { pressed {} }
       All -> GlassStyle {
         hovered {}
+        if (includesFocusedResponse) focused {}
         pressed {}
       }
     }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
@@ -36,13 +36,15 @@ import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.glass.GlassDefaults
+import dev.chrisbanes.haze.glass.GlassReducedMotionPolicy
 import dev.chrisbanes.haze.glass.GlassStyle
-import dev.chrisbanes.haze.glass.GlassVisualEffect
-import dev.chrisbanes.haze.glass.glassEffect
+import dev.chrisbanes.haze.glass.GlassTransformPivot
+import dev.chrisbanes.haze.glass.GlassTransformTarget
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.glass.then
-import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 
 @Composable
@@ -150,21 +152,23 @@ internal fun GlassSurface(
   shape: RoundedCornerShape,
   modifier: Modifier = Modifier,
   interactionSource: InteractionSource? = null,
-  interaction: (GlassVisualEffect.() -> Unit)? = null,
+  interactionStyle: GlassStyle = GlassStyle,
   content: @Composable BoxScope.() -> Unit,
 ) {
   Box(
     modifier = modifier
       // Let Glass own the material silhouette. An outer Compose clip creates a second,
       // independently-rasterized rounded boundary and exposes isolated carrier pixels on Skiko.
-      .hazeEffect(state = hazeState) {
-        glassEffect {
-          this.style = style
-          this.shape = shape
-          this.interactionSource = interactionSource
-          interaction?.invoke(this)
-        }
-      }
+      .hazeGlass(
+        input = HazeInput.Sources(hazeState),
+        style = style.then {
+          this.shape(shape)
+        }.then(interactionStyle),
+        interactionSource = interactionSource,
+        interactionTransformTarget = GlassTransformTarget.MaterialAndContent,
+        interactionTransformPivot = GlassTransformPivot.Pointer,
+        interactionReducedMotionPolicy = GlassReducedMotionPolicy.System,
+      )
       // This clip is inside the effect node, so it only constrains foreground content.
       .clip(shape),
     content = content,

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
@@ -165,7 +165,7 @@ private fun LabSpecimen(
       style = state.style,
       shape = RoundedCornerShape(32.dp),
       interactionSource = interactionSource,
-      interaction = { state.interaction.applyTo(this) },
+      interactionStyle = state.interaction.style,
       modifier = Modifier
         .align(Alignment.Center)
         .fillMaxWidth(0.85f)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
@@ -48,13 +48,14 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassReducedMotionPolicy
 import dev.chrisbanes.haze.glass.GlassTransformPivot
 import dev.chrisbanes.haze.glass.GlassTransformTarget
-import dev.chrisbanes.haze.glass.GlassVisualEffect
-import dev.chrisbanes.haze.hazeEffect
+import dev.chrisbanes.haze.glass.hazeGlass
+import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.math.roundToInt
 import kotlinx.coroutines.Job
@@ -373,13 +374,11 @@ private fun PlaygroundSurface(
     IntSize(size.width.roundToPx(), size.height.roundToPx())
   }
   val interactionSource = interactionSourceProvider(id)
-  val effect = remember(id, interactionSource) {
-    GlassVisualEffect().apply {
-      style = glassPlaygroundStyle(id)
-      shape = glassPlaygroundShape(id)
-      configurePlaygroundInteraction(interactionSource)
-    }
-  }
+  var lightPosition by remember(id) { mutableStateOf(Offset.Unspecified) }
+  val style = glassPlaygroundStyle(id).then {
+    shape(glassPlaygroundShape(id))
+    lightPosition(lightPosition)
+  }.then(playgroundInteractionStyle())
   val latestProgressProvider by rememberUpdatedState(progressProvider)
   val latestSceneSizeProvider by rememberUpdatedState(sceneSizeProvider)
   val latestDragOffsetProvider by rememberUpdatedState(dragOffsetProvider)
@@ -387,7 +386,7 @@ private fun PlaygroundSurface(
   val latestOnDrag by rememberUpdatedState(onDrag)
   val latestOnDragEnd by rememberUpdatedState(onDragEnd)
 
-  LaunchedEffect(effect, id, surfaceSize) {
+  LaunchedEffect(id, surfaceSize) {
     snapshotFlow {
       val frame = glassPlaygroundFrame(latestProgressProvider())
       resolvePlaygroundSurfaceLightPosition(
@@ -399,13 +398,21 @@ private fun PlaygroundSurface(
       )
     }
       .distinctUntilChanged()
-      .collect { effect.lightPosition = it }
+      .collect { lightPosition = it }
   }
 
   Box(
     modifier = Modifier
       .size(size)
-      .hazeEffect(state = hazeState) { visualEffect = effect }
+      .hazeGlass(
+        input = HazeInput.Sources(hazeState),
+        style = style,
+        interactionSource = interactionSource,
+        interactionTransformTarget = GlassTransformTarget.MaterialAndContent,
+        interactionTransformPivot = GlassTransformPivot.Pointer,
+        interactionPositionAnimationSpec = GlassDefaults.positionAnimationSpec,
+        interactionReducedMotionPolicy = GlassReducedMotionPolicy.System,
+      )
       .pointerInput(id) {
         detectDragGestures(
           onDragStart = { latestOnDragStart(id) },
@@ -429,13 +436,8 @@ private fun PlaygroundSurface(
   }
 }
 
-internal fun GlassVisualEffect.configurePlaygroundInteraction(source: InteractionSource?) {
-  interactionSource = source
-  interactionTransformTarget = GlassTransformTarget.MaterialAndContent
-  interactionTransformPivot = GlassTransformPivot.Pointer
-  interactionPositionAnimationSpec = GlassDefaults.positionAnimationSpec
-  interactionReducedMotionPolicy = GlassReducedMotionPolicy.System
-  hovered()
+internal fun playgroundInteractionStyle() = dev.chrisbanes.haze.glass.GlassStyle {
+  hovered {}
   pressed {
     animate(
       toSpec = GlassDefaults.pressAnimationSpec,

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimeline.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimeline.kt
@@ -78,9 +78,17 @@ internal fun glassPlaygroundFrame(progress: Float): GlassPlaygroundFrame {
 internal fun glassPlaygroundStyle(id: GlassPlaygroundSurfaceId): GlassStyle = when (id) {
   GlassPlaygroundSurfaceId.Lens,
   GlassPlaygroundSurfaceId.Pill,
-  -> GlassDefaults.style.then { optics(GlassOptics.Adaptive) }
+  -> GlassDefaults.style.then { optics(glassPlaygroundOptics(id)) }
   GlassPlaygroundSurfaceId.Card -> glassLabPresetStyle(GlassLabPresetId.Deep)
   GlassPlaygroundSurfaceId.Prism -> glassLabPresetStyle(GlassLabPresetId.Prism)
+}
+
+internal fun glassPlaygroundOptics(id: GlassPlaygroundSurfaceId): GlassOptics = when (id) {
+  GlassPlaygroundSurfaceId.Lens,
+  GlassPlaygroundSurfaceId.Pill,
+  -> GlassOptics.Adaptive
+  GlassPlaygroundSurfaceId.Card -> (glassLabPresetValues(GlassLabPresetId.Deep)).optics
+  GlassPlaygroundSurfaceId.Prism -> (glassLabPresetValues(GlassLabPresetId.Prism)).optics
 }
 
 internal fun glassPlaygroundShape(id: GlassPlaygroundSurfaceId): RoundedCornerShape = when (id) {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassProductSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassProductSample.kt
@@ -208,7 +208,10 @@ private fun ProductTopBar(
     style = productGlassStyle(androidx.compose.foundation.isSystemInDarkTheme()),
     shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
     modifier = modifier,
-    interaction = { interactable() },
+    interactionStyle = GlassStyle {
+      hovered {}
+      pressed {}
+    },
   ) {
     Row(
       modifier = Modifier.padding(4.dp),
@@ -290,7 +293,10 @@ private fun ProductActionDock(
     style = productGlassStyle(androidx.compose.foundation.isSystemInDarkTheme()),
     shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
     modifier = modifier,
-    interaction = { interactable() },
+    interactionStyle = GlassStyle {
+      hovered {}
+      pressed {}
+    },
   ) {
     val actions: @Composable () -> Unit = {
       IconButton(onClick = onPrevious) {

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
@@ -7,15 +7,13 @@ package dev.chrisbanes.haze.sample
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isLessThan
 import assertk.assertions.isNotEqualTo
-import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
 import dev.chrisbanes.haze.glass.GlassOptics
-import dev.chrisbanes.haze.glass.GlassVisualEffect
+import dev.chrisbanes.haze.glass.GlassStyle
 import kotlin.test.Test
 
 class GlassGalleryModelsTest {
@@ -58,24 +56,10 @@ class GlassGalleryModelsTest {
   }
 
   @Test
-  fun interactionModes_configureExpectedPointerSlots() {
-    val off = GlassVisualEffect()
-    GlassLabInteractionMode.Off.applyTo(off)
-    assertThat(off.observesPointerEvents).isFalse()
-
-    val pressed = GlassVisualEffect()
-    GlassLabInteractionMode.Pressed.applyTo(pressed)
-    assertThat(pressed.observesPointerEvents).isTrue()
-    pressed.clearPressed()
-    assertThat(pressed.observesPointerEvents).isFalse()
-
-    val all = GlassVisualEffect()
-    GlassLabInteractionMode.All.applyTo(all)
-    assertThat(all.observesPointerEvents).isTrue()
-    all.clearPressed()
-    assertThat(all.observesPointerEvents).isTrue()
-    all.clearHovered()
-    assertThat(all.observesPointerEvents).isFalse()
+  fun interactionModes_produceDeclarativeStyles() {
+    assertThat(GlassLabInteractionMode.Off.style).isEqualTo(GlassStyle)
+    assertThat(GlassLabInteractionMode.Pressed.style).isNotEqualTo(GlassStyle)
+    assertThat(GlassLabInteractionMode.All.style).isNotEqualTo(GlassStyle)
   }
 
   @Test

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
@@ -10,6 +10,8 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isLessThan
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
 import dev.chrisbanes.haze.glass.GlassOptics
@@ -60,6 +62,8 @@ class GlassGalleryModelsTest {
     assertThat(GlassLabInteractionMode.Off.style).isEqualTo(GlassStyle)
     assertThat(GlassLabInteractionMode.Pressed.style).isNotEqualTo(GlassStyle)
     assertThat(GlassLabInteractionMode.All.style).isNotEqualTo(GlassStyle)
+    assertThat(GlassLabInteractionMode.All.includesFocusedResponse).isTrue()
+    assertThat(GlassLabInteractionMode.Pressed.includesFocusedResponse).isFalse()
   }
 
   @Test

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
@@ -7,10 +7,10 @@ package dev.chrisbanes.haze.sample
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isLessThan
 import assertk.assertions.isNotEqualTo
-import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSampleTest.kt
@@ -3,7 +3,6 @@
 
 package dev.chrisbanes.haze.sample
 
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
@@ -14,12 +13,10 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.IntSize
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
-import dev.chrisbanes.haze.glass.GlassTransformPivot
-import dev.chrisbanes.haze.glass.GlassTransformTarget
-import dev.chrisbanes.haze.glass.GlassVisualEffect
+import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
@@ -86,21 +83,8 @@ class GlassPlaygroundSampleTest : ContextTest() {
   }
 
   @Test
-  fun playgroundInteraction_keepsHoverAfterPressAndUsesPointerContentTransform() {
-    val source = MutableInteractionSource()
-    val effect = GlassVisualEffect()
-
-    effect.configurePlaygroundInteraction(source)
-
-    assertThat(effect.interactionSource).isEqualTo(source)
-    assertThat(effect.interactionTransformTarget).isEqualTo(GlassTransformTarget.MaterialAndContent)
-    assertThat(effect.interactionTransformPivot).isEqualTo(GlassTransformPivot.Pointer)
-    assertThat(effect.observesPointerEvents).isTrue()
-
-    effect.clearPressed()
-    assertThat(effect.observesPointerEvents).isTrue()
-    effect.clearHovered()
-    assertThat(effect.observesPointerEvents).isFalse()
+  fun playgroundInteraction_isDeclaredInTheTypedStyle() {
+    assertThat(playgroundInteractionStyle()).isNotEqualTo(GlassStyle)
   }
 
   @Test

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
@@ -16,7 +16,6 @@ import assertk.assertions.isLessThanOrEqualTo
 import assertk.assertions.isNotEqualTo
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.GlassOptics
-import dev.chrisbanes.haze.glass.GlassVisualEffect
 import kotlin.test.Test
 
 class GlassPlaygroundTimelineTest {
@@ -104,6 +103,4 @@ class GlassPlaygroundTimelineTest {
 }
 
 private fun resolvedOptics(id: GlassPlaygroundSurfaceId): GlassOptics =
-  GlassVisualEffect().apply {
-    style = glassPlaygroundStyle(id)
-  }.optics
+  glassPlaygroundOptics(id)


### PR DESCRIPTION
## Summary

- migrate Gallery, Lab, Product, Playground, and profiling samples to typed `hazeGlass` and replayable `GlassStyle`
- migrate ordinary library, source-transition, rounded-edge, content, JVM, and Android-host screenshot callers
- replace dynamic effect mutation with Style replacement through Compose state
- update Glass and v2 migration guidance while isolating only legacy plumbing/removal seams for #1128

## Validation

- Glass JVM and Android-host suites
- shared sample JVM and Android-host tests
- both full screenshot suites
- strict Dokka/MkDocs build
- Spotless and diff checks
- no image or Roborazzi reference changes

Closes #1127
