### PR TITLE
Reject invalid Glass configuration at construction

### DIFF
--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -55,10 +55,35 @@ Adaptive content behavior, interaction-driven deformation, and morphing are unsu
 - **chromaticAberrationMode**: Quality mode for chromatic aberration. `Simple` (default, fast) or `Full` (spectral, more expensive).
 - **alpha**: Overall opacity multiplier `0..1` (default 1).
 
+All direct Glass numbers fail fast at value or Style construction. Invalid inputs throw
+`IllegalArgumentException` with a message shaped as `<property> must be <accepted domain>`; they
+are not clamped by Style resolution or a renderer.
+
+| Public input | Accepted domain and sentinel policy |
+| --- | --- |
+| `refractionStrength`, `refractionHeightFraction`, `depth` | finite `0f..1f` |
+| `refractionDisplacement`, `blurRadius` | specified, finite, non-negative `Dp`; no authored upper limit |
+| `specularIntensity`, `ambientResponse`, `chromaticAberrationStrength`, `alpha`, `contentNormalBlend` | finite `0f..1f` |
+| `contrast`, `whitePoint` | finite `-1f..1f` |
+| `chromaMultiplier`, `interactionLightRadiusFraction` | finite `0f..2f` |
+| `edgeSoftness` | specified, finite, non-negative `Dp`; no authored upper limit |
+| `specularExponent`, `fresnelExponent` | finite and non-negative; no authored upper limit |
+| `tint` | any specified `Color`, including transparent; `Color.Unspecified` is rejected |
+| known `lightPosition` biases | finite horizontal and vertical axes; finite values outside `-1f..1f` are accepted |
+| interaction `lightingIntensity`, `refractionMultiplier`, `whitePointDelta` | finite `0f..1f`, `0f..2f`, and `-1f..1f`, respectively |
+| interaction `scale`, `scaleX`, `scaleY` | finite `0f < value <= 1f` |
+
+The direct six-parameter `optics(...)` function constructs `GlassOptics.Fixed`, so both routes have
+identical failures. `progressive = null` intentionally means no progressive blur. `GlassOptics`,
+`RoundedCornerShape`, `FiniteAnimationSpec`, `HazeProgressive`, arbitrary custom `Alignment`, and
+`HazeSampling` otherwise retain their owning contracts; Glass does not inspect opaque
+implementations. In particular, `HazeSampling.Fixed` already validates its finite
+`0f < pixelFraction <= 1f` value before the modifier receives it.
+
 ## GlassStyle
 
 `GlassStyle` is an opaque, immutable sequence of appearance writes. Its builder executes once when
-the Style is constructed, canonicalizing and recording each value. Compose Styles with the
+the Style is constructed, validating and recording each value. Compose Styles with the
 intrinsic `then` members; later writes win. A Style can be shared by any number of `hazeGlass`
 nodes: each node replays defaults, `LocalGlassStyle`, and its explicit Style into its own snapshot
 without rerunning caller code.
@@ -97,7 +122,9 @@ val sharedLighting = GlassStyle {
 
 Use `BiasAlignment` for a continuously moving proportional light. Biases `-1f`, `0f`, and `1f`
 represent the start/top edge, center, and end/bottom edge respectively, and values outside that
-range place the virtual light beyond the material bounds.
+range place the virtual light beyond the material bounds. Both bias axes must be finite.
+`BiasAbsoluteAlignment` follows the same finite-axis rule without RTL mirroring. Arbitrary custom
+`Alignment` implementations are accepted unchanged and evaluated only at layout resolution.
 
 ```kotlin
 val movingLighting = GlassStyle {

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -179,7 +179,7 @@ The typed Blur API does not change the other Haze 2 migrations.
 
 Glass also has a typed modifier and an opaque, replayable `GlassStyle`. Replace the complete Style
 through recomposition; do not mutate an effect, use sentinel patches, `copy`, or `clear*` calls.
-The `GlassStyle` builder executes once during construction and records immutable, canonicalized
+The `GlassStyle` builder executes once during construction and records immutable, validated
 writes. Resolution never reruns the builder, so mutating state captured by an unchanged Style is
 inert; construct and supply a replacement Style to reflect new inputs.
 
@@ -187,6 +187,33 @@ Keep one final `GlassStyle` for all platforms. Remove renderer-capability checks
 Style variants, and secondary fallback Styles: `hazeGlass` selects its private renderer
 automatically, replaying the same Style while limited renderers approximate supported appearance
 and omit unsupported optics.
+
+Glass numeric authoring now fails fast. Values that older Style or renderer paths clamped,
+normalized, or replaced now throw `IllegalArgumentException` when `GlassOptics.Fixed` or
+`GlassStyle` is constructed. This includes non-finite values; out-of-domain ratios, adjustments,
+multipliers, exponents, and scales; negative or unspecified distances; `Color.Unspecified`; and
+non-finite axes on `BiasAlignment` or `BiasAbsoluteAlignment`. Direct `optics(...)` uses the same
+`GlassOptics.Fixed` validation and messages as complete-value construction.
+
+If an application intentionally wants clamping, make that policy explicit before authoring the
+Style:
+
+```kotlin
+val safeAlpha = requestedAlpha.coerceIn(0f, 1f)
+require(requestedEdgeSoftness.isSpecified && requestedEdgeSoftness.value.isFinite())
+val safeEdgeSoftness = requestedEdgeSoftness.coerceAtLeast(0.dp)
+
+val style = GlassStyle {
+  alpha(safeAlpha)
+  edgeSoftness(safeEdgeSoftness)
+}
+```
+
+Otherwise validate upstream and surface the invalid configuration. Large finite non-negative
+distances and exponents remain valid; renderer physical caps do not become authoring limits.
+`progressive = null` remains intentional, arbitrary custom `Alignment` and opaque shape/animation/
+progressive implementations keep their owning contracts, and modifier sampling continues to be
+validated by `HazeSampling.Fixed` (`0f < pixelFraction <= 1f`).
 
 | Legacy | Typed replacement |
 | --- | --- |

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
@@ -290,7 +290,7 @@ private fun DrawScope.drawFallbackEdge(
   }
 }
 
-internal fun fallbackEdgeAlpha(ambientResponse: Float): Float = 0.18f * ambientResponse.coerceIn(0f, 1f)
+internal fun fallbackEdgeAlpha(ambientResponse: Float): Float = 0.18f * ambientResponse
 
 private data class FallbackGlassPreparedDraw(
   val size: Size,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteraction.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteraction.kt
@@ -48,25 +48,26 @@ public enum class GlassReducedMotionPolicy {
 @ExperimentalHazeApi
 @GlassStyleDsl
 public sealed interface GlassInteractionScope {
-  /** Sets the lighting multiplier in the range `0f..1f`. */
+  /** Sets the finite lighting multiplier in the inclusive range `0f..1f`. */
   public fun lightingIntensity(intensity: Float)
 
-  /** Sets the refraction multiplier in the range `0f..2f`. */
+  /** Sets the finite refraction multiplier in the inclusive range `0f..2f`. */
   public fun refractionMultiplier(multiplier: Float)
 
-  /** Sets the additive white-point adjustment in the range `-1f..1f`. */
+  /** Sets the finite additive white-point adjustment in the inclusive range `-1f..1f`. */
   public fun whitePointDelta(delta: Float)
 
-  /** Sets a uniform positive scale no greater than `1f`. */
+  /** Sets a finite uniform scale in `0f < scale <= 1f`. */
   public fun scale(scale: Float) {
     scale(scaleX = scale, scaleY = scale)
   }
 
-  /** Sets positive horizontal and vertical scales no greater than `1f`. */
+  /** Sets finite horizontal and vertical scales in `0f < value <= 1f`. */
   public fun scale(scaleX: Float, scaleY: Float)
 
   /**
    * Applies [toSpec] when entering and [fromSpec] when leaving the response declared by [block].
+   * Animation specs retain the contract of their owning [FiniteAnimationSpec] type.
    */
   public fun animate(
     toSpec: FiniteAnimationSpec<Float>,
@@ -104,25 +105,28 @@ internal class GlassInteractionScopeImpl : GlassInteractionScope {
   private var yScale: GlassResponseValue? = null
 
   override fun lightingIntensity(intensity: Float) {
-    requireFiniteInRange("lightingIntensity", intensity, 0f..1f)
-    lighting = value(intensity)
+    lighting = value(
+      requireFiniteInRange("lightingIntensity", intensity, 0f..1f, UNIT_INTERVAL_DOMAIN),
+    )
   }
 
   override fun refractionMultiplier(multiplier: Float) {
-    requireFiniteInRange("refractionMultiplier", multiplier, 0f..2f)
-    refraction = value(multiplier)
+    refraction = value(
+      requireFiniteInRange("refractionMultiplier", multiplier, 0f..2f, DOUBLE_INTERVAL_DOMAIN),
+    )
   }
 
   override fun whitePointDelta(delta: Float) {
-    requireFiniteInRange("whitePointDelta", delta, -1f..1f)
-    whitePoint = value(delta)
+    whitePoint = value(
+      requireFiniteInRange("whitePointDelta", delta, -1f..1f, SIGNED_UNIT_INTERVAL_DOMAIN),
+    )
   }
 
   override fun scale(scaleX: Float, scaleY: Float) {
-    requireFiniteScale("scaleX", scaleX)
-    requireFiniteScale("scaleY", scaleY)
-    xScale = value(scaleX)
-    yScale = value(scaleY)
+    val validatedX = requirePositiveAtMostOne("scaleX", scaleX)
+    val validatedY = requirePositiveAtMostOne("scaleY", scaleY)
+    xScale = value(validatedX)
+    yScale = value(validatedY)
   }
 
   override fun animate(
@@ -158,17 +162,3 @@ internal class GlassInteractionScopeImpl : GlassInteractionScope {
 internal fun buildGlassInteractionResponse(
   block: GlassInteractionScope.() -> Unit,
 ): GlassInteractionResponse = GlassInteractionScopeImpl().apply(block).build()
-
-private fun requireFiniteInRange(
-  name: String,
-  value: Float,
-  range: ClosedFloatingPointRange<Float>,
-) {
-  require(value.isFinite() && value in range) { "$name must be finite and in range" }
-}
-
-private fun requireFiniteScale(name: String, value: Float) {
-  require(value.isFinite() && value > 0f && value <= 1f) {
-    "$name must be finite, greater than zero, and at most one"
-  }
-}

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassOptics.kt
@@ -6,7 +6,6 @@ package dev.chrisbanes.haze.glass
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.isSpecified
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeProgressive
 
@@ -33,13 +32,20 @@ public sealed interface GlassOptics {
    * is capped at 38.5 physical pixels; this renderer quality bound does not limit accepted input
    * values.
    *
-   * @param refractionStrength Strength of the refraction response, in the range `0f..1f`.
-   * @param refractionDisplacement Maximum distance that refraction displaces content.
+   * Invalid numeric values throw [IllegalArgumentException] when this value is constructed.
+   * [progressive] is optional and retains the contract of its owning [HazeProgressive] type.
+   *
+   * @param refractionStrength Finite strength of the refraction response, in the inclusive range
+   * `0f..1f`.
+   * @param refractionDisplacement Specified, finite, non-negative maximum distance that refraction
+   * displaces content. There is no authored upper limit.
    * @param refractionHeightFraction Fraction of the material's shortest side used by the
-   * refraction profile, in the range `0f..1f`.
-   * @param depth Depth perception factor. Values greater than `0f` require drawing an additional
-   * blurred sample for the glass content, which has a rendering cost.
-   * @param blurRadius Maximum blur radius before the renderer's adaptive scale is applied.
+   * refraction profile, as a finite value in the inclusive range `0f..1f`.
+   * @param depth Finite depth perception factor in the inclusive range `0f..1f`. Values greater
+   * than `0f` require drawing an additional blurred sample for the glass content, which has a
+   * rendering cost.
+   * @param blurRadius Specified, finite, non-negative maximum blur radius before the renderer's
+   * adaptive scale is applied. There is no authored upper limit.
    * @param progressive Optional progressive intensity applied to the blur.
    */
   public data class Fixed(
@@ -51,27 +57,16 @@ public sealed interface GlassOptics {
     val progressive: HazeProgressive? = null,
   ) : GlassOptics {
     init {
-      require(refractionStrength.isFinite() && refractionStrength in 0f..1f) {
-        "refractionStrength must be finite and in 0f..1f"
-      }
-      require(
-        refractionHeightFraction.isFinite() && refractionHeightFraction in 0f..1f,
-      ) {
-        "refractionHeightFraction must be finite and in 0f..1f"
-      }
-      require(
-        refractionDisplacement.isSpecified &&
-          refractionDisplacement.value.isFinite() &&
-          refractionDisplacement >= 0.dp,
-      ) {
-        "refractionDisplacement must be specified, finite, and non-negative"
-      }
-      require(depth.isFinite() && depth in 0f..1f) {
-        "depth must be finite and in 0f..1f"
-      }
-      require(blurRadius.isSpecified && blurRadius.value.isFinite() && blurRadius >= 0.dp) {
-        "blurRadius must be specified, finite, and non-negative"
-      }
+      requireFiniteInRange("refractionStrength", refractionStrength, 0f..1f, UNIT_INTERVAL_DOMAIN)
+      requireFiniteInRange(
+        "refractionHeightFraction",
+        refractionHeightFraction,
+        0f..1f,
+        UNIT_INTERVAL_DOMAIN,
+      )
+      requireSpecifiedFiniteNonNegative("refractionDisplacement", refractionDisplacement)
+      requireFiniteInRange("depth", depth, 0f..1f, UNIT_INTERVAL_DOMAIN)
+      requireSpecifiedFiniteNonNegative("blurRadius", blurRadius)
     }
   }
 }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -533,9 +533,7 @@ internal fun resolveGlassInteraction(
   radiusFraction: Float,
 ): ResolvedGlassInteraction = ResolvedGlassInteraction(
   position = state.position,
-  radiusFraction = radiusFraction
-    .finiteOr(GlassDefaults.interactionLightRadiusFraction)
-    .coerceIn(0f, 2f),
+  radiusFraction = radiusFraction,
   lightingIntensity = state.lightingIntensity.finiteOr(0f).coerceIn(0f, 1f),
   refractionMultiplier = state.refractionMultiplier.finiteOr(1f).coerceIn(0f, 2f),
   whitePointDelta = state.whitePointDelta.finiteOr(0f).coerceIn(-1f, 1f),
@@ -592,30 +590,23 @@ internal fun resolveGlassStyle(
   )
   return ResolvedGlassStyle(
     resolvedOptics = resolveGlassOptics(effect.optics, materialSizePx, density, cornerRadii),
-    specularIntensity = effect.specularIntensity
-      .finiteOr(GlassDefaults.specularIntensity).coerceIn(0f, 1f),
-    ambientResponse = effect.ambientResponse
-      .finiteOr(GlassDefaults.ambientResponse).coerceIn(0f, 1f),
+    specularIntensity = effect.specularIntensity,
+    ambientResponse = effect.ambientResponse,
     tint = effect.tint,
     edgeSoftnessPx = with(density) { effect.edgeSoftness.toPx() }
       .finiteOr(defaultEdgeSoftnessPx)
       .coerceAtLeast(0f),
     lightPosition = alignedLightPosition,
-    chromaticAberrationStrength = effect.chromaticAberrationStrength
-      .finiteOr(GlassDefaults.chromaticAberrationStrength).coerceIn(0f, 1f),
+    chromaticAberrationStrength = effect.chromaticAberrationStrength,
     surfaceProfile = effect.surfaceProfile.ordinal.toFloat(),
     chromaticAberrationMode = effect.chromaticAberrationMode.ordinal.toFloat(),
-    alpha = effect.alpha.finiteOr(GlassDefaults.alpha).coerceIn(0f, 1f),
-    contrast = effect.contrast.finiteOr(GlassDefaults.contrast).coerceIn(-1f, 1f),
-    whitePoint = effect.whitePoint.finiteOr(GlassDefaults.whitePoint).coerceIn(-1f, 1f),
-    chromaMultiplier = effect.chromaMultiplier
-      .finiteOr(GlassDefaults.chromaMultiplier).coerceIn(0f, 2f),
-    contentNormalBlend = effect.contentNormalBlend
-      .finiteOr(GlassDefaults.contentNormalBlend).coerceIn(0f, 1f),
-    specularExponent = effect.specularExponent
-      .finiteOr(GlassDefaults.specularExponent).coerceAtLeast(0f),
-    fresnelExponent = effect.fresnelExponent
-      .finiteOr(GlassDefaults.fresnelExponent).coerceAtLeast(0f),
+    alpha = effect.alpha,
+    contrast = effect.contrast,
+    whitePoint = effect.whitePoint,
+    chromaMultiplier = effect.chromaMultiplier,
+    contentNormalBlend = effect.contentNormalBlend,
+    specularExponent = effect.specularExponent,
+    fresnelExponent = effect.fresnelExponent,
     cornerRadii = cornerRadii,
   )
 }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -11,12 +11,13 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAbsoluteAlignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.isSpecified
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.Poko
@@ -35,7 +36,7 @@ public val LocalGlassStyle: ProvidableCompositionLocal<GlassStyle> =
  * An opaque, immutable sequence of recorded Glass appearance writes.
  *
  * The builder passed to [GlassStyle] executes once during construction. Each property is
- * canonicalized and captured as an immutable write; resolving a Style only replays those captured
+ * validated and captured as an immutable write; resolving a Style only replays those captured
  * values and never invokes caller code. Combine Styles with [then]. Writes run in order and the
  * last write to a property wins. The companion object is the empty Style and performs no writes.
  *
@@ -70,7 +71,7 @@ public sealed interface GlassStyle {
 /**
  * Creates a recorded, replayable [GlassStyle].
  *
- * [block] executes exactly once during this call. Its canonicalized property values are captured
+ * [block] executes exactly once during this call. Its validated property values are captured
  * as immutable writes which can later be replayed into fresh node-local state without invoking
  * [block] again.
  */
@@ -111,8 +112,9 @@ public annotation class GlassStyleDsl
 /**
  * Receiver for Glass appearance property writes.
  *
- * Property functions canonicalize values while the Style is constructed and record them for later
- * replay. Calling a function again records a later write which takes precedence.
+ * Property functions validate values while the Style is constructed and record them for later
+ * replay. Invalid direct Glass numbers throw [IllegalArgumentException]. Calling a function again
+ * records a later write which takes precedence.
  */
 @ExperimentalHazeApi
 @GlassStyleDsl
@@ -145,13 +147,16 @@ public class GlassStyleScope internal constructor(
   /**
    * Sets the interaction-light radius as a fraction of the material's shortest side.
    *
-   * The value must be finite and in the range `0f..2f`.
+   * The value must be finite and in the inclusive range `0f..2f`.
    */
   public fun interactionLightRadiusFraction(radiusFraction: Float) {
-    require(radiusFraction.isFinite() && radiusFraction in 0f..2f) {
-      "interactionLightRadiusFraction must be finite and in range"
-    }
-    writes += { interactionLightRadiusFraction = radiusFraction }
+    val validated = requireFiniteInRange(
+      "interactionLightRadiusFraction",
+      radiusFraction,
+      0f..2f,
+      DOUBLE_INTERVAL_DOMAIN,
+    )
+    writes += { interactionLightRadiusFraction = validated }
   }
 
   /**
@@ -168,7 +173,11 @@ public class GlassStyleScope internal constructor(
     writes += { this.shape = shape }
   }
 
-  /** Sets a complete fixed optical model used to refract and blur captured content. */
+  /**
+   * Sets a complete fixed optical model used to refract and blur captured content.
+   *
+   * This constructs [GlassOptics.Fixed] and enforces its same fail-fast domains.
+   */
   public fun optics(
     refractionStrength: Float = 0.7f,
     refractionHeightFraction: Float = 0.25f,
@@ -189,34 +198,40 @@ public class GlassStyleScope internal constructor(
     )
   }
 
-  /** Sets the optical model used to refract and blur captured content. */
+  /**
+   * Sets the optical model used to refract and blur captured content.
+   *
+   * Complete optics values retain the contracts enforced by their concrete [GlassOptics] type.
+   */
   public fun optics(optics: GlassOptics) {
     writes += { this.optics = optics }
   }
 
-  /** Sets specular-highlight intensity, coerced to the range `0f..1f`. */
+  /** Sets finite specular-highlight intensity in the inclusive range `0f..1f`. */
   public fun specularIntensity(intensity: Float) {
-    val canonical = intensity.coerceIn(0f, 1f)
-    writes += { specularIntensity = canonical }
+    val validated = requireFiniteInRange("specularIntensity", intensity, 0f..1f, UNIT_INTERVAL_DOMAIN)
+    writes += { specularIntensity = validated }
   }
 
-  /** Sets ambient-light response, coerced to the range `0f..1f`. */
+  /** Sets finite ambient-light response in the inclusive range `0f..1f`. */
   public fun ambientResponse(response: Float) {
-    val canonical = response.coerceIn(0f, 1f)
-    writes += { ambientResponse = canonical }
+    val validated = requireFiniteInRange("ambientResponse", response, 0f..1f, UNIT_INTERVAL_DOMAIN)
+    writes += { ambientResponse = validated }
   }
 
-  /** Sets the tint applied to refracted content. */
+  /** Sets any specified tint, including transparent, applied to refracted content. */
   public fun tint(color: Color) {
     require(color.isSpecified) { "tint must be specified" }
     writes += { tint = color }
   }
 
-  /** Sets the non-negative softening distance around the material boundary. */
+  /**
+   * Sets a specified, finite, non-negative softening distance around the material boundary.
+   * There is no authored upper limit.
+   */
   public fun edgeSoftness(softness: Dp) {
-    require(softness.isSpecified) { "edgeSoftness must be specified" }
-    val canonical = softness.coerceAtLeast(0.dp)
-    writes += { edgeSoftness = canonical }
+    val validated = requireSpecifiedFiniteNonNegative("edgeSoftness", softness)
+    writes += { edgeSoftness = validated }
   }
 
   /**
@@ -224,15 +239,35 @@ public class GlassStyleScope internal constructor(
    *
    * The default is [Alignment.Center]. Logical start and end alignments use the node's current
    * layout direction, and a shared Style is resolved independently for each consuming node's size.
+   * [BiasAlignment] and [BiasAbsoluteAlignment] require finite horizontal and vertical biases;
+   * finite values outside `-1f..1f` intentionally place the light beyond the material. Other
+   * [Alignment] implementations retain their own contract and are not evaluated during Style
+   * construction.
    */
   public fun lightPosition(alignment: Alignment) {
+    when (alignment) {
+      is BiasAlignment -> validateLightPositionBiases(
+        horizontalBias = alignment.horizontalBias,
+        verticalBias = alignment.verticalBias,
+      )
+      is BiasAbsoluteAlignment -> validateLightPositionBiases(
+        horizontalBias = alignment.horizontalBias,
+        verticalBias = alignment.verticalBias,
+      )
+      else -> Unit
+    }
     writes += { lightPosition = alignment }
   }
 
-  /** Sets chromatic dispersion strength, coerced to the range `0f..1f`. */
+  /** Sets finite chromatic dispersion strength in the inclusive range `0f..1f`. */
   public fun chromaticAberrationStrength(strength: Float) {
-    val canonical = strength.coerceIn(0f, 1f)
-    writes += { chromaticAberrationStrength = canonical }
+    val validated = requireFiniteInRange(
+      "chromaticAberrationStrength",
+      strength,
+      0f..1f,
+      UNIT_INTERVAL_DOMAIN,
+    )
+    writes += { chromaticAberrationStrength = validated }
   }
 
   /** Sets the cross-section profile used by the refraction bezel. */
@@ -245,47 +280,63 @@ public class GlassStyleScope internal constructor(
     writes += { chromaticAberrationMode = mode }
   }
 
-  /** Sets overall material opacity, coerced to the range `0f..1f`. */
+  /** Sets finite overall material opacity in the inclusive range `0f..1f`. */
   public fun alpha(alpha: Float) {
-    val canonical = alpha.coerceIn(0f, 1f)
-    writes += { this.alpha = canonical }
+    val validated = requireFiniteInRange("alpha", alpha, 0f..1f, UNIT_INTERVAL_DOMAIN)
+    writes += { this.alpha = validated }
   }
 
-  /** Sets contrast adjustment, coerced to the range `-1f..1f`. */
+  /** Sets finite contrast adjustment in the inclusive range `-1f..1f`. */
   public fun contrast(contrast: Float) {
-    val canonical = contrast.coerceIn(-1f, 1f)
-    writes += { this.contrast = canonical }
+    val validated = requireFiniteInRange("contrast", contrast, -1f..1f, SIGNED_UNIT_INTERVAL_DOMAIN)
+    writes += { this.contrast = validated }
   }
 
-  /** Sets white-point adjustment, coerced to the range `-1f..1f`. */
+  /** Sets finite white-point adjustment in the inclusive range `-1f..1f`. */
   public fun whitePoint(whitePoint: Float) {
-    val canonical = whitePoint.coerceIn(-1f, 1f)
-    writes += { this.whitePoint = canonical }
+    val validated = requireFiniteInRange(
+      "whitePoint",
+      whitePoint,
+      -1f..1f,
+      SIGNED_UNIT_INTERVAL_DOMAIN,
+    )
+    writes += { this.whitePoint = validated }
   }
 
-  /** Sets the chroma multiplier, coerced to the range `0f..2f`. */
+  /** Sets the finite chroma multiplier in the inclusive range `0f..2f`. */
   public fun chromaMultiplier(multiplier: Float) {
-    val canonical = multiplier.coerceIn(0f, 2f)
-    writes += { chromaMultiplier = canonical }
+    val validated = requireFiniteInRange("chromaMultiplier", multiplier, 0f..2f, DOUBLE_INTERVAL_DOMAIN)
+    writes += { chromaMultiplier = validated }
   }
 
-  /** Sets the blend between generated and captured normals, coerced to `0f..1f`. */
+  /** Sets the finite blend between generated and captured normals in inclusive `0f..1f`. */
   public fun contentNormalBlend(blend: Float) {
-    val canonical = blend.coerceIn(0f, 1f)
-    writes += { contentNormalBlend = canonical }
+    val validated = requireFiniteInRange("contentNormalBlend", blend, 0f..1f, UNIT_INTERVAL_DOMAIN)
+    writes += { contentNormalBlend = validated }
   }
 
-  /** Sets the non-negative exponent controlling specular highlight concentration. */
+  /**
+   * Sets a finite, non-negative exponent controlling specular highlight concentration.
+   * There is no authored upper limit.
+   */
   public fun specularExponent(exponent: Float) {
-    val canonical = exponent.coerceAtLeast(0f)
-    writes += { specularExponent = canonical }
+    val validated = requireFiniteNonNegative("specularExponent", exponent)
+    writes += { specularExponent = validated }
   }
 
-  /** Sets the non-negative exponent controlling Fresnel response falloff. */
+  /**
+   * Sets a finite, non-negative exponent controlling Fresnel response falloff.
+   * There is no authored upper limit.
+   */
   public fun fresnelExponent(exponent: Float) {
-    val canonical = exponent.coerceAtLeast(0f)
-    writes += { fresnelExponent = canonical }
+    val validated = requireFiniteNonNegative("fresnelExponent", exponent)
+    writes += { fresnelExponent = validated }
   }
+}
+
+private fun validateLightPositionBiases(horizontalBias: Float, verticalBias: Float) {
+  requireFinite("lightPosition.horizontalBias", horizontalBias)
+  requireFinite("lightPosition.verticalBias", verticalBias)
 }
 
 private fun recordGlassStyleWrites(

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassValidation.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassValidation.kt
@@ -1,0 +1,49 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+
+internal const val UNIT_INTERVAL_DOMAIN: String = "finite and in 0f..1f"
+internal const val SIGNED_UNIT_INTERVAL_DOMAIN: String = "finite and in -1f..1f"
+internal const val DOUBLE_INTERVAL_DOMAIN: String = "finite and in 0f..2f"
+internal const val NON_NEGATIVE_DOMAIN: String = "finite and non-negative"
+internal const val NON_NEGATIVE_DP_DOMAIN: String = "specified, finite, and non-negative"
+internal const val POSITIVE_AT_MOST_ONE_DOMAIN: String = "finite and in 0f < value <= 1f"
+
+internal fun requireFinite(property: String, value: Float): Float {
+  require(value.isFinite()) { "$property must be finite" }
+  return value
+}
+
+internal fun requireFiniteInRange(
+  property: String,
+  value: Float,
+  range: ClosedFloatingPointRange<Float>,
+  domain: String,
+): Float {
+  require(value.isFinite() && value in range) { "$property must be $domain" }
+  return value
+}
+
+internal fun requireFiniteNonNegative(property: String, value: Float): Float {
+  require(value.isFinite() && value >= 0f) { "$property must be $NON_NEGATIVE_DOMAIN" }
+  return value
+}
+
+internal fun requireSpecifiedFiniteNonNegative(property: String, value: Dp): Dp {
+  require(value.isSpecified && value.value.isFinite() && value >= 0.dp) {
+    "$property must be $NON_NEGATIVE_DP_DOMAIN"
+  }
+  return value
+}
+
+internal fun requirePositiveAtMostOne(property: String, value: Float): Float {
+  require(value.isFinite() && value > 0f && value <= 1f) {
+    "$property must be $POSITIVE_AT_MOST_ONE_DOMAIN"
+  }
+  return value
+}

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
@@ -37,7 +37,8 @@ import dev.chrisbanes.haze.hazeEffect
  * @param style Explicit appearance applied after defaults and [LocalGlassStyle].
  * @param sampling Input sampling policy. [HazeSampling.Default] currently points to
  * [HazeSampling.Adaptive], which selects approximately 50% or 25% of full-resolution input pixels
- * from retained-layer work and recent update cadence.
+ * from retained-layer work and recent update cadence. [HazeSampling.Fixed] owns validation of its
+ * finite `0f < pixelFraction <= 1f` value; Glass does not add another sampling contract.
  * @param expandLayerBounds Whether Glass may expand its capture layer for optical sampling.
  * @param interactionSource Optional external interaction source owned by this modifier node.
  * @param interactionTransformTarget Visual layers that receive the interaction scale transform.

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassOpticsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassOpticsTest.kt
@@ -7,10 +7,10 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNull
-import assertk.assertions.messageContains
 import kotlin.test.Test
 
 class GlassOpticsTest {
@@ -78,8 +78,7 @@ private fun assertInvalidFixedFraction(property: String, create: (Float) -> Unit
     .forEach { invalid ->
       val failure = assertFailure { create(invalid) }
       failure.isInstanceOf<IllegalArgumentException>()
-      failure.messageContains(property)
-      failure.messageContains("0f..1f")
+      failure.hasMessage("$property must be finite and in 0f..1f")
     }
 }
 
@@ -93,7 +92,6 @@ private fun assertInvalidFixedDistance(property: String, create: (Dp) -> Unit) {
   ).forEach { invalid ->
     val failure = assertFailure { create(invalid) }
     failure.isInstanceOf<IllegalArgumentException>()
-    failure.messageContains(property)
-    failure.messageContains("specified, finite, and non-negative")
+    failure.hasMessage("$property must be specified, finite, and non-negative")
   }
 }

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -370,19 +370,19 @@ class GlassRenderParamsTest {
   }
 
   @Test
-  fun resolvedStyle_canonicalizesAllScalarsEquallyAcrossPrecedenceLevels() {
+  fun resolvedStyle_propagatesValidBoundariesEquallyAcrossPrecedenceLevels() {
     val inheritedStyle = GlassStyle {
-      specularIntensity(2f)
-      ambientResponse(-1f)
-      specularExponent(-1f)
-      fresnelExponent(-1f)
-      alpha(2f)
-      contrast(2f)
-      whitePoint(-2f)
-      chromaMultiplier(3f)
-      edgeSoftness(Float.POSITIVE_INFINITY.dp)
-      contentNormalBlend(2f)
-      chromaticAberrationStrength(-1f)
+      specularIntensity(1f)
+      ambientResponse(0f)
+      specularExponent(Float.MAX_VALUE)
+      fresnelExponent(0f)
+      alpha(1f)
+      contrast(1f)
+      whitePoint(-1f)
+      chromaMultiplier(2f)
+      edgeSoftness(Float.MAX_VALUE.dp)
+      contentNormalBlend(1f)
+      chromaticAberrationStrength(0f)
     }
     val effects = listOf(
       GlassRuntimeEffect().apply { style = inheritedStyle },
@@ -395,12 +395,39 @@ class GlassRenderParamsTest {
     }
 
     assertThat(resolved[1]).isEqualTo(resolved[0])
+    assertThat(resolved[0].specularIntensity).isEqualTo(1f)
+    assertThat(resolved[0].ambientResponse).isEqualTo(0f)
+    assertThat(resolved[0].specularExponent).isEqualTo(Float.MAX_VALUE)
+    assertThat(resolved[0].fresnelExponent).isEqualTo(0f)
+    assertThat(resolved[0].alpha).isEqualTo(1f)
+    assertThat(resolved[0].contrast).isEqualTo(1f)
+    assertThat(resolved[0].whitePoint).isEqualTo(-1f)
+    assertThat(resolved[0].chromaMultiplier).isEqualTo(2f)
+    assertThat(resolved[0].edgeSoftnessPx).isEqualTo(Float.MAX_VALUE)
+    assertThat(resolved[0].contentNormalBlend).isEqualTo(1f)
     assertThat(resolved[0].chromaticAberrationStrength).isEqualTo(0f)
-    assertThat(resolved[0].edgeSoftnessPx).isEqualTo(GlassDefaults.edgeSoftness.value)
 
     val rect = Rect(0f, 0f, size.width, size.height)
     val bounds = effects.map { it.calculateLayerBounds(rect, density) }
     assertThat(bounds[1]).isEqualTo(bounds[0])
+  }
+
+  @Test
+  fun resolvedStyle_densityOverflowUsesSafeDefaultEdgeSoftness() {
+    val effect = GlassRuntimeEffect().apply {
+      style = GlassStyle { edgeSoftness(Float.MAX_VALUE.dp) }
+    }
+    val density = Density(2f)
+
+    val resolved = resolveGlassStyle(
+      effect = effect,
+      materialSizePx = Size(100f, 80f),
+      density = density,
+      layoutDirection = LayoutDirection.Ltr,
+    )
+
+    assertThat(resolved.edgeSoftnessPx)
+      .isEqualTo(with(density) { GlassDefaults.edgeSoftness.toPx() })
   }
 
   @Test
@@ -455,9 +482,9 @@ class GlassRenderParamsTest {
   }
 
   @Test
-  fun preparedRender_carriesCanonicalAlphaForRuntimeDrawing() {
+  fun preparedRender_carriesValidatedAlphaForRuntimeDrawing() {
     val effect = GlassRuntimeEffect().apply {
-      style = GlassStyle { alpha(Float.POSITIVE_INFINITY) }
+      style = GlassStyle { alpha(1f) }
     }
     val style = resolveGlassStyle(
       effect = effect,
@@ -482,7 +509,7 @@ class GlassRenderParamsTest {
       outputSize = coordinates.materialSize.roundToIntSize(),
     )
 
-    assertThat(prepared.alpha).isEqualTo(GlassDefaults.alpha)
+    assertThat(prepared.alpha).isEqualTo(1f)
   }
 
   @Test
@@ -601,7 +628,7 @@ class GlassRenderParamsTest {
   }
 
   @Test
-  fun fallbackInteractionLighting_usesRuntimeCanonicalization() {
+  fun fallbackInteractionLighting_preservesRadiusAndCanonicalizesAnimatedState() {
     val uniforms = resolveFallbackGlassInteraction(
       state = GlassInteractionRenderState(
         position = Offset(Float.NaN, Float.POSITIVE_INFINITY),
@@ -609,14 +636,12 @@ class GlassRenderParamsTest {
         refractionMultiplier = Float.POSITIVE_INFINITY,
         whitePointDelta = Float.NaN,
       ),
-      radiusFraction = Float.NaN,
+      radiusFraction = 2f,
       size = Size(100f, 80f),
     )
 
     assertThat(uniforms.position).isEqualTo(Offset(50f, 40f))
-    assertThat(uniforms.radiusPx).isEqualTo(
-      80f * GlassDefaults.interactionLightRadiusFraction,
-    )
+    assertThat(uniforms.radiusPx).isEqualTo(160f)
     assertThat(uniforms.lightingIntensity).isEqualTo(1f)
     assertThat(uniforms.refractionMultiplier).isEqualTo(1f)
     assertThat(uniforms.whitePointDelta).isEqualTo(0f)

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -4,15 +4,20 @@
 package dev.chrisbanes.haze.glass
 
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAbsoluteAlignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
@@ -20,7 +25,6 @@ import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
-import assertk.assertions.messageContains
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
 import dev.chrisbanes.haze.HazeProgressive
@@ -84,19 +88,31 @@ class GlassStyleTest {
 
   @Test
   fun directOptics_usesFixedValidation() {
-    val invalidWrites = listOf<Pair<String, GlassStyleScope.() -> Unit>>(
-      "refractionStrength" to { optics(refractionStrength = Float.NaN) },
-      "refractionHeightFraction" to { optics(refractionHeightFraction = 1.1f) },
-      "refractionDisplacement" to { optics(refractionDisplacement = Dp.Unspecified) },
-      "depth" to { optics(depth = Float.NEGATIVE_INFINITY) },
-      "blurRadius" to { optics(blurRadius = (-1).dp) },
+    assertFixedAndDirectOpticsFailure(
+      "refractionStrength must be finite and in 0f..1f",
+      fixed = { GlassOptics.Fixed(refractionStrength = Float.NaN) },
+      direct = { optics(refractionStrength = Float.NaN) },
     )
-
-    invalidWrites.forEach { (property, write) ->
-      val failure = assertFailure { GlassStyle(write) }
-      failure.isInstanceOf<IllegalArgumentException>()
-      failure.messageContains(property)
-    }
+    assertFixedAndDirectOpticsFailure(
+      "refractionHeightFraction must be finite and in 0f..1f",
+      fixed = { GlassOptics.Fixed(refractionHeightFraction = 1.1f) },
+      direct = { optics(refractionHeightFraction = 1.1f) },
+    )
+    assertFixedAndDirectOpticsFailure(
+      "refractionDisplacement must be specified, finite, and non-negative",
+      fixed = { GlassOptics.Fixed(refractionDisplacement = Dp.Unspecified) },
+      direct = { optics(refractionDisplacement = Dp.Unspecified) },
+    )
+    assertFixedAndDirectOpticsFailure(
+      "depth must be finite and in 0f..1f",
+      fixed = { GlassOptics.Fixed(depth = Float.NEGATIVE_INFINITY) },
+      direct = { optics(depth = Float.NEGATIVE_INFINITY) },
+    )
+    assertFixedAndDirectOpticsFailure(
+      "blurRadius must be specified, finite, and non-negative",
+      fixed = { GlassOptics.Fixed(blurRadius = (-1).dp) },
+      direct = { optics(blurRadius = (-1).dp) },
+    )
   }
 
   @Test
@@ -156,8 +172,81 @@ class GlassStyleTest {
       .forEach { invalid ->
         assertFailure {
           GlassStyle { interactionLightRadiusFraction(invalid) }
-        }.isInstanceOf<IllegalArgumentException>()
+        }.apply {
+          isInstanceOf<IllegalArgumentException>()
+          hasMessage("interactionLightRadiusFraction must be finite and in 0f..2f")
+        }
       }
+  }
+
+  @Test
+  fun interactionLightRadiusFraction_acceptsBoundaries() {
+    val minimum = resolveGlassStyleValues(
+      GlassStyle,
+      GlassStyle { interactionLightRadiusFraction(0f) },
+    )
+    val maximum = resolveGlassStyleValues(
+      GlassStyle,
+      GlassStyle { interactionLightRadiusFraction(2f) },
+    )
+
+    assertThat(minimum.interactionLightRadiusFraction).isEqualTo(0f)
+    assertThat(maximum.interactionLightRadiusFraction).isEqualTo(2f)
+  }
+
+  @Test
+  fun interactionResponses_rejectInvalidValuesAtConstruction() {
+    assertInvalidFloatWrites(
+      invalidUnitInterval("lightingIntensity") { hovered { lightingIntensity(it) } },
+      invalidDoubleInterval("refractionMultiplier") { hovered { refractionMultiplier(it) } },
+      invalidSignedUnitInterval("whitePointDelta") { hovered { whitePointDelta(it) } },
+      invalidPositiveAtMostOne("scaleX") { hovered { scale(scaleX = it, scaleY = 1f) } },
+      invalidPositiveAtMostOne("scaleY") { hovered { scale(scaleX = 1f, scaleY = it) } },
+    )
+  }
+
+  @Test
+  fun uniformScale_delegatesToAxisValidation() {
+    assertInvalidFloatWrites(
+      invalidPositiveAtMostOne("scaleX") { hovered { scale(it) } },
+    )
+  }
+
+  @Test
+  fun interactionResponses_acceptBoundaries() {
+    val lowerValues = resolveGlassStyleValues(
+      GlassStyle,
+      GlassStyle {
+        hovered {
+          lightingIntensity(0f)
+          refractionMultiplier(0f)
+          whitePointDelta(-1f)
+          scale(scaleX = Float.MIN_VALUE, scaleY = 1f)
+        }
+      },
+    )
+    val upperValues = resolveGlassStyleValues(
+      GlassStyle,
+      GlassStyle {
+        focused {
+          lightingIntensity(1f)
+          refractionMultiplier(2f)
+          whitePointDelta(1f)
+          scale(1f)
+        }
+      },
+    )
+
+    assertThat(lowerValues.hoveredInteraction?.lightingIntensity?.value).isEqualTo(0f)
+    assertThat(lowerValues.hoveredInteraction?.refractionMultiplier?.value).isEqualTo(0f)
+    assertThat(lowerValues.hoveredInteraction?.whitePointDelta?.value).isEqualTo(-1f)
+    assertThat(lowerValues.hoveredInteraction?.scaleX?.value).isEqualTo(Float.MIN_VALUE)
+    assertThat(lowerValues.hoveredInteraction?.scaleY?.value).isEqualTo(1f)
+    assertThat(upperValues.focusedInteraction?.lightingIntensity?.value).isEqualTo(1f)
+    assertThat(upperValues.focusedInteraction?.refractionMultiplier?.value).isEqualTo(2f)
+    assertThat(upperValues.focusedInteraction?.whitePointDelta?.value).isEqualTo(1f)
+    assertThat(upperValues.focusedInteraction?.scaleX?.value).isEqualTo(1f)
+    assertThat(upperValues.focusedInteraction?.scaleY?.value).isEqualTo(1f)
   }
 
   @Test
@@ -304,47 +393,152 @@ class GlassStyleTest {
   }
 
   @Test
-  fun staticPropertyWrites_preserveCanonicalization() {
-    val optics = GlassOptics.Fixed(refractionStrength = 0.3f)
-    val shape = RoundedCornerShape(12.dp)
-    val style = GlassStyle {
-      shape(shape)
-      optics(optics)
-      specularIntensity(2f)
-      ambientResponse(-1f)
-      tint(Color.Blue)
-      edgeSoftness(6.dp)
-      lightPosition(Alignment.BottomEnd)
-      chromaticAberrationStrength(2f)
-      surfaceProfile(SurfaceProfile.Concave)
-      chromaticAberrationMode(ChromaticAberrationMode.Full)
-      alpha(2f)
-      contrast(-2f)
-      whitePoint(2f)
-      chromaMultiplier(3f)
-      contentNormalBlend(-1f)
-      specularExponent(-1f)
-      fresnelExponent(-1f)
-    }
-    val resolved = resolveGlassStyleValues(GlassStyle, style)
+  fun staticPropertyWrites_rejectInvalidValuesAtConstruction() {
+    assertInvalidFloatWrites(
+      invalidUnitInterval("specularIntensity") { specularIntensity(it) },
+      invalidUnitInterval("ambientResponse") { ambientResponse(it) },
+      invalidUnitInterval("chromaticAberrationStrength") { chromaticAberrationStrength(it) },
+      invalidUnitInterval("alpha") { alpha(it) },
+      invalidUnitInterval("contentNormalBlend") { contentNormalBlend(it) },
+      invalidSignedUnitInterval("contrast") { contrast(it) },
+      invalidSignedUnitInterval("whitePoint") { whitePoint(it) },
+      invalidDoubleInterval("chromaMultiplier") { chromaMultiplier(it) },
+      invalidNonNegative("specularExponent") { specularExponent(it) },
+      invalidNonNegative("fresnelExponent") { fresnelExponent(it) },
+    )
+  }
 
-    assertThat(resolved.shape).isEqualTo(shape)
-    assertThat(resolved.optics).isEqualTo(optics)
-    assertThat(resolved.specularIntensity).isEqualTo(1f)
-    assertThat(resolved.ambientResponse).isEqualTo(0f)
-    assertThat(resolved.tint).isEqualTo(Color.Blue)
-    assertThat(resolved.edgeSoftness).isEqualTo(6.dp)
-    assertThat(resolved.lightPosition).isEqualTo(Alignment.BottomEnd)
-    assertThat(resolved.chromaticAberrationStrength).isEqualTo(1f)
-    assertThat(resolved.surfaceProfile).isEqualTo(SurfaceProfile.Concave)
-    assertThat(resolved.chromaticAberrationMode).isEqualTo(ChromaticAberrationMode.Full)
-    assertThat(resolved.alpha).isEqualTo(1f)
-    assertThat(resolved.contrast).isEqualTo(-1f)
-    assertThat(resolved.whitePoint).isEqualTo(1f)
-    assertThat(resolved.chromaMultiplier).isEqualTo(2f)
-    assertThat(resolved.contentNormalBlend).isEqualTo(0f)
-    assertThat(resolved.specularExponent).isEqualTo(0f)
-    assertThat(resolved.fresnelExponent).isEqualTo(0f)
+  @Test
+  fun staticPropertyWrites_acceptBoundariesAndLargeValues() {
+    val lowerStyle = GlassStyle {
+      specularIntensity(0f)
+      ambientResponse(0f)
+      chromaticAberrationStrength(0f)
+      alpha(0f)
+      contentNormalBlend(0f)
+      contrast(-1f)
+      whitePoint(-1f)
+      chromaMultiplier(0f)
+      edgeSoftness(0.dp)
+      specularExponent(0f)
+      fresnelExponent(0f)
+      tint(Color.Transparent)
+    }
+    val upperStyle = GlassStyle {
+      specularIntensity(1f)
+      ambientResponse(1f)
+      chromaticAberrationStrength(1f)
+      alpha(1f)
+      contentNormalBlend(1f)
+      contrast(1f)
+      whitePoint(1f)
+      chromaMultiplier(2f)
+      edgeSoftness(Float.MAX_VALUE.dp)
+      specularExponent(Float.MAX_VALUE)
+      fresnelExponent(Float.MAX_VALUE)
+    }
+    val lower = resolveGlassStyleValues(GlassStyle, lowerStyle)
+    val upper = resolveGlassStyleValues(GlassStyle, upperStyle)
+
+    assertThat(lower.specularIntensity).isEqualTo(0f)
+    assertThat(lower.ambientResponse).isEqualTo(0f)
+    assertThat(lower.chromaticAberrationStrength).isEqualTo(0f)
+    assertThat(lower.alpha).isEqualTo(0f)
+    assertThat(lower.contentNormalBlend).isEqualTo(0f)
+    assertThat(lower.contrast).isEqualTo(-1f)
+    assertThat(lower.whitePoint).isEqualTo(-1f)
+    assertThat(lower.chromaMultiplier).isEqualTo(0f)
+    assertThat(lower.edgeSoftness).isEqualTo(0.dp)
+    assertThat(lower.specularExponent).isEqualTo(0f)
+    assertThat(lower.fresnelExponent).isEqualTo(0f)
+    assertThat(lower.tint).isEqualTo(Color.Transparent)
+    assertThat(upper.specularIntensity).isEqualTo(1f)
+    assertThat(upper.ambientResponse).isEqualTo(1f)
+    assertThat(upper.chromaticAberrationStrength).isEqualTo(1f)
+    assertThat(upper.alpha).isEqualTo(1f)
+    assertThat(upper.contentNormalBlend).isEqualTo(1f)
+    assertThat(upper.contrast).isEqualTo(1f)
+    assertThat(upper.whitePoint).isEqualTo(1f)
+    assertThat(upper.chromaMultiplier).isEqualTo(2f)
+    assertThat(upper.edgeSoftness).isEqualTo(Float.MAX_VALUE.dp)
+    assertThat(upper.specularExponent).isEqualTo(Float.MAX_VALUE)
+    assertThat(upper.fresnelExponent).isEqualTo(Float.MAX_VALUE)
+  }
+
+  @Test
+  fun edgeSoftness_rejectsInvalidValuesAtConstruction() {
+    listOf(Dp.Unspecified, Float.NaN.dp, Float.NEGATIVE_INFINITY.dp, (-1).dp, Float.POSITIVE_INFINITY.dp)
+      .forEach { invalid ->
+        assertFailure { GlassStyle { edgeSoftness(invalid) } }.apply {
+          isInstanceOf<IllegalArgumentException>()
+          hasMessage("edgeSoftness must be specified, finite, and non-negative")
+        }
+      }
+  }
+
+  @Test
+  fun tint_rejectsUnspecifiedAtConstruction() {
+    assertFailure { GlassStyle { tint(Color.Unspecified) } }.apply {
+      isInstanceOf<IllegalArgumentException>()
+      hasMessage("tint must be specified")
+    }
+  }
+
+  @Test
+  fun defaults_constructThroughTheValidatedStyleSurface() {
+    val values = resolveGlassStyleValues(GlassStyle, GlassDefaults.style)
+
+    assertThat(values.specularIntensity).isEqualTo(GlassDefaults.specularIntensity)
+    assertThat(values.ambientResponse).isEqualTo(GlassDefaults.ambientResponse)
+    assertThat(values.tint).isEqualTo(GlassDefaults.tint)
+    assertThat(values.edgeSoftness).isEqualTo(GlassDefaults.edgeSoftness)
+    assertThat(values.chromaticAberrationStrength)
+      .isEqualTo(GlassDefaults.chromaticAberrationStrength)
+    assertThat(values.alpha).isEqualTo(GlassDefaults.alpha)
+    assertThat(values.contrast).isEqualTo(GlassDefaults.contrast)
+    assertThat(values.whitePoint).isEqualTo(GlassDefaults.whitePoint)
+    assertThat(values.chromaMultiplier).isEqualTo(GlassDefaults.chromaMultiplier)
+    assertThat(values.contentNormalBlend).isEqualTo(GlassDefaults.contentNormalBlend)
+    assertThat(values.specularExponent).isEqualTo(GlassDefaults.specularExponent)
+    assertThat(values.fresnelExponent).isEqualTo(GlassDefaults.fresnelExponent)
+    assertThat(values.interactionLightRadiusFraction)
+      .isEqualTo(GlassDefaults.interactionLightRadiusFraction)
+  }
+
+  @Test
+  fun lightPosition_rejectsNonFiniteKnownBiasesAtConstruction() {
+    val cases = listOf<Pair<String, (Float) -> Alignment>>(
+      "horizontalBias" to { invalid: Float -> BiasAlignment(invalid, 0f) },
+      "verticalBias" to { invalid: Float -> BiasAlignment(0f, invalid) },
+      "horizontalBias" to { invalid: Float -> BiasAbsoluteAlignment(invalid, 0f) },
+      "verticalBias" to { invalid: Float -> BiasAbsoluteAlignment(0f, invalid) },
+    )
+
+    cases.forEach { (axis, createAlignment) ->
+      listOf(Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY).forEach { invalid ->
+        assertFailure { GlassStyle { lightPosition(createAlignment(invalid)) } }.apply {
+          isInstanceOf<IllegalArgumentException>()
+          hasMessage("lightPosition.$axis must be finite")
+        }
+      }
+    }
+  }
+
+  @Test
+  fun lightPosition_acceptsFiniteOutsideBiasesAndArbitraryAlignment() {
+    val relative = BiasAlignment(2.5f, -3.5f)
+    val absolute = BiasAbsoluteAlignment(-4.5f, 5.5f)
+    val custom = object : Alignment {
+      override fun align(size: IntSize, space: IntSize, layoutDirection: LayoutDirection): IntOffset =
+        IntOffset(7, 9)
+    }
+
+    assertThat(resolveGlassStyleValues(GlassStyle, GlassStyle { lightPosition(relative) }).lightPosition)
+      .isSameInstanceAs(relative)
+    assertThat(resolveGlassStyleValues(GlassStyle, GlassStyle { lightPosition(absolute) }).lightPosition)
+      .isSameInstanceAs(absolute)
+    assertThat(resolveGlassStyleValues(GlassStyle, GlassStyle { lightPosition(custom) }).lightPosition)
+      .isSameInstanceAs(custom)
   }
 
   @Test
@@ -374,6 +568,86 @@ class GlassStyleTest {
     assertThat(effect.shouldDrawRetainedOutput()).isFalse()
   }
 }
+
+private class InvalidFloatWrite(
+  val property: String,
+  val domain: String,
+  val invalidValues: List<Float>,
+  val write: GlassStyleScope.(Float) -> Unit,
+)
+
+private fun assertFixedAndDirectOpticsFailure(
+  message: String,
+  fixed: () -> Unit,
+  direct: GlassStyleScope.() -> Unit,
+) {
+  listOf(fixed, { GlassStyle(direct) }).forEach { invalidWrite ->
+    assertFailure { invalidWrite() }
+      .isInstanceOf<IllegalArgumentException>()
+      .hasMessage(message)
+  }
+}
+
+private fun assertInvalidFloatWrites(vararg cases: InvalidFloatWrite) {
+  cases.forEach { case ->
+    case.invalidValues.forEach { invalid ->
+      assertFailure { GlassStyle { case.write(this, invalid) } }.apply {
+        isInstanceOf<IllegalArgumentException>()
+        hasMessage("${case.property} must be ${case.domain}")
+      }
+    }
+  }
+}
+
+private fun invalidUnitInterval(
+  property: String,
+  write: GlassStyleScope.(Float) -> Unit,
+): InvalidFloatWrite = InvalidFloatWrite(
+  property,
+  "finite and in 0f..1f",
+  listOf(Float.NaN, Float.NEGATIVE_INFINITY, -0.1f, 1.1f, Float.POSITIVE_INFINITY),
+  write,
+)
+
+private fun invalidSignedUnitInterval(
+  property: String,
+  write: GlassStyleScope.(Float) -> Unit,
+): InvalidFloatWrite = InvalidFloatWrite(
+  property,
+  "finite and in -1f..1f",
+  listOf(Float.NaN, Float.NEGATIVE_INFINITY, -1.1f, 1.1f, Float.POSITIVE_INFINITY),
+  write,
+)
+
+private fun invalidDoubleInterval(
+  property: String,
+  write: GlassStyleScope.(Float) -> Unit,
+): InvalidFloatWrite = InvalidFloatWrite(
+  property,
+  "finite and in 0f..2f",
+  listOf(Float.NaN, Float.NEGATIVE_INFINITY, -0.1f, 2.1f, Float.POSITIVE_INFINITY),
+  write,
+)
+
+private fun invalidNonNegative(
+  property: String,
+  write: GlassStyleScope.(Float) -> Unit,
+): InvalidFloatWrite = InvalidFloatWrite(
+  property,
+  "finite and non-negative",
+  listOf(Float.NaN, Float.NEGATIVE_INFINITY, -0.1f, Float.POSITIVE_INFINITY),
+  write,
+)
+
+private fun invalidPositiveAtMostOne(
+  property: String,
+  write: GlassStyleScope.(Float) -> Unit,
+): InvalidFloatWrite = InvalidFloatWrite(
+  property,
+  "finite and in 0f < value <= 1f",
+  listOf(Float.NaN, Float.NEGATIVE_INFINITY, -0.1f, 0f, 1.1f, Float.POSITIVE_INFINITY),
+  write,
+)
 
 private class RetainedTrackingGlassDelegate :
   GlassRuntimeEffect.Delegate,

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/HazeGlassModifierTest.kt
@@ -80,14 +80,19 @@ class HazeGlassModifierTest : ContextTest() {
       val sharedStyle = GlassStyle {
         optics(fixedOptics)
         tint(tint)
-        specularIntensity(0.71f)
-        ambientResponse(0.23f)
+        specularIntensity(1f)
+        ambientResponse(0f)
+        edgeSoftness(Float.MAX_VALUE.dp)
+        chromaMultiplier(2f)
+        specularExponent(Float.MAX_VALUE)
+        fresnelExponent(0f)
+        interactionLightRadiusFraction(2f)
         lightPosition(Alignment.TopStart)
         pressed {
-          lightingIntensity(0.81f)
-          refractionMultiplier(1.4f)
-          whitePointDelta(0.12f)
-          scale(0.96f)
+          lightingIntensity(1f)
+          refractionMultiplier(2f)
+          whitePointDelta(-1f)
+          scale(Float.MIN_VALUE)
         }
       }
       var failedRuntimeCreationAttempts = 0
@@ -140,8 +145,8 @@ class HazeGlassModifierTest : ContextTest() {
           assertThat(params.blurRadiusPx)
             .isEqualTo(with(context.requireDensity()) { 7.dp.toPx() })
           assertThat(params.tint).isEqualTo(tint)
-          assertThat(params.specularIntensity).isEqualTo(0.71f)
-          assertThat(params.ambientResponse).isEqualTo(0.23f)
+          assertThat(params.specularIntensity).isEqualTo(1f)
+          assertThat(params.ambientResponse).isEqualTo(0f)
           assertThat(params.lightPosition).isEqualTo(Offset.Zero)
         }
       }
@@ -150,11 +155,16 @@ class HazeGlassModifierTest : ContextTest() {
           GlassInteractionTopology(
             hasOptics = true,
             hasLighting = true,
-            maxRefractionMultiplier = 1.4f,
+            maxRefractionMultiplier = 2f,
           ),
         )
       assertThat(fallback.resolvedInteractionTopology)
         .isEqualTo(full.resolvedInteractionTopology)
+      assertThat(full.edgeSoftness).isEqualTo(Float.MAX_VALUE.dp)
+      assertThat(full.chromaMultiplier).isEqualTo(2f)
+      assertThat(full.specularExponent).isEqualTo(Float.MAX_VALUE)
+      assertThat(full.fresnelExponent).isEqualTo(0f)
+      assertThat(full.interactionLightRadiusFraction).isEqualTo(2f)
       assertThat(failedRuntimeCreationAttempts).isEqualTo(1)
 
       onRoot().captureToImage()


### PR DESCRIPTION
## Summary

- enforce one shared fail-fast validation vocabulary across fixed optics, style, known light biases, and interaction responses
- remove only late correction for newly validated authored values while preserving derived and runtime safety
- document the full input and sentinel matrix, including migration guidance

## Validation

- focused Glass unit and integration tests pass
- Metalava compatibility and Spotless checks pass
- documentation build passes
- public API and screenshot baseline diffs are empty
- the exact aggregate validation command reached the screenshot test aggregate after its constituent suites completed, but did not exit locally; CI remains authoritative for the aggregate lifecycle

Fixes #1187

Plan: https://github.com/chrisbanes/haze/issues/1187#issuecomment-5179102529
