### PR TITLE
Skip Blur and Glass rendering work at zero alpha

### DIFF
--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectDelegate.kt
@@ -73,6 +73,8 @@ internal class RenderScriptBlurVisualEffectDelegate(
   private var contentLayer: GraphicsLayer? = null
 
   override fun DrawScope.draw(context: HazeEffectRuntimeDrawScope) {
+    if (blurVisualEffect.alpha == 0f) return
+
     val density = context.requireDensity()
     val offset = context.layerOffset
     var scaleFactor = blurVisualEffect.resolveInputScaleFactor(context)

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
@@ -36,6 +36,8 @@ internal class RenderEffectBlurVisualEffectDelegate(
   private var retainedOutputAvailable: Boolean = false
 
   override fun DrawScope.draw(context: HazeEffectRuntimeDrawScope) {
+    if (blurVisualEffect.alpha == 0f) return
+
     // Calculate scaled layer size to detect size changes (needs re-allocation)
     val scaleFactor = blurVisualEffect.resolveInputScaleFactor(context)
     val currentScaledSize = (context.layerSize * scaleFactor).roundToIntSize().let {

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -108,6 +108,12 @@ internal class BlurVisualEffect :
     }
   }
 
+  override fun shouldPrepareDraw(style: HazeBlurStyle): Boolean {
+    if (alpha != 0f) return true
+    resetDirtyTracker()
+    return false
+  }
+
   override fun HazeEffectDrawScope.draw(style: HazeBlurStyle) {
     val runtimeScope = this as HazeEffectRuntimeDrawScope
     try {

--- a/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurModifierTest.kt
+++ b/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurModifierTest.kt
@@ -11,9 +11,14 @@ import androidx.compose.runtime.CompositionLocal
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
@@ -22,12 +27,24 @@ import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isTrue
+import dev.chrisbanes.haze.Bitmask
+import dev.chrisbanes.haze.HazeEffectDrawScope
+import dev.chrisbanes.haze.HazeEffectFactory
+import dev.chrisbanes.haze.HazeEffectInputSnapshot
 import dev.chrisbanes.haze.HazeEffectLifecycleScope
+import dev.chrisbanes.haze.HazeEffectRenderer
+import dev.chrisbanes.haze.HazeEffectRendererDrawHooks
+import dev.chrisbanes.haze.HazeEffectRendererLifecycle
+import dev.chrisbanes.haze.HazeEffectRendererRetainedOutput
 import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeSampling
@@ -35,6 +52,7 @@ import dev.chrisbanes.haze.HazeSourceRetention
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.PlatformContext
+import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -43,6 +61,207 @@ import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalTestApi::class, InternalHazeApi::class)
 class HazeBlurModifierTest {
+
+  @Test
+  fun sourceInput_zeroAlphaDefersInvalidationAndKeepsLastFrame() = runComposeUiTest {
+    val hazeState = HazeState()
+    val sourceColor = mutableStateOf(Color.Red)
+    val showSource = mutableStateOf(true)
+    val alpha = mutableStateOf(0.5f)
+    val renderer = RecordingBlurRenderer()
+    val factory = HazeEffectFactory<HazeBlurStyle> { renderer }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        if (showSource.value) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .background(sourceColor.value)
+              .hazeSource(hazeState),
+          )
+        }
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("effect")
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Sources(
+                state = hazeState,
+                retention = HazeSourceRetention.KeepLastFrame,
+              ),
+              style = testBlurStyle(alpha.value),
+              sampling = HazeSampling.FullResolution,
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val visibleDraws = renderer.drawCount
+    assertThat(renderer.canDrawRetainedOutput()).isTrue()
+
+    alpha.value = 0f
+    waitForIdle()
+    val drawsBeforeInvalidation = renderer.drawCount
+    sourceColor.value = Color.Blue
+    waitForIdle()
+    showSource.value = false
+    waitForIdle()
+
+    assertThat(drawsBeforeInvalidation).isEqualTo(visibleDraws)
+    assertThat(renderer.drawCount).isEqualTo(drawsBeforeInvalidation)
+    assertThat(renderer.canDrawRetainedOutput()).isTrue()
+
+    alpha.value = 0.5f
+    waitForIdle()
+
+    assertThat(renderer.drawCount).isGreaterThan(drawsBeforeInvalidation)
+    val drawsWithoutSource = renderer.drawCount
+
+    showSource.value = true
+    waitForIdle()
+
+    assertThat(renderer.drawCount).isGreaterThan(drawsWithoutSource)
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Blue)
+  }
+
+  @Test
+  fun sourceInput_clearWhenUnavailableStillReleasesWhileAlphaIsZero() = runComposeUiTest {
+    val hazeState = HazeState()
+    val showSource = mutableStateOf(true)
+    val alpha = mutableStateOf(0.5f)
+    val renderer = RecordingBlurRenderer()
+    val factory = HazeEffectFactory<HazeBlurStyle> { renderer }
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        if (showSource.value) {
+          Box(Modifier.fillMaxSize().background(Color.Red).hazeSource(hazeState))
+        }
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Sources(
+                state = hazeState,
+                retention = HazeSourceRetention.ClearWhenUnavailable,
+              ),
+              style = testBlurStyle(alpha.value),
+              sampling = HazeSampling.FullResolution,
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    assertThat(renderer.canDrawRetainedOutput()).isTrue()
+    val clearsBeforeUnavailable = renderer.clearCount
+
+    alpha.value = 0f
+    waitForIdle()
+    showSource.value = false
+    waitForIdle()
+
+    assertThat(renderer.clearCount).isGreaterThan(clearsBeforeUnavailable)
+    assertThat(renderer.canDrawRetainedOutput()).isFalse()
+  }
+
+  @Test
+  fun contentInput_zeroAlphaRetainsEffectLayerAndRefreshesCurrentContentWhenVisible() =
+    runComposeUiTest {
+      val contentColor = mutableStateOf(Color.Red)
+      val alpha = mutableStateOf(0.5f)
+      val renderer = RecordingBlurRenderer()
+      val factory = HazeEffectFactory<HazeBlurStyle> { renderer }
+
+      setContent {
+        Box(
+          Modifier
+            .size(100.dp)
+            .testTag("effect")
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Content,
+              style = testBlurStyle(alpha.value),
+              sampling = HazeSampling.FullResolution,
+            )
+            .background(contentColor.value),
+        )
+      }
+      waitForIdle()
+
+      val visibleDraws = renderer.drawCount
+      assertThat(renderer.canDrawRetainedOutput()).isTrue()
+
+      alpha.value = 0f
+      waitForIdle()
+      val drawsBeforeInvalidation = renderer.drawCount
+      contentColor.value = Color.Blue
+      waitForIdle()
+
+      assertThat(drawsBeforeInvalidation).isEqualTo(visibleDraws)
+      assertThat(renderer.drawCount).isEqualTo(drawsBeforeInvalidation)
+      assertThat(renderer.canDrawRetainedOutput()).isTrue()
+      assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+        .isEqualTo(Color.Blue)
+
+      alpha.value = 0.5f
+      waitForIdle()
+
+      assertThat(renderer.drawCount).isGreaterThan(drawsBeforeInvalidation)
+      assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+        .isEqualTo(Color.Blue)
+    }
+
+  @Test
+  fun zeroAlpha_closesPreparationGateWithoutClearingRetainedOutput() {
+    val effect = BlurVisualEffect()
+    val delegate = ModifierTrackingDelegate(retainedOutputAvailable = true)
+    effect.delegate = delegate
+
+    effect.update(
+      TestLifecycleScope,
+      HazeBlurStyle { alpha(0f) },
+      HazeSampling.Default,
+    )
+
+    assertThat(effect.shouldPrepareDraw(HazeBlurStyle)).isFalse()
+    assertThat(effect.dirtyTracker).isEqualTo(Bitmask())
+    assertThat(effect.canDrawRetainedOutput()).isTrue()
+    assertThat(delegate.clearCount).isEqualTo(0)
+
+    effect.update(
+      TestLifecycleScope,
+      HazeBlurStyle { alpha(0.5f) },
+      HazeSampling.Default,
+    )
+
+    assertThat(effect.shouldPrepareDraw(HazeBlurStyle)).isTrue()
+    assertThat(effect.canDrawRetainedOutput()).isTrue()
+    assertThat(delegate.clearCount).isEqualTo(0)
+  }
+
+  @Test
+  fun zeroAlpha_directRenderEffectEntryDoesNoWork() {
+    val effect = BlurVisualEffect()
+    effect.update(
+      TestLifecycleScope,
+      HazeBlurStyle { alpha(0f) },
+      HazeSampling.Default,
+    )
+    val delegate = RenderEffectBlurVisualEffectDelegate(effect)
+    val context = ZeroAlphaDrawContext()
+
+    context.draw {
+      with(delegate) { draw(context) }
+    }
+
+    assertThat(context.graphicsContextRequests).isEqualTo(0)
+  }
 
   @Test
   fun contentInput_resolvesDefaultsLocalAndExplicitStyles() = runComposeUiTest {
@@ -167,10 +386,59 @@ class HazeBlurModifierTest {
   }
 }
 
-private class ModifierTrackingDelegate : BlurVisualEffect.Delegate {
+private fun testBlurStyle(alpha: Float): HazeBlurStyle = HazeBlurStyle {
+  blurRadius(0.dp)
+  noiseFactor(0f)
+  alpha(alpha)
+}
+
+private class RecordingBlurRenderer :
+  HazeEffectRenderer<HazeBlurStyle>,
+  HazeEffectRendererLifecycle<HazeBlurStyle>,
+  HazeEffectRendererDrawHooks<HazeBlurStyle>,
+  HazeEffectRendererRetainedOutput {
+  private val effect = BlurVisualEffect()
+  private var retainedOutputAvailable = false
+  var drawCount = 0
+    private set
+  var clearCount = 0
+    private set
+
+  override fun attach(scope: HazeEffectLifecycleScope) = effect.attach(scope)
+
+  override fun update(
+    scope: HazeEffectLifecycleScope,
+    style: HazeBlurStyle,
+    sampling: HazeSampling,
+  ) = effect.update(scope, style, sampling)
+
+  override fun shouldPrepareDraw(style: HazeBlurStyle): Boolean =
+    effect.shouldPrepareDraw(style)
+
+  override fun HazeEffectDrawScope.draw(style: HazeBlurStyle) {
+    drawCount++
+    drawInput()
+    retainedOutputAvailable = true
+  }
+
+  override fun canDrawRetainedOutput(): Boolean = retainedOutputAvailable
+
+  override fun clearRetainedOutput() {
+    clearCount++
+    retainedOutputAvailable = false
+  }
+
+  override fun detach() = effect.detach()
+}
+
+private class ModifierTrackingDelegate(
+  private val retainedOutputAvailable: Boolean = false,
+) : BlurVisualEffect.Delegate, RetainedOutputDelegate {
   var attachCount = 0
     private set
   var detachCount = 0
+    private set
+  var clearCount = 0
     private set
 
   override fun attach() {
@@ -182,6 +450,52 @@ private class ModifierTrackingDelegate : BlurVisualEffect.Delegate {
   override fun detach() {
     detachCount++
   }
+
+  override fun canDrawRetainedOutput(): Boolean = retainedOutputAvailable
+
+  override fun clearRetainedOutput() {
+    clearCount++
+  }
+}
+
+@OptIn(InternalHazeApi::class)
+private class ZeroAlphaDrawContext(
+  private val drawScope: CanvasDrawScope = CanvasDrawScope(),
+) : HazeEffectRuntimeDrawScope, DrawScope by drawScope {
+  var graphicsContextRequests = 0
+    private set
+
+  override val modifierSize: Size = Size(10f, 10f)
+  override val modifierBounds: Rect = Rect(Offset.Zero, modifierSize)
+  override val sampling: HazeSampling = HazeSampling.FullResolution
+  override val layerSize: Size = modifierSize
+  override val layerOffset: Offset = Offset.Zero
+  override val hasDrawableInput: Boolean = true
+  override val inputSnapshot: HazeEffectInputSnapshot? = null
+  override val coroutineScope: CoroutineScope = object : CoroutineScope {
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext
+  }
+
+  fun draw(block: DrawScope.() -> Unit) {
+    drawScope.draw(
+      density = Density(1f),
+      layoutDirection = LayoutDirection.Ltr,
+      canvas = Canvas(ImageBitmap(10, 10)),
+      size = modifierSize,
+      block = block,
+    )
+  }
+
+  override fun requirePlatformContext(): PlatformContext = error("Unexpected platform access")
+  override fun requireGraphicsContext(): GraphicsContext {
+    graphicsContextRequests++
+    error("Unexpected graphics context access")
+  }
+  override fun requireDensity(): Density = Density(1f)
+  override fun <T> currentValueOf(local: CompositionLocal<T>): T = error("Unexpected local read")
+  override fun invalidateDraw() = Unit
+  override fun drawInput() = error("Unexpected input capture")
+  override fun DrawScope.drawInput() = error("Unexpected input capture")
 }
 
 @OptIn(InternalHazeApi::class)

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
@@ -32,6 +32,8 @@ internal class FallbackGlassDelegate(
   private var graphicsContext: GraphicsContext? = null
 
   override fun DrawScope.prepareDraw(context: HazeEffectRuntimeDrawScope) {
+    if (effect.alpha == 0f) return
+
     val density = context.requireDensity()
     val layoutDirection = context.currentValueOf(LocalLayoutDirection)
     val style = resolveGlassStyle(effect, size, density, layoutDirection)

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
@@ -383,6 +383,12 @@ internal class GlassRuntimeEffect() :
     }
   }
 
+  override fun shouldPrepareDraw(style: GlassNodeConfiguration): Boolean {
+    if (alpha != 0f) return true
+    resetDirtyTracker()
+    return false
+  }
+
   private fun canReusePreparedDraw(context: HazeEffectRuntimeDrawScope): Boolean {
     val key = preparedDrawCacheKey ?: return false
     val style = resolvedStyleCache ?: return false

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
@@ -76,18 +76,28 @@ class FallbackGlassDelegateTest {
   }
 
   @Test
-  fun alphaZero_releasesAndOwnsNoFallbackGroupLayer() {
-    val effect = GlassRuntimeEffect().apply { alpha = 0.5f }
+  fun alphaZero_skipsFirstPreparationAndRetainsExistingFallbackGroupLayer() {
+    val effect = GlassRuntimeEffect().apply { alpha = 0f }
     val delegate = FallbackGlassDelegate(effect)
     val context = FallbackRecordingContext(size = Size(100f, 100f))
+
+    delegate.prepare(context)
+
+    assertThat(delegate.preparedDrawForTest()).isNull()
+    assertThat(context.graphicsContext.createdLayers).isEqualTo(emptyList())
+
+    effect.alpha = 0.5f
     delegate.prepare(context)
     val groupLayer = checkNotNull(delegate.groupAlphaForTest().layer)
+    val prepared = checkNotNull(delegate.preparedDrawForTest())
 
     effect.alpha = 0f
     delegate.prepare(context)
 
-    assertThat(delegate.groupAlphaForTest().layer).isNull()
-    assertThat(groupLayer in context.graphicsContext.releasedLayers).isTrue()
+    assertThat(delegate.preparedDrawForTest()).isSameInstanceAs(prepared)
+    assertThat(delegate.groupAlphaForTest().layer).isSameInstanceAs(groupLayer)
+    assertThat(context.graphicsContext.createdLayers).isEqualTo(listOf(groupLayer))
+    assertThat(context.graphicsContext.releasedLayers).isEqualTo(emptyList())
   }
 
   @Test
@@ -300,6 +310,12 @@ class FallbackGlassDelegateTest {
     javaClass.getDeclaredField("groupAlpha").run {
       isAccessible = true
       get(this@groupAlphaForTest) as RetainedGlassGroupAlphaLayer
+    }
+
+  private fun FallbackGlassDelegate.preparedDrawForTest(): Any? =
+    javaClass.getDeclaredField("preparedDraw").run {
+      isAccessible = true
+      get(this@preparedDrawForTest)
     }
 
   private fun FallbackGlassDelegate.preparedResourcesForTest(): PreparedResourcesForTest {

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -41,6 +41,7 @@ import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
+import dev.chrisbanes.haze.Bitmask
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeEffectFactory
 import dev.chrisbanes.haze.HazeInput
@@ -65,24 +66,79 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     mutableMapOf<GlassRuntimeEffect, HazeEffectFactory<GlassNodeConfiguration>>()
 
   @Test
-  fun alphaZero_clearsRetainedOutputUntilVisibleFrameRefreshesIt() = runComposeUiTest {
-    val effect = activeDetailEffect().apply { alpha = 0.5f }
+  fun firstAlphaZeroFrame_skipsRuntimeShaderAndLayerGraphPreparation() = runComposeUiTest {
+    var creationAttempts = 0
+    val effect = activeDetailEffect().apply {
+      alpha = 0f
+      runtimeEffectFactory = GlassRuntimeEffectFactory { create ->
+        creationAttempts++
+        create()
+      }
+    }
+
     setContent { RuntimeGlassTestContent(effect, tag = "glass") }
     waitForIdle()
 
+    assertThat(runtime(effect).preparedRender).isNull()
+    assertThat(runtime(effect).delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(runtime(effect).dirtyTracker).isEqualTo(Bitmask())
+    assertThat(creationAttempts).isEqualTo(0)
+
+    effect.alpha = 0.5f
+    waitForIdle()
+
     val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
-    val sourceRecordsBeforeZero = delegate.sourceRecordCount
+    assertThat(creationAttempts).isGreaterThan(0)
+    assertThat(delegate.sourceRecordCount).isGreaterThan(0)
+  }
+
+  @Test
+  fun alphaZero_retainsOutputAndDefersSourceRefreshUntilVisible() = runComposeUiTest {
+    val hazeState = HazeState()
+    val sourceColor = mutableStateOf(Color.Red)
+    val effect = activeDetailEffect().apply { alpha = 0.5f }
+    setContent {
+      Box(Modifier.size(120.dp)) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .background(sourceColor.value)
+            .hazeSource(hazeState),
+        )
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testTag("glass")
+            .testGlass(effect, input = HazeInput.Sources(hazeState)),
+        )
+      }
+    }
+    waitForIdle()
+
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
+    val recordsBeforeZero = delegate.stageRecordCounts
+    val sourceSnapshotBeforeZero = checkNotNull(delegate.lastSuccessfulSourceSnapshot)
 
     effect.alpha = 0f
     waitForIdle()
 
-    assertThat(delegate.canDrawRetainedOutput()).isFalse()
+    assertThat(delegate.canDrawRetainedOutput()).isTrue()
+    assertThat(delegate.stageRecordCounts).isEqualTo(recordsBeforeZero)
+    assertThat(delegate.lastSuccessfulSourceSnapshot).isSameInstanceAs(sourceSnapshotBeforeZero)
+
+    sourceColor.value = Color.Blue
+    waitForIdle()
+
+    assertThat(delegate.canDrawRetainedOutput()).isTrue()
+    assertThat(delegate.stageRecordCounts).isEqualTo(recordsBeforeZero)
+    assertThat(delegate.lastSuccessfulSourceSnapshot).isSameInstanceAs(sourceSnapshotBeforeZero)
 
     effect.alpha = 0.5f
     waitForIdle()
 
     assertThat(delegate.canDrawRetainedOutput()).isTrue()
-    assertThat(delegate.sourceRecordCount).isGreaterThan(sourceRecordsBeforeZero)
+    assertThat(delegate.sourceRecordCount).isGreaterThan(recordsBeforeZero.source)
+    assertThat(delegate.lastSuccessfulSourceSnapshot).isNotSameInstanceAs(sourceSnapshotBeforeZero)
   }
 
   @Test

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -150,6 +150,9 @@ public interface HazeEffectLifecycleScope {
 /** Built-in-only draw hooks which are not part of the third-party renderer contract. */
 @InternalHazeApi
 public interface HazeEffectRendererDrawHooks<Style> {
+  /** Whether the renderer should prepare and draw effect output for the current frame. */
+  public fun shouldPrepareDraw(style: Style): Boolean = true
+
   /** Prepares renderer state immediately before the effect is drawn. */
   public fun HazeEffectRuntimeDrawScope.prepareDraw(style: Style): Unit = Unit
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -496,13 +496,14 @@ internal class HazeEffectNode(
       }
 
       if (this@HazeEffectNode.size.isSpecified && this@HazeEffectNode.layerSize.isSpecified) {
+        val shouldPrepareDraw = shouldPrepareEffectDraw()
         if (state != null) {
           val hasDrawableSourceLayers = hasDrawableSourceLayers()
           if (!retainOutputWhenSourceUnavailable && !hasDrawableSourceLayers) {
             clearRetainedOutput()
           }
 
-          val shouldDrawEffect = if (retainOutputWhenSourceUnavailable) {
+          val shouldDrawEffect = shouldPrepareDraw && if (retainOutputWhenSourceUnavailable) {
             areas.isNotEmpty() || shouldDrawRetainedOutput()
           } else {
             hasDrawableSourceLayers
@@ -522,7 +523,7 @@ internal class HazeEffectNode(
               drawEffectForeground()
             }
           }
-        } else {
+        } else if (shouldPrepareDraw) {
           // Else we're doing content (foreground) blurring, so we need to use our
           // contentDrawArea
           val contentLayer = contentDrawArea.contentLayer
@@ -550,6 +551,10 @@ internal class HazeEffectNode(
             drawEffect()
             drawEffectForeground()
           }
+        } else {
+          withVisualEffectTransform {
+            drawContentSafely()
+          }
         }
       } else {
         HazeLogger.d(TAG) { "-> State not valid, so no need to draw effect." }
@@ -560,6 +565,13 @@ internal class HazeEffectNode(
       onPostDraw()
       HazeLogger.d(TAG) { "-> end draw()" }
     }
+  }
+
+  @OptIn(InternalHazeApi::class)
+  private fun shouldPrepareEffectDraw(): Boolean {
+    val renderer = typedEffectRenderer ?: return true
+    val hooks = renderer as? HazeEffectRendererDrawHooks<Any?> ?: return true
+    return hooks.shouldPrepareDraw(typedEffectStyle)
   }
 
   @OptIn(InternalHazeApi::class)

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectRendererCapabilitiesTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectRendererCapabilitiesTest.kt
@@ -5,14 +5,19 @@
 
 package dev.chrisbanes.haze
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTouchInput
@@ -27,6 +32,32 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class HazeEffectRendererCapabilitiesTest : ContextTest() {
+
+  @Test
+  fun closedPreparationGate_drawsContentWithoutInvokingRendererHooks() = runComposeUiTest {
+    val factory = RecordingCapabilityFactory(shouldPrepareDraw = false)
+
+    setContent {
+      Box(
+        Modifier
+          .size(10.dp)
+          .testTag("effect")
+          .hazeEffect(
+            factory = factory,
+            input = HazeInput.Content,
+            style = "transparent",
+          )
+          .background(Color.Red),
+      )
+    }
+    waitForIdle()
+
+    val renderer = factory.renderers.single()
+    assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[5, 5]).isEqualTo(Color.Red)
+    assertThat(renderer.prepareDrawCalls).isEqualTo(0)
+    assertThat(renderer.drawCalls).isEqualTo(0)
+    assertThat(renderer.drawForegroundCalls).isEqualTo(0)
+  }
 
   @Test
   fun nodeOwnedCapabilities_preserveExactLifecycleAndStyleOwnership() = runComposeUiTest {
@@ -87,14 +118,18 @@ class HazeEffectRendererCapabilitiesTest : ContextTest() {
   }
 }
 
-private class RecordingCapabilityFactory : HazeEffectFactory<String> {
+private class RecordingCapabilityFactory(
+  private val shouldPrepareDraw: Boolean = true,
+) : HazeEffectFactory<String> {
   val renderers = mutableListOf<RecordingCapabilityRenderer>()
 
   override fun createRenderer(): HazeEffectRenderer<String> =
-    RecordingCapabilityRenderer().also(renderers::add)
+    RecordingCapabilityRenderer(shouldPrepareDraw).also(renderers::add)
 }
 
-private class RecordingCapabilityRenderer :
+private class RecordingCapabilityRenderer(
+  private val shouldPrepareDraw: Boolean,
+) :
   HazeEffectRenderer<String>,
   HazeEffectRendererLifecycle<String>,
   HazeEffectRendererDrawHooks<String>,
@@ -126,6 +161,8 @@ private class RecordingCapabilityRenderer :
   override fun HazeEffectRuntimeDrawScope.prepareDraw(style: String) {
     prepareDrawCalls++
   }
+
+  override fun shouldPrepareDraw(style: String): Boolean = shouldPrepareDraw
 
   override fun HazeEffectDrawScope.draw(style: String) {
     drawCalls++


### PR DESCRIPTION
## Rationale

Blur and Glass still prepared and captured effect input when their resolved effective alpha was exactly zero. This adds a built-in, default-open preparation gate so transparent frames draw ordinary content without performing effect work or clearing previously retained output.

## Changes

- Gate both source and content-input preparation in `HazeEffectNode` before effect-layer capture or renderer hooks.
- Close the gate only for exactly-zero resolved Blur and Glass alpha, while resetting per-frame dirty tracking and preserving delegate selection and retained resources.
- Add defensive no-work guards to direct Blur RenderEffect, RenderScript, and fallback Glass entry points.
- Cover initial transparent frames, transparent invalidation, retained-output ownership, source-retention clears, and visibility restoration for Blur and Glass.

## Tests

- `./gradlew :haze:jvmTest :haze-blur:jvmTest :haze-glass:jvmTest :haze:metalavaCheckCompatibility :haze-blur:metalavaCheckCompatibility :haze-glass:metalavaCheckCompatibility :haze-blur:compileAndroidMain :haze-screenshot-tests:test spotlessCheck`
- Required standards/spec, reuse, quality, efficiency, clarity, and over-engineering reviews completed cleanly on the final semantic diff.
- Screenshot tests passed without baseline changes.

## Risks

- The new hook is built-in-only and default-open, so existing renderers and nonzero alpha behavior remain unchanged.
- Android RenderScript source compiled successfully, but physical-device execution was unavailable because this runner did not hold a device lease.

Fixes #1169
