### PR TITLE
Resolve Glass light position from Alignment

### DIFF
--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -49,7 +49,8 @@ Adaptive content behavior, interaction-driven deformation, and morphing are unsu
 - **edgeSoftness**: Soft fade at the edges (default 2.dp). Set to 0.dp for hard edges.
 - **shape** (`RoundedCornerShape`): Rounded-rect boundary for refraction and masking (default 16.dp corners).
 - **surfaceProfile**: Cross-section profile for the refraction bezel. Options: `Circle` (default), `Squircle`, `Lip`, `Concave`.
-- **lightPosition**: Optional light source; defaults to the layer center.
+- **lightPosition**: `Alignment` of the light within the material's measured bounds (default
+  `Alignment.Center`). Logical start and end follow the node's layout direction.
 - **chromaticAberrationStrength**: Dispersion strength `0..1` (default 0). Higher values produce prismatic color splitting at edges.
 - **chromaticAberrationMode**: Quality mode for chromatic aberration. `Simple` (default, fast) or `Full` (spectral, more expensive).
 - **alpha**: Overall opacity multiplier `0..1` (default 1).
@@ -77,6 +78,30 @@ val emphasizedStyle = baseStyle.then { specularIntensity(0.7f) }
 
 CompositionLocalProvider(LocalGlassStyle provides baseStyle) {
   // Each node gets a fresh snapshot; an explicit Style is applied last.
+}
+```
+
+### Light alignment
+
+Light position is authored semantically with Compose `Alignment` and resolved independently for
+each node. A shared Style therefore places `Alignment.Center` at the center of every consuming
+material, even when their measured sizes differ. Logical alignments such as `Alignment.TopStart`,
+`Alignment.CenterStart`, and `Alignment.CenterEnd` automatically follow LTR or RTL layout direction;
+use physical alignments only when that is the intended semantic.
+
+```kotlin
+val sharedLighting = GlassStyle {
+  lightPosition(Alignment.CenterStart)
+}
+```
+
+Use `BiasAlignment` for a continuously moving proportional light. Biases `-1f`, `0f`, and `1f`
+represent the start/top edge, center, and end/bottom edge respectively, and values outside that
+range place the virtual light beyond the material bounds.
+
+```kotlin
+val movingLighting = GlassStyle {
+  lightPosition(BiasAlignment(horizontalBias = 0.4f, verticalBias = -0.6f))
 }
 ```
 

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -202,10 +202,30 @@ inert; construct and supply a replacement Style to reflect new inputs.
 | implicit source/content | explicit `HazeInput.Sources` or `HazeInput.Content` |
 | raw optical displacement/caps | semantic `GlassOptics` and `Dp` controls |
 | `GlassOptics.Absolute` | `GlassOptics.Fixed`; this is a hard rename with no alias or compatibility bridge |
+| `lightPosition(Offset)` and `Offset.Unspecified` | `lightPosition(Alignment)`; omit the write or use `Alignment.Center` for the former automatic center |
 
 For ordinary inline fixed Style authoring, pass the complete fixed parameter set directly to
 `optics(...)`. The complete-value overload remains available for `GlassOptics.Adaptive`, reusable
 fixed values, copies, storage, and programmatic selection.
+
+Glass light position is now an intentional source break from pixel `Offset` to semantic
+`Alignment`, with no compatibility overload. The Alignment is resolved inside each node's current
+measured bounds and layout direction. Use `Alignment.Center` (or omit the write) for the former
+`Offset.Unspecified` behavior, logical start/end alignments for directional intent, and
+`BiasAlignment` for continuous proportional positions:
+
+```kotlin
+val normalizedX = 0.7f
+val normalizedY = 0.2f
+val style = GlassStyle {
+  lightPosition(
+    BiasAlignment(
+      horizontalBias = normalizedX * 2f - 1f,
+      verticalBias = normalizedY * 2f - 1f,
+    ),
+  )
+}
+```
 
 Write each property through the Style scope, then pass the Style and structural policies to
 `hazeGlass`:

--- a/haze-glass/api/api.txt
+++ b/haze-glass/api/api.txt
@@ -122,7 +122,7 @@ package dev.chrisbanes.haze.glass {
     method public void hovered(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> response);
     method public void interactionLightRadiusFraction(float radiusFraction);
     method public void interactionPositionAnimationSpec(androidx.compose.animation.core.FiniteAnimationSpec<androidx.compose.ui.geometry.Offset> animationSpec);
-    method @KotlinOnly public void lightPosition(androidx.compose.ui.geometry.Offset position);
+    method public void lightPosition(androidx.compose.ui.Alignment alignment);
     method public void optics(dev.chrisbanes.haze.glass.GlassOptics optics);
     method @KotlinOnly public void optics(optional float refractionStrength, optional float refractionHeightFraction, optional androidx.compose.ui.unit.Dp refractionDisplacement, optional float depth, optional androidx.compose.ui.unit.Dp blurRadius, optional dev.chrisbanes.haze.HazeProgressive? progressive);
     method public void pressed(kotlin.jvm.functions.Function1<? super dev.chrisbanes.haze.glass.GlassInteractionScope,kotlin.Unit> response);

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -518,7 +519,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       val rimShader = delegate.rimShader
       val rimEffect = delegate.rimEffect
       val rimLayerEffect = checkNotNull(delegate.layers.rim?.renderEffect)
-      effect.lightPosition = Offset(10f, 20f)
+      effect.lightPosition = exactLightAlignment(Offset(10f, 20f))
       waitForIdle()
       drawFrame()
 
@@ -801,7 +802,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
     )
     specularIntensity = 1f
     ambientResponse = 0.5f
-    lightPosition = Offset(60f, 60f)
+    lightPosition = Alignment.Center
   }
 
   private fun interactiveEffect() = GlassRuntimeEffect().apply {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -333,6 +333,7 @@ internal data class GlassRenderParams(
   val geometryToneGain: Float,
   val geometryNeutralLift: Float,
   val cornerRadii: CornerRadii,
+  /** Light position resolved from authored Alignment into material-local pixels. */
   val lightPosition: Offset,
   val sampleStepPx: Float,
   val refractionDetailIntensity: Float = GLASS_REFRACTION_DETAIL_INTENSITY,
@@ -582,7 +583,11 @@ internal fun resolveGlassStyle(
     defaultRadii.isFiniteAndNonNegative() -> defaultRadii
     else -> CornerRadii.zero
   }
-  val materialCenter = materialSizePx.center
+  val alignedLightPosition = effect.lightPosition.align(
+    size = IntSize.Zero,
+    space = materialSizePx.roundToIntSize(),
+    layoutDirection = layoutDirection,
+  )
   return ResolvedGlassStyle(
     resolvedOptics = resolveGlassOptics(effect.optics, materialSizePx, density, cornerRadii),
     specularIntensity = effect.specularIntensity
@@ -593,9 +598,10 @@ internal fun resolveGlassStyle(
     edgeSoftnessPx = with(density) { effect.edgeSoftness.toPx() }
       .finiteOr(defaultEdgeSoftnessPx)
       .coerceAtLeast(0f),
-    lightPosition = effect.lightPosition
-      .takeIf { it.x.isFinite() && it.y.isFinite() }
-      ?: materialCenter,
+    lightPosition = Offset(
+      x = alignedLightPosition.x.toFloat(),
+      y = alignedLightPosition.y.toFloat(),
+    ),
     chromaticAberrationStrength = effect.chromaticAberrationStrength
       .finiteOr(GlassDefaults.chromaticAberrationStrength).coerceIn(0f, 1f),
     surfaceProfile = effect.surfaceProfile.ordinal.toFloat(),

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -3,6 +3,9 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAbsoluteAlignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.center
@@ -583,9 +586,8 @@ internal fun resolveGlassStyle(
     defaultRadii.isFiniteAndNonNegative() -> defaultRadii
     else -> CornerRadii.zero
   }
-  val alignedLightPosition = effect.lightPosition.align(
-    size = IntSize.Zero,
-    space = materialSizePx.roundToIntSize(),
+  val alignedLightPosition = effect.lightPosition.resolveLightPosition(
+    materialSizePx = materialSizePx,
     layoutDirection = layoutDirection,
   )
   return ResolvedGlassStyle(
@@ -598,10 +600,7 @@ internal fun resolveGlassStyle(
     edgeSoftnessPx = with(density) { effect.edgeSoftness.toPx() }
       .finiteOr(defaultEdgeSoftnessPx)
       .coerceAtLeast(0f),
-    lightPosition = Offset(
-      x = alignedLightPosition.x.toFloat(),
-      y = alignedLightPosition.y.toFloat(),
-    ),
+    lightPosition = alignedLightPosition,
     chromaticAberrationStrength = effect.chromaticAberrationStrength
       .finiteOr(GlassDefaults.chromaticAberrationStrength).coerceIn(0f, 1f),
     surfaceProfile = effect.surfaceProfile.ordinal.toFloat(),
@@ -620,6 +619,40 @@ internal fun resolveGlassStyle(
     cornerRadii = cornerRadii,
   )
 }
+
+private fun Alignment.resolveLightPosition(
+  materialSizePx: Size,
+  layoutDirection: LayoutDirection,
+): Offset = when (this) {
+  is BiasAlignment -> resolveBiasPosition(
+    center = materialSizePx.center,
+    horizontalBias = if (layoutDirection == LayoutDirection.Ltr) {
+      horizontalBias
+    } else {
+      -horizontalBias
+    },
+    verticalBias = verticalBias,
+  )
+  is BiasAbsoluteAlignment -> resolveBiasPosition(
+    center = materialSizePx.center,
+    horizontalBias = horizontalBias,
+    verticalBias = verticalBias,
+  )
+  else -> align(
+    size = IntSize.Zero,
+    space = materialSizePx.roundToIntSize(),
+    layoutDirection = layoutDirection,
+  ).let { Offset(it.x.toFloat(), it.y.toFloat()) }
+}
+
+private fun resolveBiasPosition(
+  center: Offset,
+  horizontalBias: Float,
+  verticalBias: Float,
+): Offset = Offset(
+  x = center.x * (1f + horizontalBias),
+  y = center.y * (1f + verticalBias),
+)
 
 internal fun buildGlassRenderParams(
   style: ResolvedGlassStyle,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeState.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeState.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.referentialEqualityPolicy
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.takeOrElse
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.unit.Dp
@@ -322,7 +322,8 @@ internal abstract class GlassRuntimeState {
     }
 
   /**
-   * Position of the virtual light source. When unspecified, the center of the layer is used.
+   * Alignment of the virtual light source within the material's measured bounds. Resolution to a
+   * renderer pixel [Offset] happens once the current size and layout direction are known.
    *
    * There are precedence rules to how this styling property is applied:
    *
@@ -330,13 +331,11 @@ internal abstract class GlassRuntimeState {
    *  - [GlassStyleScope.lightPosition] value set in [style], if specified.
    *  - [GlassStyleScope.lightPosition] value set in [LocalGlassStyle], if specified.
    *
-   * If no value is specified through any of the above, the delegate falls back to the
-   * center of the layer at draw time.
+   * If no value is specified through any of the above, [Alignment.Center] is used.
    */
-  internal var _lightPosition: Offset = Offset.Unspecified
-  internal var lightPosition: Offset
-    get() = _lightPosition
-      .takeOrElse { inheritedStyleValues.lightPosition }
+  internal var _lightPosition: Alignment? = null
+  internal var lightPosition: Alignment
+    get() = _lightPosition ?: inheritedStyleValues.lightPosition
     set(value) {
       if (_lightPosition != value) {
         HazeLogger.d(TAG) { "lightPosition changed. Current: $_lightPosition. New: $value" }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.isSpecified
@@ -214,16 +215,13 @@ public class GlassStyleScope internal constructor(
   }
 
   /**
-   * Sets the virtual light position. [Offset.Unspecified] keeps the automatic material center.
+   * Aligns the virtual light within each material's measured bounds.
+   *
+   * The default is [Alignment.Center]. Logical start and end alignments use the node's current
+   * layout direction, and a shared Style is resolved independently for each consuming node's size.
    */
-  public fun lightPosition(position: Offset) {
-    require(
-      position == Offset.Unspecified ||
-        (position.x.isFinite() && position.y.isFinite()),
-    ) {
-      "lightPosition must be finite or Offset.Unspecified"
-    }
-    writes += { lightPosition = position }
+  public fun lightPosition(alignment: Alignment) {
+    writes += { lightPosition = alignment }
   }
 
   /** Sets chromatic dispersion strength, coerced to the range `0f..1f`. */
@@ -299,7 +297,7 @@ internal class GlassStyleValues(
   var ambientResponse: Float = GlassDefaults.ambientResponse,
   var tint: Color = GlassDefaults.tint,
   var edgeSoftness: Dp = GlassDefaults.edgeSoftness,
-  var lightPosition: Offset = Offset.Unspecified,
+  var lightPosition: Alignment = Alignment.Center,
   var chromaticAberrationStrength: Float = GlassDefaults.chromaticAberrationStrength,
   var surfaceProfile: SurfaceProfile = GlassDefaults.surfaceProfile,
   var chromaticAberrationMode: ChromaticAberrationMode = GlassDefaults.chromaticAberrationMode,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/ExactLightAlignment.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/ExactLightAlignment.kt
@@ -1,0 +1,23 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass
+
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.math.roundToInt
+
+internal fun exactLightAlignment(position: Offset): Alignment = ExactLightAlignment(position)
+
+private class ExactLightAlignment(
+  private val position: Offset,
+) : Alignment {
+  override fun align(
+    size: IntSize,
+    space: IntSize,
+    layoutDirection: LayoutDirection,
+  ): IntOffset = IntOffset(position.x.roundToInt(), position.y.roundToInt())
+}

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -7,6 +7,7 @@ package dev.chrisbanes.haze.glass
 
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -28,6 +29,58 @@ import kotlin.math.sqrt
 import kotlin.test.Test
 
 class GlassRenderParamsTest {
+
+  @Test
+  fun lightAlignment_resolvesForEachSizeAndLayoutDirectionAndScalesOnce() {
+    val alignments = listOf(
+      LightAlignmentCase(Alignment.Center, 0.5f, 0.5f, 0.5f),
+      LightAlignmentCase(Alignment.TopStart, 0f, 1f, 0f),
+      LightAlignmentCase(Alignment.TopEnd, 1f, 0f, 0f),
+      LightAlignmentCase(Alignment.BottomStart, 0f, 1f, 1f),
+      LightAlignmentCase(Alignment.BottomEnd, 1f, 0f, 1f),
+      LightAlignmentCase(Alignment.CenterStart, 0f, 1f, 0.5f),
+      LightAlignmentCase(Alignment.CenterEnd, 1f, 0f, 0.5f),
+    )
+    val sizes = listOf(Size(100f, 80f), Size(240f, 120f))
+
+    sizes.forEach { size ->
+      LayoutDirection.entries.forEach { layoutDirection ->
+        alignments.forEach { case ->
+          val effect = GlassRuntimeEffect().apply {
+            style = GlassStyle { lightPosition(case.alignment) }
+          }
+          val resolved = resolveGlassStyle(
+            effect = effect,
+            materialSizePx = size,
+            density = Density(1f),
+            layoutDirection = layoutDirection,
+          )
+          val expected = Offset(
+            x = size.width * case.xFraction(layoutDirection),
+            y = size.height * case.yFraction,
+          )
+          val rendered = buildGlassRenderParams(
+            style = resolved,
+            coordinates = GlassCoordinates(
+              sampleSize = size * 0.5f,
+              materialOrigin = Offset.Zero,
+              materialSize = size * 0.5f,
+              scaleFactor = 0.5f,
+            ),
+          )
+
+          assertThat(
+            resolved.lightPosition,
+            name = "$size/$layoutDirection/${case.alignment}",
+          ).isEqualTo(expected)
+          assertThat(
+            rendered.lightPosition,
+            name = "$size/$layoutDirection/${case.alignment}/scaled",
+          ).isEqualTo(expected * 0.5f)
+        }
+      }
+    }
+  }
 
   @Test
   fun interactionTopology_usesConfiguredWorstCaseInsteadOfAnimatedValues() {
@@ -1270,5 +1323,17 @@ class GlassRenderParamsTest {
     first.values().zip(second.values()).forEach { (firstValue, secondValue) ->
       assertThat(abs(firstValue - secondValue)).isLessThan(maximumDelta)
     }
+  }
+}
+
+private class LightAlignmentCase(
+  val alignment: Alignment,
+  val ltrXFraction: Float,
+  val rtlXFraction: Float,
+  val yFraction: Float,
+) {
+  fun xFraction(layoutDirection: LayoutDirection): Float = when (layoutDirection) {
+    LayoutDirection.Ltr -> ltrXFraction
+    LayoutDirection.Rtl -> rtlXFraction
   }
 }

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -8,10 +8,14 @@ package dev.chrisbanes.haze.glass
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAbsoluteAlignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.roundToIntSize
@@ -29,6 +33,94 @@ import kotlin.math.sqrt
 import kotlin.test.Test
 
 class GlassRenderParamsTest {
+
+  @Test
+  fun lightAlignment_defaultCenterPreservesFractionalPixelsForOddSize() {
+    val materialSize = Size(101f, 81f)
+    val effect = GlassRuntimeEffect()
+
+    LayoutDirection.entries.forEach { layoutDirection ->
+      val resolved = resolveGlassStyle(
+        effect = effect,
+        materialSizePx = materialSize,
+        density = Density(1f),
+        layoutDirection = layoutDirection,
+      )
+
+      assertThat(resolved.lightPosition, name = layoutDirection.name)
+        .isEqualTo(Offset(50.5f, 40.5f))
+    }
+  }
+
+  @Test
+  fun lightAlignment_fractionalBiasPreservesSubpixelPositionAndLayoutDirection() {
+    val materialSize = Size(101f, 81f)
+    val effect = GlassRuntimeEffect().apply {
+      style = GlassStyle {
+        lightPosition(BiasAlignment(horizontalBias = 0.25f, verticalBias = -0.5f))
+      }
+    }
+    val expectedPositions = mapOf(
+      LayoutDirection.Ltr to Offset(63.125f, 20.25f),
+      LayoutDirection.Rtl to Offset(37.875f, 20.25f),
+    )
+
+    expectedPositions.forEach { (layoutDirection, expected) ->
+      val resolved = resolveGlassStyle(
+        effect = effect,
+        materialSizePx = materialSize,
+        density = Density(1f),
+        layoutDirection = layoutDirection,
+      )
+
+      assertThat(resolved.lightPosition, name = layoutDirection.name).isEqualTo(expected)
+    }
+  }
+
+  @Test
+  fun lightAlignment_fractionalAbsoluteBiasPreservesSubpixelPosition() {
+    val materialSize = Size(101f, 81f)
+    val effect = GlassRuntimeEffect().apply {
+      style = GlassStyle {
+        lightPosition(BiasAbsoluteAlignment(horizontalBias = 0.25f, verticalBias = -0.5f))
+      }
+    }
+
+    LayoutDirection.entries.forEach { layoutDirection ->
+      val resolved = resolveGlassStyle(
+        effect = effect,
+        materialSizePx = materialSize,
+        density = Density(1f),
+        layoutDirection = layoutDirection,
+      )
+
+      assertThat(resolved.lightPosition, name = layoutDirection.name)
+        .isEqualTo(Offset(63.125f, 20.25f))
+    }
+  }
+
+  @Test
+  fun lightAlignment_arbitraryAlignmentUsesComposeAlignmentContract() {
+    val alignment = object : Alignment {
+      override fun align(
+        size: IntSize,
+        space: IntSize,
+        layoutDirection: LayoutDirection,
+      ): IntOffset = IntOffset(space.width - 7, space.height - 9)
+    }
+    val effect = GlassRuntimeEffect().apply {
+      style = GlassStyle { lightPosition(alignment) }
+    }
+
+    val resolved = resolveGlassStyle(
+      effect = effect,
+      materialSizePx = Size(101f, 81f),
+      density = Density(1f),
+      layoutDirection = LayoutDirection.Rtl,
+    )
+
+    assertThat(resolved.lightPosition).isEqualTo(Offset(94f, 72f))
+  }
 
   @Test
   fun lightAlignment_resolvesForEachSizeAndLayoutDirectionAndScalesOnce() {

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -5,6 +5,7 @@ package dev.chrisbanes.haze.glass
 
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
@@ -27,6 +28,33 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class)
 class GlassStyleTest {
+
+  @Test
+  fun lightPosition_defaultsToCenter() {
+    assertThat(resolveGlassStyleValues(GlassStyle, GlassStyle).lightPosition)
+      .isEqualTo(Alignment.Center)
+  }
+
+  @Test
+  fun lightPosition_recordsAlignment() {
+    val values = resolveGlassStyleValues(
+      GlassStyle,
+      GlassStyle { lightPosition(Alignment.BottomEnd) },
+    )
+
+    assertThat(values.lightPosition).isEqualTo(Alignment.BottomEnd)
+  }
+
+  @Test
+  fun lightPosition_followsStylePrecedence() {
+    val local = GlassStyle { lightPosition(Alignment.TopStart) }
+    val explicit = GlassStyle { lightPosition(Alignment.CenterEnd) }
+      .then { lightPosition(Alignment.BottomCenter) }
+
+    val values = resolveGlassStyleValues(local, explicit)
+
+    assertThat(values.lightPosition).isEqualTo(Alignment.BottomCenter)
+  }
 
   @Test
   fun directOptics_constructsTheCompleteFixedValue() {
@@ -286,7 +314,7 @@ class GlassStyleTest {
       ambientResponse(-1f)
       tint(Color.Blue)
       edgeSoftness(6.dp)
-      lightPosition(Offset(4f, 8f))
+      lightPosition(Alignment.BottomEnd)
       chromaticAberrationStrength(2f)
       surfaceProfile(SurfaceProfile.Concave)
       chromaticAberrationMode(ChromaticAberrationMode.Full)
@@ -306,7 +334,7 @@ class GlassStyleTest {
     assertThat(resolved.ambientResponse).isEqualTo(0f)
     assertThat(resolved.tint).isEqualTo(Color.Blue)
     assertThat(resolved.edgeSoftness).isEqualTo(6.dp)
-    assertThat(resolved.lightPosition).isEqualTo(Offset(4f, 8f))
+    assertThat(resolved.lightPosition).isEqualTo(Alignment.BottomEnd)
     assertThat(resolved.chromaticAberrationStrength).isEqualTo(1f)
     assertThat(resolved.surfaceProfile).isEqualTo(SurfaceProfile.Concave)
     assertThat(resolved.chromaticAberrationMode).isEqualTo(ChromaticAberrationMode.Full)

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -181,7 +182,7 @@ class FallbackGlassDelegateTest {
         tint = Color.Transparent
         specularIntensity = 1f
         edgeSoftness = 0.dp
-        lightPosition = Offset(60f, 60f)
+        lightPosition = Alignment.Center
       },
       sample = Offset(60f, 60f),
     )
@@ -213,7 +214,7 @@ class FallbackGlassDelegateTest {
       specularIntensity = 1f
       ambientResponse = 0f
       edgeSoftness = 0.dp
-      lightPosition = Offset(60f, 60f)
+      lightPosition = Alignment.Center
     }
     val fallback = FallbackGlassDelegate(effect)
     val context = FallbackRecordingContext(size = Size(120f, 120f))
@@ -259,7 +260,7 @@ class FallbackGlassDelegateTest {
     assertThat(stable.edgeBrush).isSameInstanceAs(first.edgeBrush)
     assertThat(stable.edgeStroke).isSameInstanceAs(first.edgeStroke)
 
-    effect.lightPosition = Offset(24f, 36f)
+    effect.lightPosition = exactLightAlignment(Offset(24f, 36f))
     delegate.prepare(context)
     val movedLight = delegate.preparedResourcesForTest()
 

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassInteractionTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassInteractionTest.kt
@@ -6,6 +6,7 @@ package dev.chrisbanes.haze.glass
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -40,7 +41,7 @@ class FallbackGlassInteractionTest : ContextTest() {
       tint = Color.Transparent
       specularIntensity = 0f
       ambientResponse = 0f
-      lightPosition = Offset(80f, 80f)
+      lightPosition = BiasAlignment(0.6f, 0.6f)
     }
     lateinit var runtime: GlassRuntimeEffect
     val factory = HazeEffectFactory<GlassNodeConfiguration> {

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
@@ -14,17 +14,21 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
+import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
@@ -57,6 +61,64 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
 class HazeGlassModifierTest : ContextTest() {
+
+  @Test
+  fun sharedLightAlignmentStyles_resolvePerNodeSizeAndLayoutDirection() = runComposeUiTest {
+    val alignmentCases = listOf(
+      ModifierLightAlignmentCase(Alignment.Center, 0.5f, 0.5f, 0.5f),
+      ModifierLightAlignmentCase(Alignment.TopStart, 0f, 1f, 0f),
+      ModifierLightAlignmentCase(Alignment.TopEnd, 1f, 0f, 0f),
+      ModifierLightAlignmentCase(Alignment.BottomStart, 0f, 1f, 1f),
+      ModifierLightAlignmentCase(Alignment.BottomEnd, 1f, 0f, 1f),
+      ModifierLightAlignmentCase(Alignment.CenterStart, 0f, 1f, 0.5f),
+      ModifierLightAlignmentCase(Alignment.CenterEnd, 1f, 0f, 0.5f),
+    )
+    val nodeCases = buildList {
+      alignmentCases.forEach { alignmentCase ->
+        val sharedStyle = GlassStyle { lightPosition(alignmentCase.alignment) }
+        listOf(20.dp to 10.dp, 30.dp to 20.dp).forEach { (width, height) ->
+          LayoutDirection.entries.forEach { layoutDirection ->
+            add(ModifierLightNodeCase(sharedStyle, alignmentCase, width, height, layoutDirection))
+          }
+        }
+      }
+    }
+    val factory = RecordingGlassFactory()
+
+    setContent {
+      Box {
+        nodeCases.forEach { case ->
+          CompositionLocalProvider(LocalLayoutDirection provides case.layoutDirection) {
+            Spacer(
+              Modifier.size(case.width, case.height).hazeGlass(
+                factory = factory,
+                input = HazeInput.Content,
+                style = case.style,
+                sampling = HazeSampling.FullResolution,
+                expandLayerBounds = true,
+                interactionSource = null,
+              ),
+            )
+          }
+        }
+      }
+    }
+    waitForIdle()
+    onRoot().captureToImage()
+
+    assertThat(factory.effects).hasSize(nodeCases.size)
+    factory.effects.zip(nodeCases).forEach { (effect, case) ->
+      val size = checkNotNull(effect.delegate.attachedContextForTest).modifierSize
+      val expected = androidx.compose.ui.geometry.Offset(
+        x = size.width * case.alignment.xFraction(case.layoutDirection),
+        y = size.height * case.alignment.yFraction,
+      )
+      assertThat(
+        checkNotNull(effect.delegate.preparedRender).params.lightPosition,
+        name = "$size/${case.layoutDirection}/${case.alignment.alignment}",
+      ).isEqualTo(expected)
+    }
+  }
 
   @Test
   fun structuralPolicies_reachTypedGlassRuntime() = runComposeUiTest {
@@ -559,6 +621,26 @@ class HazeGlassModifierTest : ContextTest() {
       .isEqualTo(GlassReducedMotionPolicy.System)
   }
 }
+
+private class ModifierLightAlignmentCase(
+  val alignment: Alignment,
+  val ltrXFraction: Float,
+  val rtlXFraction: Float,
+  val yFraction: Float,
+) {
+  fun xFraction(layoutDirection: LayoutDirection): Float = when (layoutDirection) {
+    LayoutDirection.Ltr -> ltrXFraction
+    LayoutDirection.Rtl -> rtlXFraction
+  }
+}
+
+private class ModifierLightNodeCase(
+  val style: GlassStyle,
+  val alignment: ModifierLightAlignmentCase,
+  val width: androidx.compose.ui.unit.Dp,
+  val height: androidx.compose.ui.unit.Dp,
+  val layoutDirection: LayoutDirection,
+)
 
 private class StructuralCase(
   val input: HazeInput,

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -799,7 +800,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
 
     val beforeRim = delegate.rimRecordCount
     val rimShader = delegate.rimShader
-    effect.lightPosition = Offset(10f, 20f)
+    effect.lightPosition = exactLightAlignment(Offset(10f, 20f))
     waitForIdle()
 
     assertThat(delegate.rimShader).isSameInstanceAs(rimShader)
@@ -897,7 +898,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     )
     specularIntensity = 1f
     ambientResponse = 0.5f
-    lightPosition = Offset(60f, 60f)
+    lightPosition = Alignment.Center
   }
 
   private fun retainedBlurEffect(

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassFallbackAndroidTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassFallbackAndroidTest.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -23,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
@@ -104,16 +102,9 @@ class GlassFallbackAndroidTest : ScreenshotTest() {
   }
 
   @Test
-  fun fallback_unspecifiedLightPositionMatchesExplicitCenter() = runScreenshotTest {
+  fun fallback_defaultLightPositionMatchesExplicitCenter() = runScreenshotTest {
     val effect = fallbackEffect(specularIntensity = 1f)
-    var materialCenter = Offset.Unspecified
     setContent {
-      val density = LocalDensity.current
-      SideEffect {
-        materialCenter = with(density) {
-          Offset(FallbackSurfaceSize.width.toPx() / 2f, FallbackSurfaceSize.height.toPx() / 2f)
-        }
-      }
       ScreenshotTheme {
         GlassInvariantSample(
           effect = effect,
@@ -126,8 +117,7 @@ class GlassFallbackAndroidTest : ScreenshotTest() {
     }
 
     val unspecified = captureRootPixels().snapshot()
-    check(materialCenter != Offset.Unspecified)
-    effect.lightPosition = materialCenter
+    effect.lightPosition = Alignment.Center
     waitForIdle()
     val explicitCenter = captureRootPixels().snapshot()
 

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassContentScreenshotTest.kt
@@ -8,7 +8,6 @@ package dev.chrisbanes.haze
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
@@ -96,11 +95,11 @@ class GlassContentScreenshotTest : ScreenshotTest() {
 
     captureRoot("center")
 
-    style = style.then { lightPosition(Offset(-96f, -64f)) }
+    style = style.then { lightPosition(exactLightAlignment(-96, -64)) }
     waitForIdle()
     captureRoot("topLeft")
 
-    style = style.then { lightPosition(Offset(120f, 80f)) }
+    style = style.then { lightPosition(exactLightAlignment(120, 80)) }
     waitForIdle()
     captureRoot("bottomRight")
   }
@@ -254,7 +253,7 @@ class GlassContentScreenshotTest : ScreenshotTest() {
       )
       specularIntensity(0.75f)
       ambientResponse(0.75f)
-      lightPosition(Offset(48f, -32f))
+      lightPosition(exactLightAlignment(48, -32))
       edgeSoftness(12.dp)
     }
   }

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassScreenshotTest.kt
@@ -333,7 +333,7 @@ class GlassScreenshotTest : ScreenshotTest() {
     var style by mutableStateOf(
       GlassStyle {
         tint(DefaultTint)
-        lightPosition(Offset.Unspecified)
+        lightPosition(Alignment.Center)
         specularIntensity(0.55f)
       },
     )
@@ -346,11 +346,11 @@ class GlassScreenshotTest : ScreenshotTest() {
 
     captureRoot("center")
 
-    style = style.then { lightPosition(Offset(-120f, -80f)) }
+    style = style.then { lightPosition(exactLightAlignment(-120, -80)) }
     waitForIdle()
     captureRoot("topLeft")
 
-    style = style.then { lightPosition(Offset(140f, 120f)) }
+    style = style.then { lightPosition(exactLightAlignment(140, 120)) }
     waitForIdle()
     captureRoot("bottomRight")
   }
@@ -554,7 +554,7 @@ class GlassScreenshotTest : ScreenshotTest() {
       )
       specularIntensity(0.75f)
       ambientResponse(0.8f)
-      lightPosition(Offset(64f, -48f))
+      lightPosition(exactLightAlignment(64, -48))
       edgeSoftness(14.dp)
     }
   }

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassTestConfiguration.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassTestConfiguration.kt
@@ -9,10 +9,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
 import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassInteractionScope
@@ -78,12 +82,10 @@ internal class GlassTestConfiguration {
       edgeSoftnessOverride = value
     }
 
-  private var hasLightPositionOverride by mutableStateOf(false)
-  private var lightPositionOverride by mutableStateOf(Offset.Unspecified)
-  var lightPosition: Offset
-    get() = lightPositionOverride
+  private var lightPositionOverride by mutableStateOf<Alignment?>(null)
+  var lightPosition: Alignment
+    get() = lightPositionOverride ?: Alignment.Center
     set(value) {
-      hasLightPositionOverride = true
       lightPositionOverride = value
     }
 
@@ -217,7 +219,7 @@ internal class GlassTestConfiguration {
         ambientResponseOverride.takeIf { hasAmbientResponseOverride }
       val resolvedTintOverride = tintOverride.takeIf { hasTintOverride }
       val resolvedEdgeSoftnessOverride = edgeSoftnessOverride.takeIf { hasEdgeSoftnessOverride }
-      val resolvedLightPositionOverride = lightPositionOverride.takeIf { hasLightPositionOverride }
+      val resolvedLightPositionOverride = lightPositionOverride
       val resolvedChromaticAberrationStrengthOverride =
         chromaticAberrationStrengthOverride.takeIf { hasChromaticAberrationStrengthOverride }
       val resolvedSurfaceProfileOverride =
@@ -272,6 +274,18 @@ internal class GlassTestConfiguration {
   fun pressed(block: GlassInteractionScope.() -> Unit) {
     style = style.then { pressed(block) }
   }
+}
+
+internal fun exactLightAlignment(x: Int, y: Int): Alignment = ExactLightAlignment(IntOffset(x, y))
+
+private class ExactLightAlignment(
+  private val position: IntOffset,
+) : Alignment {
+  override fun align(
+    size: IntSize,
+    space: IntSize,
+    layoutDirection: LayoutDirection,
+  ): IntOffset = position
 }
 
 internal fun GlassTestConfiguration.applyTestHoverAndPressResponses() {

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
@@ -128,7 +129,6 @@ private fun GlassProfilingScene(
       profilingGlassStyle(
         scenario,
         styleFrame ?: glassProfilingFrame(scenario, progress = 0f),
-        effectSurfaceSizePx,
       )
     }
   }
@@ -321,7 +321,6 @@ private fun GlassProfilingEffectGrid(
 internal fun profilingGlassStyle(
   scenario: GlassProfilingScenario,
   frame: GlassProfilingFrame,
-  surfaceSize: Size,
 ): GlassStyle = GlassDefaults.style.then {
   scenario.opticsOverride?.let(::optics)
   if (scenario.fullChroma) {
@@ -332,9 +331,9 @@ internal fun profilingGlassStyle(
   when (scenario) {
     GlassProfilingScenario.OpticalUpdate -> {
       lightPosition(
-        Offset(
-          x = surfaceSize.width * frame.lightPosition.x,
-          y = surfaceSize.height * frame.lightPosition.y,
+        BiasAlignment(
+          horizontalBias = frame.lightPosition.x * 2f - 1f,
+          verticalBias = frame.lightPosition.y * 2f - 1f,
         ),
       )
     }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.geometry.Offset
@@ -405,7 +406,7 @@ private fun PlaygroundSurface(
     IntSize(size.width.roundToPx(), size.height.roundToPx())
   }
   val interactionSource = interactionSourceProvider(id)
-  var lightPosition by remember(id) { mutableStateOf(Offset.Unspecified) }
+  var lightPosition by remember(id) { mutableStateOf<Alignment>(Alignment.Center) }
   val style = glassPlaygroundStyle(id).then {
     shape(glassPlaygroundShape(id))
     lightPosition(lightPosition)
@@ -435,7 +436,12 @@ private fun PlaygroundSurface(
       )
     }
       .distinctUntilChanged()
-      .collect { lightPosition = it }
+      .collect { position ->
+        lightPosition = BiasAlignment(
+          horizontalBias = (position.x / surfaceSize.width) * 2f - 1f,
+          verticalBias = (position.y / surfaceSize.height) * 2f - 1f,
+        )
+      }
   }
 
   Box(


### PR DESCRIPTION
## Summary

- replace the Glass light-position `Offset` API with replayable `Alignment`
- resolve logical alignment per material size and layout direction before render scaling
- migrate samples, profiling, screenshot fixtures, and runtime tests without changing screenshot assets
- document the new semantic API and 2.0 migration

Fixes #1185

Plan: https://github.com/chrisbanes/haze/issues/1185#issuecomment-5177327805

## Testing

- `./gradlew :haze-glass:jvmTest --tests '*GlassStyleTest*' --tests '*GlassRenderParamsTest*' --tests '*HazeGlassModifierTest*'`
- `./gradlew spotlessApply :haze-glass:jvmTest --tests '*GlassStyleTest*' --tests '*GlassRenderParamsTest*' --tests '*HazeGlassModifierTest*' :sample:shared:check :haze-glass:metalavaCheckCompatibility spotlessCheck`
- `./gradlew :haze-glass:check :haze-glass:metalavaCheckCompatibility :haze-screenshot-tests:test :sample:screenshot-tests:test :sample:shared:check spotlessCheck` (all completed gates passed; the library Android-host screenshot worker did not terminate locally after bounded combined and isolated attempts)
- `./scripts/build_docs.sh build`
- verified no changes under `haze-screenshot-tests/screenshots` or `sample/screenshot-tests/screenshots`

