### PR TITLE
Reuse unchanged Blur input captures

### DIFF
--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.blur
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -16,10 +17,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.roundToIntSize
 import androidx.compose.ui.util.lerp
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeEffectInputSnapshot
 import dev.chrisbanes.haze.HazeEffectLifecycleScope
 import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
 import dev.chrisbanes.haze.HazeProgressive as RootHazeProgressive
 import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.Poko
 import dev.chrisbanes.haze.TrimMemoryLevel
 import kotlin.math.ceil
 import kotlin.math.max
@@ -34,6 +37,7 @@ internal class RenderEffectBlurVisualEffectDelegate(
   private var lastScaledLayerSize: Size? = null
   private var graphicsContext: GraphicsContext? = null
   private var retainedOutputAvailable: Boolean = false
+  private var inputCaptureKey: InputCaptureKey? = null
 
   override fun DrawScope.draw(context: HazeEffectRuntimeDrawScope) {
     if (blurVisualEffect.alpha == 0f) return
@@ -47,7 +51,15 @@ internal class RenderEffectBlurVisualEffectDelegate(
 
     if (!hasDrawableSourceLayers) {
       val retainedLayer = scaledContentLayer
-        ?.takeUnless { it.isReleased }
+        ?.takeUnless {
+          if (it.isReleased) {
+            inputCaptureKey = null
+            retainedOutputAvailable = false
+            true
+          } else {
+            false
+          }
+        }
         ?.takeIf { retainedOutputAvailable }
         ?: return
 
@@ -60,29 +72,43 @@ internal class RenderEffectBlurVisualEffectDelegate(
       return
     }
 
-    // Allocate the scaled content layer once, re-recording into it each frame
+    val currentCaptureKey = InputCaptureKey(
+      inputSnapshot = context.inputSnapshot,
+      scaleFactor = scaleFactor,
+      scaledLayerSize = currentScaledSize,
+      layerOffset = context.layerOffset,
+      backgroundColor = blurVisualEffect.backgroundColor,
+    )
+
+    // Allocate the scaled content layer when its capture geometry changes.
     if (scaledContentLayer == null || scaledContentLayer!!.isReleased || lastScaledLayerSize != currentScaledSize) {
       graphicsContext = context.requireGraphicsContext()
       scaledContentLayer?.let { graphicsContext!!.releaseGraphicsLayer(it) }
       scaledContentLayer = graphicsContext!!.createGraphicsLayer()
       lastScaledLayerSize = currentScaledSize
       retainedOutputAvailable = false
+      inputCaptureKey = null
     }
 
     val layer = scaledContentLayer!!
 
-    // Always re-record — the source area layers change each frame during scrolling.
-    // Returns null when the scaled size is 0 (e.g., window minimized).
-    val resultLayer = createScaledContentLayer(
-      context = context,
-      scaleFactor = scaleFactor,
-      layerSize = context.layerSize,
-      layerOffset = context.layerOffset,
-      backgroundColor = blurVisualEffect.backgroundColor,
-      existingLayer = layer,
-    ) ?: return
-    retainedOutputAvailable = true
+    val resultLayer = if (inputCaptureKey == currentCaptureKey) {
+      layer
+    } else {
+      // Returns null when the scaled size is 0 (e.g., window minimized).
+      createScaledContentLayer(
+        context = context,
+        scaleFactor = scaleFactor,
+        layerSize = context.layerSize,
+        layerOffset = context.layerOffset,
+        backgroundColor = blurVisualEffect.backgroundColor,
+        existingLayer = layer,
+      )?.also {
+        inputCaptureKey = currentCaptureKey
+      } ?: return
+    }
 
+    retainedOutputAvailable = true
     drawRetainedLayer(resultLayer, context, scaleFactor)
   }
 
@@ -143,6 +169,7 @@ internal class RenderEffectBlurVisualEffectDelegate(
     renderEffect = null
     graphicsContext = null
     retainedOutputAvailable = false
+    inputCaptureKey = null
   }
 
   private fun updateRenderEffectIfDirty(
@@ -155,6 +182,15 @@ internal class RenderEffectBlurVisualEffectDelegate(
     // the effect's local dirty flags only.
     renderEffect = blurVisualEffect.getOrCreateRenderEffect(context, inputScale = scaleFactor)
   }
+
+  @Poko
+  private class InputCaptureKey(
+    val inputSnapshot: HazeEffectInputSnapshot?,
+    val scaleFactor: Float,
+    val scaledLayerSize: Size,
+    val layerOffset: Offset,
+    val backgroundColor: Color,
+  )
 
   companion object {
     const val TAG = "RenderEffectBlurVisualEffectDelegate"

--- a/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegateTrimMemoryTest.kt
+++ b/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegateTrimMemoryTest.kt
@@ -6,15 +6,29 @@
 package dev.chrisbanes.haze.blur
 
 import androidx.compose.runtime.CompositionLocal
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.GraphicsContext
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.SkiaGraphicsContext
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isTrue
+import dev.chrisbanes.haze.HazeEffectInputSnapshot
 import dev.chrisbanes.haze.HazeEffectLifecycleScope
+import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
+import dev.chrisbanes.haze.HazeSampling
+import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.PlatformContext
 import dev.chrisbanes.haze.TrimMemoryLevel
 import kotlin.coroutines.CoroutineContext
@@ -63,6 +77,141 @@ class RenderEffectBlurVisualEffectDelegateTrimMemoryTest {
   }
 
   @Test
+  fun detach_releasesCaptureSoTheNextDrawableFrameRecordsAgain() {
+    val delegate = RenderEffectBlurVisualEffectDelegate(
+      HazeBlurFactory.createRenderer() as BlurVisualEffect,
+    )
+    val context = RecordingDrawContext()
+
+    context.render { with(delegate) { draw(context) } }
+    context.render { with(delegate) { draw(context) } }
+    delegate.detach()
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(context.inputCaptureCount).isEqualTo(2)
+  }
+
+  @Test
+  fun onTrimMemory_moderateReleasesCaptureSoTheNextDrawableFrameRecordsAgain() {
+    val delegate = RenderEffectBlurVisualEffectDelegate(
+      HazeBlurFactory.createRenderer() as BlurVisualEffect,
+    )
+    val context = RecordingDrawContext()
+
+    context.render { with(delegate) { draw(context) } }
+    context.render { with(delegate) { draw(context) } }
+    delegate.onTrimMemory(RecordingLifecycleScope(), TrimMemoryLevel.MODERATE)
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(context.inputCaptureCount).isEqualTo(2)
+  }
+
+  @Test
+  fun releasedLayer_releasesCaptureSoTheNextDrawableFrameRecordsAgain() {
+    val delegate = RenderEffectBlurVisualEffectDelegate(
+      HazeBlurFactory.createRenderer() as BlurVisualEffect,
+    )
+    val context = RecordingDrawContext()
+
+    context.render { with(delegate) { draw(context) } }
+    context.render { with(delegate) { draw(context) } }
+    context.releaseLatestLayer()
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(context.inputCaptureCount).isEqualTo(2)
+  }
+
+  @Test
+  fun releasedLayerWithoutDrawableInput_isNotReusedAndNextDrawableFrameRecordsAgain() {
+    val delegate = RenderEffectBlurVisualEffectDelegate(
+      HazeBlurFactory.createRenderer() as BlurVisualEffect,
+    )
+    val context = RecordingDrawContext()
+
+    context.render { with(delegate) { draw(context) } }
+    context.render { with(delegate) { draw(context) } }
+    context.hasDrawableInput = false
+    context.releaseLatestLayer()
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(delegate.canDrawRetainedOutput()).isFalse()
+    assertThat(context.inputCaptureCount).isEqualTo(1)
+
+    context.hasDrawableInput = true
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(context.inputCaptureCount).isEqualTo(2)
+  }
+
+  @Test
+  fun drawableInputReturningAtOriginalSize_restoresRetainedOutputAfterCacheReuse() {
+    val delegate = RenderEffectBlurVisualEffectDelegate(
+      HazeBlurFactory.createRenderer() as BlurVisualEffect,
+    )
+    val context = RecordingDrawContext()
+
+    context.render { with(delegate) { draw(context) } }
+    context.hasDrawableInput = false
+    context.layerSize = Size(11f, 10f)
+    context.render { with(delegate) { draw(context) } }
+
+    context.hasDrawableInput = true
+    context.layerSize = context.modifierSize
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(context.inputCaptureCount).isEqualTo(1)
+    assertThat(delegate.canDrawRetainedOutput()).isTrue()
+
+    context.hasDrawableInput = false
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(delegate.canDrawRetainedOutput()).isTrue()
+  }
+
+  @Test
+  fun captureKeyChanges_recordInputAgain() {
+    val effect = BlurVisualEffect()
+    val delegate = RenderEffectBlurVisualEffectDelegate(effect)
+    val context = RecordingDrawContext()
+
+    context.render { with(delegate) { draw(context) } }
+    context.inputSnapshot = DifferentCaptureSnapshot
+    context.render { with(delegate) { draw(context) } }
+    context.sampling = HazeSampling.Fixed(0.8f)
+    context.render { with(delegate) { draw(context) } }
+    context.layerSize = Size(11f, 10f)
+    context.render { with(delegate) { draw(context) } }
+    context.layerOffset = Offset(1f, 0f)
+    context.render { with(delegate) { draw(context) } }
+
+    effect.update(
+      BlurLifecycleScope,
+      HazeBlurStyle { backgroundColor(Color.Blue) },
+      HazeSampling.Fixed(0.8f),
+    )
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(context.inputCaptureCount).isEqualTo(6)
+  }
+
+  @Test
+  fun styleOnlyChange_drawsWithoutRecapturingInput() {
+    val effect = BlurVisualEffect()
+    val delegate = RenderEffectBlurVisualEffectDelegate(effect)
+    val context = RecordingDrawContext()
+
+    context.render { with(delegate) { draw(context) } }
+    effect.update(
+      BlurLifecycleScope,
+      HazeBlurStyle { alpha(0.5f) },
+      HazeSampling.FullResolution,
+    )
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(context.inputCaptureCount).isEqualTo(1)
+  }
+
+  @Test
   fun clearRetainedOutput_releasesLayerMetadataAndAvailability() {
     val delegate = RenderEffectBlurVisualEffectDelegate(
       HazeBlurFactory.createRenderer() as BlurVisualEffect,
@@ -76,6 +225,21 @@ class RenderEffectBlurVisualEffectDelegateTrimMemoryTest {
     assertThat(delegate.getPrivateField<Size?>("lastScaledLayerSize")).isEqualTo(null)
     assertThat(delegate.getPrivateField<Any?>("scaledContentLayer")).isEqualTo(null)
     assertThat(delegate.getPrivateField<Any?>("graphicsContext")).isEqualTo(null)
+  }
+
+  @Test
+  fun clearRetainedOutput_releasesCaptureSoTheNextDrawableFrameRecordsAgain() {
+    val delegate = RenderEffectBlurVisualEffectDelegate(
+      HazeBlurFactory.createRenderer() as BlurVisualEffect,
+    )
+    val context = RecordingDrawContext()
+
+    context.render { with(delegate) { draw(context) } }
+    context.render { with(delegate) { draw(context) } }
+    delegate.clearRetainedOutput()
+    context.render { with(delegate) { draw(context) } }
+
+    assertThat(context.inputCaptureCount).isEqualTo(2)
   }
 }
 
@@ -112,4 +276,87 @@ private class RecordingLifecycleScope : HazeEffectLifecycleScope {
   }
 
   override fun invalidateLayerBounds() = Unit
+}
+
+private data object BlurLifecycleScope : HazeEffectLifecycleScope {
+  override val modifierSize: Size = Size.Zero
+  override val coroutineScope: CoroutineScope = object : CoroutineScope {
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext
+  }
+
+  override fun requirePlatformContext(): PlatformContext = PlatformContext.INSTANCE
+  override fun requireDensity(): Density = Density(1f)
+  override fun <T> currentValueOf(local: CompositionLocal<T>): T {
+    @Suppress("UNCHECKED_CAST")
+    return HazeBlurStyle as T
+  }
+  override fun requireGraphicsContext(): GraphicsContext = error("Unused in direct-draw tests")
+  override fun invalidateDraw() = Unit
+  override fun invalidateLayerBounds() = Unit
+}
+
+@OptIn(InternalComposeUiApi::class, InternalHazeApi::class)
+private class RecordingDrawContext(
+  private val drawScope: CanvasDrawScope = CanvasDrawScope(),
+) : HazeEffectRuntimeDrawScope, DrawScope by drawScope {
+  private val graphicsContext = RecordingGraphicsContext()
+
+  var inputCaptureCount = 0
+    private set
+
+  override val modifierSize: Size = Size(10f, 10f)
+  override val modifierBounds: Rect = Rect(Offset.Zero, modifierSize)
+  override var sampling: HazeSampling = HazeSampling.FullResolution
+  override var layerSize: Size = modifierSize
+  override var layerOffset: Offset = Offset.Zero
+  override var hasDrawableInput: Boolean = true
+  override var inputSnapshot: HazeEffectInputSnapshot? = CaptureSnapshot
+  override val coroutineScope: CoroutineScope = object : CoroutineScope {
+    override val coroutineContext: CoroutineContext = EmptyCoroutineContext
+  }
+
+  fun render(block: DrawScope.() -> Unit) {
+    drawScope.draw(
+      density = Density(1f),
+      layoutDirection = LayoutDirection.Ltr,
+      canvas = Canvas(ImageBitmap(10, 10)),
+      size = modifierSize,
+      block = block,
+    )
+  }
+
+  fun releaseLatestLayer() {
+    graphicsContext.releaseLatestLayer()
+  }
+
+  override fun requirePlatformContext(): PlatformContext = PlatformContext.INSTANCE
+  override fun requireGraphicsContext(): GraphicsContext = graphicsContext
+  override fun requireDensity(): Density = Density(1f)
+  override fun <T> currentValueOf(local: CompositionLocal<T>): T = error("Unused in direct-draw tests")
+  override fun invalidateDraw() = Unit
+  override fun drawInput() = Unit
+
+  override fun DrawScope.drawInput() {
+    this@RecordingDrawContext.inputCaptureCount++
+    drawRect(Color.Red)
+  }
+}
+
+private data object CaptureSnapshot : HazeEffectInputSnapshot
+private data object DifferentCaptureSnapshot : HazeEffectInputSnapshot
+
+@OptIn(InternalComposeUiApi::class)
+private class RecordingGraphicsContext : GraphicsContext {
+  private val delegate = SkiaGraphicsContext()
+  private var latestLayer: androidx.compose.ui.graphics.layer.GraphicsLayer? = null
+
+  override fun createGraphicsLayer() = delegate.createGraphicsLayer().also { latestLayer = it }
+
+  override fun releaseGraphicsLayer(layer: androidx.compose.ui.graphics.layer.GraphicsLayer) {
+    delegate.releaseGraphicsLayer(layer)
+  }
+
+  fun releaseLatestLayer() {
+    latestLayer?.let(::releaseGraphicsLayer)
+  }
 }


### PR DESCRIPTION
Fixes #1170

## Rationale
Reuse the RenderEffect Blur input capture whenever its opaque input snapshot, scale, scaled size, offset, and background are unchanged, while still applying the current output path on every drawable frame.

## Coverage
- Direct-draw JVM tests cover unchanged reuse, every capture-key change, style-only output changes, clear, detach, moderate trim, released layers, and a released layer with unavailable input before a fresh recapture.
- No screenshot baselines changed.

## Validation
- `./gradlew :haze-blur:jvmTest :haze-screenshot-tests:test`
- `./gradlew spotlessCheck`

## Reviews
- `review-and-simplify-changes` fix-and-validate: nested the key inside the delegate; no remaining findings.
- `ponytail-review`: Lean already. Ship.

## Residual risk
The optimization relies on the existing equality contract of `HazeEffectInputSnapshot`; all capture-defining fields named in the approved plan are included and lifecycle/resource release paths invalidate the key.