### PR TITLE
Record immutable GlassStyle writes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,8 +90,10 @@ on that same runtime.
 
 Glass exposes only the typed `hazeGlass` modifier, replayable `GlassStyle`, and structural modifier
 arguments. The shared factory is stateless. Each modifier creates one internal node-owned runtime
-which evaluates defaults, `LocalGlassStyle`, and the explicit Style into a fresh snapshot and owns
-its interaction controller, delegate, caches, retained layers, and platform resources.
+which replays the immutable writes recorded by defaults, `LocalGlassStyle`, and the explicit Style
+into a fresh snapshot and owns its interaction controller, delegate, caches, retained layers, and
+platform resources. A Style builder executes only during Style construction; changing a captured
+input requires replacing the Style through recomposition.
 
 The old public effect, renderer, cache, grouped sentinel values, and `glassEffect` DSL are removed.
 No renderer or lifecycle object can be shared between Glass nodes.

--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -55,11 +55,16 @@ Adaptive content behavior, interaction-driven deformation, and morphing are unsu
 
 ## GlassStyle
 
-`GlassStyle` is an opaque, replayable appearance program. Create it with a block and compose
-values with `then`; later writes win. A style can be shared by any number of `hazeGlass` nodes:
-each node evaluates defaults, `LocalGlassStyle`, and its explicit style into its own snapshot.
-Replacing a Style through recomposition also removes properties and interaction blocks omitted by
-the replacement.
+`GlassStyle` is an opaque, immutable sequence of appearance writes. Its builder executes once when
+the Style is constructed, canonicalizing and recording each value. Compose Styles with the
+intrinsic `then` members; later writes win. A Style can be shared by any number of `hazeGlass`
+nodes: each node replays defaults, `LocalGlassStyle`, and its explicit Style into its own snapshot
+without rerunning caller code.
+
+Values captured while constructing a Style are frozen into those writes. Mutating captured state
+does not update attached nodes; construct and supply a replacement Style through recomposition to
+change their appearance. Replacement also removes properties and interaction blocks omitted by the
+new Style.
 
 ```kotlin
 val baseStyle = GlassStyle {
@@ -76,7 +81,7 @@ CompositionLocalProvider(LocalGlassStyle provides baseStyle) {
 
 ## Default style
 
-`GlassDefaults.style` uses the built-in Haze `GlassOptics.Adaptive` material and is evaluated
+`GlassDefaults.style` uses the built-in Haze `GlassOptics.Adaptive` material and is replayed
 before `LocalGlassStyle` and the modifier's explicit Style.
 
 ```kotlin

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -177,6 +177,9 @@ The typed Blur API does not change the other Haze 2 migrations.
 
 Glass also has a typed modifier and an opaque, replayable `GlassStyle`. Replace the complete Style
 through recomposition; do not mutate an effect, use sentinel patches, `copy`, or `clear*` calls.
+The `GlassStyle` builder executes once during construction and records immutable, canonicalized
+writes. Resolution never reruns the builder, so mutating state captured by an unchanged Style is
+inert; construct and supply a replacement Style to reflect new inputs.
 
 | Legacy | Typed replacement |
 | --- | --- |

--- a/haze-glass/api/api.txt
+++ b/haze-glass/api/api.txt
@@ -46,7 +46,7 @@ package dev.chrisbanes.haze.glass {
     field public static final float whitePoint = 0.0f;
   }
 
-  @dev.chrisbanes.haze.ExperimentalHazeApi public interface GlassInteractionScope {
+  @dev.chrisbanes.haze.ExperimentalHazeApi @dev.chrisbanes.haze.glass.GlassStyleDsl public interface GlassInteractionScope {
     method public void animate(androidx.compose.animation.core.FiniteAnimationSpec<java.lang.Float> toSpec, androidx.compose.animation.core.FiniteAnimationSpec<java.lang.Float> fromSpec, kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> block);
     method public void lightingIntensity(float intensity);
     method public void refractionMultiplier(float multiplier);
@@ -91,41 +91,44 @@ package dev.chrisbanes.haze.glass {
   }
 
   @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public sealed nonexhaustive interface GlassStyle {
+    method public default infix dev.chrisbanes.haze.glass.GlassStyle then(dev.chrisbanes.haze.glass.GlassStyle other);
+    method public default dev.chrisbanes.haze.glass.GlassStyle then(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassStyleScope,kotlin.Unit> block);
     field public static final dev.chrisbanes.haze.glass.GlassStyle.Companion Companion;
   }
 
   public static final class GlassStyle.Companion implements dev.chrisbanes.haze.glass.GlassStyle {
   }
 
+  @dev.chrisbanes.haze.ExperimentalHazeApi @kotlin.DslMarker public @interface GlassStyleDsl {
+  }
+
   public final class GlassStyleKt {
     method @dev.chrisbanes.haze.ExperimentalHazeApi public static dev.chrisbanes.haze.glass.GlassStyle GlassStyle(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassStyleScope,kotlin.Unit> block);
     method @InaccessibleFromKotlin public static androidx.compose.runtime.ProvidableCompositionLocal<dev.chrisbanes.haze.glass.GlassStyle> getLocalGlassStyle();
-    method @dev.chrisbanes.haze.ExperimentalHazeApi public static infix dev.chrisbanes.haze.glass.GlassStyle then(dev.chrisbanes.haze.glass.GlassStyle, dev.chrisbanes.haze.glass.GlassStyle other);
-    method @dev.chrisbanes.haze.ExperimentalHazeApi public static dev.chrisbanes.haze.glass.GlassStyle then(dev.chrisbanes.haze.glass.GlassStyle, kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassStyleScope,kotlin.Unit> block);
     property @dev.chrisbanes.haze.ExperimentalHazeApi public static androidx.compose.runtime.ProvidableCompositionLocal<dev.chrisbanes.haze.glass.GlassStyle> LocalGlassStyle;
   }
 
-  @dev.chrisbanes.haze.ExperimentalHazeApi public final class GlassStyleScope {
-    method public void alpha(float value);
-    method public void ambientResponse(float value);
-    method public void chromaMultiplier(float value);
-    method public void chromaticAberrationMode(dev.chrisbanes.haze.glass.ChromaticAberrationMode value);
-    method public void chromaticAberrationStrength(float value);
-    method public void contentNormalBlend(float value);
-    method public void contrast(float value);
-    method @KotlinOnly public void edgeSoftness(androidx.compose.ui.unit.Dp value);
-    method public void focused(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> block);
-    method public void fresnelExponent(float value);
-    method public void hovered(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> block);
-    method @KotlinOnly public void lightPosition(androidx.compose.ui.geometry.Offset value);
-    method public void optics(dev.chrisbanes.haze.glass.GlassOptics value);
-    method public void pressed(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> block);
-    method public void shape(androidx.compose.foundation.shape.RoundedCornerShape value);
-    method public void specularExponent(float value);
-    method public void specularIntensity(float value);
-    method public void surfaceProfile(dev.chrisbanes.haze.glass.SurfaceProfile value);
-    method @KotlinOnly public void tint(androidx.compose.ui.graphics.Color value);
-    method public void whitePoint(float value);
+  @dev.chrisbanes.haze.ExperimentalHazeApi @dev.chrisbanes.haze.glass.GlassStyleDsl public final class GlassStyleScope {
+    method public void alpha(float alpha);
+    method public void ambientResponse(float response);
+    method public void chromaMultiplier(float multiplier);
+    method public void chromaticAberrationMode(dev.chrisbanes.haze.glass.ChromaticAberrationMode mode);
+    method public void chromaticAberrationStrength(float strength);
+    method public void contentNormalBlend(float blend);
+    method public void contrast(float contrast);
+    method @KotlinOnly public void edgeSoftness(androidx.compose.ui.unit.Dp softness);
+    method public void focused(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> response);
+    method public void fresnelExponent(float exponent);
+    method public void hovered(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> response);
+    method @KotlinOnly public void lightPosition(androidx.compose.ui.geometry.Offset position);
+    method public void optics(dev.chrisbanes.haze.glass.GlassOptics optics);
+    method public void pressed(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> response);
+    method public void shape(androidx.compose.foundation.shape.RoundedCornerShape shape);
+    method public void specularExponent(float exponent);
+    method public void specularIntensity(float intensity);
+    method public void surfaceProfile(dev.chrisbanes.haze.glass.SurfaceProfile profile);
+    method @KotlinOnly public void tint(androidx.compose.ui.graphics.Color color);
+    method public void whitePoint(float whitePoint);
   }
 
   @dev.chrisbanes.haze.ExperimentalHazeApi public enum GlassTransformPivot {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteraction.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteraction.kt
@@ -41,6 +41,7 @@ public enum class GlassReducedMotionPolicy {
 
 /** Declares the visual response for one Glass interaction state. */
 @ExperimentalHazeApi
+@GlassStyleDsl
 public interface GlassInteractionScope {
   /** Sets the lighting multiplier in the range `0f..1f`. */
   public fun lightingIntensity(intensity: Float)

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -21,7 +21,7 @@ import dev.chrisbanes.haze.Poko
 /**
  * A [ProvidableCompositionLocal] which provides inherited Glass appearance.
  *
- * A Glass node evaluates [GlassDefaults.style], this Style, and its explicit [GlassStyle] in that
+ * A Glass node replays [GlassDefaults.style], this Style, and its explicit [GlassStyle] in that
  * order. Each node uses a fresh accumulator, so a Style may be shared safely by concurrent nodes.
  */
 @ExperimentalHazeApi
@@ -29,72 +29,85 @@ public val LocalGlassStyle: ProvidableCompositionLocal<GlassStyle> =
   compositionLocalOf { GlassStyle }
 
 /**
- * An opaque, stateless, replayable Glass appearance program.
+ * An opaque, immutable sequence of recorded Glass appearance writes.
  *
- * Create a Style with [GlassStyle] and combine Styles with [then]. Writes run in order and the last
- * write to a property wins. The companion object is the empty Style and performs no writes.
+ * The builder passed to [GlassStyle] executes once during construction. Each property is
+ * canonicalized and captured as an immutable write; resolving a Style only replays those captured
+ * values and never invokes caller code. Combine Styles with [then]. Writes run in order and the
+ * last write to a property wins. The companion object is the empty Style and performs no writes.
  *
- * A Style contains no renderer or mutable evaluation state. [GlassStyleScope.hovered],
+ * Mutating an input captured by a previously constructed Style has no effect. To update a node,
+ * construct and supply a replacement Style through recomposition.
+ *
+ * A Style contains no renderer or mutable runtime state. [GlassStyleScope.hovered],
  * [GlassStyleScope.focused], and [GlassStyleScope.pressed] record declarative responses only;
- * each `hazeGlass` node evaluates them into a fresh node-owned snapshot and owns its signals,
+ * each `hazeGlass` node replays them into a fresh node-owned snapshot and owns its signals,
  * animations, pointer observation, and renderer resources.
  */
 @ExperimentalHazeApi
 @Immutable
 public sealed interface GlassStyle {
+  /** Returns a Style which replays [other] after this Style. */
+  public infix fun then(other: GlassStyle): GlassStyle = combineGlassStyles(this, other)
+
+  /** Returns a Style which replays the writes recorded by [block] after this Style. */
+  public fun then(block: GlassStyleScope.() -> Unit): GlassStyle = then(GlassStyle(block))
+
   /** The empty Glass Style, which performs no writes. */
   public companion object : GlassStyle
 }
 
 /**
- * Creates a replayable [GlassStyle].
+ * Creates a recorded, replayable [GlassStyle].
  *
- * The [block] is retained as immutable configuration and replayed into fresh node-local state.
+ * [block] executes exactly once during this call. Its canonicalized property values are captured
+ * as immutable writes which can later be replayed into fresh node-local state without invoking
+ * [block] again.
  */
 @ExperimentalHazeApi
-public fun GlassStyle(block: GlassStyleScope.() -> Unit): GlassStyle = BlockGlassStyle(block)
+public fun GlassStyle(block: GlassStyleScope.() -> Unit): GlassStyle =
+  RecordedGlassStyle(recordGlassStyleWrites(block))
 
-/**
- * Returns a Style which evaluates this Style followed by [other].
- *
- * When both Styles write the same property, [other] wins.
- */
-@ExperimentalHazeApi
-public infix fun GlassStyle.then(other: GlassStyle): GlassStyle = when {
-  this === GlassStyle -> other
-  other === GlassStyle -> this
-  else -> CombinedGlassStyle(this, other)
+@Immutable
+private class RecordedGlassStyle(
+  private val writes: List<GlassStyleValues.() -> Unit>,
+) : GlassStyle {
+  fun replay(values: GlassStyleValues) {
+    for (write in writes) {
+      values.write()
+    }
+  }
+
+  fun then(other: RecordedGlassStyle): GlassStyle =
+    RecordedGlassStyle(writes + other.writes)
 }
 
-/**
- * Returns a Style which evaluates this Style followed by [block].
- *
- * Writes in [block] take precedence over earlier writes.
- */
+private fun combineGlassStyles(
+  first: GlassStyle,
+  second: GlassStyle,
+): GlassStyle = when (first) {
+  GlassStyle -> second
+  is RecordedGlassStyle -> when (second) {
+    GlassStyle -> first
+    is RecordedGlassStyle -> first.then(second)
+  }
+}
+
+/** Marks the nested receiver scopes used while constructing a [GlassStyle]. */
+@DslMarker
 @ExperimentalHazeApi
-public fun GlassStyle.then(block: GlassStyleScope.() -> Unit): GlassStyle =
-  this then GlassStyle(block)
-
-@Immutable
-private class BlockGlassStyle(
-  val block: GlassStyleScope.() -> Unit,
-) : GlassStyle
-
-@Immutable
-private class CombinedGlassStyle(
-  val first: GlassStyle,
-  val second: GlassStyle,
-) : GlassStyle
+public annotation class GlassStyleDsl
 
 /**
  * Receiver for Glass appearance property writes.
  *
- * Property functions canonicalize values as they are written. Calling a function again replaces
- * its previous value in the current evaluation.
+ * Property functions canonicalize values while the Style is constructed and record them for later
+ * replay. Calling a function again records a later write which takes precedence.
  */
 @ExperimentalHazeApi
+@GlassStyleDsl
 public class GlassStyleScope internal constructor(
-  private val values: GlassStyleValues,
+  private val writes: MutableList<GlassStyleValues.() -> Unit>,
 ) {
   /**
    * Declares the response evaluated by each node while it is hovered.
@@ -102,114 +115,134 @@ public class GlassStyleScope internal constructor(
    * The last declaration for this state wins. Pointer observation is installed only when hover or
    * press has a declaration, and observes without consuming application input.
    */
-  public fun hovered(block: GlassInteractionScope.() -> Unit) {
-    values.hoveredInteraction = buildGlassInteractionResponse(block)
+  public fun hovered(response: GlassInteractionScope.() -> Unit) {
+    val recorded = buildGlassInteractionResponse(response)
+    writes += { hoveredInteraction = recorded }
   }
 
   /** Declares the response evaluated by each node while it is focused. */
-  public fun focused(block: GlassInteractionScope.() -> Unit) {
-    values.focusedInteraction = buildGlassInteractionResponse(block)
+  public fun focused(response: GlassInteractionScope.() -> Unit) {
+    val recorded = buildGlassInteractionResponse(response)
+    writes += { focusedInteraction = recorded }
   }
 
   /** Declares the response evaluated by each node while it is pressed. */
-  public fun pressed(block: GlassInteractionScope.() -> Unit) {
-    values.pressedInteraction = buildGlassInteractionResponse(block)
+  public fun pressed(response: GlassInteractionScope.() -> Unit) {
+    val recorded = buildGlassInteractionResponse(response)
+    writes += { pressedInteraction = recorded }
   }
 
   /** Sets the rounded boundary used for refraction and masking. */
-  public fun shape(value: RoundedCornerShape) {
-    values.shape = value
+  public fun shape(shape: RoundedCornerShape) {
+    writes += { this.shape = shape }
   }
 
   /** Sets the optical model used to refract and blur captured content. */
-  public fun optics(value: GlassOptics) {
-    values.optics = value
+  public fun optics(optics: GlassOptics) {
+    writes += { this.optics = optics }
   }
 
   /** Sets specular-highlight intensity, coerced to the range `0f..1f`. */
-  public fun specularIntensity(value: Float) {
-    values.specularIntensity = value.coerceIn(0f, 1f)
+  public fun specularIntensity(intensity: Float) {
+    val canonical = intensity.coerceIn(0f, 1f)
+    writes += { specularIntensity = canonical }
   }
 
   /** Sets ambient-light response, coerced to the range `0f..1f`. */
-  public fun ambientResponse(value: Float) {
-    values.ambientResponse = value.coerceIn(0f, 1f)
+  public fun ambientResponse(response: Float) {
+    val canonical = response.coerceIn(0f, 1f)
+    writes += { ambientResponse = canonical }
   }
 
   /** Sets the tint applied to refracted content. */
-  public fun tint(value: Color) {
-    require(value.isSpecified) { "tint must be specified" }
-    values.tint = value
+  public fun tint(color: Color) {
+    require(color.isSpecified) { "tint must be specified" }
+    writes += { tint = color }
   }
 
   /** Sets the non-negative softening distance around the material boundary. */
-  public fun edgeSoftness(value: Dp) {
-    require(value.isSpecified) { "edgeSoftness must be specified" }
-    values.edgeSoftness = value.coerceAtLeast(0.dp)
+  public fun edgeSoftness(softness: Dp) {
+    require(softness.isSpecified) { "edgeSoftness must be specified" }
+    val canonical = softness.coerceAtLeast(0.dp)
+    writes += { edgeSoftness = canonical }
   }
 
   /**
    * Sets the virtual light position. [Offset.Unspecified] keeps the automatic material center.
    */
-  public fun lightPosition(value: Offset) {
+  public fun lightPosition(position: Offset) {
     require(
-      value == Offset.Unspecified ||
-        (value.x.isFinite() && value.y.isFinite()),
+      position == Offset.Unspecified ||
+        (position.x.isFinite() && position.y.isFinite()),
     ) {
       "lightPosition must be finite or Offset.Unspecified"
     }
-    values.lightPosition = value
+    writes += { lightPosition = position }
   }
 
   /** Sets chromatic dispersion strength, coerced to the range `0f..1f`. */
-  public fun chromaticAberrationStrength(value: Float) {
-    values.chromaticAberrationStrength = value.coerceIn(0f, 1f)
+  public fun chromaticAberrationStrength(strength: Float) {
+    val canonical = strength.coerceIn(0f, 1f)
+    writes += { chromaticAberrationStrength = canonical }
   }
 
   /** Sets the cross-section profile used by the refraction bezel. */
-  public fun surfaceProfile(value: SurfaceProfile) {
-    values.surfaceProfile = value
+  public fun surfaceProfile(profile: SurfaceProfile) {
+    writes += { surfaceProfile = profile }
   }
 
   /** Sets the quality mode used to render chromatic aberration. */
-  public fun chromaticAberrationMode(value: ChromaticAberrationMode) {
-    values.chromaticAberrationMode = value
+  public fun chromaticAberrationMode(mode: ChromaticAberrationMode) {
+    writes += { chromaticAberrationMode = mode }
   }
 
   /** Sets overall material opacity, coerced to the range `0f..1f`. */
-  public fun alpha(value: Float) {
-    values.alpha = value.coerceIn(0f, 1f)
+  public fun alpha(alpha: Float) {
+    val canonical = alpha.coerceIn(0f, 1f)
+    writes += { this.alpha = canonical }
   }
 
   /** Sets contrast adjustment, coerced to the range `-1f..1f`. */
-  public fun contrast(value: Float) {
-    values.contrast = value.coerceIn(-1f, 1f)
+  public fun contrast(contrast: Float) {
+    val canonical = contrast.coerceIn(-1f, 1f)
+    writes += { this.contrast = canonical }
   }
 
   /** Sets white-point adjustment, coerced to the range `-1f..1f`. */
-  public fun whitePoint(value: Float) {
-    values.whitePoint = value.coerceIn(-1f, 1f)
+  public fun whitePoint(whitePoint: Float) {
+    val canonical = whitePoint.coerceIn(-1f, 1f)
+    writes += { this.whitePoint = canonical }
   }
 
   /** Sets the chroma multiplier, coerced to the range `0f..2f`. */
-  public fun chromaMultiplier(value: Float) {
-    values.chromaMultiplier = value.coerceIn(0f, 2f)
+  public fun chromaMultiplier(multiplier: Float) {
+    val canonical = multiplier.coerceIn(0f, 2f)
+    writes += { chromaMultiplier = canonical }
   }
 
   /** Sets the blend between generated and captured normals, coerced to `0f..1f`. */
-  public fun contentNormalBlend(value: Float) {
-    values.contentNormalBlend = value.coerceIn(0f, 1f)
+  public fun contentNormalBlend(blend: Float) {
+    val canonical = blend.coerceIn(0f, 1f)
+    writes += { contentNormalBlend = canonical }
   }
 
   /** Sets the non-negative exponent controlling specular highlight concentration. */
-  public fun specularExponent(value: Float) {
-    values.specularExponent = value.coerceAtLeast(0f)
+  public fun specularExponent(exponent: Float) {
+    val canonical = exponent.coerceAtLeast(0f)
+    writes += { specularExponent = canonical }
   }
 
   /** Sets the non-negative exponent controlling Fresnel response falloff. */
-  public fun fresnelExponent(value: Float) {
-    values.fresnelExponent = value.coerceAtLeast(0f)
+  public fun fresnelExponent(exponent: Float) {
+    val canonical = exponent.coerceAtLeast(0f)
+    writes += { fresnelExponent = canonical }
   }
+}
+
+private fun recordGlassStyleWrites(
+  block: GlassStyleScope.() -> Unit,
+): List<GlassStyleValues.() -> Unit> = buildList {
+  GlassStyleScope(this).block()
 }
 
 @Poko
@@ -240,19 +273,14 @@ internal fun resolveGlassStyleValues(
   localStyle: GlassStyle,
   explicitStyle: GlassStyle,
 ): GlassStyleValues = GlassStyleValues().also { values ->
-  val scope = GlassStyleScope(values)
-  GlassDefaults.style.applyTo(scope)
-  localStyle.applyTo(scope)
-  explicitStyle.applyTo(scope)
+  GlassDefaults.style.replay(values)
+  localStyle.replay(values)
+  explicitStyle.replay(values)
 }
 
-private fun GlassStyle.applyTo(scope: GlassStyleScope) {
+private fun GlassStyle.replay(values: GlassStyleValues) {
   when (this) {
     GlassStyle -> Unit
-    is BlockGlassStyle -> scope.block()
-    is CombinedGlassStyle -> {
-      first.applyTo(scope)
-      second.applyTo(scope)
-    }
+    is RecordedGlassStyle -> replay(values)
   }
 }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
@@ -21,10 +21,14 @@ import dev.chrisbanes.haze.hazeEffect
 /**
  * Draws a Glass material using an explicit Haze [input].
  *
- * [style] is a stateless, replayable appearance program. Haze evaluates
- * [GlassDefaults.style] → [LocalGlassStyle] → [style] into a fresh snapshot owned by this modifier
- * node. The same Style may therefore be shared by concurrent nodes. Its hover, focus, and press
- * response blocks are likewise evaluated and animated by each node independently.
+ * [style] is an immutable sequence of appearance writes recorded when its builder executes. Haze
+ * replays [GlassDefaults.style] → [LocalGlassStyle] → [style] into a fresh snapshot owned by this
+ * modifier node without invoking any Style builder. The same Style may therefore be shared by
+ * concurrent nodes. Each node independently owns and animates the recorded hover, focus, and press
+ * responses.
+ *
+ * Values captured by a previously constructed Style do not update when they are mutated. To update
+ * appearance, construct and supply a replacement Style through recomposition.
  *
  * [input], [sampling], [expandLayerBounds], and [interactionSource] are structural modifier
  * configuration rather than Style properties. Recomposition replaces each value completely,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNotSameInstanceAs
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
@@ -19,6 +21,70 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class)
 class GlassStyleTest {
+
+  @Test
+  fun construction_recordsWritesOnceAndResolutionCreatesFreshValues() {
+    var styleExecutions = 0
+    var interactionExecutions = 0
+    val style = GlassStyle {
+      styleExecutions++
+      alpha(0.4f)
+      pressed {
+        interactionExecutions++
+        lightingIntensity(0.6f)
+      }
+    }
+
+    assertThat(styleExecutions).isEqualTo(1)
+    assertThat(interactionExecutions).isEqualTo(1)
+
+    val first = resolveGlassStyleValues(GlassStyle, style)
+    val second = resolveGlassStyleValues(GlassStyle, style)
+
+    assertThat(styleExecutions).isEqualTo(1)
+    assertThat(interactionExecutions).isEqualTo(1)
+    assertThat(first).isNotSameInstanceAs(second)
+    assertThat(first.alpha).isEqualTo(0.4f)
+    assertThat(second.alpha).isEqualTo(0.4f)
+    assertThat(first.pressedInteraction?.lightingIntensity?.value).isEqualTo(0.6f)
+    assertThat(second.pressedInteraction?.lightingIntensity?.value).isEqualTo(0.6f)
+  }
+
+  @Test
+  fun then_composesRecordedStylesWithoutRerunningBuilders() {
+    var baseExecutions = 0
+    var overrideExecutions = 0
+    var appendedExecutions = 0
+    val base = GlassStyle {
+      baseExecutions++
+      optics(GlassOptics.Absolute(depth = 0.2f))
+      pressed {
+        lightingIntensity(0.2f)
+        refractionMultiplier(1.2f)
+      }
+    }
+    val override = GlassStyle {
+      overrideExecutions++
+      optics(GlassOptics.Absolute(depth = 0.6f))
+      pressed { lightingIntensity(0.7f) }
+    }
+    val combined = base.then(override).then {
+      appendedExecutions++
+      alpha(0.5f)
+    }
+
+    val first = resolveGlassStyleValues(GlassStyle, combined)
+    val second = resolveGlassStyleValues(GlassStyle, combined)
+
+    assertThat(baseExecutions).isEqualTo(1)
+    assertThat(overrideExecutions).isEqualTo(1)
+    assertThat(appendedExecutions).isEqualTo(1)
+    assertThat(first.optics).isEqualTo(GlassOptics.Absolute(depth = 0.6f))
+    assertThat(first.pressedInteraction?.lightingIntensity?.value).isEqualTo(0.7f)
+    assertThat(first.pressedInteraction?.refractionMultiplier).isNull()
+    assertThat(first.alpha).isEqualTo(0.5f)
+    assertThat(second).isEqualTo(first)
+  }
 
   @Test
   fun interactionBlocks_chainAndReplacePerState() {

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
@@ -237,9 +238,9 @@ class HazeGlassModifierTest : ContextTest() {
   }
 
   @Test
-  fun reusedStateBackedStyle_replaysInEachNodeWhenSnapshotChanges() = runComposeUiTest {
+  fun capturedStateMutation_requiresReplacementStyleToUpdateSharedNodes() = runComposeUiTest {
     val alpha = mutableFloatStateOf(0.2f)
-    val sharedStyle = GlassStyle { alpha(alpha.floatValue) }
+    val sharedStyle = mutableStateOf(GlassStyle { alpha(alpha.floatValue) })
     val factory = RecordingGlassFactory()
 
     setContent {
@@ -251,7 +252,7 @@ class HazeGlassModifierTest : ContextTest() {
               .hazeGlass(
                 factory = factory,
                 input = HazeInput.Content,
-                style = sharedStyle,
+                style = sharedStyle.value,
                 sampling = HazeSampling.Default,
                 expandLayerBounds = true,
                 interactionSource = null,
@@ -272,8 +273,68 @@ class HazeGlassModifierTest : ContextTest() {
     waitForIdle()
 
     assertThat(factory.effects.size).isEqualTo(2)
+    assertThat(firstRuntime.alpha).isEqualTo(0.2f)
+    assertThat(secondRuntime.alpha).isEqualTo(0.2f)
+
+    sharedStyle.value = GlassStyle { alpha(alpha.floatValue) }
+    waitForIdle()
+
+    assertThat(factory.effects.size).isEqualTo(2)
     assertThat(firstRuntime.alpha).isEqualTo(0.8f)
     assertThat(secondRuntime.alpha).isEqualTo(0.8f)
+  }
+
+  @Test
+  fun stylePrecedence_reachesRuntimeWithAtomicCompoundWrites() = runComposeUiTest {
+    val localStyle = GlassStyle {
+      alpha(0.3f)
+      whitePoint(0.2f)
+      optics(GlassOptics.Absolute(depth = 0.2f, blurRadius = 12.dp))
+      pressed {
+        lightingIntensity(0.2f)
+        refractionMultiplier(1.2f)
+      }
+    }
+    val explicitStyle = GlassStyle {
+      alpha(0.6f)
+      specularIntensity(0.6f)
+      optics(GlassOptics.Absolute(depth = 0.5f, blurRadius = 16.dp))
+      pressed {
+        lightingIntensity(0.5f)
+        refractionMultiplier(1.5f)
+      }
+    }.then {
+      alpha(0.8f)
+      optics(GlassOptics.Absolute(depth = 0.7f))
+      pressed { lightingIntensity(0.9f) }
+    }
+    val factory = RecordingGlassFactory()
+
+    setContent {
+      CompositionLocalProvider(LocalGlassStyle provides localStyle) {
+        Spacer(
+          Modifier.size(10.dp).hazeGlass(
+            factory = factory,
+            input = HazeInput.Content,
+            style = explicitStyle,
+            sampling = HazeSampling.Default,
+            expandLayerBounds = true,
+            interactionSource = null,
+          ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val runtime = factory.effects.single().delegate
+    val pressed = runtime.resolvedInteractionSlots.pressed?.response
+    assertThat(runtime.contrast).isEqualTo(GlassDefaults.contrast)
+    assertThat(runtime.alpha).isEqualTo(0.8f)
+    assertThat(runtime.whitePoint).isEqualTo(0.2f)
+    assertThat(runtime.specularIntensity).isEqualTo(0.6f)
+    assertThat(runtime.optics).isEqualTo(GlassOptics.Absolute(depth = 0.7f))
+    assertThat(pressed?.lightingIntensity?.value).isEqualTo(0.9f)
+    assertThat(pressed?.refractionMultiplier).isNull()
   }
 
   @Test

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceTransitionAndroidScreenshotTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceTransitionAndroidScreenshotTest.kt
@@ -18,7 +18,6 @@ import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.HazeColorEffect
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
-import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
@@ -15,7 +15,6 @@ import dev.chrisbanes.haze.glass.ChromaticAberrationMode
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.glass.SurfaceProfile
-import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
@@ -38,7 +38,6 @@ import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.glass.SurfaceProfile
 import dev.chrisbanes.haze.glass.hazeGlass
-import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassTestConfiguration.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassTestConfiguration.kt
@@ -23,7 +23,6 @@ import dev.chrisbanes.haze.glass.GlassTransformPivot
 import dev.chrisbanes.haze.glass.GlassTransformTarget
 import dev.chrisbanes.haze.glass.SurfaceProfile
 import dev.chrisbanes.haze.glass.hazeGlass as typedHazeGlass
-import dev.chrisbanes.haze.glass.then
 
 /**
  * Mutable screenshot-test fixture which emits only the public, typed Glass API.

--- a/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/SourceTransitionScreenshotTest.kt
+++ b/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/SourceTransitionScreenshotTest.kt
@@ -18,7 +18,6 @@ import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.HazeColorEffect
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
-import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
 import dev.chrisbanes.haze.test.runScreenshotTest

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
@@ -50,7 +50,6 @@ import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassReducedMotionPolicy
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.glass.hazeGlass
-import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlinx.coroutines.delay

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
@@ -44,7 +44,6 @@ import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.glass.GlassTransformPivot
 import dev.chrisbanes.haze.glass.GlassTransformTarget
 import dev.chrisbanes.haze.glass.hazeGlass
-import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.hazeSource
 
 @Composable

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
@@ -58,7 +58,6 @@ import dev.chrisbanes.haze.glass.GlassReducedMotionPolicy
 import dev.chrisbanes.haze.glass.GlassTransformPivot
 import dev.chrisbanes.haze.glass.GlassTransformTarget
 import dev.chrisbanes.haze.glass.hazeGlass
-import dev.chrisbanes.haze.glass.then
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.math.roundToInt

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimeline.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimeline.kt
@@ -13,7 +13,6 @@ import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
-import dev.chrisbanes.haze.glass.then
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin


### PR DESCRIPTION
## Summary

- execute GlassStyle builders once and record canonical immutable writes for fresh node-owned resolution
- make both then overloads intrinsic members, add the Glass DSL marker, and publish semantic parameter names
- cover sharing, replacement, precedence, atomic compound writes, API signatures, and the migration contract

## Validation

- ./gradlew :haze-glass:check :haze-glass:metalavaCheckCompatibility :haze-screenshot-tests:test
- ./scripts/build_docs.sh build
- focused GlassStyle and HazeGlassModifier JVM tests during TDD and final review reconciliation
- screenshot baseline-path diff remained empty

## Reviews

- review-and-simplify-changes: reuse, quality, efficiency, and clarity clean
- ponytail-review: Lean already. Ship.

## Risk

The API signature changes are the intentional Haze 2 source changes scoped by the approved plan. Rendering defaults, renderer topology, and screenshot baselines are unchanged.

Fixes #1182