### PR TITLE
Publish haze-glass documentation

### DIFF
--- a/internal/dokka/build.gradle.kts
+++ b/internal/dokka/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
 dependencies {
   dokka(projects.haze)
   dokka(projects.hazeBlur)
+  dokka(projects.hazeGlass)
   dokka(projects.hazeMaterials)
   dokka(projects.hazeUtils)
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,9 @@ nav:
     - "Materials": blur/materials.md
     - "FAQs": blur/faq.md
     - "Platforms": blur/platforms.md
+  - "Glass":
+    - "Overview": effects/glass.md
+    - "Performance": glass/performance.md
   - "Custom Effects": custom-effects.md
   - "Performance": performance.md
   - "Recipes": recipes.md


### PR DESCRIPTION
## Summary

- Add the haze-glass overview and performance guides to the MkDocs navigation.
- Include the haze-glass module in the aggregated Dokka API reference.

## Why

The Glass Markdown pages existed and were being copied into the docs build, but they were not discoverable from site navigation. The Dokka aggregator omitted `haze-glass`, so its API reference was not generated or published.

## Validation

- `./scripts/build_docs.sh build`
- `git diff --check`
- Confirmed generated artifacts:
  - `site/effects/glass/index.html`
  - `site/glass/performance/index.html`
  - `site/api/haze-glass/index.html`