### PR TITLE
Add temporary deprecated Blur construction shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Source-selection predicates receive only `HazeSourceInfo`.
 - `HazeInputScale` is removed. Use `HazeSampling` to choose default, adaptive, full-resolution, or
   fixed input sampling for typed effects.
-- Blur now exposes only `Modifier.hazeBlur`, immutable `HazeBlurStyle`, and
-  `HazeBlurDefaults.style`. The mutable `BlurVisualEffect` runtime, scope extension, sentinel
-  `HazeBlurStyle.Unspecified`, legacy singular-effect constructors, and deprecated defaults
-  builder are removed.
+- Blur now exposes `Modifier.hazeBlur`, opaque replayable `HazeBlurStyle`, and
+  `HazeBlurDefaults.style`. The mutable `BlurVisualEffect` runtime, scope extension, readable Style
+  properties, `copy`, and destructuring are removed permanently.
 - Glass now exposes only the typed `Modifier.hazeGlass` and replayable `GlassStyle` surface.
   `GlassVisualEffect`, `glassEffect`, the old `hazeGlass` overload, `GlassRenderer`,
   `GlassRendererCache`, `GlassStyleConfiguration`, grouped `GlassLighting`/`GlassColor`/
@@ -36,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Temporarily retain the former plural and singular `HazeBlurStyle(...)` construction forms,
+  `HazeBlurStyle.Unspecified`, and `HazeBlurDefaults.style(...)` builder as warning-level,
+  source-only migration shims. They preserve legacy sentinel behavior and will be removed before
+  Haze 2.0 stable; they do not provide binary compatibility with the former Style class.
 - Blur effects now adapt `HazeSampling.Default` between `1.0`, `0.8`, and `0.5` using physical
   blur radius and expanded capture-layer area, with hysteresis and a `0.8` progressive-blur cap.
   Glass remains unscaled by default; explicit sampling choices remain authoritative.

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -76,6 +76,50 @@ value is retained.
 An explicit `colorEffects(emptyList())` clears inherited effects. Caller-owned lists are
 snapshotted before replay.
 
+### Temporary Blur construction shims
+
+During the remaining Haze 2 prereleases, the former `HazeBlurStyle(...)` construction forms,
+`HazeBlurStyle.Unspecified`, and `HazeBlurDefaults.style(...)` builder remain available as
+warning-level deprecations. They are source-migration aids only: code already compiled against the
+former `HazeBlurStyle` class is not binary compatible with the replayable Style interface. Every
+shim will be removed before Haze 2.0 stable.
+
+The plural construction form translates to guarded Style writes:
+
+```kotlin
+val migrated = HazeBlurStyle {
+  if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+  if (colorEffects != null) colorEffects(colorEffects)
+  if (blurRadius.isSpecified) blurRadius(blurRadius)
+  if (!(noiseFactor < 0f)) noiseFactor(noiseFactor)
+  if (fallbackColorEffect.isSpecified) fallbackColorEffect(fallbackColorEffect)
+}
+```
+
+For the singular form, replace the effects line with:
+
+```kotlin
+if (colorEffect != null) colorEffects(listOf(colorEffect))
+```
+
+`null` omits the color-effects write and reveals a lower-precedence value. A non-null empty plural
+list explicitly clears inherited effects, and non-empty caller-owned lists are snapshotted. An
+unspecified color, dimension, or fallback effect also omits its write. Negative numeric noise is
+the legacy omission sentinel; other values use normal Style resolution, so values above `1f`
+clamp and `NaN` fails validation.
+
+Replace `HazeBlurStyle.Unspecified` with `HazeBlurStyle`. Migrate the defaults builder by replaying
+the canonical defaults first and guarding its overrides in the same way:
+
+```kotlin
+val migrated = HazeBlurDefaults.style.then {
+  if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+  if (tint.isSpecified) colorEffects(listOf(tint))
+  if (blurRadius.isSpecified) blurRadius(blurRadius)
+  if (!(noiseFactor < 0f)) noiseFactor(noiseFactor)
+}
+```
+
 ## Migrate material presets
 
 Before:
@@ -186,9 +230,10 @@ selection is handled internally by Haze.
 ## Removed compatibility APIs
 
 `VisualEffect`, `VisualEffectContext`, `HazeEffectScope`, `BlurVisualEffect`,
-`HazeEffectScope.blurEffect`, and the lambda-based `hazeEffect` overloads are removed. The
-sentinel-based `HazeBlurStyle(...)` constructors, `HazeBlurStyle.Unspecified`, and the deprecated
-`HazeBlurDefaults.style(...)` builder are also removed. Use replayable Style blocks and `then`.
+`HazeEffectScope.blurEffect`, and the lambda-based `hazeEffect` overloads are removed. Readable
+`HazeBlurStyle` properties, `copy`, destructuring, and mutable runtime interfaces remain removed.
+Only the temporary source construction shims described above survive during the prerelease cycle;
+use replayable Style blocks and `then` before Haze 2.0 stable.
 
 ## Complete API mapping
 

--- a/haze-blur/api/api.txt
+++ b/haze-blur/api/api.txt
@@ -4,6 +4,7 @@ package dev.chrisbanes.haze.blur {
   public final class HazeBlurDefaults {
     method public boolean blurEnabled();
     method @InaccessibleFromKotlin public dev.chrisbanes.haze.blur.HazeBlurStyle getStyle();
+    method @KotlinOnly @Deprecated public dev.chrisbanes.haze.blur.HazeBlurStyle style(androidx.compose.ui.graphics.Color backgroundColor, optional dev.chrisbanes.haze.blur.HazeColorEffect tint, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor);
     method @KotlinOnly public dev.chrisbanes.haze.blur.HazeColorEffect tint(androidx.compose.ui.graphics.Color color);
     property public androidx.compose.ui.unit.Dp blurRadius;
     property public androidx.compose.ui.draw.BlurredEdgeTreatment blurredEdgeTreatment;
@@ -26,9 +27,13 @@ package dev.chrisbanes.haze.blur {
   }
 
   public static final class HazeBlurStyle.Companion implements dev.chrisbanes.haze.blur.HazeBlurStyle {
+    method @InaccessibleFromKotlin @Deprecated public dev.chrisbanes.haze.blur.HazeBlurStyle getUnspecified();
+    property @Deprecated public dev.chrisbanes.haze.blur.HazeBlurStyle Unspecified;
   }
 
   public final class HazeBlurStyleKt {
+    method @KotlinOnly @Deprecated public static dev.chrisbanes.haze.blur.HazeBlurStyle HazeBlurStyle(optional androidx.compose.ui.graphics.Color backgroundColor, dev.chrisbanes.haze.blur.HazeColorEffect? colorEffect, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor, optional dev.chrisbanes.haze.blur.HazeColorEffect fallbackColorEffect);
+    method @KotlinOnly @Deprecated public static dev.chrisbanes.haze.blur.HazeBlurStyle HazeBlurStyle(optional androidx.compose.ui.graphics.Color backgroundColor, optional java.util.List<dev.chrisbanes.haze.blur.HazeColorEffect>? colorEffects, optional androidx.compose.ui.unit.Dp blurRadius, optional float noiseFactor, optional dev.chrisbanes.haze.blur.HazeColorEffect fallbackColorEffect);
     method public static dev.chrisbanes.haze.blur.HazeBlurStyle HazeBlurStyle(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.blur.HazeBlurStyleScope,kotlin.Unit> block);
     method @InaccessibleFromKotlin public static androidx.compose.runtime.ProvidableCompositionLocal<dev.chrisbanes.haze.blur.HazeBlurStyle> getLocalHazeBlurStyle();
     property public static androidx.compose.runtime.ProvidableCompositionLocal<dev.chrisbanes.haze.blur.HazeBlurStyle> LocalHazeBlurStyle;

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurDefaults.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurDefaults.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import dev.chrisbanes.haze.blur.HazeBlurDefaults.tint
 
 /**
@@ -51,6 +52,45 @@ public object HazeBlurDefaults {
     mask(null)
     progressive(null)
     blurredEdgeTreatment(blurredEdgeTreatment)
+  }
+
+  /**
+   * Temporary source adapter for the former default Blur Style builder.
+   *
+   * The canonical [style] is replayed first, then specified legacy arguments are appended as
+   * overrides. This source-only shim will be removed before Haze 2.0 stable.
+   *
+   * @param backgroundColor color drawn behind the blurred content.
+   * @param tint color effect applied to the blurred content.
+   * @param blurRadius radius of the blur.
+   * @param noiseFactor amount of noise applied to the content.
+   */
+  @Deprecated(
+    message =
+    "Use HazeBlurDefaults.style.then { ... }. " +
+      "This source-only shim will be removed before Haze 2.0 stable.",
+    replaceWith = ReplaceWith(
+      expression = """HazeBlurDefaults.style.then {
+        if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+        if (tint.isSpecified) colorEffects(listOf(tint))
+        if (blurRadius.isSpecified) blurRadius(blurRadius)
+        if (!(noiseFactor < 0f)) noiseFactor(noiseFactor)
+      }""",
+      "androidx.compose.ui.graphics.isSpecified",
+      "androidx.compose.ui.unit.isSpecified",
+    ),
+    level = DeprecationLevel.WARNING,
+  )
+  public fun style(
+    backgroundColor: Color,
+    tint: HazeColorEffect = tint(backgroundColor),
+    blurRadius: Dp = this.blurRadius,
+    noiseFactor: Float = this.noiseFactor,
+  ): HazeBlurStyle = style.then {
+    if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+    if (tint.isSpecified) colorEffects(listOf(tint))
+    if (blurRadius.isSpecified) blurRadius(blurRadius)
+    if (!(noiseFactor < 0f)) noiseFactor(noiseFactor)
   }
 
   /**

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
@@ -44,7 +44,19 @@ public sealed interface HazeBlurStyle {
     then(HazeBlurStyle(block))
 
   /** The empty Blur Style, which performs no writes. */
-  public companion object : HazeBlurStyle
+  public companion object : HazeBlurStyle {
+    /**
+     * Temporary source-compatibility name for the empty Style.
+     *
+     * This alias will be removed before Haze 2.0 stable.
+     */
+    @Deprecated(
+      message = "Use HazeBlurStyle. This source-only shim will be removed before Haze 2.0 stable.",
+      replaceWith = ReplaceWith("HazeBlurStyle"),
+      level = DeprecationLevel.WARNING,
+    )
+    public val Unspecified: HazeBlurStyle get() = this
+  }
 }
 
 @Immutable
@@ -64,6 +76,79 @@ private class RecordedHazeBlurStyle(
 /** Creates an opaque, replayable Blur Style from [block]. */
 public fun HazeBlurStyle(block: HazeBlurStyleScope.() -> Unit): HazeBlurStyle =
   RecordedHazeBlurStyle(recordWrites(block))
+
+/**
+ * Temporary source adapter for the former plural Blur Style construction form.
+ *
+ * Sentinel values omit their corresponding writes, while a non-null empty [colorEffects] list
+ * explicitly clears inherited effects. This source-only shim will be removed before Haze 2.0
+ * stable.
+ */
+@Deprecated(
+  message =
+  "Use HazeBlurStyle { ... }. This source-only shim will be removed before Haze 2.0 stable.",
+  replaceWith = ReplaceWith(
+    expression = """HazeBlurStyle {
+      if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+      if (colorEffects != null) colorEffects(colorEffects)
+      if (blurRadius.isSpecified) blurRadius(blurRadius)
+      if (!(noiseFactor < 0f)) noiseFactor(noiseFactor)
+      if (fallbackColorEffect.isSpecified) fallbackColorEffect(fallbackColorEffect)
+    }""",
+    "androidx.compose.ui.graphics.isSpecified",
+    "androidx.compose.ui.unit.isSpecified",
+  ),
+  level = DeprecationLevel.WARNING,
+)
+public fun HazeBlurStyle(
+  backgroundColor: Color = Color.Unspecified,
+  colorEffects: List<HazeColorEffect>? = null,
+  blurRadius: Dp = Dp.Unspecified,
+  noiseFactor: Float = -1f,
+  fallbackColorEffect: HazeColorEffect = HazeColorEffect.Unspecified,
+): HazeBlurStyle = HazeBlurStyle {
+  if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+  if (colorEffects != null) colorEffects(colorEffects)
+  if (blurRadius.isSpecified) blurRadius(blurRadius)
+  if (!(noiseFactor < 0f)) noiseFactor(noiseFactor)
+  if (fallbackColorEffect.isSpecified) fallbackColorEffect(fallbackColorEffect)
+}
+
+/**
+ * Temporary source adapter for the former singular Blur Style construction form.
+ *
+ * A null [colorEffect] omits the color-effects write. This source-only shim will be removed before
+ * Haze 2.0 stable.
+ */
+@Deprecated(
+  message =
+  "Use HazeBlurStyle { ... }. This source-only shim will be removed before Haze 2.0 stable.",
+  replaceWith = ReplaceWith(
+    expression = """HazeBlurStyle {
+      if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+      if (colorEffect != null) colorEffects(listOf(colorEffect))
+      if (blurRadius.isSpecified) blurRadius(blurRadius)
+      if (!(noiseFactor < 0f)) noiseFactor(noiseFactor)
+      if (fallbackColorEffect.isSpecified) fallbackColorEffect(fallbackColorEffect)
+    }""",
+    "androidx.compose.ui.graphics.isSpecified",
+    "androidx.compose.ui.unit.isSpecified",
+  ),
+  level = DeprecationLevel.WARNING,
+)
+public fun HazeBlurStyle(
+  backgroundColor: Color = Color.Unspecified,
+  colorEffect: HazeColorEffect?,
+  blurRadius: Dp = Dp.Unspecified,
+  noiseFactor: Float = -1f,
+  fallbackColorEffect: HazeColorEffect = HazeColorEffect.Unspecified,
+): HazeBlurStyle = HazeBlurStyle {
+  if (backgroundColor.isSpecified) backgroundColor(backgroundColor)
+  if (colorEffect != null) colorEffects(listOf(colorEffect))
+  if (blurRadius.isSpecified) blurRadius(blurRadius)
+  if (!(noiseFactor < 0f)) noiseFactor(noiseFactor)
+  if (fallbackColorEffect.isSpecified) fallbackColorEffect(fallbackColorEffect)
+}
 
 private fun combineHazeBlurStyles(
   first: HazeBlurStyle,

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyleTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyleTest.kt
@@ -6,6 +6,7 @@ package dev.chrisbanes.haze.blur
 import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import assertk.assertFailure
 import assertk.assertThat
@@ -18,11 +19,345 @@ import assertk.assertions.isSameInstanceAs
 import dev.chrisbanes.haze.HazeProgressive
 import kotlin.test.Test
 
+@Suppress("DEPRECATION")
 class HazeBlurStyleTest {
 
   @Test
   fun defaultStyle_isShared() {
     assertThat(HazeBlurDefaults.style).isSameInstanceAs(HazeBlurDefaults.style)
+  }
+
+  @Test
+  fun deprecatedEmptyStyles_matchTheEmptyStyle() {
+    val empty = resolveHazeBlurStyle(HazeBlurStyle, HazeBlurStyle)
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, HazeBlurStyle()))
+      .isEqualTo(empty)
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, HazeBlurStyle.Unspecified))
+      .isEqualTo(empty)
+  }
+
+  @Test
+  fun deprecatedSingularFactory_matchesReplacementStyle() {
+    val effect = HazeColorEffect.tint(Color.Red)
+    val fallback = HazeColorEffect.tint(Color.Blue)
+    val legacy = HazeBlurStyle(
+      backgroundColor = Color.Black,
+      colorEffect = effect,
+      blurRadius = 24.dp,
+      noiseFactor = 0.4f,
+      fallbackColorEffect = fallback,
+    )
+    val replacement = HazeBlurStyle {
+      backgroundColor(Color.Black)
+      colorEffects(listOf(effect))
+      blurRadius(24.dp)
+      noiseFactor(0.4f)
+      fallbackColorEffect(fallback)
+    }
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy))
+      .isEqualTo(resolveHazeBlurStyle(HazeBlurStyle, replacement))
+  }
+
+  @Test
+  fun deprecatedDefaultsBuilder_matchesCanonicalDefaultsWithLegacyDefaults() {
+    val backgroundColor = Color.Magenta
+    val legacy = HazeBlurDefaults.style(backgroundColor)
+    val replacement = HazeBlurDefaults.style.then {
+      backgroundColor(backgroundColor)
+      colorEffects(listOf(HazeBlurDefaults.tint(backgroundColor)))
+      blurRadius(HazeBlurDefaults.blurRadius)
+      noiseFactor(HazeBlurDefaults.noiseFactor)
+    }
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy))
+      .isEqualTo(resolveHazeBlurStyle(HazeBlurStyle, replacement))
+  }
+
+  @Test
+  fun deprecatedPluralFactory_matchesReplacementStyle() {
+    val effect = HazeColorEffect.tint(Color.Red)
+    val fallback = HazeColorEffect.tint(Color.Blue)
+    val legacy = HazeBlurStyle(
+      backgroundColor = Color.Black,
+      colorEffects = listOf(effect),
+      blurRadius = 24.dp,
+      noiseFactor = 0.4f,
+      fallbackColorEffect = fallback,
+    )
+    val replacement = HazeBlurStyle {
+      backgroundColor(Color.Black)
+      colorEffects(listOf(effect))
+      blurRadius(24.dp)
+      noiseFactor(0.4f)
+      fallbackColorEffect(fallback)
+    }
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy))
+      .isEqualTo(resolveHazeBlurStyle(HazeBlurStyle, replacement))
+  }
+
+  @Test
+  fun deprecatedPluralFactory_nullEffectsOmitWrite() {
+    val effect = HazeColorEffect.tint(Color.Red)
+    val inherited = HazeBlurStyle {
+      colorEffects(listOf(effect))
+    }
+    val legacy = HazeBlurStyle(colorEffects = null)
+    val replacement = HazeBlurStyle {}
+
+    assertThat(resolveHazeBlurStyle(inherited, legacy))
+      .isEqualTo(resolveHazeBlurStyle(inherited, replacement))
+    assertThat(resolveHazeBlurStyle(inherited, legacy).colorEffects)
+      .containsExactly(effect)
+  }
+
+  @Test
+  fun deprecatedSingularFactory_nullEffectOmitsWrite() {
+    val effect = HazeColorEffect.tint(Color.Red)
+    val inherited = HazeBlurStyle {
+      colorEffects(listOf(effect))
+    }
+    val legacy = HazeBlurStyle(colorEffect = null)
+    val replacement = HazeBlurStyle {}
+
+    assertThat(resolveHazeBlurStyle(inherited, legacy))
+      .isEqualTo(resolveHazeBlurStyle(inherited, replacement))
+    assertThat(resolveHazeBlurStyle(inherited, legacy).colorEffects)
+      .containsExactly(effect)
+  }
+
+  @Test
+  fun deprecatedFactories_unspecifiedBackgroundColorOmitsWrite() {
+    val inherited = HazeBlurStyle {
+      backgroundColor(Color.Red)
+    }
+    val replacement = HazeBlurStyle {}
+    val expected = resolveHazeBlurStyle(inherited, replacement)
+
+    assertThat(resolveHazeBlurStyle(inherited, HazeBlurStyle(backgroundColor = Color.Unspecified)))
+      .isEqualTo(expected)
+    assertThat(
+      resolveHazeBlurStyle(
+        inherited,
+        HazeBlurStyle(backgroundColor = Color.Unspecified, colorEffect = null),
+      ),
+    ).isEqualTo(expected)
+  }
+
+  @Test
+  fun deprecatedFactories_unspecifiedBlurRadiusOmitsWrite() {
+    val inherited = HazeBlurStyle {
+      blurRadius(12.dp)
+    }
+    val replacement = HazeBlurStyle {}
+    val expected = resolveHazeBlurStyle(inherited, replacement)
+
+    assertThat(resolveHazeBlurStyle(inherited, HazeBlurStyle(blurRadius = Dp.Unspecified)))
+      .isEqualTo(expected)
+    assertThat(
+      resolveHazeBlurStyle(
+        inherited,
+        HazeBlurStyle(colorEffect = null, blurRadius = Dp.Unspecified),
+      ),
+    ).isEqualTo(expected)
+  }
+
+  @Test
+  fun deprecatedFactories_unspecifiedFallbackEffectOmitsWrite() {
+    val inherited = HazeBlurStyle {
+      fallbackColorEffect(HazeColorEffect.tint(Color.Blue))
+    }
+    val replacement = HazeBlurStyle {}
+    val expected = resolveHazeBlurStyle(inherited, replacement)
+
+    assertThat(
+      resolveHazeBlurStyle(
+        inherited,
+        HazeBlurStyle(fallbackColorEffect = HazeColorEffect.Unspecified),
+      ),
+    ).isEqualTo(expected)
+    assertThat(
+      resolveHazeBlurStyle(
+        inherited,
+        HazeBlurStyle(
+          colorEffect = null,
+          fallbackColorEffect = HazeColorEffect.Unspecified,
+        ),
+      ),
+    ).isEqualTo(expected)
+  }
+
+  @Test
+  fun deprecatedFactories_negativeNoiseOmitsWrite() {
+    val inherited = HazeBlurStyle {
+      noiseFactor(0.3f)
+    }
+    val replacement = HazeBlurStyle {}
+    val expected = resolveHazeBlurStyle(inherited, replacement)
+
+    assertThat(resolveHazeBlurStyle(inherited, HazeBlurStyle(noiseFactor = -0.1f)))
+      .isEqualTo(expected)
+    assertThat(
+      resolveHazeBlurStyle(
+        inherited,
+        HazeBlurStyle(colorEffect = null, noiseFactor = -0.1f),
+      ),
+    ).isEqualTo(expected)
+  }
+
+  @Test
+  fun deprecatedPluralFactory_emptyEffectsClearInheritedEffects() {
+    val inherited = HazeBlurStyle {
+      colorEffects(listOf(HazeColorEffect.tint(Color.Red)))
+    }
+    val legacy = HazeBlurStyle(colorEffects = emptyList())
+    val replacement = HazeBlurStyle {
+      colorEffects(emptyList())
+    }
+
+    assertThat(resolveHazeBlurStyle(inherited, legacy))
+      .isEqualTo(resolveHazeBlurStyle(inherited, replacement))
+    assertThat(resolveHazeBlurStyle(inherited, legacy).colorEffects).isEmpty()
+  }
+
+  @Test
+  fun deprecatedPluralFactory_snapshotsCallerOwnedEffects() {
+    val first = HazeColorEffect.tint(Color.Red)
+    val second = HazeColorEffect.tint(Color.Blue)
+    val input = mutableListOf(first)
+    val legacy = HazeBlurStyle(colorEffects = input)
+    val replacement = HazeBlurStyle {
+      colorEffects(listOf(first))
+    }
+
+    input += second
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy))
+      .isEqualTo(resolveHazeBlurStyle(HazeBlurStyle, replacement))
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy).colorEffects)
+      .containsExactly(first)
+  }
+
+  @Test
+  fun deprecatedFactories_explicitNoiseUsesAccumulatorClamping() {
+    val plural = HazeBlurStyle(noiseFactor = 2f)
+    val singular = HazeBlurStyle(colorEffect = null, noiseFactor = 2f)
+    val replacement = HazeBlurStyle {
+      noiseFactor(2f)
+    }
+    val expected = resolveHazeBlurStyle(HazeBlurStyle, replacement)
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, plural)).isEqualTo(expected)
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, singular)).isEqualTo(expected)
+    assertThat(expected.noiseFactor).isEqualTo(1f)
+  }
+
+  @Test
+  fun deprecatedFactories_explicitNaNUsesAccumulatorValidation() {
+    assertFailure {
+      resolveHazeBlurStyle(HazeBlurStyle, HazeBlurStyle(noiseFactor = Float.NaN))
+    }.isInstanceOf<IllegalArgumentException>()
+    assertFailure {
+      resolveHazeBlurStyle(
+        HazeBlurStyle,
+        HazeBlurStyle(colorEffect = null, noiseFactor = Float.NaN),
+      )
+    }.isInstanceOf<IllegalArgumentException>()
+  }
+
+  @Test
+  fun deprecatedDefaultsBuilder_matchesCanonicalDefaultsWithOverrides() {
+    val tint = HazeColorEffect.tint(Color.Cyan)
+    val legacy = HazeBlurDefaults.style(
+      backgroundColor = Color.Black,
+      tint = tint,
+      blurRadius = 32.dp,
+      noiseFactor = 0.6f,
+    )
+    val replacement = HazeBlurDefaults.style.then {
+      backgroundColor(Color.Black)
+      colorEffects(listOf(tint))
+      blurRadius(32.dp)
+      noiseFactor(0.6f)
+    }
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy))
+      .isEqualTo(resolveHazeBlurStyle(HazeBlurStyle, replacement))
+  }
+
+  @Test
+  fun deprecatedDefaultsBuilder_unspecifiedBackgroundColorOmitsOverride() {
+    val legacy = HazeBlurDefaults.style(
+      backgroundColor = Color.Unspecified,
+    )
+    val replacement = HazeBlurDefaults.style.then {}
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy))
+      .isEqualTo(resolveHazeBlurStyle(HazeBlurStyle, replacement))
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy).backgroundColor)
+      .isEqualTo(Color.Transparent)
+  }
+
+  @Test
+  fun deprecatedDefaultsBuilder_unspecifiedTintOmitsOverride() {
+    val legacy = HazeBlurDefaults.style(
+      backgroundColor = Color.Unspecified,
+      tint = HazeColorEffect.Unspecified,
+    )
+    val replacement = HazeBlurDefaults.style.then {}
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy))
+      .isEqualTo(resolveHazeBlurStyle(HazeBlurStyle, replacement))
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy).colorEffects).isEmpty()
+  }
+
+  @Test
+  fun deprecatedDefaultsBuilder_unspecifiedBlurRadiusOmitsOverride() {
+    val legacy = HazeBlurDefaults.style(
+      backgroundColor = Color.Unspecified,
+      blurRadius = Dp.Unspecified,
+    )
+    val replacement = HazeBlurDefaults.style.then {}
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy))
+      .isEqualTo(resolveHazeBlurStyle(HazeBlurStyle, replacement))
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy).blurRadius)
+      .isEqualTo(HazeBlurDefaults.blurRadius)
+  }
+
+  @Test
+  fun deprecatedDefaultsBuilder_negativeNoiseOmitsOverride() {
+    val legacy = HazeBlurDefaults.style(
+      backgroundColor = Color.Unspecified,
+      noiseFactor = -0.1f,
+    )
+    val replacement = HazeBlurDefaults.style.then {}
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy))
+      .isEqualTo(resolveHazeBlurStyle(HazeBlurStyle, replacement))
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, legacy).noiseFactor)
+      .isEqualTo(HazeBlurDefaults.noiseFactor)
+  }
+
+  @Test
+  fun deprecatedDefaultsBuilder_explicitNoiseUsesAccumulatorBehavior() {
+    val clamped = HazeBlurDefaults.style(
+      backgroundColor = Color.Unspecified,
+      noiseFactor = 2f,
+    )
+
+    assertThat(resolveHazeBlurStyle(HazeBlurStyle, clamped).noiseFactor).isEqualTo(1f)
+    assertFailure {
+      resolveHazeBlurStyle(
+        HazeBlurStyle,
+        HazeBlurDefaults.style(
+          backgroundColor = Color.Unspecified,
+          noiseFactor = Float.NaN,
+        ),
+      )
+    }.isInstanceOf<IllegalArgumentException>()
   }
 
   @Test


### PR DESCRIPTION
## Summary
- restore the former plural and singular `HazeBlurStyle(...)` construction forms as warning-level source adapters
- restore `HazeBlurStyle.Unspecified` and `HazeBlurDefaults.style(...)` with semantics-preserving `ReplaceWith` expressions
- lock the temporary surface in Metalava and document the source-only prerelease migration bridge

## Rationale
The replayable Blur Style interface can preserve the former construction semantics without reopening readable Style state or renderer/runtime APIs. Guarded writes retain null-versus-empty behavior, omission sentinels, caller-list snapshotting, and accumulator validation/clamping.

## Verification
- `./gradlew :haze-blur:jvmTest --tests dev.chrisbanes.haze.blur.HazeBlurStyleTest`
- `./gradlew :haze-blur:metalavaGenerateSignature :haze-blur:metalavaCheckCompatibility :haze-blur:check`
- `./gradlew :haze-blur:check` on rebased `main`
- isolated clean Wasm compilation after one transient incremental compiler failure, followed by a green full module check
- `./scripts/build_docs.sh build`
- `git diff --check origin/main...HEAD`
- Standards, Spec, reuse, quality, efficiency, clarity, and over-engineering reviews passed on the final rebased commit

## Residual risk
The repository has no IDE rewrite harness. Each `ReplaceWith` expression was manually inspected against equivalent replacement DSL compiled by the semantic tests; actual IDE UI application remains a manual integration check. No screenshot or runtime behavior changes are expected.

Fixes #1159