### PR TITLE
Make Glass Lab specimen draggable

### DIFF
--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
@@ -6,9 +6,15 @@
 package dev.chrisbanes.haze.sample
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -19,6 +25,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.rememberScrollState
@@ -33,20 +40,29 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.rememberHazeState
+import kotlin.math.roundToInt
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 @Composable
 public fun GlassLabSample(navController: NavHostController) {
@@ -69,9 +85,12 @@ internal fun GlassLabSampleContent(
   onStateChanged: (GlassLabState) -> Unit,
   onRecordingModeChanged: (Boolean) -> Unit,
   onBack: () -> Unit,
+  specimenInteractionSource: MutableInteractionSource? = null,
   modifier: Modifier = Modifier,
 ) {
   val hazeState = rememberHazeState()
+  val defaultSpecimenInteractionSource = remember { MutableInteractionSource() }
+  val resolvedSpecimenInteractionSource = specimenInteractionSource ?: defaultSpecimenInteractionSource
   BoxWithConstraints(modifier = modifier.fillMaxSize()) {
     val landscape = maxWidth > maxHeight
     if (landscape) {
@@ -81,6 +100,7 @@ internal fun GlassLabSampleContent(
           state = state,
           recordingMode = recordingMode,
           onRevealChrome = { onRecordingModeChanged(false) },
+          interactionSource = resolvedSpecimenInteractionSource,
           modifier = Modifier.weight(0.6f).fillMaxHeight(),
         )
         LabControls(
@@ -97,6 +117,7 @@ internal fun GlassLabSampleContent(
           state = state,
           recordingMode = recordingMode,
           onRevealChrome = { onRecordingModeChanged(false) },
+          interactionSource = resolvedSpecimenInteractionSource,
           modifier = Modifier.weight(0.52f).fillMaxWidth(),
         )
         LabControls(
@@ -144,10 +165,42 @@ private fun LabSpecimen(
   state: GlassLabState,
   recordingMode: Boolean,
   onRevealChrome: () -> Unit,
+  interactionSource: MutableInteractionSource,
   modifier: Modifier = Modifier,
 ) {
-  val interactionSource = remember { MutableInteractionSource() }
-  Box(modifier = modifier) {
+  val scope = rememberCoroutineScope()
+  var dragOffset by remember { mutableStateOf(Offset.Zero) }
+  var viewportSize by remember { mutableStateOf(IntSize.Zero) }
+  var returnJob by remember { mutableStateOf<Job?>(null) }
+  var pressInteraction by remember { mutableStateOf<PressInteraction.Press?>(null) }
+  val returnToCenter = {
+    returnJob?.cancel()
+    returnJob = scope.launch {
+      Animatable(dragOffset, Offset.VectorConverter).animateTo(
+        targetValue = Offset.Zero,
+        animationSpec = spring(
+          dampingRatio = 0.78f,
+          stiffness = Spring.StiffnessMediumLow,
+        ),
+      ) {
+        dragOffset = value
+      }
+    }
+  }
+  val finishDrag = { cancelled: Boolean ->
+    pressInteraction?.let { press ->
+      interactionSource.tryEmit(
+        if (cancelled) PressInteraction.Cancel(press) else PressInteraction.Release(press),
+      )
+    }
+    pressInteraction = null
+    returnToCenter()
+  }
+  Box(
+    modifier = modifier
+      .onSizeChanged { viewportSize = it }
+      .testTag("glass_lab_specimen_viewport"),
+  ) {
     GalleryBackdrop(
       hazeState = hazeState,
       artworkIndex = 0,
@@ -168,9 +221,28 @@ private fun LabSpecimen(
       interactionStyle = state.interaction.style,
       modifier = Modifier
         .align(Alignment.Center)
+        .offset {
+          IntOffset(dragOffset.x.roundToInt(), dragOffset.y.roundToInt())
+        }
         .fillMaxWidth(0.85f)
         .sizeIn(maxWidth = 360.dp, maxHeight = 240.dp)
-        .pointerInput(Unit) { detectTapGestures {} }
+        .pointerInput(interactionSource) {
+          try {
+            detectDragGestures(
+              onDragStart = { position ->
+                returnJob?.cancel()
+                pressInteraction = PressInteraction.Press(position).also(interactionSource::tryEmit)
+              },
+              onDragEnd = { finishDrag(false) },
+              onDragCancel = { finishDrag(true) },
+            ) { change, amount ->
+              change.consume()
+              dragOffset = (dragOffset + amount).coerceCenterTo(viewportSize)
+            }
+          } finally {
+            if (pressInteraction != null) finishDrag(true)
+          }
+        }
         .focusable(interactionSource = interactionSource)
         .semantics { contentDescription = "Glass specimen" },
     ) {
@@ -183,6 +255,11 @@ private fun LabSpecimen(
     }
   }
 }
+
+private fun Offset.coerceCenterTo(viewportSize: IntSize): Offset = Offset(
+  x = x.coerceIn(-viewportSize.width / 2f, viewportSize.width / 2f),
+  y = y.coerceIn(-viewportSize.height / 2f, viewportSize.height / 2f),
+)
 
 @Composable
 internal fun LabControls(

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassLabSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassLabSampleTest.kt
@@ -3,12 +3,16 @@
 
 package dev.chrisbanes.haze.sample
 
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
@@ -16,6 +20,7 @@ import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
@@ -26,13 +31,264 @@ import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isLessThanOrEqualTo
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
 class GlassLabSampleTest : ContextTest() {
+  @Test
+  fun specimenFollowsDrag() = runComposeUiTest {
+    setContent {
+      GlassLabSampleContent(
+        state = GlassLabState(),
+        recordingMode = false,
+        onStateChanged = {},
+        onRecordingModeChanged = {},
+        onBack = {},
+      )
+    }
+
+    val specimen = onNodeWithContentDescription("Glass specimen")
+    val initialCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+    specimen.performTouchInput { down(center) }
+    specimen.performTouchInput {
+      updatePointerTo(0, center + Offset(80f, 40f))
+      move()
+    }
+    waitForIdle()
+    val draggedCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+
+    assertThat(draggedCenter.x).isGreaterThan(initialCenter.x)
+    assertThat(draggedCenter.y).isGreaterThan(initialCenter.y)
+    specimen.performTouchInput { cancel() }
+  }
+
+  @Test
+  fun specimenSpringsBackToCenterAfterRelease() = runComposeUiTest {
+    setContent {
+      GlassLabSampleContent(
+        state = GlassLabState(),
+        recordingMode = false,
+        onStateChanged = {},
+        onRecordingModeChanged = {},
+        onBack = {},
+      )
+    }
+
+    val specimen = onNodeWithContentDescription("Glass specimen")
+    val initialCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+    specimen.performTouchInput { down(center) }
+    specimen.performTouchInput {
+      updatePointerTo(0, center + Offset(80f, 40f))
+      move()
+    }
+    val autoAdvance = mainClock.autoAdvance
+    mainClock.autoAdvance = false
+    try {
+      specimen.performTouchInput { up() }
+      mainClock.advanceTimeUntil(timeoutMillis = 5_000) {
+        specimen.fetchSemanticsNode().boundsInRoot.center == initialCenter
+      }
+
+      assertThat(specimen.fetchSemanticsNode().boundsInRoot.center).isEqualTo(initialCenter)
+    } finally {
+      mainClock.autoAdvance = autoAdvance
+    }
+  }
+
+  @Test
+  fun specimenCenterIsClampedToViewportDuringDrag() = runComposeUiTest {
+    setContent {
+      GlassLabSampleContent(
+        state = GlassLabState(),
+        recordingMode = false,
+        onStateChanged = {},
+        onRecordingModeChanged = {},
+        onBack = {},
+      )
+    }
+
+    val viewport = onNodeWithTag("glass_lab_specimen_viewport")
+    val specimen = onNodeWithContentDescription("Glass specimen")
+    specimen.performTouchInput { down(center) }
+    specimen.performTouchInput {
+      updatePointerTo(0, center + Offset(10_000f, 10_000f))
+      move()
+    }
+    waitForIdle()
+
+    assertThat(specimen.fetchSemanticsNode().boundsInRoot.center)
+      .isEqualTo(viewport.fetchSemanticsNode().boundsInRoot.bottomRight)
+    specimen.performTouchInput { cancel() }
+  }
+
+  @Test
+  fun specimenDragEmitsPressAndReleaseInteractions() = runComposeUiTest {
+    val interactionSource = MutableInteractionSource()
+    val interactions = mutableListOf<Interaction>()
+    val collectionScope = CoroutineScope(Dispatchers.Unconfined)
+    try {
+      collectionScope.launch {
+        interactionSource.interactions.collect(interactions::add)
+      }
+      setContent {
+        GlassLabSampleContent(
+          state = GlassLabState(),
+          recordingMode = false,
+          onStateChanged = {},
+          onRecordingModeChanged = {},
+          onBack = {},
+          specimenInteractionSource = interactionSource,
+        )
+      }
+
+      val specimen = onNodeWithContentDescription("Glass specimen")
+      specimen.performTouchInput { down(center) }
+      specimen.performTouchInput {
+        updatePointerTo(0, center + Offset(80f, 40f))
+        move()
+      }
+      specimen.performTouchInput { up() }
+      waitUntil { interactions.size >= 2 }
+
+      assertThat(interactions[0]).isInstanceOf<PressInteraction.Press>()
+      assertThat(interactions[1]).isInstanceOf<PressInteraction.Release>()
+      val press = interactions[0] as PressInteraction.Press
+      val release = interactions[1] as PressInteraction.Release
+      assertThat(release.press).isSameInstanceAs(press)
+    } finally {
+      collectionScope.cancel()
+    }
+  }
+
+  @Test
+  fun cancelledSpecimenDragEmitsPressAndCancelInteractions() = runComposeUiTest {
+    val interactionSource = MutableInteractionSource()
+    val interactions = mutableListOf<Interaction>()
+    val collectionScope = CoroutineScope(Dispatchers.Unconfined)
+    var showSpecimen by mutableStateOf(true)
+    try {
+      collectionScope.launch {
+        interactionSource.interactions.collect(interactions::add)
+      }
+      setContent {
+        if (showSpecimen) {
+          GlassLabSampleContent(
+            state = GlassLabState(),
+            recordingMode = false,
+            onStateChanged = {},
+            onRecordingModeChanged = {},
+            onBack = {},
+            specimenInteractionSource = interactionSource,
+          )
+        }
+      }
+
+      val specimen = onNodeWithContentDescription("Glass specimen")
+      specimen.performTouchInput { down(center) }
+      specimen.performTouchInput {
+        updatePointerTo(0, center + Offset(80f, 40f))
+        move()
+      }
+      showSpecimen = false
+      waitUntil { interactions.size >= 2 }
+
+      assertThat(interactions[0]).isInstanceOf<PressInteraction.Press>()
+      assertThat(interactions[1]).isInstanceOf<PressInteraction.Cancel>()
+      val press = interactions[0] as PressInteraction.Press
+      val cancel = interactions[1] as PressInteraction.Cancel
+      assertThat(cancel.press).isSameInstanceAs(press)
+    } finally {
+      collectionScope.cancel()
+    }
+  }
+
+  @Test
+  fun regrabbingSpecimenCancelsReturnAtCurrentPosition() = runComposeUiTest {
+    var showSpecimen by mutableStateOf(true)
+    setContent {
+      if (showSpecimen) {
+        GlassLabSampleContent(
+          state = GlassLabState(interaction = GlassLabInteractionMode.Off),
+          recordingMode = false,
+          onStateChanged = {},
+          onRecordingModeChanged = {},
+          onBack = {},
+        )
+      }
+    }
+
+    val specimen = onNodeWithContentDescription("Glass specimen")
+    val initialCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+    specimen.performTouchInput { down(center) }
+    specimen.performTouchInput {
+      updatePointerTo(0, center + Offset(120f, 0f))
+      move()
+    }
+    val autoAdvance = mainClock.autoAdvance
+    mainClock.autoAdvance = false
+    try {
+      specimen.performTouchInput { up() }
+      mainClock.advanceTimeByFrame()
+      mainClock.advanceTimeBy(64)
+      val returningCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+      specimen.performTouchInput { down(center) }
+      specimen.performTouchInput {
+        updatePointerTo(0, center + Offset(0f, 60f))
+        move()
+      }
+      mainClock.advanceTimeByFrame()
+      val regrabbedCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+
+      assertThat(regrabbedCenter.x).isGreaterThan(initialCenter.x)
+      assertThat(regrabbedCenter.x).isLessThanOrEqualTo(returningCenter.x)
+      assertThat(regrabbedCenter.y).isGreaterThan(returningCenter.y)
+      mainClock.advanceTimeBy(500)
+
+      assertThat(specimen.fetchSemanticsNode().boundsInRoot.center.x).isEqualTo(regrabbedCenter.x)
+    } finally {
+      showSpecimen = false
+      mainClock.autoAdvance = autoAdvance
+      waitForIdle()
+    }
+  }
+
+  @Test
+  fun recordingModeSpecimenRemainsDraggable() = runComposeUiTest {
+    setContent {
+      GlassLabSampleContent(
+        state = GlassLabState(),
+        recordingMode = true,
+        onStateChanged = {},
+        onRecordingModeChanged = {},
+        onBack = {},
+      )
+    }
+
+    val specimen = onNodeWithContentDescription("Glass specimen")
+    val initialCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+    specimen.performTouchInput { down(center) }
+    specimen.performTouchInput {
+      updatePointerTo(0, center + Offset(80f, 40f))
+      move()
+    }
+
+    assertThat(specimen.fetchSemanticsNode().boundsInRoot.center.x)
+      .isGreaterThan(initialCenter.x)
+    specimen.performTouchInput { cancel() }
+  }
+
   @Test
   fun narrowLabShowsEveryPresetWithoutHorizontalScrolling() = runComposeUiTest {
     setContent {


### PR DESCRIPTION
## Summary

- make the Glass Lab specimen directly draggable with touch and mouse
- clamp its center to the specimen viewport and spring it back on release or cancellation
- preserve interaction feedback, focus behavior, re-grab interruption, and recording-mode dragging
- add focused Compose UI coverage for drag movement, bounds, lifecycle interactions, return animation, and interruption

## Why

The Glass Lab card was static, which made it harder to explore how glass presets and interaction styles respond over different parts of the backdrop. Direct manipulation makes those effects easier to inspect while keeping the Lab controls and public API unchanged.

## Validation

- `./gradlew :sample:shared:jvmTest :sample:shared:spotlessCheck`
- `./gradlew :sample:screenshot-tests:jvmTest --tests dev.chrisbanes.haze.GlassGalleryDesktopScreenshotTest.labPresets`
- `./gradlew :sample:screenshot-tests:testAndroidHostTest --tests dev.chrisbanes.haze.GlassGalleryPortraitAndroidScreenshotTest.labPresets`
- review-and-simplify and ponytail pre-push reviews