### PR TITLE
Move Glass interaction presentation into style

### DIFF
--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -210,6 +210,21 @@ activation useful, retain one `MutableInteractionSource` and share it with both 
 and your behavior modifiers:
 
 ```kotlin
+val interactionStyle = GlassStyle {
+  hovered { lightingIntensity(0.35f) }
+  focused { lightingIntensity(0.35f) }
+  pressed {
+    lightingIntensity(1f)
+    refractionMultiplier(1.08f)
+    whitePointDelta(0.04f)
+    scale(0.98f)
+  }
+  interactionLightRadiusFraction(0.7f)
+  interactionPositionAnimationSpec(
+    spring(dampingRatio = 1f, stiffness = Spring.StiffnessMedium),
+  )
+}
+
 val interactionSource = remember { MutableInteractionSource() }
 
 Modifier
@@ -217,17 +232,21 @@ Modifier
   .focusable(interactionSource = interactionSource)
   .hazeGlass(
     input = HazeInput.Sources(hazeState),
+    style = interactionStyle,
     interactionSource = interactionSource,
-    style = GlassStyle {
-      hovered { lightingIntensity(0.35f) }
-      focused { lightingIntensity(0.35f) }
-      pressed {
-        lightingIntensity(1f)
-        scale(0.98f)
-      }
-    },
+    interactionTransformTarget = GlassTransformTarget.MaterialAndContent,
+    interactionTransformPivot = GlassTransformPivot.Pointer,
+    interactionReducedMotionPolicy = GlassReducedMotionPolicy.System,
   )
 ```
+
+Hover, focus, and press responses, the localized-light radius, and light-position animation are
+presentation. They travel with `GlassStyle`, compose through `LocalGlassStyle` and `then`, and can
+be reused across nodes. Each consuming node still owns its `InteractionSource`, transform target,
+transform pivot, reduced-motion policy, geometry, animation state, controller, renderer, and
+platform resources. Sharing `interactionStyle` therefore shares appearance without coupling
+interaction signals or runtime state. Replace the Style to update presentation on the existing
+renderer; replace modifier mechanics to reconfigure only that node.
 
 Custom blocks replace that state's preset from identity. Resolve each property with fixed
 precedence: focused, then hovered, then pressed. Use `animate(toSpec, fromSpec)` inside a custom
@@ -250,11 +269,13 @@ GlassStyle {
 }
 ```
 
-The `interactionTransformTarget` argument selects whether a response transforms only the material
-or the material and content. `interactionTransformPivot` selects `Pointer` or `Center`. Omit a
-state block from a replacement Style to remove it. `GlassReducedMotionPolicy.System` follows the
-available system duration scale, `Reduced` snaps lighting and optics while suppressing transforms,
-and `Full` forces motion.
+The node-owned `interactionTransformTarget` argument selects whether a response transforms only
+the material or the material and content. `interactionTransformPivot` selects `Pointer` or
+`Center`. Omit a state block from a replacement Style to remove it.
+`GlassReducedMotionPolicy.System` follows the available system duration scale, `Reduced` snaps
+lighting and optics while suppressing transforms, and `Full` forces motion. The
+`GlassInteractionScope` receiver is sealed and implemented by Haze; it is a declaration DSL, not a
+consumer implementation point.
 
 ## Usage
 

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -190,9 +190,13 @@ inert; construct and supply a replacement Style to reflect new inputs.
 | mutable effect properties | replace `GlassStyle` through recomposition |
 | sentinel patches and `copy` | `GlassStyle { … }`, `then`, and `LocalGlassStyle` |
 | interaction mutation and `clear*` | declarative `hovered`, `focused`, and `pressed` blocks; omit blocks in a replacement Style |
+| `Modifier.hazeGlass(interactionLightRadiusFraction = value)` | `GlassStyle { interactionLightRadiusFraction(value) }` |
+| `Modifier.hazeGlass(interactionPositionAnimationSpec = spec)` | `GlassStyle { interactionPositionAnimationSpec(spec) }` |
 | `GlassDefaults.hoverAnimationSpec`, `pressAnimationSpec`, `releaseAnimationSpec` | explicit `animate(toSpec, fromSpec) { … }` declarations |
+| consumer implementation of `GlassInteractionScope` | removed; the sealed receiver is implemented by Haze and used only as the interaction-response DSL |
 | `GlassStyleConfiguration`, `GlassRenderer`, `GlassRendererCache`, retained-output methods, delegate and lifecycle hooks | no public replacement; each `hazeGlass` node owns and disposes these internal resources |
-| effect-owned interaction controls | typed modifier arguments |
+| effect-owned hover, focus, press, light-radius, and light-position animation presentation | property writes inside `GlassStyle { … }` |
+| effect-owned interaction source, transform target/pivot, and reduced-motion policy | explicit `Modifier.hazeGlass` arguments owned by each node |
 | implicit source/content | explicit `HazeInput.Sources` or `HazeInput.Content` |
 | raw optical displacement/caps | semantic `GlassOptics` and `Dp` controls |
 
@@ -211,6 +215,8 @@ val glassStyle = GlassStyle {
   specularIntensity(0.4f)
   edgeSoftness(12.dp)
   pressed { scale(0.98f) }
+  interactionLightRadiusFraction(0.7f)
+  interactionPositionAnimationSpec(spring())
 }
 
 Modifier.hazeGlass(
@@ -218,8 +224,18 @@ Modifier.hazeGlass(
   style = glassStyle,
   sampling = HazeSampling.Default,
   expandLayerBounds = true,
+  interactionSource = interactionSource,
+  interactionTransformTarget = GlassTransformTarget.MaterialOnly,
+  interactionTransformPivot = GlassTransformPivot.Pointer,
+  interactionReducedMotionPolicy = GlassReducedMotionPolicy.System,
 )
 ```
+
+Interaction presentation composes with the rest of `GlassStyle` and can be shared. The modifier
+arguments above remain per-node mechanics: sharing a Style never shares signals, geometry,
+animation state, controllers, renderers, retained layers, or platform resources. Replacing a Style
+updates presentation on the existing renderer; replacing mechanics updates only that modifier
+node.
 
 ### Position and geometry
 

--- a/haze-glass/api/api.txt
+++ b/haze-glass/api/api.txt
@@ -46,7 +46,7 @@ package dev.chrisbanes.haze.glass {
     field public static final float whitePoint = 0.0f;
   }
 
-  @dev.chrisbanes.haze.ExperimentalHazeApi @dev.chrisbanes.haze.glass.GlassStyleDsl public interface GlassInteractionScope {
+  @dev.chrisbanes.haze.ExperimentalHazeApi @dev.chrisbanes.haze.glass.GlassStyleDsl public sealed nonexhaustive interface GlassInteractionScope {
     method public void animate(androidx.compose.animation.core.FiniteAnimationSpec<java.lang.Float> toSpec, androidx.compose.animation.core.FiniteAnimationSpec<java.lang.Float> fromSpec, kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> block);
     method public void lightingIntensity(float intensity);
     method public void refractionMultiplier(float multiplier);
@@ -120,6 +120,8 @@ package dev.chrisbanes.haze.glass {
     method public void focused(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> response);
     method public void fresnelExponent(float exponent);
     method public void hovered(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> response);
+    method public void interactionLightRadiusFraction(float radiusFraction);
+    method public void interactionPositionAnimationSpec(androidx.compose.animation.core.FiniteAnimationSpec<androidx.compose.ui.geometry.Offset> animationSpec);
     method @KotlinOnly public void lightPosition(androidx.compose.ui.geometry.Offset position);
     method public void optics(dev.chrisbanes.haze.glass.GlassOptics optics);
     method public void pressed(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> response);
@@ -142,7 +144,7 @@ package dev.chrisbanes.haze.glass {
   }
 
   public final class HazeGlassKt {
-    method @androidx.compose.runtime.Stable @dev.chrisbanes.haze.ExperimentalHazeApi public static androidx.compose.ui.Modifier hazeGlass(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeInput input, optional dev.chrisbanes.haze.glass.GlassStyle style, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds, optional androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional float interactionLightRadiusFraction, optional dev.chrisbanes.haze.glass.GlassTransformTarget interactionTransformTarget, optional dev.chrisbanes.haze.glass.GlassTransformPivot interactionTransformPivot, optional androidx.compose.animation.core.FiniteAnimationSpec<androidx.compose.ui.geometry.Offset> interactionPositionAnimationSpec, optional dev.chrisbanes.haze.glass.GlassReducedMotionPolicy interactionReducedMotionPolicy);
+    method @androidx.compose.runtime.Stable @dev.chrisbanes.haze.ExperimentalHazeApi public static androidx.compose.ui.Modifier hazeGlass(androidx.compose.ui.Modifier, dev.chrisbanes.haze.HazeInput input, optional dev.chrisbanes.haze.glass.GlassStyle style, optional dev.chrisbanes.haze.HazeSampling sampling, optional boolean expandLayerBounds, optional androidx.compose.foundation.interaction.InteractionSource? interactionSource, optional dev.chrisbanes.haze.glass.GlassTransformTarget interactionTransformTarget, optional dev.chrisbanes.haze.glass.GlassTransformPivot interactionTransformPivot, optional dev.chrisbanes.haze.glass.GlassReducedMotionPolicy interactionReducedMotionPolicy);
   }
 
   @dev.chrisbanes.haze.ExperimentalHazeApi public enum SurfaceProfile {

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -337,7 +337,9 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       val effect = animatedStageEffect().apply {
         interactionSource = callerInteractionSource
         shape = callerShape
-        interactionPositionAnimationSpec = callerPositionAnimationSpec
+        style = GlassStyle {
+          interactionPositionAnimationSpec(callerPositionAnimationSpec)
+        }
       }
       val attached = mutableStateOf(true)
       setContent {
@@ -831,8 +833,10 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
         whitePointDelta(0.04f)
       }
     }
-    interactionLightRadiusFraction = 0.25f
-    interactionPositionAnimationSpec = tween(1)
+    style = GlassStyle {
+      interactionLightRadiusFraction(0.25f)
+      interactionPositionAnimationSpec(tween(1))
+    }
     interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
   }
 
@@ -981,14 +985,12 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     return hazeGlass(
       factory = factory,
       input = input,
-      style = GlassStyle,
+      style = effect.style,
       sampling = HazeSampling.FullResolution,
       expandLayerBounds = true,
       interactionSource = effect.interactionSource,
-      interactionLightRadiusFraction = effect.interactionLightRadiusFraction,
       interactionTransformTarget = effect.interactionTransformTarget,
       interactionTransformPivot = effect.interactionTransformPivot,
-      interactionPositionAnimationSpec = effect.interactionPositionAnimationSpec,
       interactionReducedMotionPolicy = effect.interactionReducedMotionPolicy,
     )
   }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
@@ -17,10 +17,10 @@ import dev.chrisbanes.haze.ExperimentalHazeApi
 @ExperimentalHazeApi
 @Suppress("ConstPropertyName", "ktlint:standard:property-naming")
 public object GlassDefaults {
-  /** Default light radius as a fraction of the material's shortest side. */
+  /** Default light radius recorded by [style] as a fraction of the material's shortest side. */
   public const val interactionLightRadiusFraction: Float = 0.7f
 
-  /** Default animation used when the interaction light moves to a new position. */
+  /** Default animation recorded by [style] when the interaction light moves to a new position. */
   public val positionAnimationSpec: FiniteAnimationSpec<Offset> = spring(
     dampingRatio = 1f,
     stiffness = Spring.StiffnessMedium,
@@ -80,6 +80,8 @@ public object GlassDefaults {
    * Glass evaluates this Style before [LocalGlassStyle] and an explicit modifier Style.
    */
   public val style: GlassStyle = GlassStyle {
+    interactionLightRadiusFraction(interactionLightRadiusFraction)
+    interactionPositionAnimationSpec(positionAnimationSpec)
     tint(tint)
     shape(shape)
     optics(optics)

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteraction.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteraction.kt
@@ -39,10 +39,15 @@ public enum class GlassReducedMotionPolicy {
   Full,
 }
 
-/** Declares the visual response for one Glass interaction state. */
+/**
+ * Declares the visual response for one Glass interaction state.
+ *
+ * This sealed receiver is implemented by Haze and is a declaration DSL, not a consumer
+ * implementation point. Each node evaluates recorded declarations into node-owned runtime state.
+ */
 @ExperimentalHazeApi
 @GlassStyleDsl
-public interface GlassInteractionScope {
+public sealed interface GlassInteractionScope {
   /** Sets the lighting multiplier in the range `0f..1f`. */
   public fun lightingIntensity(intensity: Float)
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteractionController.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteractionController.kt
@@ -245,6 +245,8 @@ internal class GlassInteractionController(
     val previous = this.configuration
     this.configuration = configuration
     val forceFullMotionChanged = previous.forceFullMotion != configuration.forceFullMotion
+    val positionAnimationSpecChanged =
+      previous.positionAnimationSpec != configuration.positionAnimationSpec
     retarget(
       previousSlots = previous.slots,
       nextSlots = configuration.slots,
@@ -252,7 +254,7 @@ internal class GlassInteractionController(
       nextSignals = signals,
       restartForMotionPolicy = forceFullMotionChanged,
     )
-    if (forceFullMotionChanged && positionJob?.isActive == true) {
+    if ((forceFullMotionChanged || positionAnimationSpecChanged) && positionJob?.isActive == true) {
       retargetPosition(positionTarget, force = true)
     }
     if (!previous.reducedMotion && configuration.reducedMotion) {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
@@ -135,10 +135,8 @@ internal class GlassRuntimeEffect() :
   private fun applyConfiguration(configuration: GlassNodeConfiguration) {
     style = configuration.style
     interactionSource = configuration.interactionSource
-    interactionLightRadiusFraction = configuration.interactionLightRadiusFraction
     interactionTransformTarget = configuration.interactionTransformTarget
     interactionTransformPivot = configuration.interactionTransformPivot
-    interactionPositionAnimationSpec = configuration.interactionPositionAnimationSpec
     interactionReducedMotionPolicy = configuration.interactionReducedMotionPolicy
   }
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeState.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeState.kt
@@ -3,7 +3,6 @@
 
 package dev.chrisbanes.haze.glass
 
-import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Stable
@@ -85,22 +84,8 @@ internal abstract class GlassRuntimeState {
       }
     }
 
-  internal var _interactionLightRadiusFraction: Float by mutableStateOf(
-    GlassDefaults.interactionLightRadiusFraction,
-  )
-
-  public var interactionLightRadiusFraction: Float
-    get() = _interactionLightRadiusFraction
-    set(value) {
-      require(value.isFinite() && value in 0f..2f) {
-        "interactionLightRadiusFraction must be finite and in range"
-      }
-      if (_interactionLightRadiusFraction != value) {
-        HazeLogger.d(TAG) { "interactionLightRadiusFraction changed. Current: $_interactionLightRadiusFraction. New: $value" }
-        _interactionLightRadiusFraction = value
-        onInteractionConfigurationChanged()
-      }
-    }
+  internal val interactionLightRadiusFraction: Float
+    get() = inheritedStyleValues.interactionLightRadiusFraction
 
   internal var _interactionTransformTarget: GlassTransformTarget by mutableStateOf(
     GlassTransformTarget.MaterialOnly,
@@ -130,19 +115,8 @@ internal abstract class GlassRuntimeState {
       }
     }
 
-  internal var _interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> by mutableStateOf(
-    GlassDefaults.positionAnimationSpec,
-  )
-
-  public var interactionPositionAnimationSpec: FiniteAnimationSpec<Offset>
-    get() = _interactionPositionAnimationSpec
-    set(value) {
-      if (_interactionPositionAnimationSpec != value) {
-        HazeLogger.d(TAG) { "interactionPositionAnimationSpec changed. Current: $_interactionPositionAnimationSpec. New: $value" }
-        _interactionPositionAnimationSpec = value
-        onInteractionConfigurationChanged()
-      }
-    }
+  internal val interactionPositionAnimationSpec
+    get() = inheritedStyleValues.interactionPositionAnimationSpec
 
   internal var _interactionReducedMotionPolicy: GlassReducedMotionPolicy by mutableStateOf(
     GlassReducedMotionPolicy.System,
@@ -659,6 +633,13 @@ internal abstract class GlassRuntimeState {
   }
 
   private fun onStyleChanged(old: GlassStyleValues, new: GlassStyleValues) {
+    if (old.interactionLightRadiusFraction != new.interactionLightRadiusFraction) {
+      markDirty(GlassDirtyFields.Interaction)
+      markDirty(GlassDirtyFields.InteractionLayerBounds)
+    }
+    if (old.interactionPositionAnimationSpec != new.interactionPositionAnimationSpec) {
+      markDirty(GlassDirtyFields.Interaction)
+    }
     if (old.optics != new.optics) {
       markDirty(GlassDirtyFields.Optics)
     }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -5,6 +5,7 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
@@ -40,9 +41,11 @@ public val LocalGlassStyle: ProvidableCompositionLocal<GlassStyle> =
  * construct and supply a replacement Style through recomposition.
  *
  * A Style contains no renderer or mutable runtime state. [GlassStyleScope.hovered],
- * [GlassStyleScope.focused], and [GlassStyleScope.pressed] record declarative responses only;
- * each `hazeGlass` node replays them into a fresh node-owned snapshot and owns its signals,
- * animations, pointer observation, and renderer resources.
+ * [GlassStyleScope.focused], [GlassStyleScope.pressed],
+ * [GlassStyleScope.interactionLightRadiusFraction], and
+ * [GlassStyleScope.interactionPositionAnimationSpec] record reusable interaction presentation;
+ * each `hazeGlass` node replays it into a fresh node-owned snapshot and owns its signals,
+ * geometry, animations, pointer observation, and renderer resources.
  */
 @ExperimentalHazeApi
 @Immutable
@@ -130,6 +133,27 @@ public class GlassStyleScope internal constructor(
   public fun pressed(response: GlassInteractionScope.() -> Unit) {
     val recorded = buildGlassInteractionResponse(response)
     writes += { pressedInteraction = recorded }
+  }
+
+  /**
+   * Sets the interaction-light radius as a fraction of the material's shortest side.
+   *
+   * The value must be finite and in the range `0f..2f`.
+   */
+  public fun interactionLightRadiusFraction(radiusFraction: Float) {
+    require(radiusFraction.isFinite() && radiusFraction in 0f..2f) {
+      "interactionLightRadiusFraction must be finite and in range"
+    }
+    writes += { interactionLightRadiusFraction = radiusFraction }
+  }
+
+  /**
+   * Sets the animation used when the interaction light moves to a new position.
+   *
+   * This presentation is replayed into fresh animation state owned by each consuming node.
+   */
+  public fun interactionPositionAnimationSpec(animationSpec: FiniteAnimationSpec<Offset>) {
+    writes += { interactionPositionAnimationSpec = animationSpec }
   }
 
   /** Sets the rounded boundary used for refraction and masking. */
@@ -267,6 +291,9 @@ internal class GlassStyleValues(
   var hoveredInteraction: GlassInteractionResponse? = null,
   var focusedInteraction: GlassInteractionResponse? = null,
   var pressedInteraction: GlassInteractionResponse? = null,
+  var interactionLightRadiusFraction: Float = GlassDefaults.interactionLightRadiusFraction,
+  var interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> =
+    GlassDefaults.positionAnimationSpec,
 )
 
 internal fun resolveGlassStyleValues(

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
@@ -5,11 +5,9 @@
 
 package dev.chrisbanes.haze.glass
 
-import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeEffectFactory
 import dev.chrisbanes.haze.HazeEffectRenderer
@@ -30,8 +28,9 @@ import dev.chrisbanes.haze.hazeEffect
  * Values captured by a previously constructed Style do not update when they are mutated. To update
  * appearance, construct and supply a replacement Style through recomposition.
  *
- * [input], [sampling], [expandLayerBounds], and [interactionSource] are structural modifier
- * configuration rather than Style properties. Recomposition replaces each value completely,
+ * [input], [sampling], [expandLayerBounds], [interactionSource], [interactionTransformTarget],
+ * [interactionTransformPivot], and [interactionReducedMotionPolicy] are node-owned modifier
+ * mechanics rather than Style presentation. Recomposition replaces each value completely,
  * including a `null` interaction source.
  *
  * @param input Source-backed content or this modifier's own content.
@@ -39,11 +38,8 @@ import dev.chrisbanes.haze.hazeEffect
  * @param sampling Input sampling policy. [HazeSampling.Default] preserves Glass's unscaled default.
  * @param expandLayerBounds Whether Glass may expand its capture layer for optical sampling.
  * @param interactionSource Optional external interaction source owned by this modifier node.
- * @param interactionLightRadiusFraction Interaction-light radius as a fraction of the material's
- * shortest side.
  * @param interactionTransformTarget Visual layers that receive the interaction scale transform.
  * @param interactionTransformPivot Pivot used by the interaction scale transform.
- * @param interactionPositionAnimationSpec Animation used when the interaction light moves.
  * @param interactionReducedMotionPolicy Motion policy for this node's Style responses.
  */
 @Stable
@@ -54,10 +50,8 @@ public fun Modifier.hazeGlass(
   sampling: HazeSampling = HazeSampling.Default,
   expandLayerBounds: Boolean = true,
   interactionSource: InteractionSource? = null,
-  interactionLightRadiusFraction: Float = GlassDefaults.interactionLightRadiusFraction,
   interactionTransformTarget: GlassTransformTarget = GlassTransformTarget.MaterialOnly,
   interactionTransformPivot: GlassTransformPivot = GlassTransformPivot.Pointer,
-  interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> = GlassDefaults.positionAnimationSpec,
   interactionReducedMotionPolicy: GlassReducedMotionPolicy = GlassReducedMotionPolicy.System,
 ): Modifier = hazeGlass(
   factory = GlassHazeEffectFactory,
@@ -66,10 +60,8 @@ public fun Modifier.hazeGlass(
   sampling = sampling,
   expandLayerBounds = expandLayerBounds,
   interactionSource = interactionSource,
-  interactionLightRadiusFraction = interactionLightRadiusFraction,
   interactionTransformTarget = interactionTransformTarget,
   interactionTransformPivot = interactionTransformPivot,
-  interactionPositionAnimationSpec = interactionPositionAnimationSpec,
   interactionReducedMotionPolicy = interactionReducedMotionPolicy,
 )
 
@@ -80,10 +72,8 @@ internal fun Modifier.hazeGlass(
   sampling: HazeSampling,
   expandLayerBounds: Boolean,
   interactionSource: InteractionSource?,
-  interactionLightRadiusFraction: Float = GlassDefaults.interactionLightRadiusFraction,
   interactionTransformTarget: GlassTransformTarget = GlassTransformTarget.MaterialOnly,
   interactionTransformPivot: GlassTransformPivot = GlassTransformPivot.Pointer,
-  interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> = GlassDefaults.positionAnimationSpec,
   interactionReducedMotionPolicy: GlassReducedMotionPolicy = GlassReducedMotionPolicy.System,
 ): Modifier = hazeEffect(
   factory = factory,
@@ -91,10 +81,8 @@ internal fun Modifier.hazeGlass(
   style = GlassNodeConfiguration(
     style = style,
     interactionSource = interactionSource,
-    interactionLightRadiusFraction = interactionLightRadiusFraction,
     interactionTransformTarget = interactionTransformTarget,
     interactionTransformPivot = interactionTransformPivot,
-    interactionPositionAnimationSpec = interactionPositionAnimationSpec,
     interactionReducedMotionPolicy = interactionReducedMotionPolicy,
   ),
   sampling = sampling,
@@ -105,10 +93,8 @@ internal fun Modifier.hazeGlass(
 internal class GlassNodeConfiguration(
   val style: GlassStyle,
   val interactionSource: InteractionSource?,
-  val interactionLightRadiusFraction: Float = GlassDefaults.interactionLightRadiusFraction,
   val interactionTransformTarget: GlassTransformTarget = GlassTransformTarget.MaterialOnly,
   val interactionTransformPivot: GlassTransformPivot = GlassTransformPivot.Pointer,
-  val interactionPositionAnimationSpec: FiniteAnimationSpec<Offset> = GlassDefaults.positionAnimationSpec,
   val interactionReducedMotionPolicy: GlassReducedMotionPolicy = GlassReducedMotionPolicy.System,
 )
 

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
@@ -84,7 +84,7 @@ class GlassInteractionControllerTest : ContextTest() {
     mainClock.autoAdvance = false
     val effect = GlassRuntimeEffect().apply {
       testPressResponse()
-      interactionPositionAnimationSpec = tween(1_000)
+      style = GlassStyle { interactionPositionAnimationSpec(tween(1_000)) }
     }
     setContent {
       Box(Modifier.size(100.dp).testGlass(effect))
@@ -837,7 +837,7 @@ class GlassInteractionControllerTest : ContextTest() {
   @Test
   fun controller_inFlightSystemAnimationRestartsWhenPolicyChangesToFull() = runComposeUiTest {
     val effect = GlassRuntimeEffect().apply {
-      interactionPositionAnimationSpec = tween(200)
+      style = GlassStyle { interactionPositionAnimationSpec(tween(200)) }
       pressed {
         animate(tween(200), tween(200)) { lightingIntensity(1f) }
       }
@@ -871,7 +871,7 @@ class GlassInteractionControllerTest : ContextTest() {
   fun controller_inFlightFullAnimationRestartsWhenPolicyChangesToSystem() = runComposeUiTest {
     val effect = GlassRuntimeEffect().apply {
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
-      interactionPositionAnimationSpec = tween(200)
+      style = GlassStyle { interactionPositionAnimationSpec(tween(200)) }
       pressed {
         animate(tween(200), tween(200)) { lightingIntensity(1f) }
       }
@@ -929,10 +929,8 @@ class GlassInteractionControllerTest : ContextTest() {
       GlassNodeConfiguration(
         style = effect.style,
         interactionSource = effect.interactionSource,
-        interactionLightRadiusFraction = effect.interactionLightRadiusFraction,
         interactionTransformTarget = effect.interactionTransformTarget,
         interactionTransformPivot = effect.interactionTransformPivot,
-        interactionPositionAnimationSpec = effect.interactionPositionAnimationSpec,
         interactionReducedMotionPolicy = effect.interactionReducedMotionPolicy,
       )
     }
@@ -947,10 +945,8 @@ class GlassInteractionControllerTest : ContextTest() {
       sampling = HazeSampling.Default,
       expandLayerBounds = true,
       interactionSource = configuration.interactionSource,
-      interactionLightRadiusFraction = configuration.interactionLightRadiusFraction,
       interactionTransformTarget = configuration.interactionTransformTarget,
       interactionTransformPivot = configuration.interactionTransformPivot,
-      interactionPositionAnimationSpec = configuration.interactionPositionAnimationSpec,
       interactionReducedMotionPolicy = configuration.interactionReducedMotionPolicy,
     )
   }
@@ -959,10 +955,8 @@ class GlassInteractionControllerTest : ContextTest() {
     val configuration = GlassNodeConfiguration(
       style = this.style,
       interactionSource = this.interactionSource,
-      interactionLightRadiusFraction = this.interactionLightRadiusFraction,
       interactionTransformTarget = this.interactionTransformTarget,
       interactionTransformPivot = this.interactionTransformPivot,
-      interactionPositionAnimationSpec = this.interactionPositionAnimationSpec,
       interactionReducedMotionPolicy = this.interactionReducedMotionPolicy,
     )
     update(

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
@@ -835,6 +835,37 @@ class GlassInteractionControllerTest : ContextTest() {
   }
 
   @Test
+  fun controller_inFlightPositionRestartsWhenAnimationSpecChanges() = runComposeUiTest {
+    val effect = GlassRuntimeEffect().apply {
+      testPressResponse()
+      style = GlassStyle { interactionPositionAnimationSpec(tween(1_000)) }
+    }
+    setContent {
+      Box(Modifier.size(100.dp).testGlass(effect))
+    }
+    waitForIdle()
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
+    mainClock.autoAdvance = false
+
+    controller.updatePosition(Offset(100f, 100f))
+    mainClock.advanceTimeBy(200)
+    val positionBeforeSpecChange = controller.renderState.position.x
+    assertThat(positionBeforeSpecChange).isGreaterThan(50f)
+    assertThat(positionBeforeSpecChange).isLessThan(100f)
+
+    controller.updateConfiguration(
+      controller.configurationForTest.copy(positionAnimationSpec = tween(100)),
+    )
+
+    assertThat(controller.renderState.position.x).isEqualTo(positionBeforeSpecChange)
+    mainClock.advanceTimeBy(50)
+    assertThat(controller.renderState.position.x).isGreaterThan(positionBeforeSpecChange)
+    assertThat(controller.renderState.position.x).isLessThan(100f)
+    mainClock.advanceTimeBy(70)
+    assertThat(controller.renderState.position.x).isEqualTo(100f)
+  }
+
+  @Test
   fun controller_inFlightSystemAnimationRestartsWhenPolicyChangesToFull() = runComposeUiTest {
     val effect = GlassRuntimeEffect().apply {
       style = GlassStyle { interactionPositionAnimationSpec(tween(200)) }

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionIntegrationTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionIntegrationTest.kt
@@ -220,10 +220,8 @@ class GlassInteractionIntegrationTest : ContextTest() {
     sampling = HazeSampling.Default,
     expandLayerBounds = true,
     interactionSource = effect.interactionSource,
-    interactionLightRadiusFraction = effect.interactionLightRadiusFraction,
     interactionTransformTarget = effect.interactionTransformTarget,
     interactionTransformPivot = effect.interactionTransformPivot,
-    interactionPositionAnimationSpec = effect.interactionPositionAnimationSpec,
     interactionReducedMotionPolicy = effect.interactionReducedMotionPolicy,
   )
 

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -9,9 +9,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.dp
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
@@ -21,6 +23,49 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class)
 class GlassStyleTest {
+
+  @Test
+  fun interactionPresentation_recordsAndComposesPerProperty() {
+    val localPositionSpec = tween<Offset>(100)
+    val explicitPositionSpec = tween<Offset>(200)
+    val local = GlassStyle {
+      hovered { lightingIntensity(0.1f) }
+      focused { lightingIntensity(0.2f) }
+      pressed { lightingIntensity(0.3f) }
+      interactionLightRadiusFraction(0.8f)
+      interactionPositionAnimationSpec(localPositionSpec)
+    }
+    val explicit = GlassStyle {
+      hovered { lightingIntensity(0.4f) }
+      interactionLightRadiusFraction(0.9f)
+    }.then {
+      focused { lightingIntensity(0.5f) }
+      interactionPositionAnimationSpec(explicitPositionSpec)
+    }
+
+    val defaults = resolveGlassStyleValues(GlassStyle, GlassStyle)
+    val resolved = resolveGlassStyleValues(local, explicit)
+
+    assertThat(defaults.interactionLightRadiusFraction)
+      .isEqualTo(GlassDefaults.interactionLightRadiusFraction)
+    assertThat(defaults.interactionPositionAnimationSpec)
+      .isEqualTo(GlassDefaults.positionAnimationSpec)
+    assertThat(resolved.hoveredInteraction?.lightingIntensity?.value).isEqualTo(0.4f)
+    assertThat(resolved.focusedInteraction?.lightingIntensity?.value).isEqualTo(0.5f)
+    assertThat(resolved.pressedInteraction?.lightingIntensity?.value).isEqualTo(0.3f)
+    assertThat(resolved.interactionLightRadiusFraction).isEqualTo(0.9f)
+    assertThat(resolved.interactionPositionAnimationSpec).isEqualTo(explicitPositionSpec)
+  }
+
+  @Test
+  fun interactionLightRadiusFraction_rejectsInvalidValues() {
+    listOf(Float.NaN, Float.NEGATIVE_INFINITY, -0.1f, 2.1f, Float.POSITIVE_INFINITY)
+      .forEach { invalid ->
+        assertFailure {
+          GlassStyle { interactionLightRadiusFraction(invalid) }
+        }.isInstanceOf<IllegalArgumentException>()
+      }
+  }
 
   @Test
   fun construction_recordsWritesOnceAndResolutionCreatesFreshValues() {

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassInteractionTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassInteractionTest.kt
@@ -35,7 +35,7 @@ class FallbackGlassInteractionTest : ContextTest() {
   fun fallback_pressedLighting_isLocalizedAtPointer() = runComposeUiTest {
     val effect = GlassRuntimeEffect().apply {
       pressed { lightingIntensity(1f) }
-      interactionLightRadiusFraction = 0.4f
+      style = GlassStyle { interactionLightRadiusFraction(0.4f) }
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
       tint = Color.Transparent
       specularIntensity = 0f
@@ -58,10 +58,8 @@ class FallbackGlassInteractionTest : ContextTest() {
             sampling = HazeSampling.Default,
             expandLayerBounds = true,
             interactionSource = effect.interactionSource,
-            interactionLightRadiusFraction = effect.interactionLightRadiusFraction,
             interactionTransformTarget = effect.interactionTransformTarget,
             interactionTransformPivot = effect.interactionTransformPivot,
-            interactionPositionAnimationSpec = effect.interactionPositionAnimationSpec,
             interactionReducedMotionPolicy = effect.interactionReducedMotionPolicy,
           )
           .background(Color.Black),

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
@@ -5,6 +5,7 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -25,10 +26,13 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeEffectContentTransform
 import dev.chrisbanes.haze.HazeEffectDrawScope
@@ -338,8 +342,92 @@ class HazeGlassModifierTest : ContextTest() {
   }
 
   @Test
+  fun sharedInteractionStyle_preservesPerNodeMechanicsAndRuntimeState() = runComposeUiTest {
+    val positionSpec = tween<androidx.compose.ui.geometry.Offset>(300)
+    val sharedStyle = GlassStyle {
+      hovered { lightingIntensity(0.2f) }
+      focused { whitePointDelta(0.1f) }
+      pressed { refractionMultiplier(1.4f) }
+      interactionLightRadiusFraction(0.9f)
+      interactionPositionAnimationSpec(positionSpec)
+    }
+    val firstSource = MutableInteractionSource()
+    val secondSource = MutableInteractionSource()
+    val factory = RecordingGlassFactory()
+
+    setContent {
+      Box {
+        Spacer(
+          Modifier.size(20.dp).hazeGlass(
+            factory = factory,
+            input = HazeInput.Content,
+            style = sharedStyle,
+            sampling = HazeSampling.Default,
+            expandLayerBounds = true,
+            interactionSource = firstSource,
+            interactionTransformTarget = GlassTransformTarget.MaterialOnly,
+            interactionTransformPivot = GlassTransformPivot.Pointer,
+            interactionReducedMotionPolicy = GlassReducedMotionPolicy.System,
+          ),
+        )
+        Spacer(
+          Modifier.size(30.dp).hazeGlass(
+            factory = factory,
+            input = HazeInput.Content,
+            style = sharedStyle,
+            sampling = HazeSampling.Default,
+            expandLayerBounds = true,
+            interactionSource = secondSource,
+            interactionTransformTarget = GlassTransformTarget.MaterialAndContent,
+            interactionTransformPivot = GlassTransformPivot.Center,
+            interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full,
+          ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val first = factory.effects[0].delegate
+    val second = factory.effects[1].delegate
+    assertThat(first.resolvedInteractionSlots).isEqualTo(second.resolvedInteractionSlots)
+    assertThat(first.interactionLightRadiusFraction).isEqualTo(0.9f)
+    assertThat(second.interactionLightRadiusFraction).isEqualTo(0.9f)
+    assertThat(first.interactionPositionAnimationSpec).isEqualTo(positionSpec)
+    assertThat(second.interactionPositionAnimationSpec).isEqualTo(positionSpec)
+    assertThat(first.interactionSource).isSameInstanceAs(firstSource)
+    assertThat(second.interactionSource).isSameInstanceAs(secondSource)
+    assertThat(first.interactionTransformTarget).isEqualTo(GlassTransformTarget.MaterialOnly)
+    assertThat(second.interactionTransformTarget)
+      .isEqualTo(GlassTransformTarget.MaterialAndContent)
+    assertThat(first.interactionTransformPivot).isEqualTo(GlassTransformPivot.Pointer)
+    assertThat(second.interactionTransformPivot).isEqualTo(GlassTransformPivot.Center)
+    assertThat(first.interactionReducedMotionPolicy).isEqualTo(GlassReducedMotionPolicy.System)
+    assertThat(second.interactionReducedMotionPolicy).isEqualTo(GlassReducedMotionPolicy.Full)
+    assertThat(first.attachedContextForTest?.modifierSize)
+      .isNotEqualTo(second.attachedContextForTest?.modifierSize)
+    assertThat(first.interactionControllerForTest)
+      .isNotSameInstanceAs(second.interactionControllerForTest)
+    assertThat(first.currentInteractionState).isNotSameInstanceAs(second.currentInteractionState)
+    assertThat(first.delegate).isNotSameInstanceAs(second.delegate)
+
+    runOnIdle { first.setPressedForTest(androidx.compose.ui.geometry.Offset(5f, 5f)) }
+    waitForIdle()
+
+    assertThat(first.currentInteractionSignals.rawPressed).isTrue()
+    assertThat(second.currentInteractionSignals.rawPressed).isFalse()
+  }
+
+  @Test
   fun typedStyle_responseReplacement_updatesPointerTopologyWithoutReplacingRenderer() = runComposeUiTest {
-    val style = mutableStateOf(GlassStyle { focused { lightingIntensity(0.2f) } })
+    val initialPositionSpec = tween<androidx.compose.ui.geometry.Offset>(100)
+    val replacementPositionSpec = tween<androidx.compose.ui.geometry.Offset>(200)
+    val style = mutableStateOf(
+      GlassStyle {
+        focused { lightingIntensity(0.2f) }
+        interactionLightRadiusFraction(0.8f)
+        interactionPositionAnimationSpec(initialPositionSpec)
+      },
+    )
     val factory = RecordingGlassFactory()
 
     setContent {
@@ -357,17 +445,110 @@ class HazeGlassModifierTest : ContextTest() {
     waitForIdle()
 
     val effect = factory.effects.single()
+    val renderer = effect.delegate.delegate
     assertThat(effect.delegate.observesPointerEvents).isEqualTo(false)
+    assertThat(effect.delegate.interactionLightRadiusFraction).isEqualTo(0.8f)
+    assertThat(effect.delegate.interactionPositionAnimationSpec).isEqualTo(initialPositionSpec)
 
-    style.value = GlassStyle { pressed { lightingIntensity(0.8f) } }
+    style.value = GlassStyle {
+      pressed { lightingIntensity(0.8f) }
+      interactionLightRadiusFraction(1.2f)
+      interactionPositionAnimationSpec(replacementPositionSpec)
+    }
     waitForIdle()
 
+    assertThat(factory.effects.single()).isSameInstanceAs(effect)
+    assertThat(effect.delegate.delegate).isSameInstanceAs(renderer)
     assertThat(effect.delegate.observesPointerEvents).isEqualTo(true)
+    assertThat(effect.delegate.interactionLightRadiusFraction).isEqualTo(1.2f)
+    assertThat(effect.delegate.interactionPositionAnimationSpec)
+      .isEqualTo(replacementPositionSpec)
 
     style.value = GlassStyle
     waitForIdle()
 
+    assertThat(factory.effects.single()).isSameInstanceAs(effect)
+    assertThat(effect.delegate.delegate).isSameInstanceAs(renderer)
     assertThat(effect.delegate.observesPointerEvents).isEqualTo(false)
+    assertThat(effect.delegate.interactionLightRadiusFraction)
+      .isEqualTo(GlassDefaults.interactionLightRadiusFraction)
+    assertThat(effect.delegate.interactionPositionAnimationSpec)
+      .isEqualTo(GlassDefaults.positionAnimationSpec)
+  }
+
+  @Test
+  fun modifierMechanicsReplacement_updatesOnlyAffectedNode() = runComposeUiTest {
+    val style = GlassStyle { focused { lightingIntensity(0.2f) } }
+    val firstSource = mutableStateOf<InteractionSource?>(MutableInteractionSource())
+    val firstTarget = mutableStateOf(GlassTransformTarget.MaterialOnly)
+    val firstPivot = mutableStateOf(GlassTransformPivot.Pointer)
+    val firstMotionPolicy = mutableStateOf(GlassReducedMotionPolicy.System)
+    val secondSource = MutableInteractionSource()
+    val factory = RecordingGlassFactory()
+
+    setContent {
+      Box {
+        Spacer(
+          Modifier.size(20.dp).hazeGlass(
+            factory = factory,
+            input = HazeInput.Content,
+            style = style,
+            sampling = HazeSampling.Default,
+            expandLayerBounds = true,
+            interactionSource = firstSource.value,
+            interactionTransformTarget = firstTarget.value,
+            interactionTransformPivot = firstPivot.value,
+            interactionReducedMotionPolicy = firstMotionPolicy.value,
+          ),
+        )
+        Spacer(
+          Modifier.size(30.dp).hazeGlass(
+            factory = factory,
+            input = HazeInput.Content,
+            style = style,
+            sampling = HazeSampling.Default,
+            expandLayerBounds = true,
+            interactionSource = secondSource,
+            interactionTransformTarget = GlassTransformTarget.MaterialOnly,
+            interactionTransformPivot = GlassTransformPivot.Pointer,
+            interactionReducedMotionPolicy = GlassReducedMotionPolicy.System,
+          ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val first = factory.effects[0]
+    val second = factory.effects[1]
+    val firstRenderer = first.delegate.delegate
+    val secondRenderer = second.delegate.delegate
+    val firstController = first.delegate.interactionControllerForTest
+    val secondController = second.delegate.interactionControllerForTest
+    val replacementSource = MutableInteractionSource()
+
+    firstSource.value = replacementSource
+    firstTarget.value = GlassTransformTarget.MaterialAndContent
+    firstPivot.value = GlassTransformPivot.Center
+    firstMotionPolicy.value = GlassReducedMotionPolicy.Full
+    waitForIdle()
+
+    assertThat(factory.effects[0]).isSameInstanceAs(first)
+    assertThat(factory.effects[1]).isSameInstanceAs(second)
+    assertThat(first.delegate.delegate).isSameInstanceAs(firstRenderer)
+    assertThat(second.delegate.delegate).isSameInstanceAs(secondRenderer)
+    assertThat(first.delegate.interactionControllerForTest).isSameInstanceAs(firstController)
+    assertThat(second.delegate.interactionControllerForTest).isSameInstanceAs(secondController)
+    assertThat(first.delegate.interactionSource).isSameInstanceAs(replacementSource)
+    assertThat(first.delegate.interactionTransformTarget)
+      .isEqualTo(GlassTransformTarget.MaterialAndContent)
+    assertThat(first.delegate.interactionTransformPivot).isEqualTo(GlassTransformPivot.Center)
+    assertThat(first.delegate.interactionReducedMotionPolicy).isEqualTo(GlassReducedMotionPolicy.Full)
+    assertThat(second.delegate.interactionSource).isSameInstanceAs(secondSource)
+    assertThat(second.delegate.interactionTransformTarget)
+      .isEqualTo(GlassTransformTarget.MaterialOnly)
+    assertThat(second.delegate.interactionTransformPivot).isEqualTo(GlassTransformPivot.Pointer)
+    assertThat(second.delegate.interactionReducedMotionPolicy)
+      .isEqualTo(GlassReducedMotionPolicy.System)
   }
 }
 

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -305,7 +305,18 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
         RuntimeLargeGlassTestContent(effect)
       }
     }
-    waitForIdle()
+    waitUntil {
+      attachedRuntimes[effect]?.let { runtime ->
+        val delegate = runtime.delegate as? RuntimeShaderGlassDelegate
+        runtime.interactionControllerForTest != null &&
+          runtime.preparedRenderBudget is GlassRenderBudgetDecision.Runtime &&
+          runtime.preparedRender != null &&
+          delegate != null &&
+          delegate.layers.source != null &&
+          delegate.layers.optical != null &&
+          delegate.layers.refractionDetail != null
+      } == true
+    }
     mainClock.autoAdvance = false
 
     val controller = checkNotNull(runtime(effect).interactionControllerForTest)
@@ -346,7 +357,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     }
     mainClock.autoAdvance = true
     showContent.value = false
-    waitForIdle()
+    waitUntil { controller.isDisposedForTest }
     assertThat(controller.isDisposedForTest).isTrue()
   }
 

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -293,8 +293,10 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
           whitePointDelta(0.04f)
         }
       }
-      interactionLightRadiusFraction = 0.25f
-      interactionPositionAnimationSpec = tween(1)
+      style = GlassStyle {
+        interactionLightRadiusFraction(0.25f)
+        interactionPositionAnimationSpec(tween(1))
+      }
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
     }
     setContent { RuntimeLargeGlassTestContent(effect) }
@@ -344,8 +346,10 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   @Test
   fun movingInteractionWithinSamePatchSize_doesNotRerecordLightingContent() = runComposeUiTest {
     val effect = runtimeInteractiveEffect().apply {
-      interactionLightRadiusFraction = 0.25f
-      interactionPositionAnimationSpec = tween(1)
+      style = GlassStyle {
+        interactionLightRadiusFraction(0.25f)
+        interactionPositionAnimationSpec(tween(1))
+      }
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
     }
     setContent { RuntimeLargeGlassTestContent(effect) }
@@ -366,8 +370,10 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   @Test
   fun movingInteractionWithinSamePatchSize_rerecordsLocalizedContent() = runComposeUiTest {
     val effect = runtimeInteractiveEffect().apply {
-      interactionLightRadiusFraction = 0.25f
-      interactionPositionAnimationSpec = tween(1)
+      style = GlassStyle {
+        interactionLightRadiusFraction(0.25f)
+        interactionPositionAnimationSpec(tween(1))
+      }
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
     }
     setContent { RuntimeLargeGlassTestContent(effect) }
@@ -849,7 +855,6 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       refractionMultiplier(1.08f)
       whitePointDelta(0.04f)
     }
-    interactionLightRadiusFraction = 0.7f
     interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
   }
 
@@ -893,10 +898,8 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     sampling = sampling,
     expandLayerBounds = true,
     interactionSource = effect.interactionSource,
-    interactionLightRadiusFraction = effect.interactionLightRadiusFraction,
     interactionTransformTarget = effect.interactionTransformTarget,
     interactionTransformPivot = effect.interactionTransformPivot,
-    interactionPositionAnimationSpec = effect.interactionPositionAnimationSpec,
     interactionReducedMotionPolicy = effect.interactionReducedMotionPolicy,
   )
 

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -299,10 +299,16 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       }
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
     }
-    setContent { RuntimeLargeGlassTestContent(effect) }
+    val showContent = mutableStateOf(true)
+    setContent {
+      if (showContent.value) {
+        RuntimeLargeGlassTestContent(effect)
+      }
+    }
     waitForIdle()
     mainClock.autoAdvance = false
 
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
     val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val source = checkNotNull(delegate.layers.source)
     val optical = checkNotNull(delegate.layers.optical)
@@ -339,8 +345,9 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       assertThat(checkNotNull(runtime(effect).preparedRender).plan.layers.map { it.kind }).isEqualTo(plannedKinds)
     }
     mainClock.autoAdvance = true
-    setContent {}
+    showContent.value = false
     waitForIdle()
+    assertThat(controller.isDisposedForTest).isTrue()
   }
 
   @Test

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -299,27 +299,10 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       }
       interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
     }
-    val showContent = mutableStateOf(true)
-    setContent {
-      if (showContent.value) {
-        RuntimeLargeGlassTestContent(effect)
-      }
-    }
-    waitUntil {
-      attachedRuntimes[effect]?.let { runtime ->
-        val delegate = runtime.delegate as? RuntimeShaderGlassDelegate
-        runtime.interactionControllerForTest != null &&
-          runtime.preparedRenderBudget is GlassRenderBudgetDecision.Runtime &&
-          runtime.preparedRender != null &&
-          delegate != null &&
-          delegate.layers.source != null &&
-          delegate.layers.optical != null &&
-          delegate.layers.refractionDetail != null
-      } == true
-    }
+    setContent { RuntimeLargeGlassTestContent(effect) }
+    waitForIdle()
     mainClock.autoAdvance = false
 
-    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
     val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val source = checkNotNull(delegate.layers.source)
     val optical = checkNotNull(delegate.layers.optical)
@@ -345,7 +328,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     }
 
     runtime(effect).setPressedForTest(positions.last(), pressed = false)
-    repeat(12) {
+    repeat(3) {
       mainClock.advanceTimeByFrame()
       assertThat(runtime(effect).delegate).isSameInstanceAs(delegate)
       assertThat(delegate.layers.source).isSameInstanceAs(source)
@@ -356,9 +339,8 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       assertThat(checkNotNull(runtime(effect).preparedRender).plan.layers.map { it.kind }).isEqualTo(plannedKinds)
     }
     mainClock.autoAdvance = true
-    showContent.value = false
-    waitUntil { controller.isDisposedForTest }
-    assertThat(controller.isDisposedForTest).isTrue()
+    setContent {}
+    waitForIdle()
   }
 
   @Test

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
@@ -767,10 +767,8 @@ private fun GlassRuntimeEffect.configuration(): GlassNodeConfiguration =
   GlassNodeConfiguration(
     style = style,
     interactionSource = interactionSource,
-    interactionLightRadiusFraction = interactionLightRadiusFraction,
     interactionTransformTarget = interactionTransformTarget,
     interactionTransformPivot = interactionTransformPivot,
-    interactionPositionAnimationSpec = interactionPositionAnimationSpec,
     interactionReducedMotionPolicy = interactionReducedMotionPolicy,
   )
 

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassTestConfiguration.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassTestConfiguration.kt
@@ -236,7 +236,11 @@ internal class GlassTestConfiguration {
         specularExponentOverride.takeIf { hasSpecularExponentOverride }
       val resolvedFresnelExponentOverride =
         fresnelExponentOverride.takeIf { hasFresnelExponentOverride }
+      val resolvedInteractionLightRadiusFraction = interactionLightRadiusFraction
+      val resolvedInteractionPositionAnimationSpec = interactionPositionAnimationSpec
       return baseStyle.then {
+        interactionLightRadiusFraction(resolvedInteractionLightRadiusFraction)
+        interactionPositionAnimationSpec(resolvedInteractionPositionAnimationSpec)
         resolvedOpticsOverride?.let(::optics)
         resolvedSpecularIntensityOverride?.let(::specularIntensity)
         resolvedAmbientResponseOverride?.let(::ambientResponse)
@@ -294,10 +298,8 @@ internal fun Modifier.hazeGlass(
   style = configuration.resolvedStyle,
   sampling = sampling,
   interactionSource = configuration.interactionSource,
-  interactionLightRadiusFraction = configuration.interactionLightRadiusFraction,
   interactionTransformTarget = configuration.interactionTransformTarget,
   interactionTransformPivot = configuration.interactionTransformPivot,
-  interactionPositionAnimationSpec = configuration.interactionPositionAnimationSpec,
   interactionReducedMotionPolicy = configuration.interactionReducedMotionPolicy,
 )
 

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
@@ -53,7 +53,6 @@ import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.HazeState
-import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassReducedMotionPolicy
 import dev.chrisbanes.haze.glass.GlassTransformPivot
 import dev.chrisbanes.haze.glass.GlassTransformTarget
@@ -454,7 +453,6 @@ private fun PlaygroundSurface(
         interactionSource = interactionSource,
         interactionTransformTarget = GlassTransformTarget.MaterialAndContent,
         interactionTransformPivot = GlassTransformPivot.Pointer,
-        interactionPositionAnimationSpec = GlassDefaults.positionAnimationSpec,
         interactionReducedMotionPolicy = GlassReducedMotionPolicy.System,
       )
       .pointerInput(id) {


### PR DESCRIPTION
## Summary

- move interaction light radius and position animation into replayable `GlassStyle` presentation
- keep interaction source, transform target/pivot, and reduced-motion policy as node-owned modifier mechanics
- seal `GlassInteractionScope` and update API signatures, first-party callers, tests, samples, and migration/docs

## Validation

- `./gradlew :haze-glass:check :haze-glass:metalavaCheckCompatibility :haze-screenshot-tests:test :sample:shared:compileKotlinJvm spotlessCheck`
- `./gradlew :sample:screenshot-tests:testAndroidHostTest`
- `./scripts/build_docs.sh build`
- focused TDD and widened Glass/runtime/Android-host checks

The desktop Glass Gallery portrait and landscape snapshot checks reproduce the same mismatch on the exact clean base commit, with byte-identical actual images and mismatch counts. No screenshot baselines were recorded or changed.

Fixes #1183
