### PR TITLE
Document portable Glass fallback behavior

### DIFF
--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -208,12 +208,28 @@ GlassStyle {
 
 ## Fallbacks
 
-- Runtime shader path: rounded SDF refraction, tint/specular/Fresnel, chromatic aberration, and
-  edge softness. On Android API 33 and newer, one single-output renderer handles single and
-  multiple effects, semantic and progressive blur, Full chromatic aberration, sharp-source
-  refraction detail, and configured interaction optics. Interaction lighting uses a localized
-  foreground patch so that it remains above content.
-- Fallback path: an approximation using tinted fill, radial highlight, and a soft rim; it respects rounded shapes and alpha when runtime shader render effects are unavailable. Interaction lighting and transforms work on this path, but interactive optics, white-point adjustment, and refraction are no-ops.
+Author one final `GlassStyle` for every platform. Haze replays that same Style unchanged into the
+private renderer it selects. Selection is automatic when preferred rendering is unavailable,
+cannot be constructed, or exceeds the render budget; application code does not query capabilities
+or provide a second fallback Style.
+
+The full runtime renderer consumes every supported authored channel. The limited fallback has this
+deterministic degradation contract:
+
+| Authored behavior | Full runtime renderer | Limited fallback renderer |
+| --- | --- | --- |
+| Tint, alpha, and rounded shape | Preserved | Preserved |
+| Ambient edge response and edge softness | Preserved | Approximated as a soft rim |
+| Specular intensity and resolved light `Alignment` | Preserved | Approximated as an aligned radial highlight |
+| Interaction lighting and node transform | Preserved | Preserved, with localized foreground lighting and the shared transform |
+| Fixed or Adaptive refraction, blur, and progressive optics | Preserved | Omitted |
+| Chromatic aberration, surface profile, and full color-adjustment math | Preserved | Omitted |
+| Interaction refraction and white-point deltas | Preserved | Omitted |
+
+On Android API 33 and newer, the full single-output renderer handles single and multiple effects,
+semantic and progressive blur, Full chromatic aberration, sharp-source refraction detail, and
+configured interaction optics. Unsupported fallback channels are safe no-ops; supported tint,
+aligned lighting, interaction lighting, and transforms remain observable.
 
 ## Performance
 

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -183,6 +183,11 @@ The `GlassStyle` builder executes once during construction and records immutable
 writes. Resolution never reruns the builder, so mutating state captured by an unchanged Style is
 inert; construct and supply a replacement Style to reflect new inputs.
 
+Keep one final `GlassStyle` for all platforms. Remove renderer-capability checks, platform-specific
+Style variants, and secondary fallback Styles: `hazeGlass` selects its private renderer
+automatically, replaying the same Style while limited renderers approximate supported appearance
+and omit unsupported optics.
+
 | Legacy | Typed replacement |
 | --- | --- |
 | `hazeEffect { glassEffect { … } }` | `hazeGlass(input, style, sampling, expandLayerBounds, …)` |

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -48,6 +48,11 @@ public val LocalGlassStyle: ProvidableCompositionLocal<GlassStyle> =
  * [GlassStyleScope.interactionPositionAnimationSpec] record reusable interaction presentation;
  * each `hazeGlass` node replays it into a fresh node-owned snapshot and owns its signals,
  * geometry, animations, pointer observation, and renderer resources.
+ *
+ * The same final Style is replayed unchanged into whichever private renderer Haze selects. Full
+ * renderers consume every supported authored channel. Limited renderers preserve supported
+ * channels, approximate supported lighting, and omit unsupported base and interaction optics.
+ * Selection is automatic; callers do not need a capability check or a second fallback Style.
  */
 @ExperimentalHazeApi
 @Immutable

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassInteractionTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassInteractionTest.kt
@@ -4,49 +4,72 @@
 package dev.chrisbanes.haze.glass
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
-import androidx.compose.ui.BiasAlignment
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PixelMap
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isInstanceOf
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeEffectFactory
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
 
 @OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class, InternalHazeApi::class)
 class FallbackGlassInteractionTest : ContextTest() {
 
   @Test
-  fun fallback_pressedLighting_isLocalizedAtPointer() = runComposeUiTest {
-    val effect = GlassRuntimeEffect().apply {
-      pressed { lightingIntensity(1f) }
-      style = GlassStyle { interactionLightRadiusFraction(0.4f) }
-      interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced
-      tint = Color.Transparent
-      specularIntensity = 0f
-      ambientResponse = 0f
-      lightPosition = BiasAlignment(0.6f, 0.6f)
-    }
+  fun automaticFallback_preservesAppearanceAndLightingWhileOmittingOptics() = runComposeUiTest {
+    val firstOptics = GlassOptics.Fixed(
+      refractionStrength = 0.8f,
+      refractionHeightFraction = 0.4f,
+      refractionDisplacement = 18.dp,
+      depth = 0.7f,
+      blurRadius = 20.dp,
+    )
+    val secondOptics = GlassOptics.Fixed(
+      refractionStrength = 0.2f,
+      refractionHeightFraction = 0.8f,
+      refractionDisplacement = 4.dp,
+      depth = 0.1f,
+      blurRadius = 2.dp,
+    )
+    val style = mutableStateOf(fallbackPortableStyle(firstOptics, includeInteractionOptics = true))
+    val interactionSource = MutableInteractionSource()
+    var failedRuntimeCreationAttempts = 0
     lateinit var runtime: GlassRuntimeEffect
     val factory = HazeEffectFactory<GlassNodeConfiguration> {
-      effect.also { runtime = it }
+      GlassRuntimeEffect().apply {
+        runtimeEffectFactory = GlassRuntimeEffectFactory {
+          failedRuntimeCreationAttempts++
+          throw RuntimeShaderRenderEffectException(
+            IllegalArgumentException("broken runtime effect"),
+          )
+        }
+      }.also { runtime = it }
     }
+
     setContent {
       Box(
         Modifier
@@ -55,24 +78,80 @@ class FallbackGlassInteractionTest : ContextTest() {
           .hazeGlass(
             factory = factory,
             input = HazeInput.Content,
-            style = effect.style,
-            sampling = HazeSampling.Default,
+            style = style.value,
+            sampling = HazeSampling.FullResolution,
             expandLayerBounds = true,
-            interactionSource = effect.interactionSource,
-            interactionTransformTarget = effect.interactionTransformTarget,
-            interactionTransformPivot = effect.interactionTransformPivot,
-            interactionReducedMotionPolicy = effect.interactionReducedMotionPolicy,
+            interactionSource = interactionSource,
+            interactionTransformTarget = GlassTransformTarget.MaterialOnly,
+            interactionTransformPivot = GlassTransformPivot.Pointer,
+            interactionReducedMotionPolicy = GlassReducedMotionPolicy.Reduced,
           )
           .background(Color.Black),
       )
     }
     waitForIdle()
-    runtime.delegate = FallbackGlassDelegate(runtime)
+    val idleWithFirstOptics = onNodeWithTag("glass").captureToImage().toPixelMap()
 
-    onNodeWithTag("glass").performTouchInput { down(Offset(20f, 20f)) }
+    assertThat(runtime.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(failedRuntimeCreationAttempts).isEqualTo(1)
+    assertThat(idleWithFirstOptics[80, 80].red)
+      .isGreaterThan(idleWithFirstOptics[80, 80].green)
+    assertThat(idleWithFirstOptics[15, 15].luminance())
+      .isGreaterThan(idleWithFirstOptics[80, 80].luminance())
+
+    style.value = fallbackPortableStyle(secondOptics, includeInteractionOptics = true)
     waitForIdle()
-    val pixels = onNodeWithTag("glass").captureToImage().toPixelMap()
+    val idleWithSecondOptics = onNodeWithTag("glass").captureToImage().toPixelMap()
 
-    assertThat(pixels[20, 20].luminance()).isGreaterThan(pixels[80, 80].luminance())
+    assertThat(idleWithSecondOptics.sampledGrid()).isEqualTo(idleWithFirstOptics.sampledGrid())
+    assertThat(runtime.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(failedRuntimeCreationAttempts).isEqualTo(1)
+
+    runTest {
+      interactionSource.emit(PressInteraction.Press(Offset(80f, 80f)))
+    }
+    waitForIdle()
+    val pressedWithInteractionOptics = onNodeWithTag("glass").captureToImage().toPixelMap()
+
+    assertThat(pressedWithInteractionOptics[80, 80].luminance())
+      .isGreaterThan(idleWithSecondOptics[80, 80].luminance())
+
+    style.value = fallbackPortableStyle(secondOptics, includeInteractionOptics = false)
+    waitForIdle()
+    val pressedWithoutInteractionOptics = onNodeWithTag("glass").captureToImage().toPixelMap()
+
+    assertThat(pressedWithoutInteractionOptics.sampledGrid())
+      .isEqualTo(pressedWithInteractionOptics.sampledGrid())
+    assertThat(runtime.delegate).isInstanceOf<FallbackGlassDelegate>()
+    assertThat(failedRuntimeCreationAttempts).isEqualTo(1)
+  }
+}
+
+private fun fallbackPortableStyle(
+  optics: GlassOptics.Fixed,
+  includeInteractionOptics: Boolean,
+): GlassStyle = GlassStyle {
+  optics(optics)
+  tint(Color.Red.copy(alpha = 0.6f))
+  ambientResponse(0f)
+  specularIntensity(1f)
+  edgeSoftness(0.dp)
+  lightPosition(Alignment.TopStart)
+  pressed {
+    lightingIntensity(1f)
+    if (includeInteractionOptics) {
+      refractionMultiplier(1.8f)
+      whitePointDelta(0.5f)
+    }
+    scale(0.96f)
+  }
+  interactionLightRadiusFraction(0.3f)
+}
+
+private fun PixelMap.sampledGrid(): List<Color> = buildList {
+  for (y in 5 until height step 10) {
+    for (x in 5 until width step 10) {
+      add(this@sampledGrid[x, y])
+    }
   }
 }

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEvent
@@ -32,7 +33,9 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isGreaterThan
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
@@ -54,6 +57,7 @@ import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.HazeSourceRetention
 import dev.chrisbanes.haze.HazeSourceSelection
 import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
 import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.test.ContextTest
@@ -61,6 +65,103 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
 class HazeGlassModifierTest : ContextTest() {
+
+  @Test
+  fun portableStyle_flowsUnchangedThroughFullAndAutomaticFallbackSelection() =
+    runComposeUiTest {
+      val fixedOptics = GlassOptics.Fixed(
+        refractionStrength = 0.63f,
+        refractionHeightFraction = 0.31f,
+        refractionDisplacement = 9.dp,
+        depth = 0.72f,
+        blurRadius = 7.dp,
+      )
+      val tint = Color(0x6655AAFF)
+      val sharedStyle = GlassStyle {
+        optics(fixedOptics)
+        tint(tint)
+        specularIntensity(0.71f)
+        ambientResponse(0.23f)
+        lightPosition(Alignment.TopStart)
+        pressed {
+          lightingIntensity(0.81f)
+          refractionMultiplier(1.4f)
+          whitePointDelta(0.12f)
+          scale(0.96f)
+        }
+      }
+      var failedRuntimeCreationAttempts = 0
+      val fullFactory = RecordingGlassFactory()
+      val fallbackFactory = RecordingGlassFactory { effect ->
+        effect.runtimeEffectFactory = GlassRuntimeEffectFactory {
+          failedRuntimeCreationAttempts++
+          throw RuntimeShaderRenderEffectException(
+            IllegalArgumentException("broken runtime effect"),
+          )
+        }
+      }
+
+      setContent {
+        Box {
+          listOf(fullFactory, fallbackFactory).forEach { factory ->
+            Spacer(
+              Modifier.size(40.dp).hazeGlass(
+                factory = factory,
+                input = HazeInput.Content,
+                style = sharedStyle,
+                sampling = HazeSampling.FullResolution,
+                expandLayerBounds = true,
+                interactionSource = null,
+              ),
+            )
+          }
+        }
+      }
+      waitForIdle()
+      onRoot().captureToImage()
+
+      val full = fullFactory.effects.single().delegate
+      val fallback = fallbackFactory.effects.single().delegate
+      assertThat(full.style).isSameInstanceAs(sharedStyle)
+      assertThat(fallback.style).isSameInstanceAs(sharedStyle)
+      assertThat(full.optics).isSameInstanceAs(fixedOptics)
+      assertThat(fallback.optics).isSameInstanceAs(fixedOptics)
+      assertThat(full.delegate).isInstanceOf<RuntimeShaderGlassDelegate>()
+      assertThat(fallback.delegate).isInstanceOf<FallbackGlassDelegate>()
+
+      assertThat(full.attachedContextForTest).isNotNull().given { context ->
+        assertThat(full.preparedRender?.params).isNotNull().given { params ->
+          assertThat(params.refractionStrength).isEqualTo(0.63f)
+          assertThat(params.refractionHeightPx)
+            .isEqualTo(context.modifierSize.minDimension * 0.31f)
+          assertThat(params.refractionScalePx)
+            .isEqualTo(with(context.requireDensity()) { 9.dp.toPx() })
+          assertThat(params.depth).isEqualTo(0.72f)
+          assertThat(params.blurRadiusPx)
+            .isEqualTo(with(context.requireDensity()) { 7.dp.toPx() })
+          assertThat(params.tint).isEqualTo(tint)
+          assertThat(params.specularIntensity).isEqualTo(0.71f)
+          assertThat(params.ambientResponse).isEqualTo(0.23f)
+          assertThat(params.lightPosition).isEqualTo(Offset.Zero)
+        }
+      }
+      assertThat(full.resolvedInteractionTopology)
+        .isEqualTo(
+          GlassInteractionTopology(
+            hasOptics = true,
+            hasLighting = true,
+            maxRefractionMultiplier = 1.4f,
+          ),
+        )
+      assertThat(fallback.resolvedInteractionTopology)
+        .isEqualTo(full.resolvedInteractionTopology)
+      assertThat(failedRuntimeCreationAttempts).isEqualTo(1)
+
+      onRoot().captureToImage()
+
+      assertThat(fallback.delegate).isInstanceOf<FallbackGlassDelegate>()
+      assertThat(failedRuntimeCreationAttempts).isEqualTo(1)
+    }
 
   @Test
   fun sharedLightAlignmentStyles_resolvePerNodeSizeAndLayoutDirection() = runComposeUiTest {
@@ -650,11 +751,13 @@ private class StructuralCase(
   val factory = RecordingGlassFactory()
 }
 
-private class RecordingGlassFactory : HazeEffectFactory<GlassNodeConfiguration> {
+private class RecordingGlassFactory(
+  private val configure: (GlassRuntimeEffect) -> Unit = {},
+) : HazeEffectFactory<GlassNodeConfiguration> {
   val effects = mutableListOf<RecordingGlassRuntimeEffect>()
 
   override fun createRenderer(): HazeEffectRenderer<GlassNodeConfiguration> {
-    return RecordingGlassRuntimeEffect(GlassRuntimeEffect()).also(effects::add)
+    return RecordingGlassRuntimeEffect(GlassRuntimeEffect().also(configure)).also(effects::add)
   }
 }
 


### PR DESCRIPTION
## Summary
- prove one authored GlassStyle reaches full and automatic fallback rendering unchanged
- verify fallback tint, aligned highlight, interaction lighting, and optical omission through public modifier tests
- document the portable preservation, approximation, and omission contract plus migration guidance

## Validation
- focused Haze Glass JVM and Android-host tests
- Metalava compatibility and Spotless
- full documentation build
- screenshot suite tasks completed without failure output, but the aggregate process did not exit after its final task markers and was interrupted after a bounded wait
- API and screenshot baseline diff audit

Fixes #1186

Plan: https://github.com/chrisbanes/haze/issues/1186#issuecomment-5178382336