### PR TITLE
Refresh guidance for recent Haze 2 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,12 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GlassRendererCache`, `GlassStyleConfiguration`, grouped `GlassLighting`/`GlassColor`/
   `GlassRendering` values, `GlassStyle.Unspecified`, and the public hover/press/release animation
   defaults are removed. Declare response channels and animation specs explicitly in `GlassStyle`.
+  `GlassOptics.Absolute` is renamed to `GlassOptics.Fixed`, `lightPosition` now accepts semantic
+  `Alignment` rather than pixel `Offset`, and interaction-light radius and position animation move
+  from modifier arguments into the Style.
 
 ### Added
 
 - Added declarative hover, focus, and press responses to `GlassStyle`, including localized lighting
   and optics plus configurable transforms and motion on `Modifier.hazeGlass`.
 - Added progressive blur support to Glass.
+- Added direct fixed-optics authoring through `GlassStyle { optics(...) }`; keep
+  `GlassOptics.Fixed` for reusable or programmatically selected values in
+  [#1192](https://github.com/chrisbanes/haze/pull/1192).
 
 ### Changed
 
@@ -39,12 +45,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `HazeBlurStyle.Unspecified`, and `HazeBlurDefaults.style(...)` builder as warning-level,
   source-only migration shims. They preserve legacy sentinel behavior and will be removed before
   Haze 2.0 stable; they do not provide binary compatibility with the former Style class.
-- Blur effects now adapt `HazeSampling.Adaptive` between `1.0`, `0.8`, and `0.5` using physical
-  blur radius, expanded capture-layer area, and recent update cadence, with hysteresis and a `0.8`
-  progressive-blur cap. Glass now uses the same adaptive default mode with effect-specific tiers.
+- Blur and Glass now use workload-aware adaptive sampling by default. Explicit sampling choices
+  still take precedence in
+  [#1189](https://github.com/chrisbanes/haze/pull/1189).
+- `GlassStyle` is now immutable, composable with `then`, and reusable across modifiers. Interaction
+  appearance now belongs to the Style, while interaction behavior remains on the modifier in
+  [#1190](https://github.com/chrisbanes/haze/pull/1190) and
+  [#1191](https://github.com/chrisbanes/haze/pull/1191).
+- Glass light positions now use semantic `Alignment` in
+  [#1193](https://github.com/chrisbanes/haze/pull/1193).
+- One portable Glass Style now works across platforms, with graceful fallback for unsupported
+  optics in
+  [#1194](https://github.com/chrisbanes/haze/pull/1194).
+- Invalid Glass configuration now fails when the Style or fixed optics are created in
+  [#1195](https://github.com/chrisbanes/haze/pull/1195).
 - Changed Glass blur composition so blur participates in refracted content.
-- Use one Android Glass output renderer per surface, independent of sibling count, while preserving
-  semantic blur, progressive masks, Full chromatic aberration, and configured interactions.
+- Improved Android Glass performance for screens with multiple effects without changing configured
+  appearance or interaction.
 - Moved `HazeProgressive` to the core `dev.chrisbanes.haze` package with a deprecated blur-package typealias.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,11 +34,22 @@ dependencies {
 ## Quick start
 
 ```kotlin
-Modifier.hazeEffect(state = hazeState) {
-    blurEffect {
-        blurRadius = 20.dp
-        colorEffects = listOf(HazeColorEffect.tint(Color.Black.copy(alpha = 0.5f)))
-    }
+val hazeState = rememberHazeState()
+
+Box {
+    Image(
+        painter = painter,
+        contentDescription = null,
+        modifier = Modifier.hazeSource(hazeState),
+    )
+    Box(
+        modifier = Modifier
+            .matchParentSize()
+            .hazeBlur(
+                input = HazeInput.Sources(hazeState),
+                style = HazeBlurStyle { blurRadius(20.dp) },
+            ),
+    )
 }
 ```
 

--- a/docs/blur/usage.md
+++ b/docs/blur/usage.md
@@ -107,10 +107,8 @@ val compact = HazeMaterials.thin().then {
 }
 ```
 
-Every evaluation starts from fresh defaults. If a replacement Style omits `blurRadius`, the local
-or default value becomes visible immediately; the previous explicit value cannot stick. A Style
-can be shared by concurrent modifiers because it contains no renderer, delegate, cache, retained
-layer, or lifecycle state.
+If a replacement Style omits `blurRadius`, the local or default value becomes visible again. Styles
+are immutable and safe to share; create a replacement Style when the appearance needs to change.
 
 Caller-owned color-effect lists are snapshotted when the Style is created. An explicit empty list
 clears inherited color effects:
@@ -163,16 +161,10 @@ Modifier.hazeBlur(
 )
 ```
 
-- `HazeSampling.Default` points to the library's current default policy, which is `Adaptive`.
-- `HazeSampling.Adaptive` uses Blur's adaptive policy.
+- `HazeSampling.Default` and `Adaptive` let Blur balance quality and cost automatically.
 - `HazeSampling.FullResolution` disables input downscaling.
 - `HazeSampling.Fixed(pixelFraction)` retains a fixed fraction of the full-resolution input pixels
-  in `0 < pixelFraction <= 1`; `0.5` scales each dimension by approximately `0.707`.
+  when you need a predictable trade-off.
 
-Adaptive Blur considers the physical Blur radius, expanded capture-layer area, and recent distinct
-input-update cadence, with hysteresis between its quality tiers.
-
-## Temporary legacy boundary
-
-`BlurVisualEffect`, `HazeEffectScope.blurEffect`, and the lambda-based `hazeEffect` overloads remain
-temporarily available for staged migration. New code should use `hazeBlur` and replayable Styles.
+Start with the default. Override it only after comparing visual quality and performance on the
+devices you support.

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -108,90 +108,18 @@ the existing renderer. Factory replacement and detachment dispose it exactly onc
 
 ## Sampling
 
-- `HazeSampling.Default` points to the library's current default policy, which is `Adaptive`.
-- `HazeSampling.Adaptive` uses the adaptive policy for built-in Blur and Glass effects.
+- `HazeSampling.Default` and `Adaptive` let built-in effects balance quality and cost automatically.
 - `HazeSampling.FullResolution` uses the full input resolution.
-- `HazeSampling.Fixed(pixelFraction)` retains that fraction of the full-resolution input pixels,
-  with `0 < pixelFraction <= 1`. For example, `0.5` scales each dimension by approximately `0.707`.
+- `HazeSampling.Fixed(pixelFraction)` uses an explicit fraction of the full-resolution input pixels.
 
-Blur and Glass use the same adaptive default mode while retaining effect-specific workload and
-quality policies. Both consider recent input-update cadence and use hysteresis between tiers.
+Start with the default. Choose `FullResolution` only when visual comparison shows that you need it,
+or `Fixed` when you deliberately want a stable quality and performance trade-off.
 
 ## Layer bounds
 
 `expandLayerBounds` lets an effect request a larger capture layer. Blur normally expands by its
 resolved radius to avoid edge artifacts. Disable it only when the surrounding pixels must not be
 captured.
-
-## Legacy effect scope
-
-Lambda-based `Modifier.hazeEffect` receives a `HazeEffectScope`. It remains available while
-existing custom effects and Blur callers migrate:
-
-```kotlin
-Modifier.hazeEffect(state = hazeState) {
-  inputScale = HazeInputScale.Auto
-  drawContentBehind = true
-  canDrawArea = { area -> area.key != "excluded" }
-  retainOutputWhenSourceUnavailable = true
-
-  blurEffect {
-    // Legacy Blur configuration
-  }
-}
-```
-
-### Input scale
-
-`inputScale` controls the resolution used to render source content:
-
-- `HazeInputScale.Default` lets the visual effect choose. Blur uses its adaptive policy; Glass
-  remains unscaled.
-- `HazeInputScale.None` disables scaling.
-- `HazeInputScale.Auto` requests the effect's automatic policy.
-- `HazeInputScale.Fixed(value)` uses an exact value greater than `0f` and at most `1f`.
-
-Typed effects express the same choice through `HazeSampling`.
-
-### Drawing content behind
-
-`drawContentBehind` draws the original source content before the effect. It defaults to `false`.
-Built-in typed effects select the required behavior themselves.
-
-### Filtering source areas
-
-`canDrawArea` filters legacy `HazeArea` instances:
-
-```kotlin
-canDrawArea = { area -> area.key != "excluded" }
-```
-
-Typed source input uses `HazeSourceSelection.where`, which intentionally exposes only immutable
-`key` and `zIndex` metadata.
-
-### Retained output
-
-Some effects can redraw their last output while source areas are temporarily unavailable.
-`retainOutputWhenSourceUnavailable` defaults to `true` for the legacy API. Set it to `false` when
-stale source pixels must be cleared immediately:
-
-```kotlin
-Modifier.hazeEffect(state = hazeState) {
-  retainOutputWhenSourceUnavailable = false
-  blurEffect {
-    // Legacy Blur configuration
-  }
-}
-```
-
-Typed source input expresses this policy with `HazeSourceRetention.KeepLastFrame` or
-`ClearWhenUnavailable`.
-
-## Temporary legacy APIs
-
-The `VisualEffect`, `HazeEffectScope`, and lambda-based `hazeEffect` APIs remain during the staged
-2.0 migration. Blur code should move to `hazeBlur`; custom effects should use
-`HazeEffectFactory`.
 
 ## Background and foreground effects
 
@@ -307,28 +235,7 @@ Box {
 }
 ```
 
-## Position strategy
-
-`HazePositionStrategy.Auto` is the default. It uses root-relative coordinates when source and
-effect share a window, and screen coordinates for cross-window arrangements such as dialogs and
-popups.
-
-```kotlin
-val hazeState = rememberHazeState()
-```
-
-Override the strategy only when the host window arrangement requires a fixed coordinate space:
-
-```kotlin
-val localState = rememberHazeState(positionStrategy = HazePositionStrategy.Local)
-val screenState = rememberHazeState(positionStrategy = HazePositionStrategy.Screen)
-```
-
-| Strategy | Coordinates | Use case |
-| --- | --- | --- |
-| `Auto` | Adapts automatically | Default for same- and cross-window layouts |
-| `Local` | Root-relative | Same-window layouts |
-| `Screen` | Screen-relative | Explicit cross-window layouts |
+Haze handles alignment between the dialog and its source automatically.
 
 ## Screenshot testing
 

--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -25,25 +25,16 @@ dependencies {
 
 ### Built-in material
 
-The default material uses Haze's geometry-aware Adaptive optics. Small surfaces retain a clearer,
-more refractive edge treatment, while larger surfaces converge toward a calmer base response.
-Aspect ratio and roundness make small bounded adjustments without changing the material boundary.
-Adaptive content behavior, interaction-driven deformation, and morphing are unsupported.
+Start with the default `GlassOptics.Adaptive` material. It adjusts to the surface's size and shape,
+which makes it a good fit for reusable components. Choose fixed optics only when the design needs
+the same values at every size.
 
 ## Parameters
 
 - **tint**: Glass tint (defaults to transparent).
 - **optics**: Optical material configuration. `GlassOptics.Adaptive` (the default) is the
-  built-in Haze material; it responds to the material's size, aspect ratio, and
-  rounded geometry. Call `optics(...)` directly for an inline fixed optical configuration, or use
-  `GlassOptics.Fixed(...)` when you need to store, reuse, copy, or select the complete value. Its
-  `refractionStrength`, `refractionHeightFraction`,
-  `refractionDisplacement`, `depth`, `blurRadius`, and optional `progressive` values are used
-  without geometry-dependent adjustment. `refractionDisplacement` and `blurRadius` are
-  density-independent `Dp`, while `refractionHeightFraction` is a unitless fraction of the
-  material's shortest side. `progressive` accepts
-  `HazeProgressive.verticalGradient`, `horizontalGradient`, `HazeProgressive.RadialGradient`,
-  or `forShader` to vary blur radius across the glass surface.
+  recommended starting point. Call `optics(...)` for an inline fixed configuration, or keep a
+  `GlassOptics.Fixed` value when it needs to be reused or selected programmatically.
 - **specularIntensity**: Highlight strength `0..1` (default 0.4).
 - **ambientResponse**: Fresnel/edge lift `0..1` (default 0.46).
 - **edgeSoftness**: Soft fade at the edges (default 2.dp). Set to 0.dp for hard edges.
@@ -55,43 +46,18 @@ Adaptive content behavior, interaction-driven deformation, and morphing are unsu
 - **chromaticAberrationMode**: Quality mode for chromatic aberration. `Simple` (default, fast) or `Full` (spectral, more expensive).
 - **alpha**: Overall opacity multiplier `0..1` (default 1).
 
-All direct Glass numbers fail fast at value or Style construction. Invalid inputs throw
-`IllegalArgumentException` with a message shaped as `<property> must be <accepted domain>`; they
-are not clamped by Style resolution or a renderer.
-
-| Public input | Accepted domain and sentinel policy |
-| --- | --- |
-| `refractionStrength`, `refractionHeightFraction`, `depth` | finite `0f..1f` |
-| `refractionDisplacement`, `blurRadius` | specified, finite, non-negative `Dp`; no authored upper limit |
-| `specularIntensity`, `ambientResponse`, `chromaticAberrationStrength`, `alpha`, `contentNormalBlend` | finite `0f..1f` |
-| `contrast`, `whitePoint` | finite `-1f..1f` |
-| `chromaMultiplier`, `interactionLightRadiusFraction` | finite `0f..2f` |
-| `edgeSoftness` | specified, finite, non-negative `Dp`; no authored upper limit |
-| `specularExponent`, `fresnelExponent` | finite and non-negative; no authored upper limit |
-| `tint` | any specified `Color`, including transparent; `Color.Unspecified` is rejected |
-| known `lightPosition` biases | finite horizontal and vertical axes; finite values outside `-1f..1f` are accepted |
-| interaction `lightingIntensity`, `refractionMultiplier`, `whitePointDelta` | finite `0f..1f`, `0f..2f`, and `-1f..1f`, respectively |
-| interaction `scale`, `scaleX`, `scaleY` | finite `0f < value <= 1f` |
-
-The direct six-parameter `optics(...)` function constructs `GlassOptics.Fixed`, so both routes have
-identical failures. `progressive = null` intentionally means no progressive blur. `GlassOptics`,
-`RoundedCornerShape`, `FiniteAnimationSpec`, `HazeProgressive`, arbitrary custom `Alignment`, and
-`HazeSampling` otherwise retain their owning contracts; Glass does not inspect opaque
-implementations. In particular, `HazeSampling.Fixed` already validates its finite
-`0f < pixelFraction <= 1f` value before the modifier receives it.
+Glass validates configuration when a Style or `GlassOptics.Fixed` value is created instead of
+silently correcting it later. Validate or clamp values from user input and remote data before
+building the Style. The generated API reference documents the accepted range for each property.
 
 ## GlassStyle
 
-`GlassStyle` is an opaque, immutable sequence of appearance writes. Its builder executes once when
-the Style is constructed, validating and recording each value. Compose Styles with the
-intrinsic `then` members; later writes win. A Style can be shared by any number of `hazeGlass`
-nodes: each node replays defaults, `LocalGlassStyle`, and its explicit Style into its own snapshot
-without rerunning caller code.
+`GlassStyle` is immutable and safe to share. Build a base Style, use `then` for variations, and
+provide a replacement Style through recomposition when the appearance changes. Values omitted by
+the replacement fall back to `LocalGlassStyle` and then `GlassDefaults.style`.
 
-Values captured while constructing a Style are frozen into those writes. Mutating captured state
-does not update attached nodes; construct and supply a replacement Style through recomposition to
-change their appearance. Replacement also removes properties and interaction blocks omitted by the
-new Style.
+A Style captures its inputs when it is constructed. Changing captured state does not update an
+existing Style; construct and provide a replacement instead.
 
 ```kotlin
 val baseStyle = GlassStyle {
@@ -102,17 +68,14 @@ val baseStyle = GlassStyle {
 val emphasizedStyle = baseStyle.then { specularIntensity(0.7f) }
 
 CompositionLocalProvider(LocalGlassStyle provides baseStyle) {
-  // Each node gets a fresh snapshot; an explicit Style is applied last.
+  // Use baseStyle as the default for Glass in this subtree.
 }
 ```
 
 ### Light alignment
 
-Light position is authored semantically with Compose `Alignment` and resolved independently for
-each node. A shared Style therefore places `Alignment.Center` at the center of every consuming
-material, even when their measured sizes differ. Logical alignments such as `Alignment.TopStart`,
-`Alignment.CenterStart`, and `Alignment.CenterEnd` automatically follow LTR or RTL layout direction;
-use physical alignments only when that is the intended semantic.
+Use Compose `Alignment` values so lighting adapts to each surface. Logical alignments such as
+`Alignment.CenterStart` and `Alignment.CenterEnd` also follow LTR or RTL layout direction.
 
 ```kotlin
 val sharedLighting = GlassStyle {
@@ -120,11 +83,8 @@ val sharedLighting = GlassStyle {
 }
 ```
 
-Use `BiasAlignment` for a continuously moving proportional light. Biases `-1f`, `0f`, and `1f`
-represent the start/top edge, center, and end/bottom edge respectively, and values outside that
-range place the virtual light beyond the material bounds. Both bias axes must be finite.
-`BiasAbsoluteAlignment` follows the same finite-axis rule without RTL mirroring. Arbitrary custom
-`Alignment` implementations are accepted unchanged and evaluated only at layout resolution.
+Use `BiasAlignment` when the light needs a continuous proportional position rather than a named
+alignment.
 
 ```kotlin
 val movingLighting = GlassStyle {
@@ -134,8 +94,8 @@ val movingLighting = GlassStyle {
 
 ## Default style
 
-`GlassDefaults.style` uses the built-in Haze `GlassOptics.Adaptive` material and is replayed
-before `LocalGlassStyle` and the modifier's explicit Style.
+`GlassDefaults.style` uses `GlassOptics.Adaptive`. Use `LocalGlassStyle` to set a default for a
+subtree, and pass an explicit Style when one element needs to differ.
 
 ```kotlin
 Box(
@@ -167,12 +127,8 @@ GlassStyle {
 }
 ```
 
-The direct function constructs `GlassOptics.Fixed`. Fixed values are not geometry-adjusted:
-`refractionStrength`, `refractionHeightFraction`, and `depth` must be finite values in `0f..1f`;
-`refractionDisplacement` and `blurRadius` must be specified, finite, non-negative `Dp`; and
-`progressive` is optional. Large logical displacement and blur distances remain valid even when a
-renderer caps effective sampling or kernel work. `refractionHeightFraction` remains relative to the
-material's shortest side.
+Fixed optics use the values you provide at every surface size. This is useful for art-directed
+components, but Adaptive is usually the better default for reusable layouts.
 
 Keep a complete value when it is reused, stored, copied, or selected programmatically:
 
@@ -181,19 +137,16 @@ val reusableOptics = GlassOptics.Fixed(blurRadius = 20.dp)
 val style = GlassStyle { optics(reusableOptics) }
 ```
 
-Backend sampling and kernel construction remain rendering details. `GlassOptics.Fixed` is distinct
-from `HazeSampling.Fixed(pixelFraction)`, which selects a sampling policy rather than optical
-values. `shape` and `tint` stay independent of the selected optics. The `shape`
-supplied to Glass is the authoritative material boundary. An outer `Modifier.clip()` is not visible
-to Glass and does not define its optical boundary; add one with the same shape only when child
-content also needs clipping.
+`GlassOptics.Fixed` controls the appearance; `HazeSampling.Fixed` controls the rendering trade-off.
+The `shape` supplied to Glass defines its material boundary. Add an outer `Modifier.clip()` with
+the same shape only when child content also needs clipping.
 
-### Retained Output
+### Retained output
 
 Glass can retain and redraw its last captured output when all source areas disappear. This
 keeps source transitions smooth, but can briefly preserve stale pixels from removed source content.
-The typed modifier preserves Glass's default retained-output policy. Keep source ownership explicit
-with `HazeInput.Sources` so transitions are visible at the call site:
+Keep the default for smooth transitions, and keep source ownership explicit with
+`HazeInput.Sources`:
 
 ```kotlin
 Box(
@@ -235,38 +188,29 @@ GlassStyle {
 
 ## Fallbacks
 
-Author one final `GlassStyle` for every platform. Haze replays that same Style unchanged into the
-private renderer it selects. Selection is automatic when preferred rendering is unavailable,
-cannot be constructed, or exceeds the render budget; application code does not query capabilities
-or provide a second fallback Style.
+Use one `GlassStyle` on every platform. Haze chooses the available implementation automatically, so
+applications do not need capability checks or a second fallback Style.
 
-The full runtime renderer consumes every supported authored channel. The limited fallback has this
-deterministic degradation contract:
+Fallback rendering keeps the material recognizable but may simplify advanced optics:
 
-| Authored behavior | Full runtime renderer | Limited fallback renderer |
+| Authored behavior | Preferred rendering | Fallback |
 | --- | --- | --- |
 | Tint, alpha, and rounded shape | Preserved | Preserved |
 | Ambient edge response and edge softness | Preserved | Approximated as a soft rim |
 | Specular intensity and resolved light `Alignment` | Preserved | Approximated as an aligned radial highlight |
-| Interaction lighting and node transform | Preserved | Preserved, with localized foreground lighting and the shared transform |
+| Interaction lighting and transforms | Preserved | Preserved |
 | Fixed or Adaptive refraction, blur, and progressive optics | Preserved | Omitted |
-| Chromatic aberration, surface profile, and full color-adjustment math | Preserved | Omitted |
+| Chromatic aberration, surface profile, and advanced color adjustments | Preserved | Omitted |
 | Interaction refraction and white-point deltas | Preserved | Omitted |
 
-On Android API 33 and newer, the full single-output renderer handles single and multiple effects,
-semantic and progressive blur, Full chromatic aberration, sharp-source refraction detail, and
-configured interaction optics. Unsupported fallback channels are safe no-ops; supported tint,
-aligned lighting, interaction lighting, and transforms remain observable.
+Do not make essential meaning depend on refraction or chromatic aberration alone, because those
+details may be omitted by a fallback.
 
 ## Performance
 
-On the modern Android path, every Glass effect composes a blurred optical branch and sharp-source
-detail branch into one retained output per surface. Renderer selection does not depend on sibling
-count. Progressive blur and Full chromatic aberration remain in the same native effect graph,
-while live interaction values update locally weighted math without allocating retained detail
-layers. See
-[Glass performance](../glass/performance.md) for the physical-device benchmark setup, results, and
-Perfetto interpretation.
+Start with adaptive sampling and tune only after measuring a representative screen. The
+[Glass performance guide](../glass/performance.md) explains which Glass-specific workloads and
+interactions to test.
 
 ## Interaction
 
@@ -322,18 +266,11 @@ Modifier
   )
 ```
 
-Hover, focus, and press responses, the localized-light radius, and light-position animation are
-presentation. They travel with `GlassStyle`, compose through `LocalGlassStyle` and `then`, and can
-be reused across nodes. Each consuming node still owns its `InteractionSource`, transform target,
-transform pivot, reduced-motion policy, geometry, animation state, controller, renderer, and
-platform resources. Sharing `interactionStyle` therefore shares appearance without coupling
-interaction signals or runtime state. Replace the Style to update presentation on the existing
-renderer; replace modifier mechanics to reconfigure only that node.
+Keep the visual response in `GlassStyle`, and pass each element's interaction source and behavior
+options to `hazeGlass`. The same Style can be reused without sharing interaction state.
 
-Custom blocks replace that state's preset from identity. Resolve each property with fixed
-precedence: focused, then hovered, then pressed. Use `animate(toSpec, fromSpec)` inside a custom
-block to own the arrival and departure animation specs respectively; entering or replacement uses
-`toSpec`, while departing uses `fromSpec`.
+When states overlap, pressed takes priority over hovered, which takes priority over focused. Use
+`animate(toSpec, fromSpec)` when arrival and departure need different motion.
 
 ```kotlin
 GlassStyle {
@@ -351,13 +288,11 @@ GlassStyle {
 }
 ```
 
-The node-owned `interactionTransformTarget` argument selects whether a response transforms only
-the material or the material and content. `interactionTransformPivot` selects `Pointer` or
-`Center`. Omit a state block from a replacement Style to remove it.
+`interactionTransformTarget` selects whether a response transforms only the material or also its
+content. `interactionTransformPivot` selects `Pointer` or `Center`. Omit a state block from a
+replacement Style to remove it.
 `GlassReducedMotionPolicy.System` follows the available system duration scale, `Reduced` snaps
-lighting and optics while suppressing transforms, and `Full` forces motion. The
-`GlassInteractionScope` receiver is sealed and implemented by Haze; it is a declaration DSL, not a
-consumer implementation point.
+lighting and optics while suppressing transforms, and `Full` forces motion.
 
 ## Usage
 

--- a/docs/glass/performance.md
+++ b/docs/glass/performance.md
@@ -1,97 +1,47 @@
 # Glass performance
 
-Glass is designed for real-time UI effects, but its cost depends on the device, the size and number
-of Glass surfaces, and how often their source content or optical properties change.
+Read the [general performance guide](../performance.md) first for the shared workflow, sampling
+choices, and measurement advice. This page focuses on the decisions that are specific to Glass.
 
-For API and usage guidance, see the [Glass overview](../effects/glass.md).
+For styling and API guidance, see the [Glass overview](../effects/glass.md).
 
-!!! abstract "At a glance"
-    On a Pixel 6 at 60 Hz, a focused scene containing nine Glass effects recorded P90 CPU frame
-    durations of **9.16 ms and 9.24 ms** across two passes using the default Glass style. In the
-    later confirmation pass, frames finished **2.74 ms before** their deadline at P90.
+## Start here
 
-    This is a whole-frame measurement, including UI-thread and RenderThread work. It is not the
-    isolated GPU cost added by Glass.
+- Use `HazeSampling.Default` with `GlassOptics.Adaptive`.
+- Build the complete screen before tuning; isolated effects do not represent a real workload.
+- Profile the slowest devices you support with realistic content and interactions.
+- Override one setting at a time and keep it only when the benefit is visible or measurable.
 
-## Results
+## Glass-specific cost drivers
 
-| Scenario | P50 | P90 | P95 | P99 | P90 deadline margin |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| One Glass effect (`steadyFull`) | 4.5 ms | 6.9 ms | 7.6 ms | 8.6 ms | -6.2 ms |
-| Nine Glass effects (`steadyFull9`) | 7.88–7.93 ms | 9.16–9.24 ms | 9.66 ms | 10.81–10.85 ms | -2.74 ms |
+- **Surface size:** Large Glass surfaces process more content and optical detail.
+- **Number of surfaces:** Several independent Glass elements add work even when they share a Style.
+- **Changing content:** Scrolling or animation behind Glass costs more than a stable background.
+- **Optical complexity:** Progressive blur and Full chromatic aberration are more expensive than
+  the default material.
+- **Interaction:** Animated lighting, refraction, and transforms add a changing workload while the
+  user hovers, focuses, or presses the element.
 
-A negative deadline margin means the frame completed before its deadline. A positive value means
-it missed the deadline by that amount. The later nine-effect confirmation pass recorded a
--1.01 ms P99 deadline margin, while the one-effect run recorded -4.6 ms, so every reported
-percentile remained before the deadline.
+## When to change sampling
 
-The one-effect scenario is a whole-frame control, not the isolated or incremental cost of one Glass
-effect. The nine-effect CPU-duration values span two clean benchmark passes; its deadline margins
-come from the later confirmation pass. The one-effect values come from one clean pass. Measurements
-were collected on 2026-07-27. These results describe two specific scenes on one device. Treat them
-as a guide, not a performance guarantee or CI threshold. Applications should measure their own
-layouts and interactions.
+Keep adaptive sampling unless a target-device comparison gives you a reason to override it:
 
-## What was tested
+- Choose `FullResolution` when fine source detail is visibly important.
+- Choose `Fixed(pixelFraction)` when you need a deliberate, stable trade-off for a known layout.
+- Return to `Default` when the override does not produce a meaningful improvement.
 
-The `steadyFull` benchmark renders one compatible Glass effect, while `steadyFull9` renders nine.
-Each scenario runs for three seconds and uses:
+## What to test
 
-- A Pixel 6 running API 37 at 1080 × 2400 and a fixed 60 Hz refresh rate.
-- Android fixed-performance mode, which stabilizes CPU and GPU clocks for development benchmarks.
-- The modern Android `RuntimeShader` renderer available on API 33 and newer.
-- The unmodified `GlassDefaults.style`, including adaptive optics, default 16 dp corners, simple
-  chromatic aberration, and default lighting, color, and rendering values.
-- A release-like, non-debuggable build with `CompilationMode.Full`.
-- Warm startup and eight measured iterations per run.
-- Navigation, initial composition, and settling outside the measured block.
+Exercise the states that represent the real screen:
 
-The device reported no thermal throttling during these runs. The fallback renderer was not
-measured.
+- the largest number of Glass surfaces visible at once;
+- scrolling or animation behind those surfaces;
+- hover, focus, and press responses;
+- resizing, orientation changes, and other layout transitions;
+- the lowest-performance devices and highest display resolutions you support.
 
-## What affects performance
+Repository contributors can use the complete [Glass benchmark runbook][benchmark-runbook]. The
+adaptive-sampling rationale and supporting measurements are recorded in [ADR-0004][sampling-adr].
 
-- **Surface area:** Larger Glass surfaces process more pixels.
-- **Number of effects:** More independent surfaces can add rendering and submission work.
-- **Effect count:** Android RuntimeShader effects use the same single-output renderer for one or
-  many surfaces; sibling attachment does not switch topology.
-- **Changing content:** Moving or updating the captured source invalidates more retained work than
-  redrawing an unchanged effect.
-- **Dynamic optics:** Progressive blur and Full chromatic aberration increase sampling within the
-  output effect graph. Configured interaction optics use that same stable renderer, while
-  interaction lighting uses a localized foreground patch to preserve content ordering. Live press,
-  hover, and focus values update retained shader providers and re-record the output without
-  allocating retained optical or detail layers.
-- **Device and display:** GPU capability, resolution, refresh rate, and thermal state all affect
-  the result.
-
-## Reproducing the measurement
-
-Run the benchmark locally on an unlocked physical device at API 33 or newer. Pin the display to one
-supported refresh rate, let the device cool, and run:
-
-```shell
-adb shell cmd power set-fixed-performance-mode-enabled true
-./gradlew :internal:benchmark:connectedCheck \
-  -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.GlassProfilingBenchmark#steadyFull9
-adb shell cmd power set-fixed-performance-mode-enabled false
-```
-
-Replace `steadyFull9` with `steadyFull` to reproduce the one-effect control.
-Always disable fixed-performance mode after profiling, including after a failed run.
-
-Results and Perfetto traces are copied to
-`internal/benchmark/build/outputs/connected_android_test_additional_output/`. Run the scenario
-without full composition tracing when collecting comparable metrics; opt in to full tracing only
-for diagnostic attribution. The complete local runbook is in `internal/benchmark/README.md`.
-
-A representative trace for the nine-effect results contains exactly nine effect-layer traversals
-and two Vulkan submissions per frame. `HazeGlass.prepare` and `HazeGlass.runtimeDraw` average less
-than 0.08 ms per effect; the remaining cost is primarily RenderThread drawing and Vulkan
-submission.
-
-The nine-effect interaction-update scenario recorded a 10.9 ms CPU P90 and a -1.2 ms
-frame-overrun P90. Its live lighting and optics updates therefore remained inside the frame
-deadline without changing retained-layer topology. Interaction-only updates retain the shader
-providers, source capture, and layer allocation, but re-record the fused output; separate local
-overlays measured slower because they restored layer replay and submission cost.
+[benchmark-runbook]: https://github.com/chrisbanes/haze/blob/main/internal/benchmark/README.md
+[sampling-adr]: ../adr/0004-use-cadence-weighted-adaptive-input-scaling-for-glass.md

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -160,16 +160,13 @@ Modifier.hazeBlur(
 ```
 
 `HazeSampling.Default` points to `Adaptive` for both Blur and Glass. Use `Adaptive` to pin that
-policy explicitly, or use `FullResolution` or `Fixed(pixelFraction)` to override it. A fixed value
-is a fraction of total input pixels rather than a per-dimension scale, so `Fixed(0.5f)` scales each
-dimension by approximately `0.707`.
+policy explicitly, `FullResolution` when fidelity is the priority, or `Fixed(pixelFraction)` for an
+explicit trade-off.
 
 ## Lifecycle and sharing
 
-A Style can be shared by any number of modifiers. Each modifier creates its own Blur runtime,
-delegate, cache, retained layers, platform resources, and adaptive-sampling history. Recomposition
-replaces the complete Style on the existing runtime; detachment releases only that node's
-resources.
+Styles are immutable and safe to share. Supply a replacement Style through recomposition when the
+appearance changes.
 
 ## Other Haze 2 migrations
 
@@ -177,43 +174,17 @@ The typed Blur API does not change the other Haze 2 migrations.
 
 ### Glass migration
 
-Glass also has a typed modifier and an opaque, replayable `GlassStyle`. Replace the complete Style
-through recomposition; do not mutate an effect, use sentinel patches, `copy`, or `clear*` calls.
-The `GlassStyle` builder executes once during construction and records immutable, validated
-writes. Resolution never reruns the builder, so mutating state captured by an unchanged Style is
-inert; construct and supply a replacement Style to reflect new inputs.
+Glass also has a typed modifier and an immutable `GlassStyle`. Replace the Style through
+recomposition instead of mutating an effect or using sentinel patches, `copy`, or `clear*` calls.
+Use `then` to build variations from a shared base Style.
 
 Keep one final `GlassStyle` for all platforms. Remove renderer-capability checks, platform-specific
-Style variants, and secondary fallback Styles: `hazeGlass` selects its private renderer
-automatically, replaying the same Style while limited renderers approximate supported appearance
-and omit unsupported optics.
+Style variants, and secondary fallback Styles. Haze selects the available implementation and
+gracefully simplifies unsupported optics.
 
-Glass numeric authoring now fails fast. Values that older Style or renderer paths clamped,
-normalized, or replaced now throw `IllegalArgumentException` when `GlassOptics.Fixed` or
-`GlassStyle` is constructed. This includes non-finite values; out-of-domain ratios, adjustments,
-multipliers, exponents, and scales; negative or unspecified distances; `Color.Unspecified`; and
-non-finite axes on `BiasAlignment` or `BiasAbsoluteAlignment`. Direct `optics(...)` uses the same
-`GlassOptics.Fixed` validation and messages as complete-value construction.
-
-If an application intentionally wants clamping, make that policy explicit before authoring the
-Style:
-
-```kotlin
-val safeAlpha = requestedAlpha.coerceIn(0f, 1f)
-require(requestedEdgeSoftness.isSpecified && requestedEdgeSoftness.value.isFinite())
-val safeEdgeSoftness = requestedEdgeSoftness.coerceAtLeast(0.dp)
-
-val style = GlassStyle {
-  alpha(safeAlpha)
-  edgeSoftness(safeEdgeSoftness)
-}
-```
-
-Otherwise validate upstream and surface the invalid configuration. Large finite non-negative
-distances and exponents remain valid; renderer physical caps do not become authoring limits.
-`progressive = null` remains intentional, arbitrary custom `Alignment` and opaque shape/animation/
-progressive implementations keep their owning contracts, and modifier sampling continues to be
-validated by `HazeSampling.Fixed` (`0f < pixelFraction <= 1f`).
+Invalid Glass values now fail when the Style or `GlassOptics.Fixed` value is created instead of
+being corrected later. Validate or clamp external values before building the Style. See the
+generated API reference for property-specific ranges.
 
 | Legacy | Typed replacement |
 | --- | --- |
@@ -227,37 +198,21 @@ validated by `HazeSampling.Fixed` (`0f < pixelFraction <= 1f`).
 | `Modifier.hazeGlass(interactionLightRadiusFraction = value)` | `GlassStyle { interactionLightRadiusFraction(value) }` |
 | `Modifier.hazeGlass(interactionPositionAnimationSpec = spec)` | `GlassStyle { interactionPositionAnimationSpec(spec) }` |
 | `GlassDefaults.hoverAnimationSpec`, `pressAnimationSpec`, `releaseAnimationSpec` | explicit `animate(toSpec, fromSpec) { … }` declarations |
-| consumer implementation of `GlassInteractionScope` | removed; the sealed receiver is implemented by Haze and used only as the interaction-response DSL |
-| `GlassStyleConfiguration`, `GlassRenderer`, `GlassRendererCache`, retained-output methods, delegate and lifecycle hooks | no public replacement; each `hazeGlass` node owns and disposes these internal resources |
+| consumer implementation of `GlassInteractionScope` | removed; it is now a sealed declaration DSL implemented by Haze |
+| `GlassStyleConfiguration`, `GlassRenderer`, `GlassRendererCache`, and lifecycle or retention hooks | removed with no public replacement |
 | effect-owned hover, focus, press, light-radius, and light-position animation presentation | property writes inside `GlassStyle { … }` |
 | effect-owned interaction source, transform target/pivot, and reduced-motion policy | explicit `Modifier.hazeGlass` arguments owned by each node |
 | implicit source/content | explicit `HazeInput.Sources` or `HazeInput.Content` |
-| raw optical displacement/caps | semantic `GlassOptics` and `Dp` controls |
 | `GlassOptics.Absolute` | `GlassOptics.Fixed`; this is a hard rename with no alias or compatibility bridge |
 | `lightPosition(Offset)` and `Offset.Unspecified` | `lightPosition(Alignment)`; omit the write or use `Alignment.Center` for the former automatic center |
 
-For ordinary inline fixed Style authoring, pass the complete fixed parameter set directly to
-`optics(...)`. The complete-value overload remains available for `GlassOptics.Adaptive`, reusable
-fixed values, copies, storage, and programmatic selection.
+Use `optics(...)` for inline fixed values. Keep a `GlassOptics.Fixed` value when the configuration
+needs to be reused or selected programmatically.
 
 Glass light position is now an intentional source break from pixel `Offset` to semantic
-`Alignment`, with no compatibility overload. The Alignment is resolved inside each node's current
-measured bounds and layout direction. Use `Alignment.Center` (or omit the write) for the former
-`Offset.Unspecified` behavior, logical start/end alignments for directional intent, and
-`BiasAlignment` for continuous proportional positions:
-
-```kotlin
-val normalizedX = 0.7f
-val normalizedY = 0.2f
-val style = GlassStyle {
-  lightPosition(
-    BiasAlignment(
-      horizontalBias = normalizedX * 2f - 1f,
-      verticalBias = normalizedY * 2f - 1f,
-    ),
-  )
-}
-```
+`Alignment`, with no compatibility overload. Use `Alignment.Center` (or omit the write) for the
+former `Offset.Unspecified` behavior, logical start/end alignments for directional intent, and
+`BiasAlignment` for continuous proportional positions.
 
 Write each property through the Style scope, then pass the Style and structural policies to
 `hazeGlass`:
@@ -288,20 +243,14 @@ Modifier.hazeGlass(
 )
 ```
 
-Interaction presentation composes with the rest of `GlassStyle` and can be shared. The modifier
-arguments above remain per-node mechanics: sharing a Style never shares signals, geometry,
-animation state, controllers, renderers, retained layers, or platform resources. Replacing a Style
-updates presentation on the existing renderer; replacing mechanics updates only that modifier
-node.
+Interaction appearance belongs in the Style and can be shared. Each element still supplies its own
+interaction source and behavior options to the modifier.
 
 ### Position and geometry
 
-Source areas, coordinates, captured layers, windows, and position strategy are no longer public.
-Custom renderers receive semantic modifier bounds through `HazeEffectDrawScope` and
-`HazeEffectLayoutScope`, and draw the selected input with `drawInput()`.
-
-Source-selection predicates receive only `HazeSourceInfo.key` and `zIndex`. Cross-window coordinate
-selection is handled internally by Haze.
+Position handling is now automatic. Source-selection predicates receive only
+`HazeSourceInfo.key` and `zIndex`; custom renderers work with modifier-relative bounds and draw the
+selected input with `drawInput()`.
 
 ## Removed compatibility APIs
 
@@ -397,13 +346,8 @@ Modifier.hazeBlur(
 
 ## Custom effects and architecture
 
-Haze 2 separates typed, shareable configuration from node-owned rendering resources:
-
-- `HazeEffectFactory<Style>` is stateless and may be shared.
-- Every modifier node creates its own `HazeEffectRenderer<Style>`.
-- Replacing a Style reuses that renderer.
-- Replacing the factory or detaching the node disposes its renderer exactly once.
-- Source capture, node lifecycle, and built-in capabilities remain internal.
+Custom effects now pair a shareable `HazeEffectFactory<Style>` with a renderer created for each
+modifier. Keep configuration in the Style and mutable resources in the renderer.
 
 Custom typed effects use the generic modifier rather than `hazeBlur`:
 
@@ -414,6 +358,8 @@ Modifier.hazeEffect(
   style = myStyle,
 )
 ```
+
+See [Custom effects](custom-effects.md) for lifecycle and ownership guidance.
 
 ## Getting help
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,89 +1,49 @@
-Real-time blurring is a non-trivial operation, especially for mobile devices, so developers are rightly worried about the performance impact of using something like Haze.
+# Performance
 
-Haze tries to use the most performant mechanism possible on each platform, which can basically be simplified into 2: `RenderEffect` on Android, and using Skia's `ImageFilter`s directly on iOS and Desktop.
+Haze uses the best available rendering path on each platform, but real-time effects still add work.
+The impact depends on the device, the affected area, how many effects are visible, and how often
+their input changes.
 
-## Input Scale
+## Recommended workflow
 
-Blur effects use adaptive input scaling by default. The common cross-platform policy uses the
-resolved blur radius in physical pixels and expanded capture-layer pixel area to choose `1.0`,
-`0.8`, or `0.5`. Stronger blur can hide more downsampling, while the area gate avoids reallocating
-small layers for negligible savings. Progressive blur is capped at `0.8`; Glass remains unscaled by
-default. Explicit `HazeSampling.FullResolution`, `Adaptive`, and `Fixed` values always win. You can
-find configuration details [here](blur/usage.md#input-scale).
+1. Start with the default Style and `HazeSampling.Default`.
+2. Build the real screen, including its scrolling, transitions, and interactions.
+3. Measure a release-like build on representative physical devices.
+4. Change one setting at a time and compare both frame timing and visual quality.
+5. Keep an override only when it provides clear value on the devices you support.
 
-In terms of the performance benefit which scaling provides, it's fairly small. In our Android benchmark tests, using an `inputScale` set to `0.5` reduced the _cost of Haze_ by **5-20%**. You can read more about this below.
+## Input scale
 
-!!! abstract "Cost of Haze"
-    Just to call out: the percentage that I mentioned is a reduction in the cost of Haze, not the total frame duration. Haze itself introduces a cost, which you can read more about below. The reduction in total frame duration duration will be in the region of 3-5%.
+Sampling controls how much input an effect processes:
 
-## Benchmarks
+- **`Default` or `Adaptive`**: Recommended for most applications. Built-in effects adjust the
+  quality and cost trade-off automatically.
+- **`FullResolution`**: Use when target-device comparisons show that adaptive sampling loses
+  important detail.
+- **`Fixed(pixelFraction)`**: Use when you want an explicit, stable pixel budget. Higher values
+  preserve more detail and cost more to render.
 
-To quantify performance, we have a number of [Macrobenchmark tests](https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview) to measure Haze's effect on drawing performance on Android. We'll be using these on every major release to ensure that we do not unwittingly regress performance.
+Blur and Glass adapt differently, so compare the result on the effect and layout you actually use.
 
-Anyway, in the words of Jerry Maguire, "Show Me The Money"...
+## Common cost drivers
 
-We currently have 4 benchmark scenarios, each of them is one of the samples in the sample app, and picked to cover different things:
+- **Affected area:** Larger effects process more content.
+- **Number of effects:** Several independent effects cost more than one.
+- **Changing input:** Scrolling and animation require more work than a stable background.
+- **Effect complexity:** Progressive effects, masks, and advanced optics can add cost.
+- **Device and display:** Resolution, refresh rate, and GPU capability affect the result.
 
-- **Scaffold**. The simple example, where the app bar and bottom navigation bar are blurred, with a scrollable list. This example uses rectangular haze areas.
-- **Scaffold, with progressive**. Same as Scaffold, but using a progressive blur.
-- **Images List**. Each item has its own `hazeSource` and `hazeBlur`. The list item content moves,
-  but its effect does not move in local coordinates, so this primarily exercises multiple
-  `RenderNode`s. This example uses rounded rectangle haze areas (that is, `clipPath`).
-- **Credit Card**. A simple example where the user can drag the `hazeBlur` modifier. This tests how
-  quickly Haze invalidates state and propagates it to the `RenderNode`s. This example uses rounded
-  rectangle haze areas like Images List.
+## Effect-specific guidance
 
-!!! abstract "Test setup"
-    All of the tests were ran with 16 iterations on a Pixel 6, running the latest version of Android available.
+For Blur, see [Sampling and layer expansion](blur/usage.md#sampling-and-layer-expansion). For Glass,
+see the [Glass performance guide](glass/performance.md), which covers optical and interaction
+choices specific to that effect.
 
-As with all benchmark tests, the results are only true for the exact things being tested. Using Haze in your own applications may result in different performance characteristics, so it is wise to write your own performance tests to validate the impact to your apps. Benchmark tests will always have variability in them too, so don't take the numbers listed below as exact values. Look at them more as a guide.
+## Measure on target devices
 
-### Adaptive default validation
+Use a release-like build on physical hardware and reproduce the interactions users will perform.
+Keep device conditions and refresh rate consistent between runs. Measurements from another device
+or layout are useful context, not a guarantee for your application.
 
-The adaptive blur default was validated with three interleaved 16-iteration Scaffold pairs on a
-Pixel 6 at 90Hz. Each pair compared explicit unscaled input with the adaptive default. Median P90
-CPU duration improved from 9.817ms to 9.746ms, while Perfetto actual-frame duration improved from
-11.889ms to 11.388ms (4.21%). CPU duration, actual-frame duration, and frame-overrun headroom
-improved in every pair.
-
-Representative progressive and masked pairs also improved actual-frame P90 by 5.76% and 6.53%
-respectively. Runs with a different or mismatched refresh rate, or with invalid app navigation
-state, were discarded and repeated before comparison.
-
-The numbers listed below the P90 frame durations in milliseconds, which tend to be a good indicator of frames where a user interaction is happening (scrolling, etc). However, as these are the P90 values, these indicate the longest 10% frame durations, and thus are (probably) not indicitive of the performance which users see most of the time. It all depends on the distribution of the frame durations, but we're quickly getting into entry-level statistics, which is beyond what we're trying to document here.
-
-#### Cost of Haze
-
-We can also measure the rough cost of using Haze in the same samples. Here we've ran the same tests, with Haze being completely disabled:
-
-| Test          | v1.x (disabled)  | v1.x      | Difference   |
-| ------------- | ------------------| -----------| ------------ |
-| Scaffold      | 7.5 ms            | 9.7 ms     | +29%         |
-| Images List   | 6.6 ms            | 9.6 ms     | +45%         |
-| Credit Card   | 6.6 ms            | 13.1 ms    | +98%         |
-
-#### Cost of features
-
-We can also measure the rough cost of using features, such as input scale, progressive and masking:
-
-| Test                                      | P90 frame duration (ms)  | Difference (in Haze cost) |
-| -------------                             | -------------------------| -----------|
-| Scaffold                                  | 9.7 ms                   | -          |
-| Scaffold (inputScale = 0.5)               | 9.6 ms                   | -5%        |
-| Scaffold (masked)                         | 9.8 ms                   | +5%        |
-| Scaffold (progressive)                    | 9.7 ms                   | 0%         |
-| Scaffold (progressive, inputScale = 0.5)  | 9.4 ms                   | -14%       |
-
-The values are all very close, with the differences easily being within a margin of error, so don't use these differences as exact values (especially with the variability that we mentioned above). I think there's two big take aways here though:
-
-- Masking has a negligible effect on frame durations.
-- Progessive has a negligible effect on frame durations, when using using our custom blur shader (Android SDK 34+, all other platforms).
-- Input Scale has a small but positive effect on frame duration.
-
-!!! example "Full results"
-    For those interested, you can find the full results in this [spreadsheet](https://docs.google.com/spreadsheets/d/1wZ9pbX0HDIa08ITwYy7BrYYwOq2sX-HUyAMQlcb3dI4/edit?usp=sharing).
-
-### Glass on Android
-
-Glass has its own [performance guide](glass/performance.md), covering the modern Android benchmark
-results and Perfetto interpretation.
+For Android, [Macrobenchmark](https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview)
+is a good starting point for repeatable frame measurements.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,9 +29,10 @@ nav:
     - "Platforms": blur/platforms.md
   - "Glass":
     - "Overview": effects/glass.md
-    - "Performance": glass/performance.md
   - "Custom Effects": custom-effects.md
-  - "Performance": performance.md
+  - "Performance":
+    - "Overview": performance.md
+    - "Glass": glass/performance.md
   - "Recipes": recipes.md
   - "Migrating to Haze 2.0": migrating-2.0.md
   - "Changelog": changelog.md


### PR DESCRIPTION
## Summary

- Refresh the README, core concepts, Blur, Glass, migration, and changelog guidance for the recent Haze 2 changes.
- Reorganize performance documentation into a general overview and Glass-specific guide.
- Keep public documentation focused on decisions and outcomes, while linking detailed validation and benchmark material from the relevant references.

## Validation

- `git diff --check`
- `mkdocs build --strict`