### PR TITLE
Publish Haze Glass

### DIFF
--- a/haze-glass/build.gradle.kts
+++ b/haze-glass/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
   id("dev.chrisbanes.kotlin.multiplatform")
   id("dev.chrisbanes.compose")
   id("org.jetbrains.dokka")
-  // Publishing is disabled until API and visual quality are finalized.
+  id("com.vanniktech.maven.publish")
   id("dev.chrisbanes.metalava")
   id("dev.drewhamilton.poko")
 }

--- a/haze-glass/gradle.properties
+++ b/haze-glass/gradle.properties
@@ -1,4 +1,2 @@
-# Publishing disabled until API and visual quality are finalized.
-# Uncomment when ready to ship, along with adding @ExperimentalHazeApi.
-# POM_ARTIFACT_ID=haze-glass
-# POM_NAME=Haze Glass
+POM_ARTIFACT_ID=haze-glass
+POM_NAME=Haze Glass


### PR DESCRIPTION
## Summary

Enables the existing Vanniktech Maven publishing convention for the haze-glass Kotlin Multiplatform module and activates its standard artifact metadata.

Fixes #1167

## Validation

- ./gradlew :haze-glass:tasks --all --console=plain :haze-glass:publishToMavenLocal :haze-glass:check
- Confirmed Android, iOS, JS, JVM, Kotlin Multiplatform, and Wasm JS Maven Local publication tasks.
- Confirmed Maven Local includes the haze-glass root POM and Gradle module metadata.

## Residual risk

This changes publication configuration only; it does not publish externally. Consumer resolution against Maven Local is covered by generated POM and Gradle module metadata inspection.