### PR TITLE
Release cleared Blur retained output

### DIFF
--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
@@ -65,18 +65,12 @@ internal class RenderScriptBlurVisualEffectDelegate(
 
   private var currentJob: Job? = null
   private var drawSkipped: Boolean = false
-  private var retainedOutputAvailable: Boolean = false
-
-  @Volatile
-  private var retainedOutputPending: Boolean = false
-
-  @Volatile
-  private var retainedOutputGeneration: Int = 0
+  private val retainedOutputState = BlurRetainedOutputState()
 
   @Volatile
   private var trimGeneration = 0
 
-  private val contentLayer: GraphicsLayer = graphicsContext.createGraphicsLayer()
+  private var contentLayer: GraphicsLayer? = null
 
   override fun DrawScope.draw(context: HazeEffectRuntimeDrawScope) {
     val density = context.requireDensity()
@@ -108,8 +102,10 @@ internal class RenderScriptBlurVisualEffectDelegate(
         backgroundColor = blurVisualEffect.backgroundColor,
       )?.let { layer ->
         layer.clip = blurVisualEffect.shouldClipToNodeBounds()
-        retainedOutputPending = true
-        val retainedOutputGenerationAtStart = retainedOutputGeneration
+        if (contentLayer == null || contentLayer!!.isReleased) {
+          contentLayer = graphicsContext.createGraphicsLayer()
+        }
+        val retainedOutputGenerationAtStart = retainedOutputState.beginOutputUpdate()
 
         currentJob = context.coroutineScope.launch(Dispatchers.Main.immediate) {
           try {
@@ -121,7 +117,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
               retainedOutputGenerationAtStart = retainedOutputGenerationAtStart,
             )
           } finally {
-            retainedOutputPending = false
+            retainedOutputState.finishOutputUpdate(retainedOutputGenerationAtStart)
             // Release the graphics layer even if updateSurface was cancelled
             graphicsContext.releaseGraphicsLayer(layer)
           }
@@ -136,7 +132,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
       // Mark this draw as skipped
       drawSkipped = true
     } else if (!canDrawRetainedOutput()) {
-      if (retainedOutputPending) {
+      if (retainedOutputState.isPending) {
         drawSkipped = true
       }
       return
@@ -158,7 +154,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
           scaledSize = size * scaleFactor,
           clip = blurVisualEffect.shouldClipToNodeBounds(),
         ) {
-          drawLayer(contentLayer)
+          contentLayer?.let(::drawLayer)
         }
 
         val expandedSize = size.expand(
@@ -216,7 +212,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
 
   private fun shouldUpdateLayer(): Boolean = when {
     // We don't have a layer yet...
-    contentLayer.size == IntSize.Zero -> true
+    contentLayer == null || contentLayer!!.isReleased || contentLayer!!.size == IntSize.Zero -> true
     // No ongoing update, so start an update...
     currentJob?.isActive != true -> true
     // Otherwise, there must be a job ongoing, skip this update
@@ -239,9 +235,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
         .onFailure { HazeLogger.d(TAG) { "Failed to recreate RenderScript after trim" } }
       // Bump generation so in-flight coroutines know their context is stale
       trimGeneration++
-      retainedOutputGeneration++
-      retainedOutputAvailable = false
-      retainedOutputPending = false
+      releaseRetainedOutput()
       // Force the next draw to recreate the layer from scratch
       drawSkipped = true
       context.invalidateDraw()
@@ -306,27 +300,29 @@ internal class RenderScriptBlurVisualEffectDelegate(
             // Finally draw the updated bitmap to our drawing graphics layer
             val output = rs.outputBitmap
 
-            contentLayer.record(
+            val outputLayer = contentLayer ?: return@trace
+            outputLayer.record(
               density = density,
               layoutDirection = context.currentValueOf(LocalLayoutDirection),
               size = IntSize(output.width, output.height),
             ) {
               drawImage(output.asImageBitmap())
             }
-            retainedOutputAvailable = true
+            retainedOutputState.completeOutputUpdate(retainedOutputGenerationAtStart)
           }
         } else {
           if (!isUpdateCurrent(generationAtStart, retainedOutputGenerationAtStart)) return@traceAsync
 
           // If the blur radius is 0, we just copy the input content into our contentLayer
-          contentLayer.record(
+          val outputLayer = contentLayer ?: return@traceAsync
+          outputLayer.record(
             density = density,
             layoutDirection = context.currentValueOf(LocalLayoutDirection),
             size = paddedContent.size,
           ) {
             drawLayer(paddedContent)
           }
-          retainedOutputAvailable = true
+          retainedOutputState.completeOutputUpdate(retainedOutputGenerationAtStart)
         }
 
         HazeLogger.d(TAG) { "Output updated in layer" }
@@ -344,7 +340,7 @@ internal class RenderScriptBlurVisualEffectDelegate(
     retainedOutputGenerationAtStart: Int,
   ): Boolean {
     return trimGeneration == trimGenerationAtStart &&
-      retainedOutputGeneration == retainedOutputGenerationAtStart
+      retainedOutputState.generation == retainedOutputGenerationAtStart
   }
 
   /**
@@ -392,29 +388,32 @@ internal class RenderScriptBlurVisualEffectDelegate(
   }
 
   override fun canDrawRetainedOutput(): Boolean {
-    return retainedOutputAvailable &&
-      !contentLayer.isReleased &&
-      contentLayer.size != IntSize.Zero
+    return retainedOutputState.isAvailable &&
+      contentLayer?.isReleased == false &&
+      contentLayer?.size != IntSize.Zero
   }
 
   override fun shouldDrawRetainedOutput(): Boolean {
-    return canDrawRetainedOutput() || retainedOutputPending
+    return canDrawRetainedOutput() || retainedOutputState.isPending
   }
 
   override fun clearRetainedOutput() {
-    retainedOutputGeneration++
-    retainedOutputAvailable = false
-    retainedOutputPending = false
+    releaseRetainedOutput()
   }
 
   override fun detach() {
-    currentJob?.cancel()
-    retainedOutputGeneration++
-    retainedOutputAvailable = false
-    retainedOutputPending = false
-    graphicsContext.releaseGraphicsLayer(contentLayer)
-    renderScriptContext?.release()
+    releaseRetainedOutput()
     runCatching { renderScript.destroy() }
+  }
+
+  private fun releaseRetainedOutput() {
+    currentJob?.cancel()
+    currentJob = null
+    retainedOutputState.clear()
+    contentLayer?.let(graphicsContext::releaseGraphicsLayer)
+    contentLayer = null
+    renderScriptContext?.release()
+    renderScriptContext = null
   }
 
   internal companion object {

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
@@ -118,7 +118,7 @@ internal class RenderEffectBlurVisualEffectDelegate(
   }
 
   override fun clearRetainedOutput() {
-    retainedOutputAvailable = false
+    releaseRetainedResources()
   }
 
   override fun detach() {

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -276,6 +276,40 @@ internal interface RetainedOutputDelegate {
   fun clearRetainedOutput()
 }
 
+/** Tracks whether an asynchronously generated Blur output is still valid for presentation. */
+internal class BlurRetainedOutputState {
+  var generation: Int = 0
+    private set
+  var isAvailable: Boolean = false
+    private set
+  var isPending: Boolean = false
+    private set
+
+  fun beginOutputUpdate(): Int {
+    isPending = true
+    return generation
+  }
+
+  fun completeOutputUpdate(generationAtStart: Int): Boolean {
+    if (generation != generationAtStart) return false
+    isPending = false
+    isAvailable = true
+    return true
+  }
+
+  fun finishOutputUpdate(generationAtStart: Int) {
+    if (generation == generationAtStart) {
+      isPending = false
+    }
+  }
+
+  fun clear() {
+    generation++
+    isAvailable = false
+    isPending = false
+  }
+}
+
 internal expect fun BlurVisualEffect.updateDelegate(
   context: HazeEffectRuntimeDrawScope,
   drawScope: DrawScope,

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurRetainedOutputStateTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurRetainedOutputStateTest.kt
@@ -1,0 +1,44 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class BlurRetainedOutputStateTest {
+
+  @Test
+  fun clear_invalidatesPendingOutputUntilFreshOutputCompletes() {
+    val state = BlurRetainedOutputState()
+    val staleGeneration = state.beginOutputUpdate()
+
+    state.clear()
+
+    assertThat(state.isAvailable).isFalse()
+    assertThat(state.isPending).isFalse()
+    assertThat(state.completeOutputUpdate(staleGeneration)).isFalse()
+    assertThat(state.isAvailable).isFalse()
+
+    val freshGeneration = state.beginOutputUpdate()
+
+    assertThat(state.isPending).isTrue()
+    assertThat(state.completeOutputUpdate(freshGeneration)).isTrue()
+    assertThat(state.isAvailable).isTrue()
+  }
+
+  @Test
+  fun repeatedClears_keepOutputUnavailableWithoutStartingWork() {
+    val state = BlurRetainedOutputState()
+
+    state.clear()
+    state.clear()
+
+    assertThat(state.isAvailable).isFalse()
+    assertThat(state.isPending).isFalse()
+    assertThat(state.generation).isEqualTo(2)
+  }
+}

--- a/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegateTrimMemoryTest.kt
+++ b/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegateTrimMemoryTest.kt
@@ -61,6 +61,22 @@ class RenderEffectBlurVisualEffectDelegateTrimMemoryTest {
     assertThat(delegate.getPrivateField<Size?>("lastScaledLayerSize")).isEqualTo(null)
     assertThat(context.invalidateDrawCalls).isEqualTo(1)
   }
+
+  @Test
+  fun clearRetainedOutput_releasesLayerMetadataAndAvailability() {
+    val delegate = RenderEffectBlurVisualEffectDelegate(
+      HazeBlurFactory.createRenderer() as BlurVisualEffect,
+    )
+    delegate.setPrivateField("retainedOutputAvailable", true)
+    delegate.setPrivateField("lastScaledLayerSize", Size(10f, 10f))
+
+    delegate.clearRetainedOutput()
+
+    assertThat(delegate.getPrivateField<Boolean>("retainedOutputAvailable")).isFalse()
+    assertThat(delegate.getPrivateField<Size?>("lastScaledLayerSize")).isEqualTo(null)
+    assertThat(delegate.getPrivateField<Any?>("scaledContentLayer")).isEqualTo(null)
+    assertThat(delegate.getPrivateField<Any?>("graphicsContext")).isEqualTo(null)
+  }
 }
 
 private fun Any.setPrivateField(name: String, value: Any?) {


### PR DESCRIPTION
Fixes #1168

## Rationale
ClearWhenUnavailable now releases backend-owned Blur output rather than only hiding it. RenderScript also cancels and generation-invalidates queued work, so stale output cannot be published after a clear.

## Validation
- ./gradlew :haze-blur:jvmTest :haze-blur:spotlessCheck
- ./gradlew :haze-blur:compileAndroidMain

## Risks
The RenderScript lifecycle is compile- and state-seam-tested only; no physical device or emulator was used because no device lease was granted.