### PR TITLE
Update GitHub Project binding

### DIFF
--- a/docs/agents/run-github-project.md
+++ b/docs/agents/run-github-project.md
@@ -35,6 +35,13 @@
 
 - Needs-triage label: `needs-triage`
 
+## Work Roles
+
+- Epic label: `epic`
+- Epic label ID: `LA_kwDOKlhej88AAAACupcs_Q`
+- Human-work label: `ready-for-human`
+- Human-work label ID: `LA_kwDOKlhej88AAAACs_Rx-w`
+
 ## Priority
 
 - Field name: `Priority`
@@ -49,6 +56,6 @@
 - Method: `squash`
 - Issue closure: `closing-keyword`
 - Required reviews: `none`
-- Required checks: `build_docs`, `emulator_tests`, `linux_build`, `mac_build`, `Greptile Review`, `Screenshot tests (android)`, `Screenshot tests (jvm)`
+- Required checks: `build_docs`, `emulator_tests`, `linux_build`, `mac_build`, `Greptile Review`, `Screenshot tests (android)`
 - Done automation: `set-status`
 - Automation description: Enabled `Item closed` and `Pull request merged` workflows set Status to `Done`; `Auto-close issue` is enabled; Done items are not automatically archived.


### PR DESCRIPTION
## What changed

- Map the dedicated `epic` work-shape label and the existing `ready-for-human` role to their live repository label IDs.
- Align the configured required checks with current `main` branch protection by removing the obsolete `Screenshot tests (jvm)` entry.

## Why

The `run-github-project` workflow now requires explicit epic and human-work mappings before it can classify the live Project frontier. The previous binding also listed a check that is no longer required by branch protection.

## Impact

This restores live validation for GitHub Project execution. It changes no library, renderer, sample, or build behavior.

## Validation

- Verified Project #7 field and option IDs against live GitHub state.
- Verified the `epic` and `ready-for-human` label IDs through the GitHub GraphQL API.
- Verified the six current required checks from `main` branch protection.
- Ran `git diff --check` against `main`.