### PR TITLE
Improve Glass Playground performance

### DIFF
--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.test.AndroidComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.containsExactly
@@ -292,6 +293,38 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
         height = 120,
       )
       assertThat(restoredDedicatedPixels).containsExactly(*dedicatedPixels)
+    }
+
+  @Test
+  fun sizeChange_reusesFusedShaderAndMatchesFreshOutput() =
+    runAndroidComposeUiTest<ComponentActivity> {
+      val resizedEffect = retainedBlurEffect()
+      val freshEffect = retainedBlurEffect()
+      val size = mutableStateOf(120.dp)
+      val showFresh = mutableStateOf(false)
+      setContent {
+        Row {
+          RuntimeGlassTestContent(resizedEffect, size = size.value)
+          if (showFresh.value) {
+            RuntimeGlassTestContent(freshEffect, size = 100.dp)
+          }
+        }
+      }
+      waitForIdle()
+      drawFrame()
+
+      val delegate = checkNotNull(runtime(resizedEffect).delegate as? RuntimeShaderGlassDelegate)
+      val fusedShader = checkNotNull(delegate.fusedShader)
+
+      size.value = 100.dp
+      showFresh.value = true
+      waitForIdle()
+      drawFrame()
+
+      assertThat(delegate.fusedShader).isSameInstanceAs(fusedShader)
+      val resizedPixels = captureRegionPixels(left = 0, top = 0, width = 100, height = 100)
+      val freshPixels = captureRegionPixels(left = 100, top = 0, width = 100, height = 100)
+      assertThat(resizedPixels).containsExactly(*freshPixels)
     }
 
   @Test
@@ -702,7 +735,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     }
 
   @Test
-  fun fusedBlurChanges_replaceDepthInputGraph() =
+  fun fusedBlurChanges_reuseShaderAndReplaceDepthInputGraph() =
     runAndroidComposeUiTest<ComponentActivity> {
       val effect = retainedBlurEffect()
       setContent { RuntimeGlassTestContent(effect) }
@@ -711,18 +744,20 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       val delegate = checkNotNull(runtime(effect).delegate as? RuntimeShaderGlassDelegate)
 
       val fusedShader = checkNotNull(delegate.fusedShader)
+      val fusedEffect = checkNotNull(delegate.layers.optical?.renderEffect)
       effect.optics = (effect.optics as GlassOptics.Absolute).copy(blurRadius = 36.dp)
       waitForIdle()
       drawFrame()
 
-      assertThat(delegate.fusedShader).isNotSameInstanceAs(fusedShader)
+      assertThat(delegate.fusedShader).isSameInstanceAs(fusedShader)
+      assertThat(delegate.layers.optical?.renderEffect).isNotSameInstanceAs(fusedEffect)
       assertThat(delegate.layers.blurHorizontal).isNull()
       assertThat(delegate.layers.blurred).isNull()
       assertThat(delegate.layers.refractionDetail).isNull()
     }
 
   @Test
-  fun progressiveBlurChanges_replaceComposedInputGraph() =
+  fun progressiveBlurChanges_reuseShaderAndReplaceComposedInputGraph() =
     runAndroidComposeUiTest<ComponentActivity> {
       val effect = retainedBlurEffect(
         progressive = HazeProgressive.verticalGradient(
@@ -748,7 +783,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
 
-      assertThat(delegate.fusedShader).isNotSameInstanceAs(fusedShader)
+      assertThat(delegate.fusedShader).isSameInstanceAs(fusedShader)
       assertThat(delegate.layers.source?.renderEffect).isNull()
       assertThat(delegate.layers.optical?.renderEffect).isNotSameInstanceAs(fusedEffect)
       assertThat(delegate.layers.blurHorizontal).isNull()
@@ -819,10 +854,11 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
   private fun RuntimeGlassTestContent(
     effect: GlassRuntimeEffect,
     attachEffect: Boolean = true,
+    size: Dp = 120.dp,
   ) {
     Box(
       Modifier
-        .size(120.dp)
+        .size(size)
         .then(
           if (attachEffect) {
             Modifier.testGlassRuntime(effect, HazeInput.Content)

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -79,6 +79,7 @@ internal class RuntimeShaderGlassDelegate(
   internal var fusedShader: MutableRuntimeShaderRenderEffect? = null
     private set
   private var fusedInputKey: GlassDepthInputKey? = null
+  private var fusedDepthInputShaders: FusedDepthInputShaders? = null
   private var fusedEffect: PlatformRenderEffect? = null
   private var interactionOpticalEffect: MutableRuntimeShaderRenderEffect? = null
   private var interactionDetailEffect: MutableRuntimeShaderRenderEffect? = null
@@ -910,6 +911,7 @@ internal class RuntimeShaderGlassDelegate(
       rimShader = null
       fusedShader = null
       fusedInputKey = null
+      fusedDepthInputShaders = null
       interactionOpticalEffect = null
       interactionDetailEffect = null
       interactionDetailCoverageEffect = null
@@ -1656,27 +1658,46 @@ internal class RuntimeShaderGlassDelegate(
           interactionOptics = render.interactionTopology.hasOptics,
           sharpDetail = key.detail != null,
         )
-        if (fusedShader == null || fusedInputKey != nextInputKey) {
+        val previousInputKey = fusedInputKey
+        val inputChanged = previousInputKey != nextInputKey
+        val topologyChanged = previousInputKey == null ||
+          previousInputKey.interactionOptics != nextInputKey.interactionOptics ||
+          previousInputKey.sharpDetail != nextInputKey.sharpDetail
+        val nextInput = if (inputChanged) {
+          updateFusedDepthInputRenderEffect(
+            blur = key.blur,
+            depth = key.depth,
+            sampleSize = key.optical.coordinates.sampleSize,
+          )
+        } else {
+          null
+        }
+        val recreatedShader = fusedShader == null || topologyChanged
+        if (recreatedShader) {
           fusedShader = traceCreateRenderEffect {
             createFusedGlassRenderEffect(
-              input = createFusedDepthInputRenderEffect(
-                blur = key.blur,
-                depth = key.depth,
-                sampleSize = key.optical.coordinates.sampleSize,
-              ),
+              input = nextInput,
               interactionOptics = nextInputKey.interactionOptics,
               sharpDetail = nextInputKey.sharpDetail,
             )
           }
           refractionDetailShader = null
-          fusedInputKey = nextInputKey
         }
         val shader = checkNotNull(fusedShader)
-        val optical = shader.updateUniforms {
+        val updateUniforms: RuntimeShaderUniformProvider.() -> Unit = {
           setOpticalUniforms(key.optical)
-          key.detail?.let(::setRefractionDetailUniforms)
-          key.interaction?.let(::setFusedInteractionOpticalUniforms)
+          key.detail?.let { setRefractionDetailUniforms(it) }
+          key.interaction?.let { setFusedInteractionOpticalUniforms(it) }
         }
+        val optical = if (inputChanged && !recreatedShader) {
+          shader.updateInputs(
+            inputs = arrayOf(nextInput),
+            uniforms = updateUniforms,
+          )
+        } else {
+          shader.updateUniforms(updateUniforms)
+        }
+        fusedInputKey = nextInputKey
         val detailKey = key.detail ?: return@let optical
         val detailShader = refractionDetailShader ?: traceCreateRenderEffect {
           createRefractionDetailRenderEffect(
@@ -1721,7 +1742,7 @@ internal class RuntimeShaderGlassDelegate(
     }
   }
 
-  private fun createFusedDepthInputRenderEffect(
+  private fun updateFusedDepthInputRenderEffect(
     blur: GlassBlurEffectKey?,
     depth: Float,
     sampleSize: Size,
@@ -1739,40 +1760,67 @@ internal class RuntimeShaderGlassDelegate(
         tap.copy(offsetPx = tap.offsetPx * offsetScale)
       },
     )
+    val progressive = blur.progressive != null
+    val shaders = fusedDepthInputShaders
+      ?.takeIf {
+        it.progressive == progressive &&
+          it.prefilters.isNotEmpty() == plan.requiresPrefilter
+      }
+      ?: FusedDepthInputShaders(
+        progressive = progressive,
+        prefilters = if (plan.requiresPrefilter) {
+          List(FUSED_DOWNSAMPLE_PREFILTER_PASSES + 1) {
+            traceCreateRenderEffect {
+              createFusedGlassBlurPrefilterRenderEffect(input = null)
+            }
+          }
+        } else {
+          emptyList()
+        },
+        horizontal = traceCreateRenderEffect {
+          createGlassBlurRenderEffectWithInput(
+            horizontal = true,
+            progressive = progressive,
+            input = null,
+          )
+        },
+        vertical = traceCreateRenderEffect {
+          createGlassBlurRenderEffectWithInput(
+            horizontal = false,
+            progressive = progressive,
+            input = null,
+          )
+        },
+      ).also { fusedDepthInputShaders = it }
     val prefilter = if (plan.requiresPrefilter) {
       // The retained path gets additional low-pass energy from rasterizing at half resolution
       // and scaling back up. Reproduce that response inside the one-layer graph.
       var result: PlatformRenderEffect? = null
-      repeat(FUSED_DOWNSAMPLE_PREFILTER_PASSES) {
-        result = createFusedGlassBlurPrefilterRenderEffect(result).updateUniforms {
+      shaders.prefilters.forEachIndexed { index, shader ->
+        result = shader.updateInputs(inputs = arrayOf(result)) {
           setFloatUniform("sampleSize", sampleSize.width, sampleSize.height)
-          setFloatUniform("strength", 1f)
+          setFloatUniform(
+            "strength",
+            if (index < FUSED_DOWNSAMPLE_PREFILTER_PASSES) {
+              1f
+            } else {
+              FUSED_DOWNSAMPLE_FINAL_PREFILTER_STRENGTH
+            },
+          )
         }
-      }
-      result = createFusedGlassBlurPrefilterRenderEffect(result).updateUniforms {
-        setFloatUniform("sampleSize", sampleSize.width, sampleSize.height)
-        setFloatUniform("strength", FUSED_DOWNSAMPLE_FINAL_PREFILTER_STRENGTH)
       }
       result
     } else {
       null
     }
-    val progressive = blur.progressive != null
-    val horizontal = createGlassBlurRenderEffectWithInput(
-      horizontal = true,
-      progressive = progressive,
-      input = prefilter,
-    ).updateUniforms {
+    val progressiveMask = blur.progressive?.toShader(blur.maskSize)
+    val horizontal = shaders.horizontal.updateInputs(inputs = arrayOf(prefilter)) {
       setGlassBlurUniforms(blur, horizontalKernel, sampleSize.width, sampleSize.height)
-      blur.progressive?.toShader(blur.maskSize)?.let { setChildShader("mask", it) }
+      progressiveMask?.let { setChildShader("mask", it) }
     }
-    val vertical = createGlassBlurRenderEffectWithInput(
-      horizontal = false,
-      progressive = progressive,
-      input = horizontal,
-    ).updateUniforms {
+    val vertical = shaders.vertical.updateInputs(inputs = arrayOf(horizontal)) {
       setGlassBlurUniforms(blur, verticalKernel, sampleSize.width, sampleSize.height)
-      blur.progressive?.toShader(blur.maskSize)?.let { setChildShader("mask", it) }
+      progressiveMask?.let { setChildShader("mask", it) }
     }
     return createGlassDepthInputRenderEffect(vertical, depth)
   }
@@ -1912,6 +1960,13 @@ private class GlassDepthInputKey(
   val depth: Float,
   val interactionOptics: Boolean = false,
   val sharpDetail: Boolean = false,
+)
+
+private class FusedDepthInputShaders(
+  val progressive: Boolean,
+  val prefilters: List<MutableRuntimeShaderRenderEffect>,
+  val horizontal: MutableRuntimeShaderRenderEffect,
+  val vertical: MutableRuntimeShaderRenderEffect,
 )
 
 // RuntimeShader child sampling does not reproduce the retained graph's raster downscale/upscale

--- a/haze-utils/api/api.txt
+++ b/haze-utils/api/api.txt
@@ -30,6 +30,7 @@ package dev.chrisbanes.haze {
   }
 
   @dev.chrisbanes.haze.InternalHazeApi public interface MutableRuntimeShaderRenderEffect {
+    method public default dev.chrisbanes.haze.PlatformRenderEffect updateInputs(dev.chrisbanes.haze.PlatformRenderEffect?[] inputs, kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.RuntimeShaderUniformProvider,kotlin.Unit> uniforms);
     method public dev.chrisbanes.haze.PlatformRenderEffect updateUniforms(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.RuntimeShaderUniformProvider,kotlin.Unit> uniforms);
   }
 

--- a/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/RuntimeShader.android.kt
+++ b/haze-utils/src/androidMain/kotlin/dev/chrisbanes/haze/RuntimeShader.android.kt
@@ -64,10 +64,12 @@ public actual fun createMutableRuntimeShaderRenderEffect(
 private class AndroidMutableRuntimeShaderRenderEffect(
   effect: PlatformRuntimeEffect,
   private val shaderNames: Array<String>,
-  private val inputs: Array<PlatformRenderEffect?>,
+  inputs: Array<PlatformRenderEffect?>,
 ) : MutableRuntimeShaderRenderEffect {
   private val shader = RuntimeShader(effect.sksl)
   private val provider = AndroidRuntimeShaderUniformProvider(shader)
+  private var inputs = inputs.copyOf()
+
   override fun updateUniforms(
     uniforms: RuntimeShaderUniformProvider.() -> Unit,
   ): PlatformRenderEffect {
@@ -75,6 +77,14 @@ private class AndroidMutableRuntimeShaderRenderEffect(
     // mutations. Callers retaining an earlier effect must replace or re-record that layer first.
     uniforms(provider)
     return createAndroidRuntimeShaderRenderEffect(shader, shaderNames, inputs)
+  }
+
+  override fun updateInputs(
+    inputs: Array<PlatformRenderEffect?>,
+    uniforms: RuntimeShaderUniformProvider.() -> Unit,
+  ): PlatformRenderEffect {
+    this.inputs = inputs.copyOf()
+    return updateUniforms(uniforms)
   }
 }
 

--- a/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/RuntimeShader.kt
+++ b/haze-utils/src/commonMain/kotlin/dev/chrisbanes/haze/RuntimeShader.kt
@@ -66,6 +66,20 @@ public interface MutableRuntimeShaderRenderEffect {
   public fun updateUniforms(
     uniforms: RuntimeShaderUniformProvider.() -> Unit,
   ): PlatformRenderEffect
+
+  /**
+   * Replaces the child [inputs], applies [uniforms], and returns the updated render effect.
+   *
+   * The compiled runtime shader is retained when the platform supports it.
+   *
+   * @throws UnsupportedOperationException if replacing child inputs is not supported.
+   */
+  public fun updateInputs(
+    inputs: Array<PlatformRenderEffect?>,
+    uniforms: RuntimeShaderUniformProvider.() -> Unit,
+  ): PlatformRenderEffect = throw UnsupportedOperationException(
+    "Updating runtime shader inputs is not supported by this implementation",
+  )
 }
 
 /**

--- a/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/RenderEffect.skiko.kt
+++ b/haze-utils/src/skikoMain/kotlin/dev/chrisbanes/haze/RenderEffect.skiko.kt
@@ -170,10 +170,11 @@ public actual fun createMutableRuntimeShaderRenderEffect(
 private class SkikoMutableRuntimeShaderRenderEffect(
   private val effect: RuntimeEffect,
   private val shaderNames: Array<String>,
-  private val inputs: Array<ImageFilter?>,
+  inputs: Array<ImageFilter?>,
 ) : MutableRuntimeShaderRenderEffect {
   private val builder = RuntimeShaderBuilder(effect)
   private val provider = SkikoRuntimeShaderUniformProvider(builder)
+  private var inputs = inputs.copyOf()
 
   override fun updateUniforms(
     uniforms: RuntimeShaderUniformProvider.() -> Unit,
@@ -183,6 +184,14 @@ private class SkikoMutableRuntimeShaderRenderEffect(
     return wrapRuntimeShaderConstruction {
       ImageFilter.makeRuntimeShader(builder, shaderNames, inputs)
     }
+  }
+
+  override fun updateInputs(
+    inputs: Array<ImageFilter?>,
+    uniforms: RuntimeShaderUniformProvider.() -> Unit,
+  ): PlatformRenderEffect {
+    this.inputs = inputs.copyOf()
+    return updateUniforms(uniforms)
   }
 }
 

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.zIndex
 import androidx.navigation.NavHostController
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassReducedMotionPolicy
@@ -448,6 +449,9 @@ private fun PlaygroundSurface(
       .hazeGlass(
         input = HazeInput.Sources(hazeState),
         style = style,
+        // Use half-resolution sampling across platforms; four large overlapping surfaces are
+        // otherwise fill-rate bound on Android.
+        sampling = HazeSampling.Fixed(0.5f),
         interactionSource = interactionSource,
         interactionTransformTarget = GlassTransformTarget.MaterialAndContent,
         interactionTransformPivot = GlassTransformPivot.Pointer,


### PR DESCRIPTION
## Summary

- render the four large Glass Playground surfaces at half-resolution to reduce fill-rate pressure
- retain the fused blur-input RuntimeShader graph and update child inputs/uniforms when size, blur, or depth changes instead of recompiling shaders
- verify shader reuse and pixel equivalence across resize, blur, and progressive-blur changes

## Why

The Android Glass Playground was both fill-rate bound and repeatedly rebuilding its fused runtime-shader graph as animated geometry changed. More emulator cores did not address either GPU-bound cost. This keeps the existing topology rebuilds when shader structure genuinely changes, while reusing compiled shaders for input-only updates.

## Performance

A fresh Pixel 6 API 37 release `playgroundTimeline` Macrobenchmark on this branch, over eight iterations, measured:

- CPU frame duration: 10.45 ms P50 / 12.25 ms P90
- frame overrun: -1.78 ms P50 / -0.002 ms P90
- median peak GPU memory: 103.7 MB
- median frame count: 1,117

The initial hot full-resolution run from this investigation measured 51.6 ms P50 / 58.2 ms P90 and 237 MB median peak GPU memory. The runs were sequential rather than interleaved, so #1178 tracks a workload-aware Adaptive policy and a direct 0.75/0.5 comparison.

## Validation

- `./gradlew :haze-utils:check :haze-glass:check :sample:shared:check :sample:screenshot-tests:test :haze-screenshot-tests:connectedAndroidDeviceTest`
- `./gradlew :internal:benchmark:connectedBenchmarkReleaseAndroidTest '-Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.GlassGalleryBenchmark#playgroundTimeline'`
- final `review-and-simplify-changes` and `ponytail-review` gates
- `git diff --check`

No screenshot baselines were refreshed.

Follow-up: #1178