### PR TITLE
Clamp Glass Lab drag return lifecycle

### DIFF
--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
@@ -46,6 +46,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToDown
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.testTag
@@ -183,7 +185,7 @@ private fun LabSpecimen(
           stiffness = Spring.StiffnessMediumLow,
         ),
       ) {
-        dragOffset = value
+        dragOffset = value.coerceCenterTo(viewportSize)
       }
     }
   }
@@ -198,7 +200,10 @@ private fun LabSpecimen(
   }
   Box(
     modifier = modifier
-      .onSizeChanged { viewportSize = it }
+      .onSizeChanged {
+        viewportSize = it
+        dragOffset = dragOffset.coerceCenterTo(it)
+      }
       .testTag("glass_lab_specimen_viewport"),
   ) {
     GalleryBackdrop(
@@ -226,6 +231,16 @@ private fun LabSpecimen(
         }
         .fillMaxWidth(0.85f)
         .sizeIn(maxWidth = 360.dp, maxHeight = 240.dp)
+        .pointerInput(Unit) {
+          awaitPointerEventScope {
+            while (true) {
+              awaitPointerEvent(PointerEventPass.Initial)
+                .changes
+                .firstOrNull { it.changedToDown() }
+                ?.let { returnJob?.cancel() }
+            }
+          }
+        }
         .pointerInput(interactionSource) {
           try {
             detectDragGestures(

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,6 +49,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.changedToDown
+import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.testTag
@@ -173,11 +175,11 @@ private fun LabSpecimen(
   val scope = rememberCoroutineScope()
   var dragOffset by remember { mutableStateOf(Offset.Zero) }
   var viewportSize by remember { mutableStateOf(IntSize.Zero) }
-  var returnJob by remember { mutableStateOf<Job?>(null) }
+  val returnJob = remember { mutableStateOf<Job?>(null) }
   var pressInteraction by remember { mutableStateOf<PressInteraction.Press?>(null) }
   val returnToCenter = {
-    returnJob?.cancel()
-    returnJob = scope.launch {
+    returnJob.value?.cancel()
+    returnJob.value = scope.launch {
       Animatable(dragOffset, Offset.VectorConverter).animateTo(
         targetValue = Offset.Zero,
         animationSpec = spring(
@@ -188,6 +190,9 @@ private fun LabSpecimen(
         dragOffset = value.coerceCenterTo(viewportSize)
       }
     }
+  }
+  LaunchedEffect(viewportSize) {
+    if (returnJob.value != null) returnToCenter()
   }
   val finishDrag = { cancelled: Boolean ->
     pressInteraction?.let { press ->
@@ -234,10 +239,9 @@ private fun LabSpecimen(
         .pointerInput(Unit) {
           awaitPointerEventScope {
             while (true) {
-              awaitPointerEvent(PointerEventPass.Initial)
-                .changes
-                .firstOrNull { it.changedToDown() }
-                ?.let { returnJob?.cancel() }
+              val changes = awaitPointerEvent(PointerEventPass.Initial).changes
+              if (changes.any { it.changedToDown() }) returnJob.value?.cancel()
+              if (changes.any { it.changedToUp() }) returnToCenter()
             }
           }
         }
@@ -245,7 +249,7 @@ private fun LabSpecimen(
           try {
             detectDragGestures(
               onDragStart = { position ->
-                returnJob?.cancel()
+                returnJob.value?.cancel()
                 pressInteraction = PressInteraction.Press(position).also(interactionSource::tryEmit)
               },
               onDragEnd = { finishDrag(false) },

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassLabSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassLabSampleTest.kt
@@ -173,6 +173,13 @@ class GlassLabSampleTest : ContextTest() {
       val viewportBounds = viewport.fetchSemanticsNode().boundsInRoot
       assertThat(specimenCenter.x).isLessThanOrEqualTo(viewportBounds.right + 0.5f)
       assertThat(specimenCenter.y).isLessThanOrEqualTo(viewportBounds.bottom + 0.5f)
+      val clampedOffsetX = specimenCenter.x - viewportBounds.center.x
+      labSize = 800.dp
+      mainClock.advanceTimeBy(64)
+
+      val expandedViewportCenterX = viewport.fetchSemanticsNode().boundsInRoot.center.x
+      assertThat(specimen.fetchSemanticsNode().boundsInRoot.center.x - expandedViewportCenterX)
+        .isLessThanOrEqualTo(clampedOffsetX + 0.5f)
     } finally {
       mainClock.autoAdvance = autoAdvance
     }
@@ -308,6 +315,42 @@ class GlassLabSampleTest : ContextTest() {
       showSpecimen = false
       mainClock.autoAdvance = autoAdvance
       waitForIdle()
+    }
+  }
+
+  @Test
+  fun tappingSpecimenDuringReturnResumesReturnToCenter() = runComposeUiTest {
+    setContent {
+      GlassLabSampleContent(
+        state = GlassLabState(interaction = GlassLabInteractionMode.Off),
+        recordingMode = false,
+        onStateChanged = {},
+        onRecordingModeChanged = {},
+        onBack = {},
+      )
+    }
+
+    val specimen = onNodeWithContentDescription("Glass specimen")
+    val initialCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+    specimen.performTouchInput { down(center) }
+    specimen.performTouchInput {
+      updatePointerTo(0, center + Offset(120f, 0f))
+      move()
+    }
+    val autoAdvance = mainClock.autoAdvance
+    mainClock.autoAdvance = false
+    try {
+      specimen.performTouchInput { up() }
+      mainClock.advanceTimeBy(64)
+      specimen.performTouchInput { down(center) }
+      specimen.performTouchInput { up() }
+      mainClock.advanceTimeUntil(timeoutMillis = 5_000) {
+        specimen.fetchSemanticsNode().boundsInRoot.center == initialCenter
+      }
+
+      assertThat(specimen.fetchSemanticsNode().boundsInRoot.center).isEqualTo(initialCenter)
+    } finally {
+      mainClock.autoAdvance = autoAdvance
     }
   }
 

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassLabSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassLabSampleTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -134,6 +135,50 @@ class GlassLabSampleTest : ContextTest() {
   }
 
   @Test
+  fun specimenReturnIsClampedWhenViewportShrinks() = runComposeUiTest {
+    var labSize by mutableStateOf(800.dp)
+    setContent {
+      GlassLabSampleContent(
+        state = GlassLabState(),
+        recordingMode = false,
+        onStateChanged = {},
+        onRecordingModeChanged = {},
+        onBack = {},
+        modifier = Modifier.size(labSize, labSize / 2),
+      )
+    }
+
+    val viewport = onNodeWithTag("glass_lab_specimen_viewport")
+    val specimen = onNodeWithContentDescription("Glass specimen")
+    specimen.performTouchInput { down(center) }
+    specimen.performTouchInput {
+      updatePointerTo(0, center + Offset(10_000f, 10_000f))
+      move()
+    }
+    waitForIdle()
+    assertThat(specimen.fetchSemanticsNode().boundsInRoot.center)
+      .isEqualTo(viewport.fetchSemanticsNode().boundsInRoot.bottomRight)
+    val autoAdvance = mainClock.autoAdvance
+    mainClock.autoAdvance = false
+    try {
+      specimen.performTouchInput { up() }
+      mainClock.advanceTimeBy(64)
+      val returningCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+      assertThat(returningCenter.x)
+        .isGreaterThan(viewport.fetchSemanticsNode().boundsInRoot.center.x)
+      labSize = 300.dp
+      mainClock.advanceTimeByFrame()
+
+      val specimenCenter = specimen.fetchSemanticsNode().boundsInRoot.center
+      val viewportBounds = viewport.fetchSemanticsNode().boundsInRoot
+      assertThat(specimenCenter.x).isLessThanOrEqualTo(viewportBounds.right + 0.5f)
+      assertThat(specimenCenter.y).isLessThanOrEqualTo(viewportBounds.bottom + 0.5f)
+    } finally {
+      mainClock.autoAdvance = autoAdvance
+    }
+  }
+
+  @Test
   fun specimenDragEmitsPressAndReleaseInteractions() = runComposeUiTest {
     val interactionSource = MutableInteractionSource()
     val interactions = mutableListOf<Interaction>()
@@ -244,6 +289,8 @@ class GlassLabSampleTest : ContextTest() {
       mainClock.advanceTimeBy(64)
       val returningCenter = specimen.fetchSemanticsNode().boundsInRoot.center
       specimen.performTouchInput { down(center) }
+      mainClock.advanceTimeBy(500)
+      assertThat(specimen.fetchSemanticsNode().boundsInRoot.center).isEqualTo(returningCenter)
       specimen.performTouchInput {
         updatePointerTo(0, center + Offset(0f, 60f))
         move()


### PR DESCRIPTION
Follow-up to #1165, which auto-merged before the review fixes were pushed.\n\n- clamp the specimen immediately and throughout return animation when the viewport changes\n- cancel return animation on pointer down, before touch slop\n- add focused regression coverage for both lifecycles\n\nValidation: Reusing configuration cache.
> Task :haze:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :haze:generateComposeResClass SKIPPED
> Task :haze-utils:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze-utils:convertXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze-utils:convertXmlValueResourcesForSkikoMain NO-SOURCE
> Task :haze:convertXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze-utils:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze:copyNonXmlValueResourcesForSkikoMain NO-SOURCE
> Task :haze-utils:copyNonXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze:copyNonXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze:kmpPartiallyResolvedDependenciesChecker
> Task :haze:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :haze-utils:checkJvmMainComposeLibrariesCompatibility
> Task :haze:checkJvmMainComposeLibrariesCompatibility
> Task :haze-utils:generateComposeResClass SKIPPED
> Task :haze-utils:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :haze:convertXmlValueResourcesForSkikoMain NO-SOURCE
> Task :haze-utils:kmpPartiallyResolvedDependenciesChecker
> Task :haze-utils:prepareComposeResourcesTaskForJvmMain NO-SOURCE
> Task :haze-utils:copyNonXmlValueResourcesForSkikoMain NO-SOURCE
> Task :haze-utils:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :haze-utils:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :haze-utils:generateResourceAccessorsForJvmMain SKIPPED
> Task :haze-utils:generateResourceAccessorsForCommonMain SKIPPED
> Task :haze-blur:generateComposeResClass SKIPPED
> Task :haze:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :haze-blur:checkJvmMainComposeLibrariesCompatibility
> Task :haze:generateResourceAccessorsForCommonMain SKIPPED
> Task :haze-blur:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :haze:prepareComposeResourcesTaskForSkikoMain NO-SOURCE
> Task :haze-blur:convertXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze-blur:convertXmlValueResourcesForSkikoMain NO-SOURCE
> Task :haze-utils:prepareComposeResourcesTaskForSkikoMain NO-SOURCE
> Task :haze-blur:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze:generateResourceAccessorsForSkikoMain SKIPPED
> Task :haze-blur:kmpPartiallyResolvedDependenciesChecker
> Task :haze:prepareComposeResourcesTaskForJvmMain NO-SOURCE
> Task :haze-glass:kmpPartiallyResolvedDependenciesChecker
> Task :haze-glass:checkJvmMainComposeLibrariesCompatibility
> Task :haze-blur:copyNonXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze-utils:generateResourceAccessorsForSkikoMain SKIPPED
> Task :haze-glass:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :haze-blur:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :haze-utils:generateActualResourceCollectorsForJvmMain SKIPPED
> Task :haze:generateResourceAccessorsForJvmMain SKIPPED
> Task :haze:generateActualResourceCollectorsForJvmMain SKIPPED
> Task :haze-blur:copyNonXmlValueResourcesForSkikoMain NO-SOURCE
> Task :haze-blur:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze-glass:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze-glass:generateComposeResClass SKIPPED
> Task :haze-glass:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :haze-blur:prepareComposeResourcesTaskForJvmMain NO-SOURCE
> Task :haze-glass:convertXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze-glass:convertXmlValueResourcesForSkikoMain NO-SOURCE
> Task :haze-blur:generateResourceAccessorsForJvmMain SKIPPED
> Task :haze-glass:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze-blur:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :haze-utils:assembleJvmMainResources UP-TO-DATE
> Task :haze-blur:generateResourceAccessorsForCommonMain SKIPPED
> Task :haze-glass:copyNonXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze-glass:copyNonXmlValueResourcesForSkikoMain NO-SOURCE
> Task :haze-materials:kmpPartiallyResolvedDependenciesChecker
> Task :haze-materials:checkJvmMainComposeLibrariesCompatibility
> Task :haze-materials:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :haze:assembleJvmMainResources UP-TO-DATE
> Task :haze-materials:generateComposeResClass SKIPPED
> Task :haze-blur:prepareComposeResourcesTaskForSkikoMain NO-SOURCE
> Task :haze-utils:jvmProcessResources UP-TO-DATE
> Task :haze-utils:processJvmMainResources SKIPPED
> Task :haze-glass:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :haze-glass:generateResourceAccessorsForCommonMain SKIPPED
> Task :haze-blur:generateResourceAccessorsForSkikoMain SKIPPED
> Task :haze-blur:generateActualResourceCollectorsForJvmMain SKIPPED
> Task :haze-materials:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze-materials:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :haze:jvmProcessResources UP-TO-DATE
> Task :haze:processJvmMainResources SKIPPED
> Task :haze-glass:prepareComposeResourcesTaskForJvmMain NO-SOURCE
> Task :haze-glass:generateResourceAccessorsForJvmMain SKIPPED
> Task :haze-blur:assembleJvmMainResources UP-TO-DATE
> Task :internal:context-test:checkJvmMainComposeLibrariesCompatibility
> Task :haze-glass:prepareComposeResourcesTaskForSkikoMain NO-SOURCE
> Task :internal:context-test:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :haze-glass:generateResourceAccessorsForSkikoMain SKIPPED
> Task :haze-glass:generateActualResourceCollectorsForJvmMain SKIPPED
> Task :haze-materials:convertXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze-blur:jvmProcessResources UP-TO-DATE
> Task :haze-blur:processJvmMainResources SKIPPED
> Task :haze-glass:assembleJvmMainResources UP-TO-DATE
> Task :internal:context-test:generateComposeResClass SKIPPED
> Task :haze-materials:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze-glass:jvmProcessResources UP-TO-DATE
> Task :haze-utils:compileKotlinJvm UP-TO-DATE
> Task :internal:context-test:convertXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze-glass:processJvmMainResources SKIPPED
> Task :internal:context-test:kmpPartiallyResolvedDependenciesChecker
> Task :sample:shared:checkJvmMainComposeLibrariesCompatibility
> Task :internal:context-test:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :haze-materials:copyNonXmlValueResourcesForJvmMain NO-SOURCE
> Task :sample:shared:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :sample:shared:kmpPartiallyResolvedDependenciesChecker
> Task :sample:shared:generateComposeResClass SKIPPED
> Task :sample:shared:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :internal:context-test:convertXmlValueResourcesForCommonMain NO-SOURCE
> Task :sample:shared:generateExpectResourceCollectorsForCommonMain SKIPPED
> Task :haze-materials:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :haze-utils:compileJvmMainJava NO-SOURCE
> Task :sample:shared:convertXmlValueResourcesForJvmMain NO-SOURCE
> Task :sample:shared:convertXmlValueResourcesForSkikoMain NO-SOURCE
> Task :internal:context-test:copyNonXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze-materials:generateResourceAccessorsForCommonMain SKIPPED
> Task :haze-utils:jvmMainClasses UP-TO-DATE
> Task :sample:shared:checkJvmTestComposeLibrariesCompatibility
> Task :haze-materials:prepareComposeResourcesTaskForJvmMain NO-SOURCE
> Task :sample:shared:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :internal:context-test:copyNonXmlValueResourcesForCommonMain NO-SOURCE
> Task :haze-materials:generateResourceAccessorsForJvmMain SKIPPED
> Task :haze-materials:generateActualResourceCollectorsForJvmMain SKIPPED
> Task :sample:shared:convertXmlValueResourcesForCommonTest NO-SOURCE
> Task :haze-materials:assembleJvmMainResources UP-TO-DATE
> Task :sample:shared:copyNonXmlValueResourcesForJvmMain NO-SOURCE
> Task :haze-utils:jvmJar UP-TO-DATE
> Task :sample:shared:copyNonXmlValueResourcesForSkikoMain NO-SOURCE
> Task :sample:shared:convertXmlValueResourcesForJvmTest NO-SOURCE
> Task :haze-materials:jvmProcessResources UP-TO-DATE
> Task :haze-materials:processJvmMainResources SKIPPED
> Task :sample:shared:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :sample:shared:generateResourceAccessorsForCommonMain SKIPPED
> Task :internal:context-test:prepareComposeResourcesTaskForCommonMain NO-SOURCE
> Task :internal:context-test:prepareComposeResourcesTaskForJvmMain NO-SOURCE
> Task :sample:shared:copyNonXmlValueResourcesForCommonTest NO-SOURCE
> Task :internal:context-test:generateResourceAccessorsForJvmMain SKIPPED
> Task :sample:shared:prepareComposeResourcesTaskForSkikoMain NO-SOURCE
> Task :internal:context-test:generateResourceAccessorsForCommonMain SKIPPED
> Task :internal:context-test:generateActualResourceCollectorsForJvmMain SKIPPED
> Task :sample:shared:prepareComposeResourcesTaskForJvmMain NO-SOURCE
> Task :sample:shared:generateResourceAccessorsForSkikoMain SKIPPED
> Task :sample:shared:generateResourceAccessorsForJvmMain SKIPPED
> Task :internal:context-test:assembleJvmMainResources UP-TO-DATE
> Task :sample:shared:generateActualResourceCollectorsForJvmMain SKIPPED
> Task :sample:shared:copyNonXmlValueResourcesForJvmTest NO-SOURCE
> Task :sample:shared:assembleJvmMainResources UP-TO-DATE
> Task :sample:shared:prepareComposeResourcesTaskForCommonTest NO-SOURCE
> Task :sample:shared:generateResourceAccessorsForCommonTest SKIPPED
> Task :internal:context-test:jvmProcessResources UP-TO-DATE
> Task :sample:shared:prepareComposeResourcesTaskForJvmTest NO-SOURCE
> Task :internal:context-test:processJvmMainResources SKIPPED
> Task :sample:shared:jvmProcessResources UP-TO-DATE
> Task :sample:shared:processJvmMainResources SKIPPED
> Task :sample:shared:generateResourceAccessorsForJvmTest SKIPPED
> Task :sample:shared:assembleJvmTestResources UP-TO-DATE
> Task :sample:shared:jvmTestProcessResources UP-TO-DATE
> Task :haze:compileKotlinJvm UP-TO-DATE
> Task :internal:context-test:compileKotlinJvm UP-TO-DATE
> Task :sample:shared:processJvmTestResources SKIPPED
> Task :haze:compileJvmMainJava NO-SOURCE
> Task :haze:jvmMainClasses UP-TO-DATE
> Task :internal:context-test:compileJvmMainJava NO-SOURCE
> Task :internal:context-test:jvmMainClasses UP-TO-DATE
> Task :haze:jvmJar UP-TO-DATE
> Task :internal:context-test:jvmJar UP-TO-DATE
> Task :sample:shared:spotlessKotlin UP-TO-DATE
> Task :sample:shared:spotlessKotlinGradle UP-TO-DATE
> Task :haze-blur:compileKotlinJvm UP-TO-DATE
> Task :haze-glass:compileKotlinJvm UP-TO-DATE
> Task :sample:shared:spotlessKotlinGradleCheck UP-TO-DATE
> Task :haze-glass:compileJvmMainJava NO-SOURCE
> Task :haze-glass:jvmMainClasses UP-TO-DATE
> Task :haze-blur:compileJvmMainJava NO-SOURCE
> Task :haze-blur:jvmMainClasses UP-TO-DATE
> Task :sample:shared:spotlessKotlinCheck UP-TO-DATE
> Task :sample:shared:spotlessCheck UP-TO-DATE
> Task :haze-blur:jvmJar UP-TO-DATE
> Task :haze-glass:jvmJar UP-TO-DATE
> Task :haze-materials:compileKotlinJvm UP-TO-DATE
> Task :haze-materials:compileJvmMainJava NO-SOURCE
> Task :haze-materials:jvmMainClasses UP-TO-DATE
> Task :haze-materials:jvmJar UP-TO-DATE
> Task :sample:shared:compileKotlinJvm UP-TO-DATE
> Task :sample:shared:compileJvmMainJava NO-SOURCE
> Task :sample:shared:jvmMainClasses UP-TO-DATE
> Task :sample:shared:jvmJar UP-TO-DATE
> Task :sample:shared:compileTestKotlinJvm UP-TO-DATE
> Task :sample:shared:compileJvmTestJava NO-SOURCE
> Task :sample:shared:jvmTestClasses UP-TO-DATE
> Task :sample:shared:jvmTest UP-TO-DATE

BUILD SUCCESSFUL in 529ms
51 actionable tasks: 15 executed, 36 up-to-date

Publishing Build Scan to Develocity...
https://gradle.com/s/sc2xz226db3ei

Configuration cache entry reused.