### PR TITLE
Rename fixed Glass optics and add direct DSL

### DIFF
--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -35,8 +35,9 @@ Adaptive content behavior, interaction-driven deformation, and morphing are unsu
 - **tint**: Glass tint (defaults to transparent).
 - **optics**: Optical material configuration. `GlassOptics.Adaptive` (the default) is the
   built-in Haze material; it responds to the material's size, aspect ratio, and
-  rounded geometry. Use `GlassOptics.Absolute(...)` when you need a complete literal optical
-  configuration. Its `refractionStrength`, `refractionHeightFraction`,
+  rounded geometry. Call `optics(...)` directly for an inline fixed optical configuration, or use
+  `GlassOptics.Fixed(...)` when you need to store, reuse, copy, or select the complete value. Its
+  `refractionStrength`, `refractionHeightFraction`,
   `refractionDisplacement`, `depth`, `blurRadius`, and optional `progressive` values are used
   without geometry-dependent adjustment. `refractionDisplacement` and `blurRadius` are
   density-independent `Dp`, while `refractionHeightFraction` is a unitless fraction of the
@@ -69,7 +70,7 @@ new Style.
 ```kotlin
 val baseStyle = GlassStyle {
   tint(Color.White.copy(alpha = 0.16f))
-  optics(GlassOptics.Absolute(refractionStrength = 0.8f))
+  optics(refractionStrength = 0.8f)
   shape(RoundedCornerShape(20.dp))
 }
 val emphasizedStyle = baseStyle.then { specularIntensity(0.7f) }
@@ -95,8 +96,8 @@ Box(
 ### Choosing optics
 
 Use `GlassOptics.Adaptive` for the built-in Haze material, which adapts its optical response to the
-material's size, aspect ratio, and roundness. Use `GlassOptics.Absolute` when your design needs a
-complete literal configuration instead:
+material's size, aspect ratio, and roundness. For ordinary inline fixed Style authoring, call the
+direct `optics(...)` function:
 
 ```kotlin
 GlassStyle { optics(GlassOptics.Adaptive) }
@@ -104,20 +105,33 @@ GlassStyle { optics(GlassOptics.Adaptive) }
 
 ```kotlin
 GlassStyle {
-  optics(GlassOptics.Absolute(
+  optics(
     blurRadius = 20.dp,
     refractionStrength = 0.8f,
     refractionHeightFraction = 0.3f,
     refractionDisplacement = 18.dp,
     depth = 0.5f,
-  ))
+  )
 }
 ```
 
-Absolute values are not geometry-adjusted. `refractionDisplacement` and `blurRadius` describe
-logical distances, while `refractionHeightFraction` remains relative to the material's shortest
-side. Backend sampling and kernel construction remain rendering details. `shape` and `tint` stay
-independent of the selected optics. The `shape`
+The direct function constructs `GlassOptics.Fixed`. Fixed values are not geometry-adjusted:
+`refractionStrength`, `refractionHeightFraction`, and `depth` must be finite values in `0f..1f`;
+`refractionDisplacement` and `blurRadius` must be specified, finite, non-negative `Dp`; and
+`progressive` is optional. Large logical displacement and blur distances remain valid even when a
+renderer caps effective sampling or kernel work. `refractionHeightFraction` remains relative to the
+material's shortest side.
+
+Keep a complete value when it is reused, stored, copied, or selected programmatically:
+
+```kotlin
+val reusableOptics = GlassOptics.Fixed(blurRadius = 20.dp)
+val style = GlassStyle { optics(reusableOptics) }
+```
+
+Backend sampling and kernel construction remain rendering details. `GlassOptics.Fixed` is distinct
+from `HazeSampling.Fixed(pixelFraction)`, which selects a sampling policy rather than optical
+values. `shape` and `tint` stay independent of the selected optics. The `shape`
 supplied to Glass is the authoritative material boundary. An outer `Modifier.clip()` is not visible
 to Glass and does not define its optical boundary; add one with the same shape only when child
 content also needs clipping.
@@ -158,12 +172,12 @@ You can select a literal optical configuration when the built-in material does n
 ```kotlin
 GlassStyle {
   tint(Color.White.copy(alpha = 0.20f))
-  optics(GlassOptics.Absolute(
+  optics(
     progressive = HazeProgressive.verticalGradient(
       startIntensity = 1f,
       endIntensity = 0.25f,
     ),
-  ))
+  )
 }
 ```
 
@@ -287,11 +301,11 @@ Box(
       input = HazeInput.Sources(hazeState),
       style = GlassStyle {
         tint(Color.White.copy(alpha = 0.16f))
-        optics(GlassOptics.Absolute(
+        optics(
           refractionStrength = 0.8f,
           refractionHeightFraction = 0.32f,
           depth = 0.5f,
-        ))
+        )
         specularIntensity(0.7f)
         ambientResponse(0.7f)
         edgeSoftness(14.dp)
@@ -306,8 +320,8 @@ Box(
 ## Tips
 
 - `GlassOptics.Adaptive` is the right starting point for material-like glass that should respond
-  naturally to its geometry. Use `GlassOptics.Absolute` only when you need to control the whole
-  optical configuration.
+  naturally to its geometry. Use direct `optics(...)` for inline fixed authoring and
+  `GlassOptics.Fixed` when the complete value needs to be reused or selected programmatically.
 - Keep `chromaticAberrationStrength` modest; start at 0.1-0.25 to avoid rainbow artifacts.
 - Combine `edgeSoftness` with rounded shapes for smooth clipping; set `edgeSoftness = 0.dp` to rely purely on the shape.
 - Use `SurfaceProfile.Concave` for an inward-curving bezel or `SurfaceProfile.Lip` for a raised rim effect.

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -201,6 +201,11 @@ inert; construct and supply a replacement Style to reflect new inputs.
 | effect-owned interaction source, transform target/pivot, and reduced-motion policy | explicit `Modifier.hazeGlass` arguments owned by each node |
 | implicit source/content | explicit `HazeInput.Sources` or `HazeInput.Content` |
 | raw optical displacement/caps | semantic `GlassOptics` and `Dp` controls |
+| `GlassOptics.Absolute` | `GlassOptics.Fixed`; this is a hard rename with no alias or compatibility bridge |
+
+For ordinary inline fixed Style authoring, pass the complete fixed parameter set directly to
+`optics(...)`. The complete-value overload remains available for `GlassOptics.Adaptive`, reusable
+fixed values, copies, storage, and programmatic selection.
 
 Write each property through the Style scope, then pass the Style and structural policies to
 `hazeGlass`:
@@ -209,10 +214,8 @@ Write each property through the Style scope, then pass the Style and structural 
 val glassStyle = GlassStyle {
   tint(Color.White.copy(alpha = 0.12f))
   optics(
-    GlassOptics.Absolute(
-      refractionStrength = 0.7f,
-      depth = 0.4f,
-    ),
+    refractionStrength = 0.7f,
+    depth = 0.4f,
   )
   specularIntensity(0.4f)
   edgeSoftness(12.dp)

--- a/haze-glass/api/api.txt
+++ b/haze-glass/api/api.txt
@@ -58,16 +58,20 @@ package dev.chrisbanes.haze.glass {
   @androidx.compose.runtime.Immutable @dev.chrisbanes.haze.ExperimentalHazeApi public sealed exhaustive interface GlassOptics {
   }
 
-  public static final class GlassOptics.Absolute implements dev.chrisbanes.haze.glass.GlassOptics {
-    ctor public GlassOptics.Absolute();
-    ctor @KotlinOnly public GlassOptics.Absolute(optional float refractionStrength, optional float refractionHeightFraction, optional androidx.compose.ui.unit.Dp refractionDisplacement, optional float depth, optional androidx.compose.ui.unit.Dp blurRadius, optional dev.chrisbanes.haze.HazeProgressive? progressive);
+  public static final class GlassOptics.Adaptive implements dev.chrisbanes.haze.glass.GlassOptics {
+    field public static final dev.chrisbanes.haze.glass.GlassOptics.Adaptive INSTANCE;
+  }
+
+  public static final class GlassOptics.Fixed implements dev.chrisbanes.haze.glass.GlassOptics {
+    ctor public GlassOptics.Fixed();
+    ctor @KotlinOnly public GlassOptics.Fixed(optional float refractionStrength, optional float refractionHeightFraction, optional androidx.compose.ui.unit.Dp refractionDisplacement, optional float depth, optional androidx.compose.ui.unit.Dp blurRadius, optional dev.chrisbanes.haze.HazeProgressive? progressive);
     method public float component1();
     method public float component2();
     method @KotlinOnly public operator androidx.compose.ui.unit.Dp component3();
     method public float component4();
     method @KotlinOnly public operator androidx.compose.ui.unit.Dp component5();
     method public dev.chrisbanes.haze.HazeProgressive? component6();
-    method @KotlinOnly public dev.chrisbanes.haze.glass.GlassOptics.Absolute copy(optional float refractionStrength, optional float refractionHeightFraction, optional androidx.compose.ui.unit.Dp refractionDisplacement, optional float depth, optional androidx.compose.ui.unit.Dp blurRadius, optional dev.chrisbanes.haze.HazeProgressive? progressive);
+    method @KotlinOnly public dev.chrisbanes.haze.glass.GlassOptics.Fixed copy(optional float refractionStrength, optional float refractionHeightFraction, optional androidx.compose.ui.unit.Dp refractionDisplacement, optional float depth, optional androidx.compose.ui.unit.Dp blurRadius, optional dev.chrisbanes.haze.HazeProgressive? progressive);
     method @InaccessibleFromKotlin public float getDepth();
     method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeProgressive? getProgressive();
     method @InaccessibleFromKotlin public float getRefractionHeightFraction();
@@ -78,10 +82,6 @@ package dev.chrisbanes.haze.glass {
     property public androidx.compose.ui.unit.Dp refractionDisplacement;
     property public float refractionHeightFraction;
     property public float refractionStrength;
-  }
-
-  public static final class GlassOptics.Adaptive implements dev.chrisbanes.haze.glass.GlassOptics {
-    field public static final dev.chrisbanes.haze.glass.GlassOptics.Adaptive INSTANCE;
   }
 
   @dev.chrisbanes.haze.ExperimentalHazeApi public enum GlassReducedMotionPolicy {
@@ -124,6 +124,7 @@ package dev.chrisbanes.haze.glass {
     method public void interactionPositionAnimationSpec(androidx.compose.animation.core.FiniteAnimationSpec<androidx.compose.ui.geometry.Offset> animationSpec);
     method @KotlinOnly public void lightPosition(androidx.compose.ui.geometry.Offset position);
     method public void optics(dev.chrisbanes.haze.glass.GlassOptics optics);
+    method @KotlinOnly public void optics(optional float refractionStrength, optional float refractionHeightFraction, optional androidx.compose.ui.unit.Dp refractionDisplacement, optional float depth, optional androidx.compose.ui.unit.Dp blurRadius, optional dev.chrisbanes.haze.HazeProgressive? progressive);
     method public void pressed(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> response);
     method public void shape(androidx.compose.foundation.shape.RoundedCornerShape shape);
     method public void specularExponent(float exponent);

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -138,7 +138,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
   fun interactiveOptics_usesFusedBaseRendererBeforeInteractionStarts() =
     assertFusedRenderer(
       interactiveEffect().apply {
-        optics = (optics as GlassOptics.Absolute).copy(
+        optics = (optics as GlassOptics.Fixed).copy(
           depth = 0.5f,
           blurRadius = 38.5.dp,
         )
@@ -169,7 +169,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
   fun singleNoBlur_usesFusedBaseRenderer() =
     assertFusedRenderer(
       retainedBlurEffect().apply {
-        optics = (optics as GlassOptics.Absolute).copy(
+        optics = (optics as GlassOptics.Fixed).copy(
           depth = 0f,
           blurRadius = 0.dp,
         )
@@ -403,7 +403,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     runAndroidComposeUiTest<ComponentActivity> {
       val callerBrush = Brush.linearGradient(listOf(Color.Transparent, Color.Black))
       val effect = animatedStageEffect().apply {
-        optics = (optics as GlassOptics.Absolute).copy(
+        optics = (optics as GlassOptics.Fixed).copy(
           progressive = HazeProgressive.Brush(callerBrush),
         )
       }
@@ -546,7 +546,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       waitForIdle()
       drawFrame()
       effect.ambientResponse = 0.6f
-      effect.optics = (effect.optics as GlassOptics.Absolute).copy(refractionDisplacement = 18.dp)
+      effect.optics = (effect.optics as GlassOptics.Fixed).copy(refractionDisplacement = 18.dp)
       waitForIdle()
       drawFrame()
 
@@ -722,7 +722,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       val fusedShader = checkNotNull(delegate.fusedShader)
       val fusedEffect = checkNotNull(delegate.layers.optical?.renderEffect)
 
-      effect.optics = (effect.optics as GlassOptics.Absolute).copy(
+      effect.optics = (effect.optics as GlassOptics.Fixed).copy(
         refractionDisplacement = 18.dp,
       )
       waitForIdle()
@@ -747,7 +747,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
 
       val fusedShader = checkNotNull(delegate.fusedShader)
       val fusedEffect = checkNotNull(delegate.layers.optical?.renderEffect)
-      effect.optics = (effect.optics as GlassOptics.Absolute).copy(blurRadius = 36.dp)
+      effect.optics = (effect.optics as GlassOptics.Fixed).copy(blurRadius = 36.dp)
       waitForIdle()
       drawFrame()
 
@@ -775,7 +775,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       val fusedShader = checkNotNull(delegate.fusedShader)
       val fusedEffect = checkNotNull(delegate.layers.optical?.renderEffect)
 
-      effect.optics = (effect.optics as GlassOptics.Absolute).copy(
+      effect.optics = (effect.optics as GlassOptics.Fixed).copy(
         blurRadius = 34.dp,
         progressive = HazeProgressive.verticalGradient(
           startIntensity = 0.1f,
@@ -793,7 +793,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     }
 
   private fun animatedStageEffect() = GlassRuntimeEffect().apply {
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.5f,
       refractionDisplacement = 20.dp,
       depth = 0.5f,
@@ -805,7 +805,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
   }
 
   private fun interactiveEffect() = GlassRuntimeEffect().apply {
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.5f,
       refractionDisplacement = 20.dp,
       blurRadius = 0.dp,
@@ -820,7 +820,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
   }
 
   private fun largePanelInteractiveEffect() = GlassRuntimeEffect().apply {
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.5f,
       refractionDisplacement = 20.dp,
       blurRadius = 0.dp,
@@ -844,7 +844,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     progressive: HazeProgressive? = null,
     refractionStrength: Float = 0.5f,
   ) = GlassRuntimeEffect().apply {
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = refractionStrength,
       refractionDisplacement = 20.dp,
       depth = 0.5f,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
@@ -19,7 +19,7 @@ public sealed interface GlassOptics {
    * The built-in Haze glass material.
    *
    * Its optical response adapts to the material's size, aspect ratio, and roundness.
-   * Its adaptive blur scaling is applied after the [Absolute] blur-radius cap, so its effective
+   * Its adaptive blur scaling is applied after the [Fixed] blur-radius cap, so its effective
    * blur radius can exceed that cap.
    */
   public data object Adaptive : GlassOptics
@@ -42,7 +42,7 @@ public sealed interface GlassOptics {
    * @param blurRadius Maximum blur radius before the renderer's adaptive scale is applied.
    * @param progressive Optional progressive intensity applied to the blur.
    */
-  public data class Absolute(
+  public data class Fixed(
     val refractionStrength: Float = 0.7f,
     val refractionHeightFraction: Float = 0.25f,
     val refractionDisplacement: Dp = 15.dp,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -248,7 +248,7 @@ internal fun resolveAdaptiveGeometryOptics(
   )
 }
 
-private val AdaptiveOpticsBaseline = GlassOptics.Absolute()
+private val AdaptiveOpticsBaseline = GlassOptics.Fixed()
 
 internal data class ResolvedGlassOptics(
   val refractionStrength: Float,
@@ -269,9 +269,9 @@ internal fun resolveGlassOptics(
   density: Density,
   cornerRadiiPx: CornerRadii,
 ): ResolvedGlassOptics {
-  val absolute = when (optics) {
+  val fixed = when (optics) {
     GlassOptics.Adaptive -> AdaptiveOpticsBaseline
-    is GlassOptics.Absolute -> optics
+    is GlassOptics.Fixed -> optics
   }
   val response = when (optics) {
     GlassOptics.Adaptive -> calculateAdaptiveGeometryResponse(
@@ -279,31 +279,31 @@ internal fun resolveGlassOptics(
       density = density,
       cornerRadiiPx = cornerRadiiPx,
     )
-    is GlassOptics.Absolute -> AdaptiveGeometryResponse.Identity
+    is GlassOptics.Fixed -> AdaptiveGeometryResponse.Identity
   }
   val resolved = resolveAdaptiveGeometryOptics(
     response = response,
-    refractionStrength = absolute.refractionStrength,
+    refractionStrength = fixed.refractionStrength,
     shortestSidePx = materialSizePx.minDimension,
-    blurRadiusPx = effectiveSemanticBlurRadiusPx(with(density) { absolute.blurRadius.toPx() }),
-    refractionScalePx = with(density) { absolute.refractionDisplacement.toPx() },
-    refractionHeight = absolute.refractionHeightFraction,
+    blurRadiusPx = effectiveSemanticBlurRadiusPx(with(density) { fixed.blurRadius.toPx() }),
+    refractionScalePx = with(density) { fixed.refractionDisplacement.toPx() },
+    refractionHeight = fixed.refractionHeightFraction,
   )
   return ResolvedGlassOptics(
-    refractionStrength = absolute.refractionStrength,
+    refractionStrength = fixed.refractionStrength,
     refractionHeightPx = resolved.refractionHeightPx,
     refractionScalePx = resolved.refractionScalePx
       .coerceIn(0f, MAX_REFRACTION_DISPLACEMENT_PX)
       .finiteOrZero(),
-    depth = absolute.depth,
+    depth = fixed.depth,
     blurRadiusPx = resolved.blurRadiusPx,
     blurSigmaPx = resolved.blurSigmaPx,
-    progressive = absolute.progressive,
+    progressive = fixed.progressive,
     toneGain = resolved.toneGain,
     neutralLiftWeight = resolved.neutralLiftWeight,
     refractionDetailIntensity = when (optics) {
       GlassOptics.Adaptive -> 0f
-      is GlassOptics.Absolute -> GLASS_REFRACTION_DETAIL_INTENSITY
+      is GlassOptics.Fixed -> GLASS_REFRACTION_DETAIL_INTENSITY
     },
   )
 }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.Poko
 
 /**
@@ -159,6 +160,27 @@ public class GlassStyleScope internal constructor(
   /** Sets the rounded boundary used for refraction and masking. */
   public fun shape(shape: RoundedCornerShape) {
     writes += { this.shape = shape }
+  }
+
+  /** Sets a complete fixed optical model used to refract and blur captured content. */
+  public fun optics(
+    refractionStrength: Float = 0.7f,
+    refractionHeightFraction: Float = 0.25f,
+    refractionDisplacement: Dp = 15.dp,
+    depth: Float = 1f,
+    blurRadius: Dp = 14.dp,
+    progressive: HazeProgressive? = null,
+  ) {
+    optics(
+      GlassOptics.Fixed(
+        refractionStrength = refractionStrength,
+        refractionHeightFraction = refractionHeightFraction,
+        refractionDisplacement = refractionDisplacement,
+        depth = depth,
+        blurRadius = blurRadius,
+        progressive = progressive,
+      ),
+    )
   }
 
   /** Sets the optical model used to refract and blur captured content. */

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassOpticsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassOpticsTest.kt
@@ -9,6 +9,8 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNull
+import assertk.assertions.messageContains
 import kotlin.test.Test
 
 class GlassOpticsTest {
@@ -21,27 +23,77 @@ class GlassOpticsTest {
   }
 
   @Test
-  fun absolute_rejectsInvalidSemanticValues() {
-    listOf<() -> Unit>(
-      { GlassOptics.Absolute(refractionStrength = Float.NaN) },
-      { GlassOptics.Absolute(refractionStrength = -0.1f) },
-      { GlassOptics.Absolute(refractionHeightFraction = 1.1f) },
-      { GlassOptics.Absolute(refractionDisplacement = Dp.Unspecified) },
-      { GlassOptics.Absolute(refractionDisplacement = Float.POSITIVE_INFINITY.dp) },
-      { GlassOptics.Absolute(refractionDisplacement = (-1).dp) },
-      { GlassOptics.Absolute(depth = Float.NaN) },
-      { GlassOptics.Absolute(blurRadius = Dp.Unspecified) },
-      { GlassOptics.Absolute(blurRadius = (-1).dp) },
-    ).forEach { create ->
-      assertFailure { create() }.isInstanceOf<IllegalArgumentException>()
+  fun fixed_rejectsInvalidSemanticValues() {
+    assertInvalidFixedFraction("refractionStrength") {
+      GlassOptics.Fixed(refractionStrength = it)
+    }
+    assertInvalidFixedFraction("refractionHeightFraction") {
+      GlassOptics.Fixed(refractionHeightFraction = it)
+    }
+    assertInvalidFixedFraction("depth") {
+      GlassOptics.Fixed(depth = it)
+    }
+    assertInvalidFixedDistance("refractionDisplacement") {
+      GlassOptics.Fixed(refractionDisplacement = it)
+    }
+    assertInvalidFixedDistance("blurRadius") {
+      GlassOptics.Fixed(blurRadius = it)
     }
   }
 
   @Test
-  fun absolute_acceptsFiniteDisplacementBeyondRendererLimit() {
-    val displacement = Float.MAX_VALUE.dp
+  fun fixed_acceptsBoundariesAndLargeRendererIndependentValues() {
+    val minimum = GlassOptics.Fixed(
+      refractionStrength = 0f,
+      refractionHeightFraction = 0f,
+      refractionDisplacement = 0.dp,
+      depth = 0f,
+      blurRadius = 0.dp,
+    )
+    val maximum = GlassOptics.Fixed(
+      refractionStrength = 1f,
+      refractionHeightFraction = 1f,
+      refractionDisplacement = Float.MAX_VALUE.dp,
+      depth = 1f,
+      blurRadius = Float.MAX_VALUE.dp,
+    )
 
-    assertThat(GlassOptics.Absolute(refractionDisplacement = displacement).refractionDisplacement)
-      .isEqualTo(displacement)
+    assertThat(minimum.refractionStrength).isEqualTo(0f)
+    assertThat(minimum.refractionHeightFraction).isEqualTo(0f)
+    assertThat(minimum.refractionDisplacement).isEqualTo(0.dp)
+    assertThat(minimum.depth).isEqualTo(0f)
+    assertThat(minimum.blurRadius).isEqualTo(0.dp)
+    assertThat(minimum.progressive).isNull()
+    assertThat(maximum.refractionStrength).isEqualTo(1f)
+    assertThat(maximum.refractionHeightFraction).isEqualTo(1f)
+    assertThat(maximum.refractionDisplacement).isEqualTo(Float.MAX_VALUE.dp)
+    assertThat(maximum.depth).isEqualTo(1f)
+    assertThat(maximum.blurRadius).isEqualTo(Float.MAX_VALUE.dp)
+    assertThat(maximum.progressive).isNull()
+  }
+}
+
+private fun assertInvalidFixedFraction(property: String, create: (Float) -> Unit) {
+  listOf(Float.NaN, Float.NEGATIVE_INFINITY, -0.1f, 1.1f, Float.POSITIVE_INFINITY)
+    .forEach { invalid ->
+      val failure = assertFailure { create(invalid) }
+      failure.isInstanceOf<IllegalArgumentException>()
+      failure.messageContains(property)
+      failure.messageContains("0f..1f")
+    }
+}
+
+private fun assertInvalidFixedDistance(property: String, create: (Dp) -> Unit) {
+  listOf(
+    Dp.Unspecified,
+    Float.NaN.dp,
+    Float.NEGATIVE_INFINITY.dp,
+    (-1).dp,
+    Float.POSITIVE_INFINITY.dp,
+  ).forEach { invalid ->
+    val failure = assertFailure { create(invalid) }
+    failure.isInstanceOf<IllegalArgumentException>()
+    failure.messageContains(property)
+    failure.messageContains("specified, finite, and non-negative")
   }
 }

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectKeysTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectKeysTest.kt
@@ -301,7 +301,7 @@ class GlassRenderEffectKeysTest {
 
   @Test
   fun defaultRefractionDetailVisibility_isFullySaturated() {
-    val regularBaseline = GlassOptics.Absolute()
+    val regularBaseline = GlassOptics.Fixed()
     assertThat(
       calculateRefractionDetailVisibility(
         refractionStrength = regularBaseline.refractionStrength,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -478,12 +478,12 @@ class GlassRenderParamsTest {
   }
 
   @Test
-  fun absoluteOptics_resolveSemanticValuesAcrossDensities() {
+  fun fixedOptics_resolveSemanticValuesAcrossDensities() {
     val progressive = dev.chrisbanes.haze.HazeProgressive.verticalGradient(
       startIntensity = 0f,
       endIntensity = 1f,
     )
-    val optics = GlassOptics.Absolute(
+    val optics = GlassOptics.Fixed(
       refractionStrength = 0.4f,
       refractionHeightFraction = 0.25f,
       refractionDisplacement = 15.dp,
@@ -526,7 +526,7 @@ class GlassRenderParamsTest {
   }
 
   @Test
-  fun absoluteOptics_blurRadiusUsesCurrentPhysicalPixelCapAcrossDensities() {
+  fun fixedOptics_blurRadiusUsesCurrentPhysicalPixelCapAcrossDensities() {
     val cases = listOf(
       Triple(20.dp, Density(1f), 20f),
       Triple(14.dp, Density(2.75f), 38.5f),
@@ -536,7 +536,7 @@ class GlassRenderParamsTest {
 
     cases.forEach { (radius, density, expectedRadiusPx) ->
       val resolved = resolveGlassOptics(
-        optics = GlassOptics.Absolute(blurRadius = radius),
+        optics = GlassOptics.Fixed(blurRadius = radius),
         materialSizePx = Size(200f, 100f),
         density = density,
         cornerRadiiPx = CornerRadii.zero,
@@ -751,18 +751,18 @@ class GlassRenderParamsTest {
   }
 
   @Test
-  fun absoluteLayerPadding_usesLiteralValues() {
-    val absolute = GlassOptics.Absolute(
+  fun fixedLayerPadding_usesLiteralValues() {
+    val fixed = GlassOptics.Fixed(
       blurRadius = 32.dp,
       refractionDisplacement = 15.dp,
     )
     val effect = GlassRuntimeEffect().apply {
-      optics = absolute
+      optics = fixed
     }
     val rect = Rect(0f, 0f, 200f, 100f)
 
     assertThat(effect.calculateLayerBounds(rect, Density(1f))).isEqualTo(
-      rect.inflate(32f + 15f * absolute.refractionStrength + 2f),
+      rect.inflate(32f + 15f * fixed.refractionStrength + 2f),
     )
   }
 
@@ -797,7 +797,7 @@ class GlassRenderParamsTest {
   @Test
   fun renderParams_deriveBlurSigmaFromScaledRadius() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(blurRadius = 20.dp)
+      optics = GlassOptics.Fixed(blurRadius = 20.dp)
     }
     val style = resolveGlassStyle(
       effect = effect,
@@ -827,7 +827,7 @@ class GlassRenderParamsTest {
   @Test
   fun renderParams_scaleResolvedOpticalDistancesExactlyOnce() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         refractionHeightFraction = 0.25f,
         refractionDisplacement = 12.dp,
         blurRadius = 10.dp,
@@ -860,7 +860,7 @@ class GlassRenderParamsTest {
   @Test
   fun renderParams_applyInputScaleAfterInternalOpticalClamping() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(refractionDisplacement = Float.MAX_VALUE.dp)
+      optics = GlassOptics.Fixed(refractionDisplacement = Float.MAX_VALUE.dp)
     }
     val style = resolveGlassStyle(
       effect = effect,
@@ -886,7 +886,7 @@ class GlassRenderParamsTest {
   @Test
   fun renderParams_zeroBlurHasZeroRadiusAndSigma() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(blurRadius = 0.dp)
+      optics = GlassOptics.Fixed(blurRadius = 0.dp)
     }
     val style = resolveGlassStyle(
       effect = effect,
@@ -999,7 +999,7 @@ class GlassRenderParamsTest {
 
   @Test
   fun defaultCircleProfile_sourceDetailSupportMapsToNarrowerInBoundsOutputBand() {
-    val regularBaseline = GlassOptics.Absolute()
+    val regularBaseline = GlassOptics.Fixed()
     val detailWidthPx = calculateRefractionDetailWidthPx(
       refractionHeightPx = 100f,
       edgeSoftnessPx = 3f,
@@ -1060,14 +1060,14 @@ class GlassRenderParamsTest {
       cornerRadiiPx = CornerRadii.zero,
     )
 
-    assertThat(resolved.blurRadiusPx).isGreaterThan(GlassOptics.Absolute().blurRadius.value)
+    assertThat(resolved.blurRadiusPx).isGreaterThan(GlassOptics.Fixed().blurRadius.value)
     assertThat(padding).isEqualTo(expectedLayerPadding(effect, rect, density))
   }
 
   @Test
   fun calculateLayerBounds_zeroRefractionUsesEffectiveSemanticBlurRadiusExactly() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         blurRadius = 32.dp,
         refractionStrength = 0f,
         refractionDisplacement = 0.dp,
@@ -1091,7 +1091,7 @@ class GlassRenderParamsTest {
     }
     val rect = Rect(0f, 0f, 240f, 80f)
     val density = Density(1f)
-    val effectiveBlurRadius = effectiveSemanticBlurRadiusPx(GlassOptics.Absolute().blurRadius.value)
+    val effectiveBlurRadius = effectiveSemanticBlurRadiusPx(GlassOptics.Fixed().blurRadius.value)
     val expectedPadding = expectedLayerPadding(effect, rect, density)
     val cornerRadii = effect.shape.toCornerRadiiPx(
       rect.size,
@@ -1144,7 +1144,7 @@ class GlassRenderParamsTest {
   @Test
   fun calculateLayerBounds_invalidGeometryProducesFiniteInflatedBounds() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         blurRadius = 32.dp,
         refractionStrength = 1f,
         refractionDisplacement = 0.dp,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import assertk.assertFailure
 import assertk.assertThat
@@ -16,13 +17,77 @@ import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
+import assertk.assertions.messageContains
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
+import dev.chrisbanes.haze.HazeProgressive
 import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class)
 class GlassStyleTest {
+
+  @Test
+  fun directOptics_constructsTheCompleteFixedValue() {
+    val progressive = HazeProgressive.verticalGradient()
+    val style = GlassStyle {
+      optics(
+        refractionStrength = 0.8f,
+        refractionHeightFraction = 0.4f,
+        refractionDisplacement = 24.dp,
+        depth = 0.6f,
+        blurRadius = 20.dp,
+        progressive = progressive,
+      )
+    }
+
+    assertThat(resolveGlassStyleValues(GlassStyle, style).optics).isEqualTo(
+      GlassOptics.Fixed(
+        refractionStrength = 0.8f,
+        refractionHeightFraction = 0.4f,
+        refractionDisplacement = 24.dp,
+        depth = 0.6f,
+        blurRadius = 20.dp,
+        progressive = progressive,
+      ),
+    )
+  }
+
+  @Test
+  fun directOptics_usesFixedValidation() {
+    val invalidWrites = listOf<Pair<String, GlassStyleScope.() -> Unit>>(
+      "refractionStrength" to { optics(refractionStrength = Float.NaN) },
+      "refractionHeightFraction" to { optics(refractionHeightFraction = 1.1f) },
+      "refractionDisplacement" to { optics(refractionDisplacement = Dp.Unspecified) },
+      "depth" to { optics(depth = Float.NEGATIVE_INFINITY) },
+      "blurRadius" to { optics(blurRadius = (-1).dp) },
+    )
+
+    invalidWrites.forEach { (property, write) ->
+      val failure = assertFailure { GlassStyle(write) }
+      failure.isInstanceOf<IllegalArgumentException>()
+      failure.messageContains(property)
+    }
+  }
+
+  @Test
+  fun completeOptics_preservesAdaptiveAndProgrammaticValues() {
+    val sharedFixed = GlassOptics.Fixed(depth = 0.4f)
+    val programmaticallySelected: GlassOptics = listOf(GlassOptics.Adaptive, sharedFixed).last()
+
+    val adaptive = resolveGlassStyleValues(
+      GlassStyle,
+      GlassStyle { optics(GlassOptics.Adaptive) },
+    )
+    val selected = resolveGlassStyleValues(
+      GlassStyle,
+      GlassStyle { optics(programmaticallySelected) },
+    )
+
+    assertThat(adaptive.optics).isSameInstanceAs(GlassOptics.Adaptive)
+    assertThat(selected.optics).isSameInstanceAs(sharedFixed)
+  }
 
   @Test
   fun interactionPresentation_recordsAndComposesPerProperty() {
@@ -102,7 +167,7 @@ class GlassStyleTest {
     var appendedExecutions = 0
     val base = GlassStyle {
       baseExecutions++
-      optics(GlassOptics.Absolute(depth = 0.2f))
+      optics(depth = 0.2f)
       pressed {
         lightingIntensity(0.2f)
         refractionMultiplier(1.2f)
@@ -110,7 +175,7 @@ class GlassStyleTest {
     }
     val override = GlassStyle {
       overrideExecutions++
-      optics(GlassOptics.Absolute(depth = 0.6f))
+      optics(depth = 0.6f)
       pressed { lightingIntensity(0.7f) }
     }
     val combined = base.then(override).then {
@@ -124,7 +189,7 @@ class GlassStyleTest {
     assertThat(baseExecutions).isEqualTo(1)
     assertThat(overrideExecutions).isEqualTo(1)
     assertThat(appendedExecutions).isEqualTo(1)
-    assertThat(first.optics).isEqualTo(GlassOptics.Absolute(depth = 0.6f))
+    assertThat(first.optics).isEqualTo(GlassOptics.Fixed(depth = 0.6f))
     assertThat(first.pressedInteraction?.lightingIntensity?.value).isEqualTo(0.7f)
     assertThat(first.pressedInteraction?.refractionMultiplier).isNull()
     assertThat(first.alpha).isEqualTo(0.5f)
@@ -212,7 +277,7 @@ class GlassStyleTest {
 
   @Test
   fun staticPropertyWrites_preserveCanonicalization() {
-    val optics = GlassOptics.Absolute(refractionStrength = 0.3f)
+    val optics = GlassOptics.Fixed(refractionStrength = 0.3f)
     val shape = RoundedCornerShape(12.dp)
     val style = GlassStyle {
       shape(shape)

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
@@ -292,7 +292,7 @@ class HazeGlassModifierTest : ContextTest() {
     val localStyle = GlassStyle {
       alpha(0.3f)
       whitePoint(0.2f)
-      optics(GlassOptics.Absolute(depth = 0.2f, blurRadius = 12.dp))
+      optics(depth = 0.2f, blurRadius = 12.dp)
       pressed {
         lightingIntensity(0.2f)
         refractionMultiplier(1.2f)
@@ -301,41 +301,50 @@ class HazeGlassModifierTest : ContextTest() {
     val explicitStyle = GlassStyle {
       alpha(0.6f)
       specularIntensity(0.6f)
-      optics(GlassOptics.Absolute(depth = 0.5f, blurRadius = 16.dp))
+      optics(GlassOptics.Adaptive)
       pressed {
         lightingIntensity(0.5f)
         refractionMultiplier(1.5f)
       }
     }.then {
       alpha(0.8f)
-      optics(GlassOptics.Absolute(depth = 0.7f))
+      optics(depth = 0.7f)
       pressed { lightingIntensity(0.9f) }
     }
+    val completeFinalOptics = GlassOptics.Fixed(refractionStrength = 0.4f)
+    val completeFinalStyle = explicitStyle.then { optics(completeFinalOptics) }
+    val directFinalStyle = completeFinalStyle.then { optics(depth = 0.9f) }
     val factory = RecordingGlassFactory()
 
     setContent {
       CompositionLocalProvider(LocalGlassStyle provides localStyle) {
-        Spacer(
-          Modifier.size(10.dp).hazeGlass(
-            factory = factory,
-            input = HazeInput.Content,
-            style = explicitStyle,
-            sampling = HazeSampling.Default,
-            expandLayerBounds = true,
-            interactionSource = null,
-          ),
-        )
+        Box {
+          listOf(completeFinalStyle, directFinalStyle).forEach { style ->
+            Spacer(
+              Modifier.size(10.dp).hazeGlass(
+                factory = factory,
+                input = HazeInput.Content,
+                style = style,
+                sampling = HazeSampling.Default,
+                expandLayerBounds = true,
+                interactionSource = null,
+              ),
+            )
+          }
+        }
       }
     }
     waitForIdle()
 
-    val runtime = factory.effects.single().delegate
-    val pressed = runtime.resolvedInteractionSlots.pressed?.response
-    assertThat(runtime.contrast).isEqualTo(GlassDefaults.contrast)
-    assertThat(runtime.alpha).isEqualTo(0.8f)
-    assertThat(runtime.whitePoint).isEqualTo(0.2f)
-    assertThat(runtime.specularIntensity).isEqualTo(0.6f)
-    assertThat(runtime.optics).isEqualTo(GlassOptics.Absolute(depth = 0.7f))
+    val completeRuntime = factory.effects[0].delegate
+    val directRuntime = factory.effects[1].delegate
+    val pressed = completeRuntime.resolvedInteractionSlots.pressed?.response
+    assertThat(completeRuntime.contrast).isEqualTo(GlassDefaults.contrast)
+    assertThat(completeRuntime.alpha).isEqualTo(0.8f)
+    assertThat(completeRuntime.whitePoint).isEqualTo(0.2f)
+    assertThat(completeRuntime.specularIntensity).isEqualTo(0.6f)
+    assertThat(completeRuntime.optics).isSameInstanceAs(completeFinalOptics)
+    assertThat(directRuntime.optics).isEqualTo(GlassOptics.Fixed(depth = 0.9f))
     assertThat(pressed?.lightingIntensity?.value).isEqualTo(0.9f)
     assertThat(pressed?.refractionMultiplier).isNull()
   }

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -205,7 +205,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   @Test
   fun maximumRefraction_foregroundContentSelectsFallbackDelegate() = runComposeUiTest {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         refractionStrength = 1f,
         refractionDisplacement = 16_384.dp,
         blurRadius = 0.dp,
@@ -472,7 +472,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       mainClock.advanceTimeBy(16)
       waitForIdle()
       effect.ambientResponse = 0.6f
-      effect.optics = (effect.optics as GlassOptics.Absolute).copy(refractionDisplacement = 18.dp)
+      effect.optics = (effect.optics as GlassOptics.Fixed).copy(refractionDisplacement = 18.dp)
       waitForIdle()
 
       assertThat(delegate.interactionShaderHandle("interactionOpticalEffect"))
@@ -641,7 +641,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
     val beforeDetail = delegate.detailRecordCount
 
-    effect.optics = (effect.optics as GlassOptics.Absolute).copy(refractionDisplacement = 18.dp)
+    effect.optics = (effect.optics as GlassOptics.Fixed).copy(refractionDisplacement = 18.dp)
     waitForIdle()
 
     assertThat(delegate.detailRecordCount).isEqualTo(beforeDetail + 3)
@@ -651,7 +651,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   fun zeroRefractionScale_doesNotAllocateOrRecordDetail() = runComposeUiTest {
     val hazeState = HazeState()
     val effect = activeDetailEffect().apply {
-      optics = (optics as GlassOptics.Absolute).copy(refractionDisplacement = 0.dp)
+      optics = (optics as GlassOptics.Fixed).copy(refractionDisplacement = 0.dp)
     }
 
     setContent {
@@ -681,7 +681,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   fun epsilonRefractionStrength_doesNotAllocateOrRecordDetail() = runComposeUiTest {
     val hazeState = HazeState()
     val effect = activeDetailEffect().apply {
-      optics = (optics as GlassOptics.Absolute).copy(refractionStrength = 1e-6f)
+      optics = (optics as GlassOptics.Fixed).copy(refractionStrength = 1e-6f)
     }
 
     setContent {
@@ -704,7 +704,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   fun lowVisibleRefractionStrength_allocatesAndRecordsDetail() = runComposeUiTest {
     val hazeState = HazeState()
     val effect = activeDetailEffect().apply {
-      optics = (optics as GlassOptics.Absolute).copy(refractionStrength = .1f)
+      optics = (optics as GlassOptics.Fixed).copy(refractionStrength = .1f)
     }
 
     setContent {
@@ -822,7 +822,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     val prefilterEffect = checkNotNull(delegate.layers.blurPrefiltered?.renderEffect)
     val detailEffect = checkNotNull(delegate.layers.refractionDetail?.renderEffect)
 
-    effect.optics = (effect.optics as GlassOptics.Absolute).copy(
+    effect.optics = (effect.optics as GlassOptics.Fixed).copy(
       blurRadius = 36.dp,
       refractionDisplacement = 18.dp,
     )
@@ -855,7 +855,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     val horizontalEffect = checkNotNull(delegate.layers.blurHorizontal?.renderEffect)
     val verticalEffect = checkNotNull(delegate.layers.blurred?.renderEffect)
 
-    effect.optics = (effect.optics as GlassOptics.Absolute).copy(
+    effect.optics = (effect.optics as GlassOptics.Fixed).copy(
       blurRadius = 34.dp,
       progressive = HazeProgressive.verticalGradient(
         startIntensity = 0.1f,
@@ -871,7 +871,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   private fun activeDetailEffect() = GlassRuntimeEffect().apply {
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.5f,
       refractionDisplacement = 20.dp,
       blurRadius = 0.dp,
@@ -889,7 +889,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   private fun animatedStageEffect() = GlassRuntimeEffect().apply {
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.5f,
       refractionDisplacement = 20.dp,
       depth = 0.5f,
@@ -903,7 +903,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   private fun retainedBlurEffect(
     progressive: HazeProgressive? = null,
   ) = GlassRuntimeEffect().apply {
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.5f,
       refractionDisplacement = 20.dp,
       depth = 0.5f,

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
@@ -122,7 +122,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
   @Test
   fun prepareDraw_consumesTheSelectedPreparedRenderParamsInstance() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(depth = 0f)
+      optics = GlassOptics.Fixed(depth = 0f)
     }
     val delegate = RuntimeShaderGlassDelegate(effect)
     val context = RecordingVisualEffectContext(
@@ -142,7 +142,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
   @Test
   fun prepareDraw_budgetScaleReductionReleasesAndRebuildsRuntimeLayers() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         refractionStrength = 0f,
         refractionDisplacement = 0.dp,
         blurRadius = 0.dp,
@@ -178,7 +178,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
   @Test
   fun prepareDraw_releasesObsoleteTopologyBeforeCreatingReplacementLayers() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         refractionStrength = 0.5f,
         refractionDisplacement = 20.dp,
         depth = 0f,
@@ -208,7 +208,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
     )
     graphicsContext.events.clear()
 
-    effect.optics = GlassOptics.Absolute(
+    effect.optics = GlassOptics.Fixed(
       refractionStrength = 0f,
       refractionDisplacement = 0.dp,
       depth = 0.5f,
@@ -271,7 +271,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
       create()
     }
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         refractionStrength = 0.5f,
         refractionDisplacement = 20.dp,
         depth = 0f,
@@ -339,7 +339,7 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
   @Test
   fun prepareDraw_impossibleMaximumRefractionGeometryCreatesNoRuntimeLayers() {
     val effect = GlassRuntimeEffect().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         refractionStrength = 1f,
         refractionDisplacement = 16_384.dp,
         blurRadius = 0.dp,

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassDepthAndroidScreenshotTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassDepthAndroidScreenshotTest.kt
@@ -8,7 +8,6 @@ package dev.chrisbanes.haze
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
@@ -154,7 +153,7 @@ class GlassDepthAndroidScreenshotTest : ScreenshotTest() {
     val shape = RoundedCornerShape(48.dp)
     val style = GlassStyle {
       tint(Color.White.copy(alpha = 0.28f))
-      optics(GlassOptics.Absolute(refractionStrength = 0f, depth = 0f, blurRadius = 32.dp))
+      optics(refractionStrength = 0f, depth = 0f, blurRadius = 32.dp)
       specularIntensity(0f)
       ambientResponse(0f)
       edgeSoftness(16.dp)

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassFallbackAndroidTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassFallbackAndroidTest.kt
@@ -149,7 +149,7 @@ class GlassFallbackAndroidTest : ScreenshotTest() {
     val interactionSource = MutableInteractionSource()
     val effect = GlassTestConfiguration().apply {
       tint = Color.Transparent
-      optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
+      optics = GlassOptics.Fixed(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
       specularIntensity = 0f
       ambientResponse = 0f
       edgeSoftness = 0.dp
@@ -204,7 +204,7 @@ private fun FallbackOpaqueContentSample(effect: GlassTestConfiguration) {
 
 private fun fallbackEffect(specularIntensity: Float): GlassTestConfiguration = GlassTestConfiguration().apply {
   tint = Color.Transparent
-  optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
+  optics = GlassOptics.Fixed(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
   this.specularIntensity = specularIntensity
   ambientResponse = 0f
   edgeSoftness = 0.dp

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceTransitionAndroidScreenshotTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceTransitionAndroidScreenshotTest.kt
@@ -16,7 +16,6 @@ import assertk.assertions.isGreaterThan
 import assertk.assertions.isLessThan
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.HazeColorEffect
-import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
@@ -65,7 +64,7 @@ class SourceTransitionAndroidScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(Color.White.copy(alpha = 0.12f))
-        optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
+        optics(refractionStrength = 0.45f, depth = 0.35f)
         specularIntensity(0.45f)
       },
     )

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
@@ -60,7 +60,7 @@ class GlassContentScreenshotTest : ScreenshotTest() {
       GlassStyle {
         tint(DefaultTint)
         alpha(0.7f)
-        optics(GlassOptics.Absolute(refractionStrength = 0.45f))
+        optics(refractionStrength = 0.45f)
       },
     )
     setContent {
@@ -138,7 +138,7 @@ class GlassContentScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(DefaultTint)
-        optics(GlassOptics.Absolute(refractionHeightFraction = 0.3f, depth = 0.45f))
+        optics(refractionHeightFraction = 0.3f, depth = 0.45f)
         specularIntensity(0.6f)
         edgeSoftness(10.dp)
         shape(androidx.compose.foundation.shape.RoundedCornerShape(22.dp))
@@ -156,7 +156,7 @@ class GlassContentScreenshotTest : ScreenshotTest() {
 
     captureRoot("rounded")
 
-    style = style.then { optics(GlassOptics.Absolute(refractionHeightFraction = 0.16f, depth = 0.45f)) }
+    style = style.then { optics(refractionHeightFraction = 0.16f, depth = 0.45f) }
     waitForIdle()
     captureRoot("shallow")
   }
@@ -165,7 +165,7 @@ class GlassContentScreenshotTest : ScreenshotTest() {
   fun creditCard_chromatic() = runScreenshotTest {
     val visualEffect = GlassTestConfiguration().apply {
       tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionStrength = 0.8f, depth = 0.5f)
+      optics = GlassOptics.Fixed(refractionStrength = 0.8f, depth = 0.5f)
       chromaticAberrationStrength = 0.22f
       ambientResponse = 0.7f
       edgeSoftness = 14.dp
@@ -188,7 +188,7 @@ class GlassContentScreenshotTest : ScreenshotTest() {
   fun creditCard_surfaceProfile() = runScreenshotTest {
     val visualEffect = GlassTestConfiguration().apply {
       tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionHeightFraction = 0.28f, depth = 0.4f)
+      optics = GlassOptics.Fixed(refractionHeightFraction = 0.28f, depth = 0.4f)
       specularIntensity = 0.5f
       shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp)
       surfaceProfile = SurfaceProfile.Squircle
@@ -218,7 +218,7 @@ class GlassContentScreenshotTest : ScreenshotTest() {
   fun creditCard_chromaticAberrationMode() = runScreenshotTest {
     val visualEffect = GlassTestConfiguration().apply {
       tint = DefaultTint
-      optics = GlassOptics.Absolute(refractionStrength = 0.8f, depth = 0.45f)
+      optics = GlassOptics.Fixed(refractionStrength = 0.8f, depth = 0.45f)
       chromaticAberrationStrength = 0.3f
       edgeSoftness = 14.dp
       shape = androidx.compose.foundation.shape.RoundedCornerShape(20.dp)
@@ -247,7 +247,7 @@ class GlassContentScreenshotTest : ScreenshotTest() {
     val VibrantStyle = GlassStyle {
       tint(Color(0xFF49E1FF).copy(alpha = 0.35f))
       optics(
-        GlassOptics.Absolute(
+        GlassOptics.Fixed(
           refractionStrength = 0.5f,
           depth = 0.35f,
         ),

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassDepthComparisonSample.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassDepthComparisonSample.kt
@@ -33,7 +33,7 @@ internal fun glassDepthProgressionVisualEffect(
 ): GlassTestConfiguration {
   return GlassTestConfiguration().apply {
     tint = Color.White.copy(alpha = 0.12f)
-    optics = GlassOptics.Absolute(depth = depth, blurRadius = 32.dp)
+    optics = GlassOptics.Fixed(depth = depth, blurRadius = 32.dp)
     specularIntensity = 0.4f
     ambientResponse = 0.5f
     edgeSoftness = 8.dp
@@ -56,18 +56,18 @@ internal fun ScreenshotUiTest.assertGlassDepthProgression() {
 
   val depth0 = captureRootPixels().snapshot()
 
-  visualEffect.updateAbsoluteOptics { copy(depth = 0.5f) }
+  visualEffect.updateFixedOptics { copy(depth = 0.5f) }
   waitForIdle()
   val depth50 = captureRootPixels().snapshot()
 
-  visualEffect.updateAbsoluteOptics { copy(depth = 1f) }
+  visualEffect.updateFixedOptics { copy(depth = 1f) }
   waitForIdle()
   val depth100 = captureRootPixels().snapshot()
 
   assertDepthProgression(depth0, depth50, depth100)
 
   listOf(0f to "0", 0.5f to "50", 1f to "100").forEach { (depth, snapshotName) ->
-    visualEffect.updateAbsoluteOptics { copy(depth = depth) }
+    visualEffect.updateFixedOptics { copy(depth = depth) }
     waitForIdle()
     captureRoot(snapshotName)
   }

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInputScaleScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInputScaleScreenshotTest.kt
@@ -23,7 +23,7 @@ class GlassInputScaleScreenshotTest : ScreenshotTest() {
   fun explicitTiers_preserveProgressiveRoundedRefractionAcrossTransition() = runScreenshotTest {
     val shape = RoundedCornerShape(32.dp)
     val effect = GlassTestConfiguration().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         refractionStrength = 1f,
         refractionDisplacement = 24.dp,
         depth = 1f,

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInteractionScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInteractionScreenshotTest.kt
@@ -95,7 +95,7 @@ class GlassInteractionScreenshotTest : ScreenshotTest() {
   fun glassInteraction_localPatchPreservesPixelsOutsideInteractionRegion() = runScreenshotTest {
     val radiusFraction = 0.22f
     val effect = GlassTestConfiguration().apply {
-      optics = GlassOptics.Absolute(
+      optics = GlassOptics.Fixed(
         refractionStrength = 0.7f,
         refractionDisplacement = 28.dp,
         depth = 0.5f,

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInvariantSample.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInvariantSample.kt
@@ -149,7 +149,7 @@ internal fun GlassChromaInvariantSample() {
   val effect = remember {
     GlassTestConfiguration().apply {
       tint = Color.Transparent
-      optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
+      optics = GlassOptics.Fixed(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
       specularIntensity = 0f
       ambientResponse = 0f
       edgeSoftness = 0.dp
@@ -292,7 +292,7 @@ internal fun ScreenshotUiTest.assertGlassMedialAxesContinuous() {
   val profiles = listOf(SurfaceProfile.Circle, SurfaceProfile.Squircle)
   val opticsCases = listOf(
     GlassOptics.Adaptive,
-    GlassOptics.Absolute(
+    GlassOptics.Fixed(
       refractionStrength = 1f,
       refractionHeightFraction = 0.75f,
       refractionDisplacement = 48.dp,
@@ -374,7 +374,7 @@ internal fun ScreenshotUiTest.assertGlassAsymmetricCornerNormalsContinuous() {
   )
   val effect = GlassTestConfiguration().apply {
     tint = Color.Transparent
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 1f,
       refractionHeightFraction = 0.5f,
       refractionDisplacement = 48.dp,
@@ -409,7 +409,7 @@ internal fun ScreenshotUiTest.assertGlassAsymmetricCornerNormalsContinuous() {
   val enabledSignal = enabled.verticalScanlineLuminance(probeX, centerYRange)
   val enabledDerivative = enabled.verticalScanlineDerivative(probeX, centerYRange)
 
-  effect.updateAbsoluteOptics { copy(refractionStrength = 0f) }
+  effect.updateFixedOptics { copy(refractionStrength = 0f) }
   waitForIdle()
   val disabled = captureInvariantPixels()
   val disabledSignal = disabled.verticalScanlineLuminance(probeX, centerYRange)
@@ -433,7 +433,7 @@ internal fun ScreenshotUiTest.assertGlassSquircleInteriorContinuous() {
   var surfaceSize by mutableStateOf(cases.first())
   val effect = GlassTestConfiguration().apply {
     tint = Color.Transparent
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 1f,
       refractionHeightFraction = 0.25f,
       refractionDisplacement = 48.dp,
@@ -483,7 +483,7 @@ internal fun ScreenshotUiTest.assertGlassSquircleInteriorContinuous() {
         y = bounds.center.y,
         xRange = bounds.left until bounds.right,
       )
-      effect.updateAbsoluteOptics { copy(refractionStrength = 0f) }
+      effect.updateFixedOptics { copy(refractionStrength = 0f) }
       waitForIdle()
       val disabledSignal = captureInvariantPixels().scanlineLuminance(
         y = bounds.center.y,
@@ -515,7 +515,7 @@ internal fun ScreenshotUiTest.assertGlassSquircleInteriorContinuous() {
         assertThat(slopeConcentration, "edge $edgeIndex refraction slope concentration")
           .isLessThanOrEqualTo(3.5f)
       }
-      effect.updateAbsoluteOptics { copy(refractionStrength = 1f) }
+      effect.updateFixedOptics { copy(refractionStrength = 1f) }
     }
   }
 }
@@ -525,7 +525,7 @@ internal fun ScreenshotUiTest.assertGlassSquircleAmbientDoesNotGlowInside() {
   val shape = RoundedCornerShape(28.dp)
   val effect = GlassTestConfiguration().apply {
     tint = Color.Transparent
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 1f,
       refractionHeightFraction = 0.25f,
       refractionDisplacement = 48.dp,
@@ -589,7 +589,7 @@ internal fun ScreenshotUiTest.assertGlassSquircleAmbientDoesNotGlowInside() {
 internal fun ScreenshotUiTest.assertGlassBlurInvariant() {
   val shape = RoundedCornerShape(28.dp)
   val effect = invariantEffect(shape).apply {
-    optics = GlassOptics.Absolute(depth = 1f, blurRadius = 0.dp)
+    optics = GlassOptics.Fixed(depth = 1f, blurRadius = 0.dp)
   }
   setContent {
     ScreenshotTheme {
@@ -598,7 +598,7 @@ internal fun ScreenshotUiTest.assertGlassBlurInvariant() {
   }
 
   val sharp = captureInvariantSnapshot()
-  effect.updateAbsoluteOptics { copy(blurRadius = 32.dp) }
+  effect.updateFixedOptics { copy(blurRadius = 32.dp) }
   waitForIdle()
   val blurred = captureInvariantSnapshot()
 
@@ -610,7 +610,7 @@ internal fun ScreenshotUiTest.assertGlassRefractionDetailPreservesSharpSourceInv
 ) {
   val shape = RoundedCornerShape(0.dp)
   val effect = invariantEffect(shape).apply {
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 1f,
       refractionDisplacement = 6.dp,
       depth = 1f,
@@ -674,7 +674,7 @@ internal fun ScreenshotUiTest.assertGlassRefractionDetailPreservesSharpSourceInv
   }
   val blurredInteriorEnergy = blurred.highFrequencyEnergy(geometry.interiorBounds)
 
-  effect.updateAbsoluteOptics { copy(blurRadius = 0.dp) }
+  effect.updateFixedOptics { copy(blurRadius = 0.dp) }
   waitForIdle()
   val sharpInteriorEnergy =
     captureInvariantSnapshot().highFrequencyEnergy(geometry.interiorBounds)
@@ -702,7 +702,7 @@ internal fun ScreenshotUiTest.assertGlassSemanticBlurHfInvariant() {
   )
   var currentCase by mutableStateOf(cases.first())
   val effect = invariantEffect(currentCase.shape).apply {
-    optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 1f)
+    optics = GlassOptics.Fixed(refractionStrength = 0f, depth = 1f)
     tint = Color.Transparent
     specularIntensity = 0f
     ambientResponse = 0f
@@ -722,7 +722,7 @@ internal fun ScreenshotUiTest.assertGlassSemanticBlurHfInvariant() {
   cases.forEach { case ->
     currentCase = case
     effect.shape = case.shape
-    effect.updateAbsoluteOptics { copy(blurRadius = 0.dp) }
+    effect.updateFixedOptics { copy(blurRadius = 0.dp) }
     waitForIdle()
     val sharp = captureInvariantSnapshot()
     val pxPerDp = sharp.width / 393f
@@ -738,14 +738,14 @@ internal fun ScreenshotUiTest.assertGlassSemanticBlurHfInvariant() {
       bottom = top + materialHeight - inset,
     )
 
-    effect.updateAbsoluteOptics { copy(blurRadius = 0.1.dp) }
+    effect.updateFixedOptics { copy(blurRadius = 0.1.dp) }
     waitForIdle()
     val subpixelEnergy = captureInvariantSnapshot().highFrequencyEnergy(bounds)
     assertThat(kotlin.math.abs(subpixelEnergy - 0.0239f)).isLessThanOrEqualTo(0.0004f)
 
     var previousEnergy = subpixelEnergy
     listOf(4.dp, 8.dp, 14.dp, 14.1.dp).forEach { radius ->
-      effect.updateAbsoluteOptics { copy(blurRadius = radius) }
+      effect.updateFixedOptics { copy(blurRadius = radius) }
       waitForIdle()
       val energy = captureInvariantSnapshot().highFrequencyEnergy(bounds)
       val (expected, tolerance) = when (radius) {
@@ -765,7 +765,7 @@ internal fun ScreenshotUiTest.assertGlassSemanticBlurHfInvariant() {
 internal fun ScreenshotUiTest.assertGlassAdversarialDownsampleInvariant() {
   val shape = RoundedCornerShape(28.dp)
   val effect = invariantEffect(shape).apply {
-    optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 1f)
+    optics = GlassOptics.Fixed(refractionStrength = 0f, depth = 1f)
     tint = Color.Transparent
     specularIntensity = 0f
     ambientResponse = 0f
@@ -804,15 +804,15 @@ internal fun ScreenshotUiTest.assertGlassAdversarialDownsampleInvariant() {
     stripePeriodPx = period
     horizontalStripes = false
     checkerStripes = checker
-    effect.updateAbsoluteOptics {
+    effect.updateFixedOptics {
       copy(blurRadius = ((thresholdPx - epsilonPx) / pxPerDp).dp)
     }
     waitForIdle()
     val below = captureInvariantSnapshot()
-    effect.updateAbsoluteOptics { copy(blurRadius = (thresholdPx / pxPerDp).dp) }
+    effect.updateFixedOptics { copy(blurRadius = (thresholdPx / pxPerDp).dp) }
     waitForIdle()
     val at = captureInvariantSnapshot()
-    effect.updateAbsoluteOptics {
+    effect.updateFixedOptics {
       copy(blurRadius = ((thresholdPx + epsilonPx) / pxPerDp).dp)
     }
     waitForIdle()
@@ -852,7 +852,7 @@ internal fun ScreenshotUiTest.assertGlassProgressiveBlurInvariant() {
       ).map { (blurRadius, progressive) ->
         remember(radius, blurRadius, progressive) {
           invariantEffect(RoundedCornerShape(0.dp)).apply {
-            optics = GlassOptics.Absolute(
+            optics = GlassOptics.Fixed(
               refractionStrength = 0f,
               depth = 1f,
               blurRadius = blurRadius,
@@ -912,7 +912,7 @@ internal fun ScreenshotUiTest.assertGlassProgressiveBlurInvariant() {
 internal fun ScreenshotUiTest.assertGlassProgressiveMaskScaleInvariant() {
   val shape = RoundedCornerShape(0.dp)
   val effect = invariantEffect(shape).apply {
-    optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 1f, blurRadius = 18.dp)
+    optics = GlassOptics.Fixed(refractionStrength = 0f, depth = 1f, blurRadius = 18.dp)
     tint = Color.Transparent
     specularIntensity = 0f
     ambientResponse = 0f
@@ -931,7 +931,7 @@ internal fun ScreenshotUiTest.assertGlassProgressiveMaskScaleInvariant() {
   }
 
   fun capture(progressive: HazeProgressive, scale: HazeSampling): PixelSnapshot {
-    effect.updateAbsoluteOptics { copy(progressive = progressive) }
+    effect.updateFixedOptics { copy(progressive = progressive) }
     sampling = scale
     waitForIdle()
     return captureInvariantSnapshot()
@@ -1189,7 +1189,7 @@ private fun PixelSnapshot.meanAbsoluteDifference(other: PixelSnapshot, bounds: I
 internal fun ScreenshotUiTest.assertGlassPaddingPreservesSourceInvariant() {
   val shape = RoundedCornerShape(28.dp)
   val effect = invariantEffect(shape).apply {
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 1f,
       refractionDisplacement = 0.dp,
       depth = 1f,
@@ -1214,7 +1214,7 @@ internal fun ScreenshotUiTest.assertGlassPaddingPreservesSourceInvariant() {
   matte = Color.Black
   waitForIdle()
   val sharpOverBlack = captureInvariantSnapshot()
-  effect.updateAbsoluteOptics { copy(blurRadius = 16.dp) }
+  effect.updateFixedOptics { copy(blurRadius = 16.dp) }
   waitForIdle()
   val smallOverBlack = captureInvariantSnapshot()
   matte = Color.White
@@ -1223,7 +1223,7 @@ internal fun ScreenshotUiTest.assertGlassPaddingPreservesSourceInvariant() {
     overBlack = smallOverBlack,
     overWhite = captureInvariantSnapshot(),
   )
-  effect.updateAbsoluteOptics { copy(refractionDisplacement = 96.dp) }
+  effect.updateFixedOptics { copy(refractionDisplacement = 96.dp) }
   matte = Color.Black
   waitForIdle()
   val largeOverBlack = captureInvariantSnapshot()
@@ -1287,7 +1287,7 @@ internal fun ScreenshotUiTest.assertGlassTransparentOutputInvariant() {
   val shape = RoundedCornerShape(28.dp)
   val effect = GlassTestConfiguration().apply {
     tint = Color.Transparent
-    optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
+    optics = GlassOptics.Fixed(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
     specularIntensity = 0f
     ambientResponse = 0f
     edgeSoftness = 0.dp
@@ -1326,7 +1326,7 @@ internal fun ScreenshotUiTest.assertGlassTranslucentSourceInvariant(
   val shape = RoundedCornerShape(28.dp)
   val effect = GlassTestConfiguration().apply {
     tint = Color.Transparent
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       depth = 0f,
       blurRadius = 0.dp,
     )
@@ -1486,7 +1486,7 @@ internal fun ScreenshotUiTest.assertGlassPaddingAndScaleInvariants() {
   val shape = RoundedCornerShape(28.dp)
   val effect = invariantEffect(shape).apply {
     // Preserve the previous effective values while making the literal contract explicit.
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.2f,
       refractionDisplacement = 24.dp,
       depth = 0.5f,
@@ -1508,7 +1508,7 @@ internal fun ScreenshotUiTest.assertGlassPaddingAndScaleInvariants() {
   }
 
   val smallPadding = captureTransparentSnapshot { matte = it }
-  effect.updateAbsoluteOptics {
+  effect.updateFixedOptics {
     copy(
       refractionStrength = 0.85f,
       refractionDisplacement = 53.25.dp,
@@ -1553,7 +1553,7 @@ internal fun ScreenshotUiTest.assertGlassPaddingAndScaleInvariants() {
 internal fun ScreenshotUiTest.assertGlassFirstEnabledFrameInvariant() {
   val shape = RoundedCornerShape(28.dp)
   val effect = invariantEffect(shape).apply {
-    optics = GlassOptics.Absolute(depth = 0.6f, blurRadius = 32.dp)
+    optics = GlassOptics.Fixed(depth = 0.6f, blurRadius = 32.dp)
   }
   var enabled by mutableStateOf(false)
   setContent {
@@ -1579,7 +1579,7 @@ internal fun ScreenshotUiTest.assertGlassFirstEnabledFrameInvariant() {
 internal fun ScreenshotUiTest.assertGlassProfileBranchContinuous() {
   val shape = RoundedCornerShape(28.dp)
   val effect = invariantEffect(shape).apply {
-    optics = GlassOptics.Absolute(refractionStrength = 0.85f, depth = 0.6f, blurRadius = 32.dp)
+    optics = GlassOptics.Fixed(refractionStrength = 0.85f, depth = 0.6f, blurRadius = 32.dp)
     edgeSoftness = 0.dp
   }
   setContent {
@@ -1608,7 +1608,7 @@ internal fun ScreenshotUiTest.assertGlassDefaultRefractionVisibleInvariant() {
   val effect = GlassTestConfiguration().apply {
     style = GlassDefaults.style
     this.shape = shape
-    optics = GlassOptics.Absolute(refractionStrength = 0f)
+    optics = GlassOptics.Fixed(refractionStrength = 0f)
   }
   var drawCarrier by mutableStateOf(true)
   setContent {
@@ -1708,7 +1708,7 @@ internal fun ScreenshotUiTest.assertGlassZeroExponentLightingInvariant() {
   val shape = RoundedCornerShape(28.dp)
   val effect = GlassTestConfiguration().apply {
     tint = Color.White.copy(alpha = 0.12f)
-    optics = GlassOptics.Absolute(refractionStrength = 0.5f, depth = 0.5f, blurRadius = 16.dp)
+    optics = GlassOptics.Fixed(refractionStrength = 0.5f, depth = 0.5f, blurRadius = 16.dp)
     specularIntensity = 0.6f
     specularExponent = 0f
     fresnelExponent = 0f
@@ -1738,7 +1738,7 @@ private fun ScreenshotUiTest.assertGlassCornersMatchComposeClipInvariant(
 ) {
   val effect = GlassTestConfiguration().apply {
     tint = Color.White
-    optics = GlassOptics.Absolute(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
+    optics = GlassOptics.Fixed(refractionStrength = 0f, depth = 0f, blurRadius = 0.dp)
     specularIntensity = 0f
     ambientResponse = 0f
     edgeSoftness = 0.dp
@@ -1853,7 +1853,7 @@ private fun centeredSurfaceBounds(
 
 private fun invariantEffect(shape: RoundedCornerShape) = GlassTestConfiguration().apply {
   tint = Color.White.copy(alpha = 0.12f)
-  optics = GlassOptics.Absolute(depth = 0.5f, blurRadius = 16.dp)
+  optics = GlassOptics.Fixed(depth = 0.5f, blurRadius = 16.dp)
   specularIntensity = 0.4f
   ambientResponse = 0.5f
   edgeSoftness = 8.dp

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassRoundedEdgeInvariant.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassRoundedEdgeInvariant.kt
@@ -43,7 +43,7 @@ internal fun ScreenshotUiTest.assertGlassRoundedEdgePixelsAreContinuous() {
   val style = GlassStyle {
     tint(Color.White.copy(alpha = 0.8f))
     optics(
-      GlassOptics.Absolute(
+      GlassOptics.Fixed(
         refractionStrength = 0f,
         depth = 0f,
         blurRadius = 0.dp,

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
@@ -79,7 +79,7 @@ class GlassScreenshotTest : ScreenshotTest() {
   fun creditCard_multiple() = runScreenshotTest {
     val style = GlassStyle {
       tint(DefaultTint)
-      optics(GlassOptics.Absolute(refractionStrength = 0.45f))
+      optics(refractionStrength = 0.45f)
     }
     val styles = List(3) { style }
 
@@ -166,7 +166,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(DefaultTint)
-        optics(GlassOptics.Absolute(refractionStrength = 0.25f, depth = 0.15f))
+        optics(refractionStrength = 0.25f, depth = 0.15f)
         specularIntensity(0.35f)
       },
     )
@@ -180,7 +180,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     captureRoot("low")
 
     style = style.then {
-      optics(GlassOptics.Absolute(refractionStrength = 0.6f, depth = 0.5f))
+      optics(refractionStrength = 0.6f, depth = 0.5f)
       specularIntensity(0.7f)
     }
     waitForIdle()
@@ -192,7 +192,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     val shape = RoundedCornerShape(28.dp)
     val style = GlassStyle {
       tint(Color.White.copy(alpha = 0.08f))
-      optics(GlassOptics.Absolute(refractionStrength = 0f, depth = 1f, blurRadius = 32.dp))
+      optics(refractionStrength = 0f, depth = 1f, blurRadius = 32.dp)
       specularIntensity(0f)
       ambientResponse(0f)
       edgeSoftness(0.dp)
@@ -221,7 +221,7 @@ class GlassScreenshotTest : ScreenshotTest() {
       GlassStyle {
         tint(Color.White.copy(alpha = 0.08f))
         optics(
-          GlassOptics.Absolute(
+          GlassOptics.Fixed(
             refractionStrength = 0f,
             depth = 1f,
             blurRadius = 0.dp,
@@ -252,7 +252,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     val zeroBlurPixels = captureRootPixels().snapshot()
 
     style = style.then {
-      optics(GlassOptics.Absolute(refractionStrength = 0f, depth = 1f, blurRadius = 100.dp))
+      optics(refractionStrength = 0f, depth = 1f, blurRadius = 100.dp)
     }
     waitForIdle()
     val densityOnePixels = captureRootPixels().snapshot()
@@ -302,7 +302,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(Color.White.copy(alpha = 0.08f))
-        optics(GlassOptics.Absolute(refractionStrength = 0.85f, depth = 0.9f, blurRadius = 0.dp))
+        optics(refractionStrength = 0.85f, depth = 0.9f, blurRadius = 0.dp)
         specularIntensity(0f)
         ambientResponse(0f)
         edgeSoftness(0.dp)
@@ -322,7 +322,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     captureRoot("zero")
 
     style = style.then {
-      optics(GlassOptics.Absolute(refractionStrength = 0.85f, depth = 0.9f, blurRadius = 32.dp))
+      optics(refractionStrength = 0.85f, depth = 0.9f, blurRadius = 32.dp)
     }
     waitForIdle()
     captureRoot("strong")
@@ -371,7 +371,7 @@ class GlassScreenshotTest : ScreenshotTest() {
             GlassStyle {
               tint(Color.Transparent)
               optics(
-                GlassOptics.Absolute(
+                GlassOptics.Fixed(
                   refractionStrength = 0.6f,
                   depth = 0.5f,
                   blurRadius = 0.dp,
@@ -440,7 +440,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(DefaultTint)
-        optics(GlassOptics.Absolute(refractionHeightFraction = 0.32f, depth = 0.45f))
+        optics(refractionHeightFraction = 0.32f, depth = 0.45f)
         specularIntensity(0.6f)
         shape(RoundedCornerShape(24.dp))
       },
@@ -455,7 +455,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     captureRoot("rounded")
 
     style = style.then {
-      optics(GlassOptics.Absolute(refractionHeightFraction = 0.18f, depth = 0.45f))
+      optics(refractionHeightFraction = 0.18f, depth = 0.45f)
     }
     waitForIdle()
     captureRoot("shallow")
@@ -466,7 +466,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(DefaultTint)
-        optics(GlassOptics.Absolute(refractionStrength = 0.8f, depth = 0.4f))
+        optics(refractionStrength = 0.8f, depth = 0.4f)
         chromaticAberrationStrength(0.0f)
         edgeSoftness(14.dp)
         shape(RoundedCornerShape(20.dp))
@@ -491,7 +491,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(DefaultTint)
-        optics(GlassOptics.Absolute(refractionHeightFraction = 0.28f, depth = 0.4f))
+        optics(refractionHeightFraction = 0.28f, depth = 0.4f)
         specularIntensity(0.5f)
         shape(RoundedCornerShape(24.dp))
         surfaceProfile(SurfaceProfile.Squircle)
@@ -520,7 +520,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(DefaultTint)
-        optics(GlassOptics.Absolute(refractionStrength = 0.8f, depth = 0.45f))
+        optics(refractionStrength = 0.8f, depth = 0.45f)
         chromaticAberrationStrength(0.3f)
         edgeSoftness(14.dp)
         shape(RoundedCornerShape(20.dp))
@@ -547,7 +547,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     val VibrantStyle = GlassStyle {
       tint(Color(0xFF3F8CFF).copy(alpha = 0.35f))
       optics(
-        GlassOptics.Absolute(
+        GlassOptics.Fixed(
           refractionStrength = 0.55f,
           depth = 0.4f,
         ),

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassTestOptics.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassTestOptics.kt
@@ -5,8 +5,8 @@ package dev.chrisbanes.haze
 
 import dev.chrisbanes.haze.glass.GlassOptics
 
-internal fun GlassTestConfiguration.updateAbsoluteOptics(
-  transform: GlassOptics.Absolute.() -> GlassOptics.Absolute,
+internal fun GlassTestConfiguration.updateFixedOptics(
+  transform: GlassOptics.Fixed.() -> GlassOptics.Fixed,
 ) {
-  optics = (optics as GlassOptics.Absolute).transform()
+  optics = (optics as GlassOptics.Fixed).transform()
 }

--- a/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/SourceTransitionScreenshotTest.kt
+++ b/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/SourceTransitionScreenshotTest.kt
@@ -16,7 +16,6 @@ import assertk.assertions.isGreaterThan
 import assertk.assertions.isLessThan
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.HazeColorEffect
-import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.test.ScreenshotTest
 import dev.chrisbanes.haze.test.ScreenshotTheme
@@ -61,7 +60,7 @@ class SourceTransitionScreenshotTest : ScreenshotTest() {
   fun glass_sourceRemoved_retainsLastOutput() = runScreenshotTest {
     val style = GlassStyle {
       tint(Color.White.copy(alpha = 0.12f))
-      optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
+      optics(refractionStrength = 0.45f, depth = 0.35f)
       specularIntensity(0.45f)
     }
     var showSource by mutableStateOf(true)
@@ -88,7 +87,7 @@ class SourceTransitionScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(Color.White.copy(alpha = 0.12f))
-        optics(GlassOptics.Absolute(refractionStrength = 0.45f, depth = 0.35f))
+        optics(refractionStrength = 0.45f, depth = 0.35f)
         specularIntensity(0.45f)
       },
     )

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -17,9 +17,9 @@ Controlled Glass scenarios start from the unmodified `GlassDefaults.style`. The 
 `steadyFull3`, and `steadyFull9` benchmarks therefore use adaptive optics, the default shape, and
 all default lighting, color, and rendering values.
 
-Scenarios named after an optical change install an explicit `GlassOptics.Absolute` override for
+Scenarios named after an optical change install an explicit `GlassOptics.Fixed` override for
 that change. For example, `steadyNoBlur` disables depth and blur, while `steadyDepth50` fixes depth
-at `0.5`. `steadyProgressive` and `steadyProgressive9` use the default absolute optical values
+at `0.5`. `steadyProgressive` and `steadyProgressive9` use the default fixed optical values
 with a vertical progressive mask because adaptive optics does not expose a progressive property.
 `steadyFullChroma` and `steadyFullChroma9` retain adaptive optics and set Full chromatic aberration
 with a non-zero `0.3` strength. Other style groups remain at their defaults.

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenarioTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenarioTest.kt
@@ -117,15 +117,15 @@ class GlassProfilingScenarioTest {
   }
 
   @Test
-  fun ablationScenarios_useExplicitAbsoluteOptics() {
+  fun ablationScenarios_useExplicitFixedOptics() {
     assertThat(GlassProfilingScenario.SteadyNoRefraction.opticsOverride).isEqualTo(
-      GlassOptics.Absolute(refractionStrength = 0f),
+      GlassOptics.Fixed(refractionStrength = 0f),
     )
     assertThat(GlassProfilingScenario.SteadyNoBlur.opticsOverride).isEqualTo(
-      GlassOptics.Absolute(depth = 0f, blurRadius = 0.dp),
+      GlassOptics.Fixed(depth = 0f, blurRadius = 0.dp),
     )
     assertThat(GlassProfilingScenario.SteadyDepth50.opticsOverride).isEqualTo(
-      GlassOptics.Absolute(depth = 0.5f),
+      GlassOptics.Fixed(depth = 0.5f),
     )
   }
 

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
@@ -342,7 +342,7 @@ internal fun profilingGlassStyle(
     GlassProfilingScenario.BlurUpdate,
     -> {
       optics(
-        (scenario.opticsOverride ?: GlassOptics.Absolute()).copy(
+        (scenario.opticsOverride ?: GlassOptics.Fixed()).copy(
           depth = frame.depth,
           blurRadius = frame.blurRadius,
         ),

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenario.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenario.kt
@@ -22,14 +22,14 @@ import dev.chrisbanes.haze.glass.GlassOptics
 internal const val GLASS_PROFILING_DURATION_MILLIS: Int = 3_000
 internal const val GLASS_PROFILING_SETTLING_FRAMES: Int = 8
 
-private val ProfilingProgressiveOptics = GlassOptics.Absolute(
+private val ProfilingProgressiveOptics = GlassOptics.Fixed(
   progressive = HazeProgressive.verticalGradient(
     startIntensity = 0f,
     endIntensity = 1f,
   ),
 )
-private val ProfilingNoRefractionOptics = GlassOptics.Absolute(refractionStrength = 0f)
-private val ProfilingNoBlurOptics = GlassOptics.Absolute(depth = 0f, blurRadius = 0.dp)
+private val ProfilingNoRefractionOptics = GlassOptics.Fixed(refractionStrength = 0f)
+private val ProfilingNoBlurOptics = GlassOptics.Fixed(depth = 0f, blurRadius = 0.dp)
 
 internal enum class GlassProfilingScenario(
   val id: String,
@@ -40,7 +40,7 @@ internal enum class GlassProfilingScenario(
   val steadyDraw: Boolean = false,
   val rimEnabled: Boolean = true,
   val fixedInputPixelFraction: Float? = null,
-  val opticsOverride: GlassOptics.Absolute? = null,
+  val opticsOverride: GlassOptics.Fixed? = null,
   val fullChroma: Boolean = false,
 ) {
   EffectAttach(
@@ -134,7 +134,7 @@ internal enum class GlassProfilingScenario(
   SteadyDepth50(
     id = "steady_depth_50",
     steadyDraw = true,
-    opticsOverride = GlassOptics.Absolute(depth = 0.5f),
+    opticsOverride = GlassOptics.Fixed(depth = 0.5f),
   ),
   SteadyBalanced(
     id = "steady_balanced",
@@ -166,8 +166,8 @@ internal enum class GlassProfilingScenario(
   InteractionUpdate("interaction_update"),
   InteractionUpdate9("interaction_update_9", effectCount = 9),
   OpticalUpdate("optical_update"),
-  DepthUpdate("depth_update", opticsOverride = GlassOptics.Absolute()),
-  BlurUpdate("blur_update", opticsOverride = GlassOptics.Absolute()),
+  DepthUpdate("depth_update", opticsOverride = GlassOptics.Fixed()),
+  BlurUpdate("blur_update", opticsOverride = GlassOptics.Fixed()),
   SourceUpdate("source_update"),
   SourceUpdate9("source_update_9", effectCount = 9),
   SourceUpdateNoGlass("source_update_no_glass", glassEnabled = false),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModels.kt
@@ -134,7 +134,7 @@ internal fun glassLabPresetValues(id: GlassLabPresetId): GlassLabStyleValues = w
   GlassLabPresetId.Adaptive -> GlassLabStyleValues()
   GlassLabPresetId.Clear -> GlassLabStyleValues(
     tint = Color.White.copy(alpha = 0.06f),
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.85f,
       refractionHeightFraction = 0.22f,
       refractionDisplacement = 18.dp,
@@ -149,7 +149,7 @@ internal fun glassLabPresetValues(id: GlassLabPresetId): GlassLabStyleValues = w
   )
   GlassLabPresetId.Frosted -> GlassLabStyleValues(
     tint = Color.White.copy(alpha = 0.18f),
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.45f,
       refractionHeightFraction = 0.18f,
       refractionDisplacement = 10.dp,
@@ -166,7 +166,7 @@ internal fun glassLabPresetValues(id: GlassLabPresetId): GlassLabStyleValues = w
   )
   GlassLabPresetId.Deep -> GlassLabStyleValues(
     tint = Color.White.copy(alpha = 0.1f),
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.9f,
       refractionHeightFraction = 0.32f,
       refractionDisplacement = 20.dp,
@@ -184,7 +184,7 @@ internal fun glassLabPresetValues(id: GlassLabPresetId): GlassLabStyleValues = w
   )
   GlassLabPresetId.Prism -> GlassLabStyleValues(
     tint = Color.White.copy(alpha = 0.08f),
-    optics = GlassOptics.Absolute(
+    optics = GlassOptics.Fixed(
       refractionStrength = 0.82f,
       refractionHeightFraction = 0.28f,
       refractionDisplacement = 18.dp,

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassLabSample.kt
@@ -355,47 +355,47 @@ private fun <T : Enum<T>> LabChipGroup(
 @Composable
 private fun LabAdvancedControls(state: GlassLabState, onStateChanged: (GlassLabState) -> Unit) {
   val values = state.styleValues
-  val absolute = (values.optics as? GlassOptics.Absolute) ?: GlassOptics.Absolute()
+  val fixed = (values.optics as? GlassOptics.Fixed) ?: GlassOptics.Fixed()
   Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
     Text("Optics", style = MaterialTheme.typography.titleMedium)
-    LabSlider("Refraction", absolute.refractionStrength, 0f..1f) { value ->
-      onStateChanged(state.editStyle { it.copy(optics = absolute.copy(refractionStrength = value)) })
+    LabSlider("Refraction", fixed.refractionStrength, 0f..1f) { value ->
+      onStateChanged(state.editStyle { it.copy(optics = fixed.copy(refractionStrength = value)) })
     }
-    LabSlider("Depth", absolute.depth, 0f..1f) { value ->
-      onStateChanged(state.editStyle { it.copy(optics = absolute.copy(depth = value)) })
+    LabSlider("Depth", fixed.depth, 0f..1f) { value ->
+      onStateChanged(state.editStyle { it.copy(optics = fixed.copy(depth = value)) })
     }
-    LabSlider("Blur", absolute.blurRadius.value, 0f..32f) { value ->
-      onStateChanged(state.editStyle { it.copy(optics = absolute.copy(blurRadius = value.dp)) })
+    LabSlider("Blur", fixed.blurRadius.value, 0f..32f) { value ->
+      onStateChanged(state.editStyle { it.copy(optics = fixed.copy(blurRadius = value.dp)) })
     }
     Text("Lighting", style = MaterialTheme.typography.titleMedium)
     LabSlider("Specular", values.specularIntensity, 0f..1f) { value ->
       onStateChanged(
-        state.editStyle { it.copy(optics = absolute, specularIntensity = value) },
+        state.editStyle { it.copy(optics = fixed, specularIntensity = value) },
       )
     }
     LabSlider("Ambient", values.ambientResponse, 0f..1f) { value ->
       onStateChanged(
-        state.editStyle { it.copy(optics = absolute, ambientResponse = value) },
+        state.editStyle { it.copy(optics = fixed, ambientResponse = value) },
       )
     }
     Text("Colour", style = MaterialTheme.typography.titleMedium)
     LabSlider("Contrast", values.contrast, -1f..1f) { value ->
-      onStateChanged(state.editStyle { it.copy(optics = absolute, contrast = value) })
+      onStateChanged(state.editStyle { it.copy(optics = fixed, contrast = value) })
     }
     LabSlider("Chroma", values.chromaMultiplier, 0f..2f) { value ->
       onStateChanged(
-        state.editStyle { it.copy(optics = absolute, chromaMultiplier = value) },
+        state.editStyle { it.copy(optics = fixed, chromaMultiplier = value) },
       )
     }
     Text("Rendering", style = MaterialTheme.typography.titleMedium)
     LabSlider("Edge softness", values.edgeSoftness.value, 0f..24f) { value ->
       onStateChanged(
-        state.editStyle { it.copy(optics = absolute, edgeSoftness = value.dp) },
+        state.editStyle { it.copy(optics = fixed, edgeSoftness = value.dp) },
       )
     }
     LabSlider("Chromatic", values.chromaticAberrationStrength, 0f..0.4f) { value ->
       onStateChanged(
-        state.editStyle { it.copy(optics = absolute, chromaticAberrationStrength = value) },
+        state.editStyle { it.copy(optics = fixed, chromaticAberrationStrength = value) },
       )
     }
   }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryModelsTest.kt
@@ -50,11 +50,11 @@ class GlassGalleryModelsTest {
   @Test
   fun editingAdaptiveStyle_changesSelectionToCustomAndLiteralOptics() {
     val edited = GlassLabState().editStyle { values ->
-      values.copy(optics = GlassOptics.Absolute(refractionStrength = 0.6f))
+      values.copy(optics = GlassOptics.Fixed(refractionStrength = 0.6f))
     }
 
     assertThat(edited.preset).isEqualTo(GlassLabPresetId.Custom)
-    assertThat(edited.styleValues.optics).isInstanceOf<GlassOptics.Absolute>()
+    assertThat(edited.styleValues.optics).isInstanceOf<GlassOptics.Fixed>()
   }
 
   @Test
@@ -73,15 +73,15 @@ class GlassGalleryModelsTest {
       backdrop = GlassGalleryBackdropId.Grid,
       interaction = GlassLabInteractionMode.Off,
       advancedExpanded = true,
-      styleValues = GlassLabStyleValues(optics = GlassOptics.Absolute()),
+      styleValues = GlassLabStyleValues(optics = GlassOptics.Fixed()),
     )
 
     assertThat(changed.reset()).isEqualTo(GlassLabState())
   }
 }
 
-private fun absoluteOpticsFor(id: GlassLabPresetId): GlassOptics.Absolute {
+private fun absoluteOpticsFor(id: GlassLabPresetId): GlassOptics.Fixed {
   val optics = GlassLabState(preset = id).styleValues.optics
-  assertThat(optics).isInstanceOf<GlassOptics.Absolute>()
-  return optics as GlassOptics.Absolute
+  assertThat(optics).isInstanceOf<GlassOptics.Fixed>()
+  return optics as GlassOptics.Fixed
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundTimelineTest.kt
@@ -75,9 +75,9 @@ class GlassPlaygroundTimelineTest {
     assertThat(resolvedOptics(GlassPlaygroundSurfaceId.Pill))
       .isEqualTo(GlassOptics.Adaptive)
     assertThat(resolvedOptics(GlassPlaygroundSurfaceId.Card))
-      .isInstanceOf<GlassOptics.Absolute>()
+      .isInstanceOf<GlassOptics.Fixed>()
     assertThat(resolvedOptics(GlassPlaygroundSurfaceId.Prism))
-      .isInstanceOf<GlassOptics.Absolute>()
+      .isInstanceOf<GlassOptics.Fixed>()
   }
 
   @Test


### PR DESCRIPTION
Fixes #1184

Implements the approved revision-2 plan: https://github.com/chrisbanes/haze/issues/1184#issuecomment-5176522049

Summary:
- hard-renames GlassOptics.Absolute to GlassOptics.Fixed without a compatibility bridge
- adds the six-parameter direct GlassStyleScope optics DSL while preserving the complete-value overload
- updates API signatures, docs, samples, benchmarks, and semantic coverage without refreshing screenshot baselines

Validation:
- targeted Glass optics, Style, modifier, and input-scale screenshot tests
- haze-glass check, API generation/compatibility, sample shared check, Spotless, and docs build
- screenshot suites reached their test tasks but Gradle did not terminate locally; both runs were bounded and interrupted after the tests completed
- repeated review-and-simplify-changes and ponytail-review on final HEAD; both clean