### PR TITLE
Measure Glass preparation in dynamic benchmarks

### DIFF
--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -63,14 +63,15 @@ Repeat with `effectAttach3` and `effectAttach9`, allowing the device to return t
 state between runs. Running all three in one instrumentation session is useful for automation
 validation, but later cases may be frequency-throttled.
 
-The reports include `HazeGlass.createRenderEffect` count and total duration, plus total
-`HazeGlass.prepareEffects` and `HazeGlass.prepareLayers` durations. Compare creation counts across
-1, 3, and 9 effects rather than assuming a fixed count: blur-plan topology and optional interaction
-or rim stages affect the number of composed effects. Linear duration growth points to per-effect
-shader/delegate construction; a mostly fixed cost points to shared process or renderer
-initialization. Also inspect RenderThread `DrawFrames`, `flush layers`, and `Vulkan finish frame`
-slices: independent Glass nodes can add render-graph submission work even when their combined
-visible area is constant.
+The cold-initialization scenarios, `depthUpdate`, and `playgroundTimeline` reports include
+`HazeGlass.createRenderEffect` count and total duration, plus total `HazeGlass.prepareEffects` and
+`HazeGlass.prepareLayers` durations. Compare creation counts across 1, 3, and 9 effects rather than
+assuming a fixed count: blur-plan topology and optional interaction or rim stages affect the
+number of composed effects. Linear duration growth points to per-effect shader/delegate
+construction; a mostly fixed cost points to shared process or renderer initialization. Also
+inspect RenderThread `DrawFrames`, `flush layers`, and `Vulkan finish frame` slices: independent
+Glass nodes can add render-graph submission work even when their combined visible area is
+constant.
 
 Full tracing adds composable function slices to Perfetto traces and is intended for diagnostic
 profiling. Omit `androidx.benchmark.fullTracing.enable` from runs used for comparable benchmark

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassBenchmarkSupport.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassBenchmarkSupport.kt
@@ -34,7 +34,7 @@ internal fun requireGlassBenchmarkDevice() {
 internal fun glassMetrics(
   includeMemory: Boolean,
   requireRuntimeMarker: Boolean = true,
-  includeColdInitializationMetrics: Boolean = false,
+  includePreparationMetrics: Boolean = false,
 ): List<Metric> = buildList {
   add(FrameTimingMetric())
   if (requireRuntimeMarker) {
@@ -49,7 +49,7 @@ internal fun glassMetrics(
   if (includeMemory) {
     add(MemoryUsageMetric(MemoryUsageMetric.Mode.Max))
   }
-  if (includeColdInitializationMetrics) {
+  if (includePreparationMetrics) {
     add(
       TraceSectionMetric(
         sectionName = GLASS_CREATE_RENDER_EFFECT_SECTION,

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassGalleryBenchmark.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassGalleryBenchmark.kt
@@ -43,7 +43,10 @@ class GlassGalleryBenchmark {
   fun playgroundTimeline() {
     benchmarkRule.measureRepeated(
       packageName = GLASS_TARGET_PACKAGE,
-      metrics = glassMetrics(includeMemory = true),
+      metrics = glassMetrics(
+        includeMemory = true,
+        includePreparationMetrics = true,
+      ),
       compilationMode = CompilationMode.Full(),
       startupMode = StartupMode.WARM,
       iterations = GLASS_BENCHMARK_ITERATIONS,

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassProfilingBenchmark.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassProfilingBenchmark.kt
@@ -104,7 +104,10 @@ class GlassProfilingBenchmark {
   fun opticalUpdate() = measureScenario("optical_update")
 
   @Test
-  fun depthUpdate() = measureScenario("depth_update")
+  fun depthUpdate() = measureScenario(
+    scenarioId = "depth_update",
+    includePreparationMetrics = true,
+  )
 
   @Test
   fun blurUpdate() = measureScenario("blur_update")
@@ -125,7 +128,7 @@ class GlassProfilingBenchmark {
     measureScenario(
       scenarioId = scenarioId,
       includeMemory = true,
-      includeColdInitializationMetrics = true,
+      includePreparationMetrics = true,
     )
   }
 
@@ -133,14 +136,14 @@ class GlassProfilingBenchmark {
     scenarioId: String,
     includeMemory: Boolean = false,
     requireRuntimeMarker: Boolean = true,
-    includeColdInitializationMetrics: Boolean = false,
+    includePreparationMetrics: Boolean = false,
   ) {
     benchmarkRule.measureRepeated(
       packageName = GLASS_TARGET_PACKAGE,
       metrics = glassMetrics(
         includeMemory = includeMemory,
         requireRuntimeMarker = requireRuntimeMarker,
-        includeColdInitializationMetrics = includeColdInitializationMetrics,
+        includePreparationMetrics = includePreparationMetrics,
       ),
       compilationMode = CompilationMode.Full(),
       startupMode = StartupMode.WARM,


### PR DESCRIPTION
## Summary

- expose the existing render-effect creation and preparation metrics in the controlled `depthUpdate` benchmark
- collect the same metrics from the real `playgroundTimeline` journey
- rename the metric switch now that it is no longer cold-initialization-only
- document which benchmarks emit the detailed preparation metrics

## Why

Issue #1116 required physical-device evidence before adding another fused blur-input cache. PR #1179 already retains the compiled shaders, so the remaining question is the cost of rebinding the depth-input graph.

A Pixel 6 API 37 run at fixed 60 Hz showed:

- `depthUpdate`: 7.2 ms CPU P90, -5.0 ms frame-overrun P90, and about 0.20 ms of `prepareEffects` work per frame
- `playgroundTimeline`: 12.3 ms CPU P90, 1.0 ms frame-overrun P90, and about 0.21 ms of `prepareEffects` work per frame across all four surfaces
- zero shader creations during both measured workloads

The representative depth trace was RenderThread/Vulkan dominated, so #1116 was closed without a production cache as its acceptance criteria specified. Keeping these metrics on the dynamic benchmarks makes that decision reproducible and protects future renderer work.

## Validation

- `./gradlew :internal:benchmark:compileBenchmarkReleaseKotlin :internal:benchmark:spotlessCheck`
- `./gradlew :internal:benchmark:connectedBenchmarkReleaseAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.GlassProfilingBenchmark#depthUpdate`
- `./gradlew :internal:benchmark:connectedBenchmarkReleaseAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.GlassGalleryBenchmark#playgroundTimeline`
- `git diff --check origin/main...HEAD`
- `review-and-simplify-changes`
- review-only `ponytail-review`

No screenshot baselines were changed.