### PR TITLE
Release resources when Desktop and Web lifecycles stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `HazeArea.position` is deprecated in favour of `HazeArea.coordinates.localPosition` (or, inside a `VisualEffect`, `VisualEffectContext.positionOf(area)`). The setter now writes through to `coordinates.localPosition` for source compatibility.
+- Direct `HazeEffectNode` construction is deprecated ahead of #1132. Custom modifier extensions
+  should migrate to the typed `Modifier.hazeEffect` overload with a `HazeEffectFactory`; direct
+  nodes do not receive automatic Desktop or Web lifecycle trimming.
 
 ### Fixed
 
+- Release rebuildable Desktop and Web effect resources when their composition lifecycle stops.
 - Bound and reuse Glass group-alpha composition surfaces, including allocation-free zero-alpha drawing and predictable fallback for oversized output in #1062.
 - Reuse retained Glass stages, prepared render data, and runtime shaders during animation in #1045.
 - **Fix cross-window recomposition livelock** in #974. When a `HazeState` is shared between effects in different windows (e.g. a host composable and a `Dialog`), the previously-shared `HazeState.resolvedStrategy` oscillated between `Local` and `Screen`, causing an infinite recomposition loop. The resolved position strategy is now per-effect (`HazeEffectNode.resolvedPositionStrategy`), so effects in different windows no longer stomp on each other.

--- a/docs/custom-effects.md
+++ b/docs/custom-effects.md
@@ -136,6 +136,16 @@ calculating bounds recalculate the bounds and then redraw.
 - Keep pointer interaction and retained-output behavior inside your effect module until those
   capabilities have dedicated public contracts.
 
+On Android and iOS, Haze forwards the platform's native memory-pressure notifications to attached
+effects. On Desktop and Web, an attached effect receives `TrimMemoryLevel.MODERATE` whenever its
+composition lifecycle reaches `ON_STOP`. Discard only resources that can be rebuilt: the next draw
+that needs them must recreate valid output.
+
+Direct `HazeEffectNode` construction is deprecated and does not receive automatic Desktop or Web
+lifecycle trimming. Custom modifier extensions should migrate to the typed `Modifier.hazeEffect`
+overload with a `HazeEffectFactory`; the node type will become internal in
+[#1132](https://github.com/chrisbanes/haze/issues/1132).
+
 Platform-specific renderer internals can use `expect`/`actual` declarations in the effect module.
 The public renderer contract intentionally does not expose platform delegates or captured layers.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "9.3.1"
 androidx-activity = "1.13.0"
 androidx-benchmark = "1.5.0-beta01"
 androidx-collection = "1.6.0"
+androidx-lifecycle = "2.11.0-beta01"
 androidx-media3 = "1.10.1"
 androidx-test-ext-junit = "1.3.0"
 assertk = "0.28.1"
@@ -47,6 +48,7 @@ androidx-core = "androidx.core:core-ktx:1.19.0"
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-collection = { module = "androidx.collection:collection", version.ref = "androidx-collection" }
+androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "androidx-media3" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }
 androidx-profileinstaller = "androidx.profileinstaller:profileinstaller:1.4.1"

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -59,7 +59,7 @@ package dev.chrisbanes.haze {
   }
 
   @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeEffectNode extends androidx.compose.ui.node.DelegatingNode implements androidx.compose.ui.node.CompositionLocalConsumerModifierNode androidx.compose.ui.node.DrawModifierNode androidx.compose.ui.node.GlobalPositionAwareModifierNode dev.chrisbanes.haze.HazeEffectScope androidx.compose.ui.node.LayoutAwareModifierNode androidx.compose.ui.modifier.ModifierLocalModifierNode androidx.compose.ui.node.ObserverModifierNode androidx.compose.ui.node.TraversableNode {
-    ctor public HazeEffectNode(optional dev.chrisbanes.haze.HazeState? state, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
+    ctor @Deprecated public HazeEffectNode(optional dev.chrisbanes.haze.HazeState? state, optional kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.HazeEffectScope,kotlin.Unit>? block);
     method public void draw(androidx.compose.ui.graphics.drawscope.ContentDrawScope);
     method @InaccessibleFromKotlin public dev.chrisbanes.haze.VisualEffect getActiveVisualEffect();
     method @InaccessibleFromKotlin public java.util.List<dev.chrisbanes.haze.HazeArea> getAreas();

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
         implementation(projects.hazeUtils)
         implementation(libs.compose.foundation)
         implementation(libs.androidx.collection)
+        implementation(libs.androidx.lifecycle.runtime.compose)
       }
     }
 

--- a/haze/src/androidHostTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.android.kt
+++ b/haze/src/androidHostTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.android.kt
@@ -1,0 +1,6 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual val supportsLifecycleTrimMemoryCallbacks: Boolean = false

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.android.kt
@@ -7,10 +7,12 @@ package dev.chrisbanes.haze
 
 import android.content.ComponentCallbacks2
 import android.content.res.Configuration
+import androidx.lifecycle.Lifecycle
 import kotlinx.coroutines.DisposableHandle
 
 internal actual fun registerTrimMemoryCallback(
   context: PlatformContext,
+  lifecycle: Lifecycle?,
   callback: (TrimMemoryLevel) -> Unit,
 ): DisposableHandle {
   val cb = object : ComponentCallbacks2 {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -5,12 +5,15 @@ package dev.chrisbanes.haze
 
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.findNearestAncestor
 import androidx.compose.ui.platform.InspectorInfo
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import kotlin.jvm.JvmInline
 
 public interface HazeEffectScope {
@@ -292,15 +295,23 @@ public fun <Style> Modifier.hazeEffect(
   style: Style,
   sampling: HazeSampling = HazeSampling.Default,
   expandLayerBounds: Boolean = true,
-): Modifier {
-  val effect = this then TypedHazeEffectNodeElement(
+): Modifier = composed(
+  "dev.chrisbanes.haze.hazeEffect",
+  factory,
+  input,
+  style,
+  sampling,
+  expandLayerBounds,
+) {
+  val effect = Modifier then TypedHazeEffectNodeElement(
     factory = factory,
     input = input,
     style = style,
     sampling = sampling,
     expandLayerBounds = expandLayerBounds,
+    lifecycle = LocalLifecycleOwner.current.lifecycle,
   )
-  return if (input === HazeInput.Content) {
+  if (input === HazeInput.Content) {
     effect.graphicsLayer() then ForegroundContentInvalidationElement
   } else {
     effect
@@ -313,15 +324,23 @@ private fun Modifier.thenHazeEffect(
   explicitSampling: HazeSampling? = null,
   explicitExpandLayerBounds: Boolean? = null,
   block: (HazeEffectScope.() -> Unit)?,
-): Modifier {
-  val effect = this then HazeEffectNodeElement(
+): Modifier = composed(
+  "dev.chrisbanes.haze.hazeEffect",
+  state,
+  explicitInput,
+  explicitSampling,
+  explicitExpandLayerBounds,
+  block,
+) {
+  val effect = Modifier then HazeEffectNodeElement(
     state = state,
     explicitInput = explicitInput,
     explicitSampling = explicitSampling,
     explicitExpandLayerBounds = explicitExpandLayerBounds,
     block = block,
+    lifecycle = LocalLifecycleOwner.current.lifecycle,
   )
-  return if (state == null) {
+  if (state == null) {
     effect.graphicsLayer() then ForegroundContentInvalidationElement
   } else {
     effect
@@ -334,8 +353,10 @@ private class TypedHazeEffectNodeElement<Style>(
   val style: Style,
   val sampling: HazeSampling,
   val expandLayerBounds: Boolean,
+  val lifecycle: Lifecycle,
 ) : ModifierNodeElement<HazeEffectNode>() {
 
+  @Suppress("DEPRECATION")
   override fun create(): HazeEffectNode = HazeEffectNode(
     state = (input as? HazeInput.Sources)?.state,
   ).also { node ->
@@ -343,6 +364,7 @@ private class TypedHazeEffectNodeElement<Style>(
     node.explicitSampling = sampling
     node.explicitExpandLayerBounds = expandLayerBounds
     node.updateTypedEffect(factory, style, sampling)
+    node.updateLifecycle(lifecycle)
   }
 
   override fun update(node: HazeEffectNode) {
@@ -351,6 +373,7 @@ private class TypedHazeEffectNodeElement<Style>(
     node.explicitExpandLayerBounds = expandLayerBounds
     node.state = (input as? HazeInput.Sources)?.state
     node.updateTypedEffect(factory, style, sampling)
+    node.updateLifecycle(lifecycle)
     node.update()
   }
 
@@ -370,7 +393,8 @@ private class TypedHazeEffectNodeElement<Style>(
       input == other.input &&
       style == other.style &&
       sampling == other.sampling &&
-      expandLayerBounds == other.expandLayerBounds
+      expandLayerBounds == other.expandLayerBounds &&
+      lifecycle === other.lifecycle
   }
 
   override fun hashCode(): Int {
@@ -378,18 +402,21 @@ private class TypedHazeEffectNodeElement<Style>(
     result = 31 * result + input.hashCode()
     result = 31 * result + (style?.hashCode() ?: 0)
     result = 31 * result + sampling.hashCode()
-    return 31 * result + expandLayerBounds.hashCode()
+    result = 31 * result + expandLayerBounds.hashCode()
+    return 31 * result + lifecycle.hashCode()
   }
 }
 
-private data class HazeEffectNodeElement(
+private class HazeEffectNodeElement(
   val state: HazeState?,
   val explicitInput: HazeInput? = null,
   val explicitSampling: HazeSampling? = null,
   val explicitExpandLayerBounds: Boolean? = null,
   val block: (HazeEffectScope.() -> Unit)? = null,
+  val lifecycle: Lifecycle,
 ) : ModifierNodeElement<HazeEffectNode>() {
 
+  @Suppress("DEPRECATION")
   override fun create(): HazeEffectNode = HazeEffectNode(
     state = state,
     block = block,
@@ -397,6 +424,7 @@ private data class HazeEffectNodeElement(
     node.explicitInput = explicitInput
     node.explicitSampling = explicitSampling
     node.explicitExpandLayerBounds = explicitExpandLayerBounds
+    node.updateLifecycle(lifecycle)
   }
 
   override fun update(node: HazeEffectNode) {
@@ -405,11 +433,32 @@ private data class HazeEffectNodeElement(
     node.explicitExpandLayerBounds = explicitExpandLayerBounds
     node.state = state
     node.block = block
+    node.updateLifecycle(lifecycle)
     node.update()
   }
 
   override fun InspectorInfo.inspectableProperties() {
     name = "HazeEffect"
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is HazeEffectNodeElement) return false
+    return state == other.state &&
+      explicitInput == other.explicitInput &&
+      explicitSampling == other.explicitSampling &&
+      explicitExpandLayerBounds == other.explicitExpandLayerBounds &&
+      block == other.block &&
+      lifecycle === other.lifecycle
+  }
+
+  override fun hashCode(): Int {
+    var result = state?.hashCode() ?: 0
+    result = 31 * result + (explicitInput?.hashCode() ?: 0)
+    result = 31 * result + (explicitSampling?.hashCode() ?: 0)
+    result = 31 * result + (explicitExpandLayerBounds?.hashCode() ?: 0)
+    result = 31 * result + (block?.hashCode() ?: 0)
+    return 31 * result + lifecycle.hashCode()
   }
 }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.node.requireGraphicsContext
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.toIntSize
 import androidx.compose.ui.unit.toSize
+import androidx.lifecycle.Lifecycle
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -47,11 +48,19 @@ import kotlinx.coroutines.launch
 /**
  * The [Modifier.Node] implementation used by [Modifier.hazeEffect].
  *
- * This is public API in order to aid custom extensible modifiers, _but_ we reserve the right
- * to be able to change the API in the future, hence why it is marked as experimental forever.
+ * Direct construction is deprecated and does not receive automatic Desktop or Web lifecycle
+ * trimming. Custom effects should use the typed [Modifier.hazeEffect] overload with a
+ * [HazeEffectFactory].
+ *
+ * This type remains public temporarily for source and binary compatibility.
  */
 @ExperimentalHazeApi
-public class HazeEffectNode(
+public class HazeEffectNode
+@Deprecated(
+  message = "Direct HazeEffectNode construction is deprecated. Use the typed Modifier.hazeEffect " +
+    "overload with a HazeEffectFactory.",
+)
+public constructor(
   state: HazeState? = null,
   public var block: (HazeEffectScope.() -> Unit)? = null,
 ) : DelegatingNode(),
@@ -68,6 +77,7 @@ public class HazeEffectNode(
     message = "For binary compatibility only. Use the hazeEffect modifier APIs.",
     level = DeprecationLevel.HIDDEN,
   )
+  @Suppress("DEPRECATION")
   public constructor() : this(state = null, block = null)
 
   override val traverseKey: Any
@@ -465,6 +475,8 @@ public class HazeEffectNode(
     onObservedReadsChanged()
   }
 
+  private var lifecycle: Lifecycle? = null
+  private var trimMemoryCallbackLifecycle: Lifecycle? = null
   private var trimMemoryCallbackDisposable: DisposableHandle? = null
 
   override fun onAttach() {
@@ -473,16 +485,7 @@ public class HazeEffectNode(
       ?: visualEffect.createRenderer()
     attachVisualEffect(runtime)
     activeVisualEffect = runtime
-    trimMemoryCallbackDisposable = registerTrimMemoryCallback(
-      requirePlatformContext(),
-    ) { level ->
-      val activeEffect = activeVisualEffect
-      if (activeEffect is TypedHazeEffectVisualEffect) {
-        activeEffect.onTrimMemory(level)
-      } else {
-        activeEffect.onTrimMemory(visualEffectContext, level)
-      }
-    }
+    rebindTrimMemoryCallback()
     update()
   }
 
@@ -490,6 +493,7 @@ public class HazeEffectNode(
     stopSourceSelectionSnapshotObserver()
     trimMemoryCallbackDisposable?.dispose()
     trimMemoryCallbackDisposable = null
+    trimMemoryCallbackLifecycle = null
     resetPendingInvalidations()
     _areas = emptyList()
     areaZIndexes.clear()
@@ -898,6 +902,38 @@ public class HazeEffectNode(
     }
 
     invalidateIfNeeded()
+  }
+
+  internal fun updateLifecycle(lifecycle: Lifecycle) {
+    if (this.lifecycle !== lifecycle) {
+      this.lifecycle = lifecycle
+      if (isAttached) {
+        rebindTrimMemoryCallback()
+      }
+    }
+  }
+
+  private fun rebindTrimMemoryCallback() {
+    val lifecycle = lifecycle
+    if (trimMemoryCallbackDisposable != null && trimMemoryCallbackLifecycle === lifecycle) return
+    trimMemoryCallbackDisposable?.dispose()
+    trimMemoryCallbackDisposable = null
+    trimMemoryCallbackLifecycle = null
+    trimMemoryCallbackDisposable = registerTrimMemoryCallback(
+      context = requirePlatformContext(),
+      lifecycle = lifecycle,
+      callback = ::dispatchTrimMemory,
+    )
+    trimMemoryCallbackLifecycle = lifecycle
+  }
+
+  private fun dispatchTrimMemory(level: TrimMemoryLevel) {
+    val activeEffect = activeVisualEffect
+    if (activeEffect is TypedHazeEffectVisualEffect) {
+      activeEffect.onTrimMemory(level)
+    } else {
+      activeEffect.onTrimMemory(visualEffectContext, level)
+    }
   }
 
   internal fun invalidateVisualEffectLayerBounds() {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.kt
@@ -3,9 +3,27 @@
 
 package dev.chrisbanes.haze
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import kotlinx.coroutines.DisposableHandle
 
 internal expect fun registerTrimMemoryCallback(
   context: PlatformContext,
+  lifecycle: Lifecycle?,
   callback: (TrimMemoryLevel) -> Unit,
 ): DisposableHandle
+
+internal fun registerLifecycleTrimMemoryCallback(
+  lifecycle: Lifecycle?,
+  callback: (TrimMemoryLevel) -> Unit,
+): DisposableHandle {
+  if (lifecycle == null) return DisposableHandle {}
+
+  val observer = LifecycleEventObserver { _, event ->
+    if (event == Lifecycle.Event.ON_STOP) {
+      callback(TrimMemoryLevel.MODERATE)
+    }
+  }
+  lifecycle.addObserver(observer)
+  return DisposableHandle { lifecycle.removeObserver(observer) }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeComposeUnitTests.kt
@@ -373,6 +373,7 @@ class HazeComposeUnitTests : ContextTest() {
   }
 
   @Test
+  @Suppress("DEPRECATION")
   fun test_visualEffectContext_positionStrategy_reflectsEffectNodeResolution() {
     // Wiring test: verifies that VisualEffectContext.positionStrategy reads through to
     // HazeEffectNode.resolvedPositionStrategy. The cross-window auto-promotion logic

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectNodeConstructorTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectNodeConstructorTest.kt
@@ -11,6 +11,7 @@ import assertk.assertions.isInstanceOf
 import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class)
+@Suppress("DEPRECATION")
 class HazeEffectNodeConstructorTest {
 
   @Test

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectTrimMemoryLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeEffectTrimMemoryLifecycleTest.kt
@@ -1,0 +1,298 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import dev.chrisbanes.haze.test.ContextTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class HazeEffectTrimMemoryLifecycleTest : ContextTest() {
+
+  @Test
+  fun typedContent_lifecycleEventsEmitModerateOnlyForEachStopTransition() = runComposeUiTest {
+    if (!supportsLifecycleTrimMemoryCallbacks) return@runComposeUiTest
+
+    val lifecycleOwner = RecordingLifecycleOwner()
+    val factory = RecordingTrimMemoryFactory()
+
+    setContent {
+      CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+        Spacer(
+          Modifier
+            .size(10.dp)
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Content,
+              style = Unit,
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    runOnIdle {
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_CREATE)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_START)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_RESUME)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_PAUSE)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_STOP)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_START)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_STOP)
+    }
+
+    assertThat(factory.renderer.trimLevels).containsExactly(
+      TrimMemoryLevel.MODERATE,
+      TrimMemoryLevel.MODERATE,
+    )
+  }
+
+  @Test
+  fun lifecycleOwnerReplacement_rebindsFromCompositionAndDetachDisposesObserver() =
+    runComposeUiTest {
+      if (!supportsLifecycleTrimMemoryCallbacks) return@runComposeUiTest
+
+      val firstOwner = RecordingLifecycleOwner()
+      val secondOwner = RecordingLifecycleOwner()
+      val lifecycleOwner = mutableStateOf(firstOwner)
+      val showEffect = mutableStateOf(true)
+      val factory = RecordingTrimMemoryFactory()
+
+      setContent {
+        CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner.value) {
+          if (showEffect.value) {
+            Spacer(
+              Modifier
+                .size(10.dp)
+                .hazeEffect(
+                  factory = factory,
+                  input = HazeInput.Content,
+                  style = Unit,
+                ),
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      runOnIdle {
+        firstOwner.handleEvent(Lifecycle.Event.ON_CREATE)
+        firstOwner.handleEvent(Lifecycle.Event.ON_START)
+      }
+
+      lifecycleOwner.value = secondOwner
+      waitForIdle()
+
+      runOnIdle {
+        firstOwner.handleEvent(Lifecycle.Event.ON_STOP)
+      }
+      assertThat(factory.renderer.trimLevels).isEmpty()
+
+      runOnIdle {
+        secondOwner.handleEvent(Lifecycle.Event.ON_CREATE)
+        secondOwner.handleEvent(Lifecycle.Event.ON_START)
+        secondOwner.handleEvent(Lifecycle.Event.ON_STOP)
+      }
+      assertThat(factory.renderer.trimLevels).containsExactly(TrimMemoryLevel.MODERATE)
+
+      showEffect.value = false
+      waitForIdle()
+
+      runOnIdle {
+        secondOwner.handleEvent(Lifecycle.Event.ON_START)
+        secondOwner.handleEvent(Lifecycle.Event.ON_STOP)
+      }
+      assertThat(factory.renderer.trimLevels).containsExactly(TrimMemoryLevel.MODERATE)
+    }
+
+  @Test
+  fun lifecycleStop_reachesTypedAndLegacyEffectsForSourcesAndContent() = runComposeUiTest {
+    if (!supportsLifecycleTrimMemoryCallbacks) return@runComposeUiTest
+
+    val lifecycleOwner = RecordingLifecycleOwner()
+    val hazeState = HazeState()
+    val typedSourcesFactory = RecordingTrimMemoryFactory()
+    val typedContentFactory = RecordingTrimMemoryFactory()
+    val legacySourcesEffect = RecordingTrimMemoryVisualEffect()
+    val legacyContentEffect = RecordingTrimMemoryVisualEffect()
+
+    setContent {
+      CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+        Box {
+          Spacer(Modifier.size(10.dp).hazeSource(hazeState))
+          Spacer(
+            Modifier
+              .size(10.dp)
+              .hazeEffect(
+                factory = typedSourcesFactory,
+                input = HazeInput.Sources(hazeState),
+                style = Unit,
+              ),
+          )
+          Spacer(
+            Modifier
+              .size(10.dp)
+              .hazeEffect(
+                factory = typedContentFactory,
+                input = HazeInput.Content,
+                style = Unit,
+              ),
+          )
+          Spacer(
+            Modifier
+              .size(10.dp)
+              .hazeEffect(hazeState) {
+                visualEffect = legacySourcesEffect
+              },
+          )
+          Spacer(
+            Modifier
+              .size(10.dp)
+              .hazeEffect {
+                visualEffect = legacyContentEffect
+              },
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    runOnIdle {
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_CREATE)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_START)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_STOP)
+    }
+
+    val expected = listOf(TrimMemoryLevel.MODERATE)
+    assertThat(typedSourcesFactory.renderer.trimLevels).containsExactly(*expected.toTypedArray())
+    assertThat(typedContentFactory.renderer.trimLevels).containsExactly(*expected.toTypedArray())
+    assertThat(legacySourcesEffect.trimLevels).containsExactly(*expected.toTypedArray())
+    assertThat(legacyContentEffect.trimLevels).containsExactly(*expected.toTypedArray())
+  }
+
+  @Test
+  @Suppress("DEPRECATION")
+  fun sameNode_detachAndReattach_retainsLifecycleAndResumesStopDelivery() = runComposeUiTest {
+    if (!supportsLifecycleTrimMemoryCallbacks) return@runComposeUiTest
+
+    val lifecycleOwner = RecordingLifecycleOwner()
+    val effect = RecordingTrimMemoryVisualEffect()
+    val node = HazeEffectNode(block = { visualEffect = effect }).also {
+      it.updateLifecycle(lifecycleOwner.lifecycle)
+    }
+    val element = FixedHazeEffectNodeElement(node)
+    val showEffect = mutableStateOf(true)
+
+    setContent {
+      if (showEffect.value) {
+        Spacer(Modifier.size(10.dp).then(element))
+      }
+    }
+    waitForIdle()
+
+    runOnIdle {
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_CREATE)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_START)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_STOP)
+    }
+    assertThat(effect.trimLevels).containsExactly(TrimMemoryLevel.MODERATE)
+
+    showEffect.value = false
+    waitForIdle()
+
+    runOnIdle {
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_START)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_STOP)
+    }
+    assertThat(effect.trimLevels).containsExactly(TrimMemoryLevel.MODERATE)
+
+    showEffect.value = true
+    waitForIdle()
+
+    runOnIdle {
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_START)
+      lifecycleOwner.handleEvent(Lifecycle.Event.ON_STOP)
+    }
+    assertThat(effect.trimLevels).containsExactly(
+      TrimMemoryLevel.MODERATE,
+      TrimMemoryLevel.MODERATE,
+    )
+  }
+}
+
+private class FixedHazeEffectNodeElement(
+  val node: HazeEffectNode,
+) : ModifierNodeElement<HazeEffectNode>() {
+
+  override fun create(): HazeEffectNode = node
+
+  override fun update(node: HazeEffectNode) = Unit
+
+  override fun InspectorInfo.inspectableProperties() {
+    name = "fixedHazeEffectNode"
+  }
+
+  override fun equals(other: Any?): Boolean =
+    this === other || other is FixedHazeEffectNodeElement && node === other.node
+
+  override fun hashCode(): Int = node.hashCode()
+}
+
+private class RecordingLifecycleOwner : LifecycleOwner {
+  private val registry = LifecycleRegistry(this)
+
+  override val lifecycle: Lifecycle
+    get() = registry
+
+  fun handleEvent(event: Lifecycle.Event) {
+    registry.handleLifecycleEvent(event)
+  }
+}
+
+private class RecordingTrimMemoryFactory : HazeEffectFactory<Unit> {
+  val renderer = RecordingTrimMemoryRenderer()
+
+  override fun createRenderer(): HazeEffectRenderer<Unit> = renderer
+}
+
+private class RecordingTrimMemoryRenderer : HazeEffectRenderer<Unit> {
+  val trimLevels = mutableListOf<TrimMemoryLevel>()
+
+  override fun HazeEffectDrawScope.draw(style: Unit) = Unit
+
+  override fun HazeEffectLayoutScope.calculateLayerBounds(style: Unit): Rect = modifierBounds
+
+  override fun onTrimMemory(level: TrimMemoryLevel) {
+    trimLevels += level
+  }
+}
+
+private class RecordingTrimMemoryVisualEffect : VisualEffect {
+  val trimLevels = mutableListOf<TrimMemoryLevel>()
+
+  override fun DrawScope.draw(context: VisualEffectContext) = Unit
+
+  override fun onTrimMemory(context: VisualEffectContext, level: TrimMemoryLevel) {
+    trimLevels += level
+  }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.kt
@@ -1,0 +1,6 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal expect val supportsLifecycleTrimMemoryCallbacks: Boolean

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/VisualEffectLifecycleTest.kt
@@ -33,6 +33,7 @@ import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class, InternalHazeApi::class)
+@Suppress("DEPRECATION")
 class VisualEffectLifecycleTest : ContextTest() {
 
   @Test

--- a/haze/src/iosMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.ios.kt
+++ b/haze/src/iosMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.ios.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze
 
+import androidx.lifecycle.Lifecycle
 import kotlinx.coroutines.DisposableHandle
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSOperationQueue
@@ -10,6 +11,7 @@ import platform.UIKit.UIApplicationDidReceiveMemoryWarningNotification
 
 internal actual fun registerTrimMemoryCallback(
   context: PlatformContext,
+  lifecycle: Lifecycle?,
   callback: (TrimMemoryLevel) -> Unit,
 ): DisposableHandle {
   val center = NSNotificationCenter.defaultCenter

--- a/haze/src/iosTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.ios.kt
+++ b/haze/src/iosTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.ios.kt
@@ -1,0 +1,6 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual val supportsLifecycleTrimMemoryCallbacks: Boolean = false

--- a/haze/src/iosTest/kotlin/dev/chrisbanes/haze/TrimMemoryCallbackTest.ios.kt
+++ b/haze/src/iosTest/kotlin/dev/chrisbanes/haze/TrimMemoryCallbackTest.ios.kt
@@ -3,6 +3,9 @@
 
 package dev.chrisbanes.haze
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isTrue
@@ -18,6 +21,7 @@ class TrimMemoryCallbackTest {
     val received = mutableListOf<TrimMemoryLevel>()
     val handle = registerTrimMemoryCallback(
       context = PlatformContext.INSTANCE,
+      lifecycle = TestLifecycleOwner().lifecycle,
       callback = received::add,
     )
 
@@ -34,4 +38,8 @@ class TrimMemoryCallbackTest {
     )
     assertThat(received).isEqualTo(listOf(TrimMemoryLevel.COMPLETE))
   }
+}
+
+private class TestLifecycleOwner : LifecycleOwner {
+  override val lifecycle: Lifecycle = LifecycleRegistry(this)
 }

--- a/haze/src/jsMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.js.kt
+++ b/haze/src/jsMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.js.kt
@@ -3,9 +3,11 @@
 
 package dev.chrisbanes.haze
 
+import androidx.lifecycle.Lifecycle
 import kotlinx.coroutines.DisposableHandle
 
 internal actual fun registerTrimMemoryCallback(
   context: PlatformContext,
+  lifecycle: Lifecycle?,
   callback: (TrimMemoryLevel) -> Unit,
-): DisposableHandle = DisposableHandle {}
+): DisposableHandle = registerLifecycleTrimMemoryCallback(lifecycle, callback)

--- a/haze/src/jsTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.js.kt
+++ b/haze/src/jsTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.js.kt
@@ -1,0 +1,6 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual val supportsLifecycleTrimMemoryCallbacks: Boolean = true

--- a/haze/src/jvmMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.jvm.kt
+++ b/haze/src/jvmMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.jvm.kt
@@ -3,9 +3,11 @@
 
 package dev.chrisbanes.haze
 
+import androidx.lifecycle.Lifecycle
 import kotlinx.coroutines.DisposableHandle
 
 internal actual fun registerTrimMemoryCallback(
   context: PlatformContext,
+  lifecycle: Lifecycle?,
   callback: (TrimMemoryLevel) -> Unit,
-): DisposableHandle = DisposableHandle {}
+): DisposableHandle = registerLifecycleTrimMemoryCallback(lifecycle, callback)

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/AutoPositionStrategyTransitionTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/AutoPositionStrategyTransitionTest.kt
@@ -33,6 +33,7 @@ import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
+@Suppress("DEPRECATION")
 class AutoPositionStrategyTransitionTest : ContextTest() {
 
   @Test

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.jvm.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.jvm.kt
@@ -1,0 +1,6 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual val supportsLifecycleTrimMemoryCallbacks: Boolean = true

--- a/haze/src/wasmJsMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.wasmJs.kt
+++ b/haze/src/wasmJsMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.wasmJs.kt
@@ -3,9 +3,11 @@
 
 package dev.chrisbanes.haze
 
+import androidx.lifecycle.Lifecycle
 import kotlinx.coroutines.DisposableHandle
 
 internal actual fun registerTrimMemoryCallback(
   context: PlatformContext,
+  lifecycle: Lifecycle?,
   callback: (TrimMemoryLevel) -> Unit,
-): DisposableHandle = DisposableHandle {}
+): DisposableHandle = registerLifecycleTrimMemoryCallback(lifecycle, callback)

--- a/haze/src/wasmJsTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.wasmJs.kt
+++ b/haze/src/wasmJsTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.wasmJs.kt
@@ -1,0 +1,6 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual val supportsLifecycleTrimMemoryCallbacks: Boolean = true


### PR DESCRIPTION
## Summary

- capture the nearest Compose lifecycle in both typed and legacy effect modifier funnels
- deliver TrimMemoryLevel.MODERATE to attached JVM, JS, and Wasm effects on lifecycle ON_STOP
- rebind observers when lifecycle ownership changes and dispose them on detach
- preserve native Android and iOS memory-pressure callbacks
- document automatic release and next-draw resource recreation

## Rationale

Desktop windows and Web pages already surface backgrounding as Compose lifecycle stops. Routing that signal through the existing trim-memory contract releases rebuildable retained Blur and Glass resources without adding a public Haze lifecycle API or platform-specific host listeners.

## Validation

- ./gradlew :haze:jvmTest :haze:testAndroidHostTest :haze:compileTestKotlinJs :haze:compileTestKotlinWasmJs :haze:compileKotlinIosArm64 :haze:compileKotlinIosSimulatorArm64 :haze-blur:jvmTest :haze-glass:jvmTest :haze:metalavaCheckCompatibility :haze:spotlessCheck
- ./scripts/build_docs.sh build --strict
- Standards and Spec reviews: clean
- review-and-simplify Reuse, Quality, Efficiency, and Clarity passes: clean
- ponytail review: Lean already. Ship.

## Residual risk

JS and Wasm browser test tasks are disabled by the repository convention, so their actuals and shared lifecycle tests are compile-validated; JVM provides executable lifecycle behavior coverage. Kotlin also reports existing dual org.jetbrains/androidx KLIB metadata-name warnings while resolving the Compose Multiplatform bridge, but all affected compilation and test tasks pass.

Fixes #1118