### PR TITLE
Document haze-glass snapshot dependency

### DIFF
--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -1,12 +1,27 @@
 # Glass
 
-!!! danger "Not yet published"
-    The Glass module is currently under active development and is **not published to Maven Central**. It exists in the repository for experimentation and internal development only. Do not attempt to add it as a Gradle dependency.
-
 A refraction-driven Glass effect that combines refraction, depth blur, tint, Fresnel/ambient lift, and specular highlights with optional rounded shapes and dispersion.
 
 !!! warning "Experimental"
     This module is experimental and may change or be removed in future releases. APIs are gated behind `@ExperimentalHazeApi`.
+
+## Download
+
+Glass is published with Haze's [snapshot builds][glass-snap]. Add the Sonatype Central snapshot
+repository and use the same snapshot version for both artifacts:
+
+```kotlin
+repositories {
+    maven("https://central.sonatype.com/repository/maven-snapshots")
+}
+
+dependencies {
+    implementation("dev.chrisbanes.haze:haze:XXX-SNAPSHOT")
+    implementation("dev.chrisbanes.haze:haze-glass:XXX-SNAPSHOT")
+}
+```
+
+[glass-snap]: https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/dev/chrisbanes/haze/haze-glass/
 
 ### Built-in material
 


### PR DESCRIPTION
## Summary

- Replace the stale instruction not to depend on `haze-glass` with working snapshot dependency guidance.
- Document the Sonatype Central snapshot repository and matching `haze` / `haze-glass` versions.

## Why

Follow-up to review feedback on #1175. The module is now included in the main publishing pipeline and its snapshot artifact is available, but no release artifact currently exists in Maven Central. The documentation should point users to the supported artifact that is actually published today.

Verified snapshot metadata reports `dev.chrisbanes.haze:haze-glass:2.0.1-SNAPSHOT`.

## Validation

- `./scripts/build_docs.sh build`
- `git diff --check`
- Verified the snapshot metadata directly from Sonatype Central.