### PR TITLE
Document Glass performance reference measurements

### DIFF
--- a/docs/glass/performance.md
+++ b/docs/glass/performance.md
@@ -17,8 +17,8 @@ For styling and API guidance, see the [Glass overview](../effects/glass.md).
 - **Surface size:** Large Glass surfaces process more content and optical detail.
 - **Number of surfaces:** Several independent Glass elements add work even when they share a Style.
 - **Changing content:** Scrolling or animation behind Glass costs more than a stable background.
-- **Optical complexity:** Progressive blur and Full chromatic aberration are more expensive than
-  the default material.
+- **Optical complexity:** Progressive blur and Full chromatic aberration can add work relative to
+  the default material. Measure them with the surfaces and content your application uses.
 - **Interaction:** Animated lighting, refraction, and transforms add a changing workload while the
   user hovers, focuses, or presses the element.
 
@@ -40,8 +40,30 @@ Exercise the states that represent the real screen:
 - resizing, orientation changes, and other layout transitions;
 - the lowest-performance devices and highest display resolutions you support.
 
-Repository contributors can use the complete [Glass benchmark runbook][benchmark-runbook]. The
-adaptive-sampling rationale and supporting measurements are recorded in [ADR-0004][sampling-adr].
+## Reference measurements
+
+The following Haze reference run is a reproducible comparison point, not a performance target or
+promise. It used the `benchmarkRelease` build at commit `334557df` on 2026-08-04: Pixel 6,
+Android 17/API 37, 1080×2400, locked 60 Hz render rate, locked CPU frequency, and eight
+Macrobenchmark iterations per scenario. The metric is P90 CPU frame duration in milliseconds.
+
+| Scenario | Workload | P90 CPU frame duration |
+| --- | --- | ---: |
+| `productPager` | Gallery paging journey | 7.5 ms |
+| `playgroundTimeline` | Gallery animated timeline journey | 11.2 ms |
+| `steadyFull` | Controlled steady state, 1 Glass effect | 5.6 ms |
+| `steadyFull3` | Controlled steady state, 3 Glass effects | 5.2 ms |
+| `steadyFull9` | Controlled steady state, 9 Glass effects | 8.1 ms |
+
+The Gallery journeys are closest to the sample's visible user work. The `steadyFull*` controls
+characterize the baseline at different effect counts. Cold-initialization `effectAttach*` results
+are deliberately omitted: they attach new effects at the measurement boundary and diagnose
+delegate/shader creation rather than representative interaction performance. They remain covered
+by the internal [Glass benchmark runbook][benchmark-runbook]. Compare the interactions, content,
+and device classes that your application supports.
+
+The adaptive-sampling rationale and supporting measurements are recorded in
+[ADR-0004][sampling-adr].
 
 [benchmark-runbook]: https://github.com/chrisbanes/haze/blob/main/internal/benchmark/README.md
 [sampling-adr]: ../adr/0004-use-cadence-weighted-adaptive-input-scaling-for-glass.md

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -47,3 +47,12 @@ or layout are useful context, not a guarantee for your application.
 
 For Android, [Macrobenchmark](https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview)
 is a good starting point for repeatable frame measurements.
+
+### A reference point, not a target
+
+In Haze's 2026-08-04 Glass reference run on a Pixel 6 (Android 17/API 37, 1080×2400 at
+60 Hz), the Gallery's `productPager` journey measured 7.5 ms P90 CPU frame duration and its
+`playgroundTimeline` journey measured 11.2 ms. These are one workload on one device, not a
+performance budget or promise for other devices and layouts. See the
+[Glass reference measurements](glass/performance.md#reference-measurements) for the setup and
+controlled scenarios.

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -37,6 +37,25 @@ Run all Glass benchmarks without meaningful measurements:
   -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.GlassGalleryBenchmark,dev.chrisbanes.haze.GlassProfilingBenchmark
 ```
 
+## Run comparable Glass measurements
+
+Run the Glass Gallery and controlled Glass profiling suites together when recording the current
+local baseline. This is the 34-test Glass suite: two realistic Gallery journeys and 32 controlled
+profiling scenarios. It deliberately excludes `BaselineProfileGenerator` and `BenchmarkTest`,
+which cover baseline-profile generation and the older Blur samples respectively.
+
+```shell
+adb shell cmd power set-fixed-performance-mode-enabled true
+./gradlew :internal:benchmark:connectedCheck \
+  -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.GlassGalleryBenchmark,dev.chrisbanes.haze.GlassProfilingBenchmark
+adb shell cmd power set-fixed-performance-mode-enabled false
+```
+
+`connectedCheck` without a class filter runs all 45 instrumentation tests, including
+`BaselineProfileGenerator`, and executes both the non-minified and benchmark-release variants.
+Use the filtered command above for Glass measurements so those workloads do not mix with the
+recorded results.
+
 ## Run a profile
 
 Run one controlled scenario:


### PR DESCRIPTION
## Summary

- document the focused, comparable 34-test Glass Macrobenchmark command
- add Pixel 6 reference measurements for representative Gallery journeys and controlled steady-state scenarios
- clarify that `effectAttach*` is a cold-initialization diagnostic, not a representative interaction metric

## Validation

- `./gradlew :internal:benchmark:connectedCheck -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.GlassGalleryBenchmark,dev.chrisbanes.haze.GlassProfilingBenchmark` — 34/34 passed on Pixel 6 (API 37)
- `mkdocs build --no-strict`
- `git diff --check`

The documentation site retains its existing strict-mode navigation and generated-API link warnings.