### PR TITLE
Animate Glass playground drag z-index

### DIFF
--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
 import androidx.compose.ui.zIndex
 import androidx.navigation.NavHostController
 import dev.chrisbanes.haze.ExperimentalHazeApi
@@ -417,6 +418,7 @@ private fun PlaygroundSurface(
   val latestOnDragStart by rememberUpdatedState(onDragStart)
   val latestOnDrag by rememberUpdatedState(onDrag)
   val latestOnDragEnd by rememberUpdatedState(onDragEnd)
+  val zIndex = playgroundSurfaceZIndex(id, returnFractionProvider(id))
 
   LaunchedEffect(id, surfaceSize) {
     snapshotFlow {
@@ -439,8 +441,8 @@ private fun PlaygroundSurface(
   Box(
     modifier = Modifier
       .size(size)
-      .hazeSource(hazeState, zIndex = 1f + id.ordinal)
-      .zIndex(1f + id.ordinal)
+      .hazeSource(hazeState, zIndex = zIndex)
+      .zIndex(zIndex)
       .hazeGlass(
         input = HazeInput.Sources(hazeState),
         style = style,
@@ -489,6 +491,15 @@ internal fun playgroundSurfaceSize(id: GlassPlaygroundSurfaceId): DpSize = when 
   GlassPlaygroundSurfaceId.Pill -> DpSize(220.dp, 88.dp)
   GlassPlaygroundSurfaceId.Card -> DpSize(280.dp, 180.dp)
   GlassPlaygroundSurfaceId.Prism -> DpSize(180.dp, 112.dp)
+}
+
+internal fun playgroundSurfaceZIndex(
+  id: GlassPlaygroundSurfaceId,
+  dragReturnFraction: Float,
+): Float {
+  val restingZIndex = 1f + id.ordinal
+  val draggedZIndex = 1f + GlassPlaygroundSurfaceId.entries.size
+  return lerp(restingZIndex, draggedZIndex, dragReturnFraction.coerceIn(0f, 1f))
 }
 
 @Composable

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
@@ -236,7 +236,9 @@ public fun GlassPlaygroundSampleContent(
   onDragEnd: (GlassPlaygroundSurfaceId) -> Unit,
   interactionSourceProvider: (GlassPlaygroundSurfaceId) -> InteractionSource? = { null },
   surfaceProgressProvider: (GlassPlaygroundSurfaceId) -> Float = { progressProvider() },
-  returnFractionProvider: (GlassPlaygroundSurfaceId) -> Float = { 1f },
+  returnFractionProvider: (GlassPlaygroundSurfaceId) -> Float = { id ->
+    if (dragOffsetProvider(id) == Offset.Zero) 0f else 1f
+  },
   modifier: Modifier = Modifier,
 ) {
   val hazeState = rememberHazeState()

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSampleTest.kt
@@ -171,6 +171,18 @@ class GlassPlaygroundSampleTest : ContextTest() {
   }
 
   @Test
+  fun draggedSurfaceZIndex_returnsFromAboveAllSurfacesToItsRestingOrder() {
+    val id = GlassPlaygroundSurfaceId.Card
+
+    assertThat(playgroundSurfaceZIndex(id, dragReturnFraction = 1f))
+      .isEqualTo(5f)
+    assertThat(playgroundSurfaceZIndex(id, dragReturnFraction = 0.5f))
+      .isEqualTo(4f)
+    assertThat(playgroundSurfaceZIndex(id, dragReturnFraction = 0f))
+      .isEqualTo(3f)
+  }
+
+  @Test
   fun localLightSubtractsResolvedSurfaceOriginIncludingDrag() {
     val light = resolvePlaygroundSurfaceLightPosition(
       normalizedLight = Offset(0.75f, 0.25f),


### PR DESCRIPTION
## Summary

- raise the actively dragged Glass playground surface above every peer surface
- animate both Compose draw order and Haze source order back to the surface's resting z-index on release
- cover the elevated, returning, and resting z-index values with a focused test

## Why

Overlapping playground surfaces could draw over the surface being dragged. Compose and Haze maintain separate ordering systems, so the sample now drives both from the same release animation value to keep the visible stack and sampled source stack aligned.

## User impact

Dragged Glass playground surfaces remain visually in front while manipulated, then return smoothly to their original stacking order.

## Testing

- `./gradlew :sample:shared:jvmTest :sample:shared:spotlessCheck`
- `git diff --check`