### PR TITLE
Document public API and enforce KDoc coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@
 
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.Copy
+import org.jetbrains.dokka.gradle.DokkaExtension
 
 plugins {
   id("dev.chrisbanes.root")
@@ -25,7 +26,34 @@ plugins {
   alias(libs.plugins.dokka)
 }
 
+val checkPublicApiDocumentation = tasks.register("checkPublicApiDocumentation") {
+  group = "verification"
+  description = "Checks that public API documentation generates without warnings."
+}
+
+tasks.named("check") {
+  dependsOn(checkPublicApiDocumentation)
+}
+
 subprojects {
+  pluginManager.withPlugin("org.jetbrains.dokka") {
+    extensions.configure<DokkaExtension> {
+      dokkaPublications.configureEach {
+        failOnWarning.set(true)
+      }
+      dokkaSourceSets.configureEach {
+        reportUndocumented.set(true)
+      }
+    }
+
+    pluginManager.withPlugin("dev.chrisbanes.metalava") {
+      val dokkaModuleTask = tasks.named("dokkaGenerateModuleHtml")
+      checkPublicApiDocumentation.configure {
+        dependsOn(dokkaModuleTask)
+      }
+    }
+  }
+
   tasks.withType<Copy>().configureEach {
     if (name.endsWith("TestDevelopmentExecutableCompileSync")) {
       // Kotlin/JS copies duplicate Skiko runtime files from main and test resources.

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
@@ -43,6 +43,7 @@ public sealed interface HazeBlurStyle {
   public fun then(block: HazeBlurStyleScope.() -> Unit): HazeBlurStyle =
     then(HazeBlurStyle(block))
 
+  /** The empty Blur Style, which performs no writes. */
   public companion object : HazeBlurStyle
 }
 
@@ -86,15 +87,34 @@ internal fun HazeBlurStyle.replay(scope: HazeBlurStyleScope) {
  * Blur-specific property functions available while constructing a [HazeBlurStyle].
  */
 public sealed interface HazeBlurStyleScope {
+  /** Enables or disables the blur pass. */
   public fun blurEnabled(enabled: Boolean)
+
+  /** Sets the non-negative blur [radius]. */
   public fun blurRadius(radius: Dp)
+
+  /** Sets the noise opacity, coerced to the range `0f..1f`. */
   public fun noiseFactor(factor: Float)
+
+  /** Sets the background color composited behind the blurred input. */
   public fun backgroundColor(color: Color)
+
+  /** Replaces the ordered color effects applied to the blurred input. */
   public fun colorEffects(effects: List<HazeColorEffect>)
+
+  /** Sets the effect used when blur rendering is unavailable. */
   public fun fallbackColorEffect(effect: HazeColorEffect)
+
+  /** Sets the overall effect opacity, coerced to the range `0f..1f`. */
   public fun alpha(alpha: Float)
+
+  /** Sets the optional alpha [mask] applied to the complete effect. */
   public fun mask(mask: Brush?)
+
+  /** Sets the optional progressive effect intensity. */
   public fun progressive(progressive: HazeProgressive?)
+
+  /** Sets how content outside the input bounds contributes to the blur. */
   public fun blurredEdgeTreatment(treatment: BlurredEdgeTreatment)
 }
 
@@ -262,6 +282,9 @@ public sealed interface HazeColorEffect {
 
   /**
    * A color filter effect.
+   *
+   * @property colorFilter Color filter applied to the input.
+   * @property blendMode Blend mode used to composite the filtered input.
    */
   @Immutable
   public data class ColorFilter(
@@ -273,6 +296,9 @@ public sealed interface HazeColorEffect {
 
   /**
    * A color-based tint effect.
+   *
+   * @property color Tint color applied to the input.
+   * @property blendMode Blend mode used to composite the tint.
    */
   @Immutable
   public data class TintColor(
@@ -284,6 +310,9 @@ public sealed interface HazeColorEffect {
 
   /**
    * A brush-based tint effect.
+   *
+   * @property brush Tint brush applied to the input.
+   * @property blendMode Blend mode used to composite the tint.
    */
   @Immutable
   public data class TintBrush(
@@ -301,6 +330,7 @@ public sealed interface HazeColorEffect {
     override val isSpecified: Boolean = false
   }
 
+  /** Factories and defaults for [HazeColorEffect] values. */
   @Suppress("NOTHING_TO_INLINE")
   public companion object {
     /**

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeProgressive.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeProgressive.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.blur
 
+/** Compatibility alias for [dev.chrisbanes.haze.HazeProgressive]. */
 @Deprecated(
   message = "Use dev.chrisbanes.haze.HazeProgressive",
   replaceWith = ReplaceWith("HazeProgressive", "dev.chrisbanes.haze.HazeProgressive"),

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
@@ -13,11 +13,14 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.ExperimentalHazeApi
 
+/** Default values used by `hazeGlass` and [GlassStyle] resolution. */
 @ExperimentalHazeApi
 @Suppress("ConstPropertyName", "ktlint:standard:property-naming")
 public object GlassDefaults {
+  /** Default light radius as a fraction of the material's shortest side. */
   public const val interactionLightRadiusFraction: Float = 0.7f
 
+  /** Default animation used when the interaction light moves to a new position. */
   public val positionAnimationSpec: FiniteAnimationSpec<Offset> = spring(
     dampingRatio = 1f,
     stiffness = Spring.StiffnessMedium,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteraction.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteraction.kt
@@ -6,39 +6,62 @@ package dev.chrisbanes.haze.glass
 import androidx.compose.animation.core.FiniteAnimationSpec
 import dev.chrisbanes.haze.ExperimentalHazeApi
 
+/** Selects which visual layers receive the interaction scale transform. */
 @ExperimentalHazeApi
 public enum class GlassTransformTarget {
+  /** Scales the generated Glass material while leaving the composable content unchanged. */
   MaterialOnly,
+
+  /** Scales both the generated Glass material and the composable content. */
   MaterialAndContent,
 }
 
+/** Selects the pivot used by the interaction scale transform. */
 @ExperimentalHazeApi
 public enum class GlassTransformPivot {
+  /** Uses the current pointer or interaction position as the transform pivot. */
   Pointer,
+
+  /** Uses the center of the material as the transform pivot. */
   Center,
 }
 
+/** Controls whether interaction motion is reduced. */
 @ExperimentalHazeApi
 public enum class GlassReducedMotionPolicy {
+  /** Follows the current platform motion-duration scale. */
   System,
+
+  /** Disables interaction scale motion and snaps animated responses to their targets. */
   Reduced,
+
+  /** Preserves full interaction motion regardless of the platform motion-duration scale. */
   Full,
 }
 
+/** Declares the visual response for one Glass interaction state. */
 @ExperimentalHazeApi
 public interface GlassInteractionScope {
+  /** Sets the lighting multiplier in the range `0f..1f`. */
   public fun lightingIntensity(intensity: Float)
 
+  /** Sets the refraction multiplier in the range `0f..2f`. */
   public fun refractionMultiplier(multiplier: Float)
 
+  /** Sets the additive white-point adjustment in the range `-1f..1f`. */
   public fun whitePointDelta(delta: Float)
 
+  /** Sets a uniform positive scale no greater than `1f`. */
   public fun scale(scale: Float) {
     scale(scaleX = scale, scaleY = scale)
   }
 
+  /** Sets positive horizontal and vertical scales no greater than `1f`. */
   public fun scale(scaleX: Float, scaleY: Float)
 
+  /**
+   * Applies [toSpec] when entering and [fromSpec] when leaving the response declared by [block].
+   */
   public fun animate(
     toSpec: FiniteAnimationSpec<Float>,
     fromSpec: FiniteAnimationSpec<Float>,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
@@ -33,11 +33,14 @@ public sealed interface GlassOptics {
    * is capped at 38.5 physical pixels; this renderer quality bound does not limit accepted input
    * values.
    *
+   * @param refractionStrength Strength of the refraction response, in the range `0f..1f`.
    * @param refractionDisplacement Maximum distance that refraction displaces content.
    * @param refractionHeightFraction Fraction of the material's shortest side used by the
    * refraction profile, in the range `0f..1f`.
    * @param depth Depth perception factor. Values greater than `0f` require drawing an additional
    * blurred sample for the glass content, which has a rendering cost.
+   * @param blurRadius Maximum blur radius before the renderer's adaptive scale is applied.
+   * @param progressive Optional progressive intensity applied to the blur.
    */
   public data class Absolute(
     val refractionStrength: Float = 0.7f,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeState.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeState.kt
@@ -621,7 +621,7 @@ internal abstract class GlassRuntimeState {
    * There are precedence rules to how each styling property is applied. The order of precedence
    * for each property are as follows:
    *
-   *  - Property value set directly on this [GlassRuntimeConfiguration], if specified.
+   *  - Property value set directly on this runtime state, if specified.
    *  - Value set here in [style], if specified.
    *  - Value set in the [LocalGlassStyle] composition local.
    */

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -42,6 +42,7 @@ public val LocalGlassStyle: ProvidableCompositionLocal<GlassStyle> =
 @ExperimentalHazeApi
 @Immutable
 public sealed interface GlassStyle {
+  /** The empty Glass Style, which performs no writes. */
   public companion object : GlassStyle
 }
 
@@ -115,27 +116,33 @@ public class GlassStyleScope internal constructor(
     values.pressedInteraction = buildGlassInteractionResponse(block)
   }
 
+  /** Sets the rounded boundary used for refraction and masking. */
   public fun shape(value: RoundedCornerShape) {
     values.shape = value
   }
 
+  /** Sets the optical model used to refract and blur captured content. */
   public fun optics(value: GlassOptics) {
     values.optics = value
   }
 
+  /** Sets specular-highlight intensity, coerced to the range `0f..1f`. */
   public fun specularIntensity(value: Float) {
     values.specularIntensity = value.coerceIn(0f, 1f)
   }
 
+  /** Sets ambient-light response, coerced to the range `0f..1f`. */
   public fun ambientResponse(value: Float) {
     values.ambientResponse = value.coerceIn(0f, 1f)
   }
 
+  /** Sets the tint applied to refracted content. */
   public fun tint(value: Color) {
     require(value.isSpecified) { "tint must be specified" }
     values.tint = value
   }
 
+  /** Sets the non-negative softening distance around the material boundary. */
   public fun edgeSoftness(value: Dp) {
     require(value.isSpecified) { "edgeSoftness must be specified" }
     values.edgeSoftness = value.coerceAtLeast(0.dp)
@@ -154,42 +161,52 @@ public class GlassStyleScope internal constructor(
     values.lightPosition = value
   }
 
+  /** Sets chromatic dispersion strength, coerced to the range `0f..1f`. */
   public fun chromaticAberrationStrength(value: Float) {
     values.chromaticAberrationStrength = value.coerceIn(0f, 1f)
   }
 
+  /** Sets the cross-section profile used by the refraction bezel. */
   public fun surfaceProfile(value: SurfaceProfile) {
     values.surfaceProfile = value
   }
 
+  /** Sets the quality mode used to render chromatic aberration. */
   public fun chromaticAberrationMode(value: ChromaticAberrationMode) {
     values.chromaticAberrationMode = value
   }
 
+  /** Sets overall material opacity, coerced to the range `0f..1f`. */
   public fun alpha(value: Float) {
     values.alpha = value.coerceIn(0f, 1f)
   }
 
+  /** Sets contrast adjustment, coerced to the range `-1f..1f`. */
   public fun contrast(value: Float) {
     values.contrast = value.coerceIn(-1f, 1f)
   }
 
+  /** Sets white-point adjustment, coerced to the range `-1f..1f`. */
   public fun whitePoint(value: Float) {
     values.whitePoint = value.coerceIn(-1f, 1f)
   }
 
+  /** Sets the chroma multiplier, coerced to the range `0f..2f`. */
   public fun chromaMultiplier(value: Float) {
     values.chromaMultiplier = value.coerceIn(0f, 2f)
   }
 
+  /** Sets the blend between generated and captured normals, coerced to `0f..1f`. */
   public fun contentNormalBlend(value: Float) {
     values.contentNormalBlend = value.coerceIn(0f, 1f)
   }
 
+  /** Sets the non-negative exponent controlling specular highlight concentration. */
   public fun specularExponent(value: Float) {
     values.specularExponent = value.coerceAtLeast(0f)
   }
 
+  /** Sets the non-negative exponent controlling Fresnel response falloff. */
   public fun fresnelExponent(value: Float) {
     values.fresnelExponent = value.coerceAtLeast(0f)
   }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
@@ -35,6 +35,11 @@ import dev.chrisbanes.haze.hazeEffect
  * @param sampling Input sampling policy. [HazeSampling.Default] preserves Glass's unscaled default.
  * @param expandLayerBounds Whether Glass may expand its capture layer for optical sampling.
  * @param interactionSource Optional external interaction source owned by this modifier node.
+ * @param interactionLightRadiusFraction Interaction-light radius as a fraction of the material's
+ * shortest side.
+ * @param interactionTransformTarget Visual layers that receive the interaction scale transform.
+ * @param interactionTransformPivot Pivot used by the interaction scale transform.
+ * @param interactionPositionAnimationSpec Animation used when the interaction light moves.
  * @param interactionReducedMotionPolicy Motion policy for this node's Style responses.
  */
 @Stable

--- a/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/PlatformContext.kt
+++ b/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/PlatformContext.kt
@@ -8,9 +8,11 @@ import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.LocalContext
 
+/** Android [Context] used as the Haze platform context. */
 @InternalHazeApi
 public actual typealias PlatformContext = Context
 
+/** Returns the Android context associated with this modifier node. */
 @InternalHazeApi
 public actual fun CompositionLocalConsumerModifierNode.requirePlatformContext(): PlatformContext {
   return currentValueOf(LocalContext)

--- a/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/RuntimeShader.android.kt
+++ b/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/RuntimeShader.android.kt
@@ -24,6 +24,7 @@ public actual fun createRuntimeEffect(sksl: String): PlatformRuntimeEffect {
   return PlatformRuntimeEffect(sksl)
 }
 
+/** Returns whether the device supports Android runtime-shader render effects. */
 @ChecksSdkIntAtLeast(api = 33)
 @InternalHazeApi
 public actual fun isRuntimeShaderRenderEffectSupported(): Boolean = Build.VERSION.SDK_INT >= 33

--- a/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/Trace.android.kt
+++ b/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/Trace.android.kt
@@ -3,11 +3,13 @@
 
 package dev.chrisbanes.haze
 
+/** Runs [block] inside a synchronous Android trace section named [sectionName]. */
 @InternalHazeApi
 public actual inline fun <R> trace(sectionName: String, block: () -> R): R {
   return androidx.tracing.trace(sectionName, block)
 }
 
+/** Runs [block] inside an asynchronous Android trace section identified by [cookie]. */
 @InternalHazeApi
 public actual suspend inline fun <R> traceAsync(
   sectionName: String,

--- a/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/Bitmask.kt
+++ b/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/Bitmask.kt
@@ -5,12 +5,22 @@ package dev.chrisbanes.haze
 
 import kotlin.jvm.JvmInline
 
+/** Immutable integer-backed set of bit flags. */
 @JvmInline
 @InternalHazeApi
 public value class Bitmask(private val value: Int = 0) {
+  /** Returns a bitmask containing [flag]. */
   public operator fun plus(flag: Int): Bitmask = Bitmask(value or flag)
+
+  /** Returns a bitmask without [flag]. */
   public operator fun minus(flag: Int): Bitmask = Bitmask(value and flag.inv())
+
+  /** Returns whether every bit in [flag] is present. */
   public operator fun contains(flag: Int): Boolean = (flag and value) == flag
+
+  /** Returns whether any bit in [flag] is present. */
   public fun any(flag: Int): Boolean = (flag and value) != 0
+
+  /** Returns whether no bits are set. */
   public fun isEmpty(): Boolean = value == 0
 }

--- a/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/InternalHazeApi.kt
+++ b/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/InternalHazeApi.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze
 
+/** Marks public declarations reserved for Haze's internal module-to-module implementation. */
 @RequiresOptIn(
   message = "This is an internal Haze API and should not be used outside of the library. " +
     "It may be changed or removed without notice.",

--- a/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/PlatformContext.kt
+++ b/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/PlatformContext.kt
@@ -5,8 +5,10 @@ package dev.chrisbanes.haze
 
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 
+/** Platform-specific context required by built-in Haze renderers. */
 @InternalHazeApi
 public expect abstract class PlatformContext
 
+/** Returns the [PlatformContext] associated with this modifier node. */
 @InternalHazeApi
 public expect fun CompositionLocalConsumerModifierNode.requirePlatformContext(): PlatformContext

--- a/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/ProgressiveBlurRenderEffect.kt
+++ b/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/ProgressiveBlurRenderEffect.kt
@@ -9,6 +9,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Shader
 
+/**
+ * Creates a separable progressive blur clipped to [size] at [offset].
+ *
+ * [mask] supplies the per-pixel blur intensity and [blurRadiusPx] supplies its maximum radius.
+ */
 @InternalHazeApi
 public fun createProgressiveBlurRenderEffect(
   blurRadiusPx: Float,

--- a/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/RuntimeShader.kt
+++ b/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/RuntimeShader.kt
@@ -39,6 +39,7 @@ internal inline fun <T> wrapRuntimeShaderConstruction(block: () -> T): T = try {
 @InternalHazeApi
 public expect fun createRuntimeEffect(sksl: String): PlatformRuntimeEffect
 
+/** Returns whether runtime-shader render effects are supported on the current platform. */
 @InternalHazeApi
 public expect fun isRuntimeShaderRenderEffectSupported(): Boolean
 
@@ -61,6 +62,7 @@ public expect fun createRuntimeShaderRenderEffect(
 /** A runtime shader render effect whose uniforms can be updated without recompiling its source. */
 @InternalHazeApi
 public interface MutableRuntimeShaderRenderEffect {
+  /** Applies [uniforms] and returns the render effect containing the updated values. */
   public fun updateUniforms(
     uniforms: RuntimeShaderUniformProvider.() -> Unit,
   ): PlatformRenderEffect

--- a/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/Trace.kt
+++ b/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/Trace.kt
@@ -3,9 +3,11 @@
 
 package dev.chrisbanes.haze
 
+/** Runs [block] inside a synchronous platform trace section named [sectionName]. */
 @InternalHazeApi
 public expect inline fun <R> trace(sectionName: String, block: () -> R): R
 
+/** Runs [block] inside an asynchronous platform trace section identified by [cookie]. */
 @InternalHazeApi
 public expect suspend inline fun <R> traceAsync(
   sectionName: String,

--- a/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/RenderEffect.skiko.kt
+++ b/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/RenderEffect.skiko.kt
@@ -129,6 +129,7 @@ private fun Rect.toIRect(): IRect = IRect.makeLTRB(
   b = bottom.toInt(),
 )
 
+/** Returns `true` because Skiko supports runtime-shader render effects. */
 @InternalHazeApi
 public actual fun isRuntimeShaderRenderEffectSupported(): Boolean = true
 

--- a/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/SkikoPlatformContext.kt
+++ b/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/SkikoPlatformContext.kt
@@ -9,13 +9,17 @@ import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
 
+/** Stateless platform context used by Skiko-backed Haze renderers. */
 @InternalHazeApi
 public actual abstract class PlatformContext private constructor() {
+  /** Provides the shared Skiko platform context. */
   public companion object {
+    /** Shared Skiko platform context instance. */
     @JvmField public val INSTANCE: PlatformContext = object : PlatformContext() {}
   }
 }
 
+/** Returns the shared Skiko [PlatformContext]. */
 @InternalHazeApi
 public actual fun CompositionLocalConsumerModifierNode.requirePlatformContext(): PlatformContext {
   return PlatformContext.INSTANCE

--- a/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/Trace.skiko.kt
+++ b/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/Trace.skiko.kt
@@ -3,11 +3,13 @@
 
 package dev.chrisbanes.haze
 
+/** Runs [block] inside a Compose trace section named [sectionName]. */
 @InternalHazeApi
 public actual inline fun <R> trace(sectionName: String, block: () -> R): R {
   return androidx.compose.ui.util.trace(sectionName, block)
 }
 
+/** Runs [block]; Skiko does not currently emit an asynchronous platform trace section. */
 @InternalHazeApi
 public actual suspend inline fun <R> traceAsync(
   sectionName: String,

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -25,9 +25,11 @@ import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
 
+/** Creates and remembers a [HazeState] for coordinating Haze sources and effects. */
 @Composable
 public fun rememberHazeState(): HazeState = remember { HazeState() }
 
+/** Shared state that associates [hazeSource] content with source-backed Haze effects. */
 @Stable
 public class HazeState {
   internal var positionStrategy: HazePositionStrategy by mutableStateOf(HazePositionStrategy.Auto)

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.CoroutineScope
  * independently owned renderer.
  */
 public fun interface HazeEffectFactory<Style> {
+  /** Creates renderer state owned by one `hazeEffect` modifier node. */
   public fun createRenderer(): HazeEffectRenderer<Style>
 }
 
@@ -104,57 +105,104 @@ public interface HazeEffectLayoutScope : Density {
  */
 @InternalHazeApi
 public interface HazeEffectRendererLifecycle<Style> {
+  /** Acquires node-owned resources when the renderer becomes attached. */
   public fun attach(scope: HazeEffectLifecycleScope): Unit = Unit
+
+  /** Applies the complete current [style] and [sampling] policy. */
   public fun update(
     scope: HazeEffectLifecycleScope,
     style: Style,
     sampling: HazeSampling,
   ): Unit = Unit
+
+  /** Releases resources that are valid only while the node is attached. */
   public fun detach(): Unit = Unit
 }
 
 /** Built-in-only resources used while a renderer is attached to one modifier node. */
 @InternalHazeApi
 public interface HazeEffectLifecycleScope {
+  /** Current size of the modifier carrying the effect. */
   public val modifierSize: Size
+
+  /** Coroutine scope cancelled when the modifier node detaches. */
   public val coroutineScope: CoroutineScope
+
+  /** Returns the platform context associated with the modifier node. */
   public fun requirePlatformContext(): PlatformContext
+
+  /** Returns the graphics context used to allocate and release graphics layers. */
   public fun requireGraphicsContext(): GraphicsContext
+
+  /** Returns the density currently associated with the modifier node. */
   public fun requireDensity(): Density
+
+  /** Returns the current value of [local] and observes it for lifecycle updates. */
   public fun <T> currentValueOf(local: CompositionLocal<T>): T
+
+  /** Schedules a redraw of the effect. */
   public fun invalidateDraw()
+
+  /** Schedules recalculation of the effect layer bounds. */
   public fun invalidateLayerBounds()
 }
 
 /** Built-in-only draw hooks which are not part of the third-party renderer contract. */
 @InternalHazeApi
 public interface HazeEffectRendererDrawHooks<Style> {
+  /** Prepares renderer state immediately before the effect is drawn. */
   public fun HazeEffectRuntimeDrawScope.prepareDraw(style: Style): Unit = Unit
+
+  /** Draws renderer output over the modifier's own content. */
   public fun HazeEffectRuntimeDrawScope.drawForeground(style: Style): Unit = Unit
+
+  /** Whether the modifier's content is drawn behind the effect output. */
   public fun shouldDrawContentBehind(): Boolean = false
+
+  /** Whether effect output is clipped to the modifier bounds. */
   public fun shouldClipToNodeBounds(): Boolean = false
+
+  /** Whether source-backed input bounds are preferred as the clipping region. */
   public fun shouldPreferClipToInputBounds(): Boolean = false
 }
 
 /** Built-in-only retained-output capability. */
 @InternalHazeApi
 public interface HazeEffectRendererRetainedOutput {
+  /** Whether the renderer currently owns output that can be drawn again. */
   public fun canDrawRetainedOutput(): Boolean
+
+  /** Whether retained output should be drawn for the current frame. */
   public fun shouldDrawRetainedOutput(): Boolean = canDrawRetainedOutput()
+
+  /** Releases and clears all retained output. */
   public fun clearRetainedOutput()
 }
 
 /** Built-in-only pointer and content-transform capability. */
 @InternalHazeApi
 public interface HazeEffectRendererInteraction {
+  /** Whether the modifier node should observe pointer events. */
   public val observesPointerEvents: Boolean
+
+  /** Handles an observed [event] without consuming application pointer input. */
   public fun onPointerEvent(event: PointerEvent, scope: HazeEffectLifecycleScope)
+
+  /** Cancels any pointer interaction currently tracked by the renderer. */
   public fun onCancelPointerInput(scope: HazeEffectLifecycleScope)
+
+  /** Returns the transform applied to the modifier's content for the current interaction state. */
   public fun currentContentTransform(): HazeEffectContentTransform =
     HazeEffectContentTransform.Identity
 }
 
-/** Built-in-only transform applied to a modifier's own content and effect output. */
+/**
+ * Built-in-only transform applied to a modifier's own content and effect output.
+ *
+ * @property scaleX Horizontal scale factor greater than zero.
+ * @property scaleY Vertical scale factor greater than zero.
+ * @property pivot Pivot in the modifier's local coordinate space.
+ */
 @InternalHazeApi
 public class HazeEffectContentTransform(
   public val scaleX: Float,
@@ -167,19 +215,23 @@ public class HazeEffectContentTransform(
     require(pivot.x.isFinite() && pivot.y.isFinite()) { "pivot must be finite" }
   }
 
+  /** Returns whether [other] describes the same scale and pivot. */
   override fun equals(other: Any?): Boolean =
     other is HazeEffectContentTransform &&
       scaleX == other.scaleX &&
       scaleY == other.scaleY &&
       pivot == other.pivot
 
+  /** Returns a hash code derived from the scale and pivot. */
   override fun hashCode(): Int {
     var result = scaleX.hashCode()
     result = 31 * result + scaleY.hashCode()
     return 31 * result + pivot.hashCode()
   }
 
+  /** Built-in transform constants. */
   public companion object {
+    /** A transform that leaves content unchanged. */
     public val Identity: HazeEffectContentTransform =
       HazeEffectContentTransform(1f, 1f, Offset.Zero)
   }
@@ -201,16 +253,37 @@ public interface HazeEffectInputSnapshot
  */
 @InternalHazeApi
 public interface HazeEffectRuntimeDrawScope : HazeEffectDrawScope {
+  /** Current size of the modifier carrying the effect. */
   public val modifierSize: Size
+
+  /** Current size of the expanded effect layer. */
   public val layerSize: Size
+
+  /** Offset from the effect layer origin to the modifier origin. */
   public val layerOffset: Offset
+
+  /** Whether the selected input currently contains drawable content. */
   public val hasDrawableInput: Boolean
+
+  /** Opaque identity of the current input capture, or `null` when no input is drawable. */
   public val inputSnapshot: HazeEffectInputSnapshot?
+
+  /** Coroutine scope cancelled when the modifier node detaches. */
   public val coroutineScope: CoroutineScope
+
+  /** Returns the platform context associated with the modifier node. */
   public fun requirePlatformContext(): PlatformContext
+
+  /** Returns the graphics context used to allocate and release graphics layers. */
   public fun requireGraphicsContext(): GraphicsContext
+
+  /** Returns the density currently associated with the modifier node. */
   public fun requireDensity(): Density = this
+
+  /** Schedules a redraw of the effect. */
   public fun invalidateDraw()
+
+  /** Draws the selected input into this [DrawScope]. */
   public fun DrawScope.drawInput()
 }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
@@ -12,6 +12,10 @@ public sealed interface HazeInput {
 
   /**
    * Content captured by [hazeSource] modifiers associated with [state].
+   *
+   * @property state Shared state that identifies the available sources.
+   * @property selection Policy that selects which associated sources are consumed.
+   * @property retention Policy for output retained while selected sources are unavailable.
    */
   @Stable
   public data class Sources(
@@ -30,6 +34,9 @@ public sealed interface HazeInput {
  * Stable source metadata exposed to [HazeSourceSelection] refinements.
  *
  * Renderer-owned geometry, content, and platform resources are intentionally not exposed.
+ *
+ * @property key Optional application key supplied to `hazeSource`.
+ * @property zIndex Source ordering value supplied to `hazeSource`.
  */
 public class HazeSourceInfo(
   public val key: Any?,

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeProgressive.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeProgressive.kt
@@ -89,10 +89,13 @@ public sealed interface HazeProgressive {
    * This allows custom effects driven from a brush. It could be using a bitmap shader, via
    * a [androidx.compose.ui.graphics.ShaderBrush] or something more complex. The RGB values from the brush's pixels will
    * be ignored, only the alpha values are used.
+   *
+   * @property brush Brush whose alpha channel controls the effect intensity.
    */
   @JvmInline
   public value class Brush(public val brush: androidx.compose.ui.graphics.Brush) : HazeProgressive
 
+  /** Convenience factories for common progressive effects. */
   public companion object {
     /**
      * A vertical gradient effect.
@@ -170,6 +173,7 @@ public sealed interface HazeProgressive {
   }
 }
 
+/** Converts this progressive effect into an alpha-mask [Brush] with [numStops] samples. */
 @InternalHazeApi
 public fun HazeProgressive.asBrush(numStops: Int = 20): Brush = when (this) {
   is HazeProgressive.LinearGradient -> asBrush(numStops)

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -27,6 +27,7 @@ import kotlin.math.roundToInt
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
+/** Marks Haze APIs that are experimental and may change without notice. */
 @RequiresOptIn(message = "Experimental Haze API", level = RequiresOptIn.Level.WARNING)
 public annotation class ExperimentalHazeApi
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Log.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Log.kt
@@ -5,6 +5,7 @@ package dev.chrisbanes.haze
 
 import androidx.compose.runtime.snapshots.Snapshot
 
+/** Debug logging controls for diagnosing Haze rendering behavior. */
 public object HazeLogger {
   /**
    * Whether to print debug log statements to the relevant system logger. Do not build release
@@ -12,10 +13,12 @@ public object HazeLogger {
    */
   public var enabled: Boolean = false
 
+  /** Logs the lazily produced [message] under [tag] when [enabled]. */
   public fun d(tag: String, message: () -> String) {
     d(tag = tag, throwable = null, message = message)
   }
 
+  /** Logs [throwable] and the lazily produced [message] under [tag] when [enabled]. */
   public fun d(tag: String, throwable: Throwable?, message: () -> String) {
     if (enabled) {
       Snapshot.withoutReadObservation {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Poko.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Poko.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze
 
+/** Generates value-based `equals`, `hashCode`, and `toString` implementations for the class. */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS)
 public annotation class Poko

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/TrimMemoryLevel.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/TrimMemoryLevel.kt
@@ -3,9 +3,21 @@
 
 package dev.chrisbanes.haze
 
+/**
+ * Relative severity of a request to release cached rendering resources.
+ *
+ * @property severity Comparable severity used to order increasingly urgent requests.
+ */
 public enum class TrimMemoryLevel(public val severity: Int) {
+  /** The UI is no longer visible, allowing UI-only cached resources to be released. */
   UI_HIDDEN(severity = 10),
+
+  /** The application is in the background or equivalent memory pressure has been reported. */
   BACKGROUND(severity = 20),
+
+  /** Moderate memory pressure warrants releasing reusable rendering resources. */
   MODERATE(severity = 40),
+
+  /** Critical memory pressure warrants releasing every disposable rendering resource. */
   COMPLETE(severity = 80),
 }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Utils.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
  * detached); callers should always route through this helper rather than catching at the call
  * site, to keep error policy consistent.
  *
- * We catch [Exception] deliberately — not [Throwable] — so that [OutOfMemoryError] and other
+ * We catch [Exception] deliberately — not [Throwable] — so that `OutOfMemoryError` and other
  * JVM errors propagate rather than being silently swallowed as an "unspecified position".
  */
 internal fun LayoutCoordinates.safePositionOnScreen(): Offset = try {


### PR DESCRIPTION
## What

- add KDoc for undocumented public API in `haze`, `haze-blur`, `haze-glass`, and `haze-utils`
- document Glass interaction and memory-trim enum values
- fix stale KDoc links
- add a root `checkPublicApiDocumentation` task that enables Dokka's undocumented-reporting checks for API-bearing modules
- wire the documentation check into the root `check` lifecycle

## Why

Recent public API additions were not consistently documented, and the build had no guardrail to prevent future gaps.

## Impact

Documentation-only source changes; no public API signatures or runtime behavior change. The build now fails when an API-bearing module emits Dokka documentation warnings.

## Root cause

Dokka generated documentation without treating undocumented declarations as build failures, so missing KDoc could be introduced unnoticed.

## Checks

- `./gradlew spotlessApply checkPublicApiDocumentation --console=plain`
- `./gradlew checkPublicApiDocumentation --console=plain`
- `./gradlew check --dry-run --console=plain`
- `git diff --check`
- final review-and-simplify pass: no findings
- final ponytail review: Lean already. Ship.
