### PR TITLE
Add Glass background color for transparent sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Glass can now composite transparent captured content onto an explicit background before
+  refraction and blur using `GlassStyle.backgroundColor`
+  ([#1207](https://github.com/chrisbanes/haze/issues/1207)).
+
 ## 2.0.0-alpha04 <small>2026-08-08</small> { id="2.0.0-alpha04" }
 
 ### Highlights

--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -28,6 +28,9 @@ the same values at every size.
 
 ## Parameters
 
+- **backgroundColor**: Color composited behind captured content before refraction and blur
+  (defaults to transparent). Use an opaque color when transparent captured content must fully
+  obscure the original sharp source.
 - **tint**: Glass tint (defaults to transparent).
 - **optics**: Optical material configuration. `GlassOptics.Adaptive` (the default) is the
   recommended starting point. Call `optics(...)` for an inline fixed configuration, or keep a
@@ -58,6 +61,7 @@ existing Style; construct and provide a replacement instead.
 
 ```kotlin
 val baseStyle = GlassStyle {
+  backgroundColor(Color.White)
   tint(Color.White.copy(alpha = 0.16f))
   optics(refractionStrength = 0.8f)
   shape(RoundedCornerShape(20.dp))

--- a/haze-glass/api/api.txt
+++ b/haze-glass/api/api.txt
@@ -15,6 +15,7 @@ package dev.chrisbanes.haze.glass {
     method @InaccessibleFromKotlin public dev.chrisbanes.haze.glass.SurfaceProfile getSurfaceProfile();
     property public static float alpha;
     property public static float ambientResponse;
+    property public androidx.compose.ui.graphics.Color backgroundColor;
     property public static float chromaMultiplier;
     property public dev.chrisbanes.haze.glass.ChromaticAberrationMode chromaticAberrationMode;
     property public static float chromaticAberrationStrength;
@@ -111,6 +112,7 @@ package dev.chrisbanes.haze.glass {
   @dev.chrisbanes.haze.ExperimentalHazeApi @dev.chrisbanes.haze.glass.GlassStyleDsl public final class GlassStyleScope {
     method public void alpha(float alpha);
     method public void ambientResponse(float response);
+    method @KotlinOnly public void backgroundColor(androidx.compose.ui.graphics.Color color);
     method public void chromaMultiplier(float multiplier);
     method public void chromaticAberrationMode(dev.chrisbanes.haze.glass.ChromaticAberrationMode mode);
     method public void chromaticAberrationStrength(float strength);

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/Canvas.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/Canvas.kt
@@ -78,6 +78,16 @@ private inline fun DrawScope.withLayerPaint(
 }
 
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
+internal fun DrawScope.drawInputWithAlpha(
+  context: HazeEffectRuntimeDrawScope,
+  alpha: Float,
+) {
+  withLayerPaint(alpha = alpha, blendMode = BlendMode.SrcOver) {
+    with(context) { this@drawInputWithAlpha.drawInput() }
+  }
+}
+
+@OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
 internal fun DrawScope.createAndDrawScaledContentLayer(
   context: HazeEffectRuntimeDrawScope,
   scaleFactor: Float,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
@@ -166,7 +166,7 @@ internal class FallbackGlassDelegate(
             drawRect(
               color = backgroundColor.copy(alpha = backgroundColor.alpha * alphaMultiplier),
             )
-            with(context) { this@drawBase.drawInput() }
+            this@drawBase.drawInputWithAlpha(context, alphaMultiplier)
           }
           if (tint.alpha > 0f) {
             drawRect(color = tint.copy(alpha = tint.alpha * alphaMultiplier))

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
@@ -153,19 +153,29 @@ internal class FallbackGlassDelegate(
   override fun DrawScope.draw(context: HazeEffectRuntimeDrawScope) {
     val prepared = preparedDraw ?: return
     val style = prepared.style
+    val backgroundColor = style.backgroundColor
     val tint = style.tint
-    if (!tint.isSpecified) return
+    if (!backgroundColor.isSpecified || !tint.isSpecified) return
     if (style.alpha <= 0f) return
     trace(GlassTraceSection.FallbackDraw) {
       val shapePath = prepared.shapePath
 
       fun DrawScope.drawFallback(alphaMultiplier: Float) {
-        if (shapePath != null) {
-          clipPath(shapePath) {
+        fun DrawScope.drawBase() {
+          if (backgroundColor.alpha > 0f) {
+            drawRect(
+              color = backgroundColor.copy(alpha = backgroundColor.alpha * alphaMultiplier),
+            )
+          }
+          if (tint.alpha > 0f) {
             drawRect(color = tint.copy(alpha = tint.alpha * alphaMultiplier))
           }
+        }
+
+        if (shapePath != null) {
+          clipPath(shapePath) { drawBase() }
         } else {
-          drawRect(color = tint.copy(alpha = tint.alpha * alphaMultiplier))
+          drawBase()
         }
 
         // The edge falloff is part of the base material and remains behind child content.

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegate.kt
@@ -166,6 +166,7 @@ internal class FallbackGlassDelegate(
             drawRect(
               color = backgroundColor.copy(alpha = backgroundColor.alpha * alphaMultiplier),
             )
+            with(context) { this@drawBase.drawInput() }
           }
           if (tint.alpha > 0f) {
             drawRect(color = tint.copy(alpha = tint.alpha * alphaMultiplier))

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
@@ -35,6 +35,9 @@ public object GlassDefaults {
   /** Default strength of the ambient lighting response and Fresnel accent, in `0f..1f`. */
   public const val ambientResponse: Float = 0.46f
 
+  /** Default color composited behind captured content before Glass optics are applied. */
+  public val backgroundColor: Color = Color.Transparent
+
   /** Default tint applied to refracted content. */
   public val tint: Color = Color.Transparent
 
@@ -82,6 +85,7 @@ public object GlassDefaults {
   public val style: GlassStyle = GlassStyle {
     interactionLightRadiusFraction(interactionLightRadiusFraction)
     interactionPositionAnimationSpec(positionAnimationSpec)
+    backgroundColor(backgroundColor)
     tint(tint)
     shape(shape)
     optics(optics)

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDirtyFields.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDirtyFields.kt
@@ -12,7 +12,8 @@ internal object GlassDirtyFields {
   const val Optics: Int = 0b1
   const val SpecularIntensity: Int = Optics shl 1
   const val AmbientResponse: Int = SpecularIntensity shl 1
-  const val Tint: Int = AmbientResponse shl 1
+  const val BackgroundColor: Int = AmbientResponse shl 1
+  const val Tint: Int = BackgroundColor shl 1
   const val EdgeSoftness: Int = Tint shl 1
   const val LightPosition: Int = EdgeSoftness shl 1
   const val ChromaticAberration: Int = LightPosition shl 1
@@ -35,6 +36,7 @@ internal object GlassDirtyFields {
     Optics or
       SpecularIntensity or
       AmbientResponse or
+      BackgroundColor or
       Tint or
       EdgeSoftness or
       LightPosition or
@@ -66,6 +68,7 @@ internal object GlassDirtyFields {
       if (Optics in dirtyTracker) add("Optics")
       if (SpecularIntensity in dirtyTracker) add("SpecularIntensity")
       if (AmbientResponse in dirtyTracker) add("AmbientResponse")
+      if (BackgroundColor in dirtyTracker) add("BackgroundColor")
       if (Tint in dirtyTracker) add("Tint")
       if (EdgeSoftness in dirtyTracker) add("EdgeSoftness")
       if (LightPosition in dirtyTracker) add("LightPosition")

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -317,6 +317,7 @@ internal data class GlassRenderParams(
   val specularIntensity: Float,
   val depth: Float,
   val ambientResponse: Float,
+  val backgroundColor: Color,
   val tint: Color,
   val edgeSoftnessPx: Float,
   val blurRadiusPx: Float,
@@ -548,6 +549,7 @@ internal data class ResolvedGlassStyle(
   val resolvedOptics: ResolvedGlassOptics,
   val specularIntensity: Float,
   val ambientResponse: Float,
+  val backgroundColor: Color,
   val tint: Color,
   val edgeSoftnessPx: Float,
   val lightPosition: Offset,
@@ -592,6 +594,7 @@ internal fun resolveGlassStyle(
     resolvedOptics = resolveGlassOptics(effect.optics, materialSizePx, density, cornerRadii),
     specularIntensity = effect.specularIntensity,
     ambientResponse = effect.ambientResponse,
+    backgroundColor = effect.backgroundColor,
     tint = effect.tint,
     edgeSoftnessPx = with(density) { effect.edgeSoftness.toPx() }
       .finiteOr(defaultEdgeSoftnessPx)
@@ -658,6 +661,7 @@ internal fun buildGlassRenderParams(
     specularIntensity = style.specularIntensity,
     depth = resolvedOptics.depth.finiteOr(0f).coerceIn(0f, 1f),
     ambientResponse = style.ambientResponse,
+    backgroundColor = style.backgroundColor,
     tint = style.tint,
     edgeSoftnessPx = style.edgeSoftnessPx * scaleFactor,
     blurRadiusPx = blurRadiusPx,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
@@ -89,6 +89,7 @@ private fun ResolvedGlassStyle.hasSameRenderParams(other: ResolvedGlassStyle): B
   resolvedOptics == other.resolvedOptics &&
     specularIntensity == other.specularIntensity &&
     ambientResponse == other.ambientResponse &&
+    backgroundColor == other.backgroundColor &&
     tint == other.tint &&
     edgeSoftnessPx == other.edgeSoftnessPx &&
     lightPosition == other.lightPosition &&

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeState.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeState.kt
@@ -280,6 +280,29 @@ internal abstract class GlassRuntimeState {
     }
 
   /**
+   * Color composited behind captured content before Glass optics are applied.
+   *
+   * There are precedence rules to how this styling property is applied:
+   *
+   *  - This property value, if specified.
+   *  - [GlassStyleScope.backgroundColor] value set in [style], if specified.
+   *  - [GlassStyleScope.backgroundColor] value set in [LocalGlassStyle], if specified.
+   */
+  internal var _backgroundColor: Color = Color.Unspecified
+  internal var backgroundColor: Color
+    get() = _backgroundColor
+      .takeOrElse { inheritedStyleValues.backgroundColor }
+    set(value) {
+      if (_backgroundColor != value) {
+        HazeLogger.d(TAG) {
+          "backgroundColor changed. Current: $_backgroundColor. New: $value"
+        }
+        _backgroundColor = value
+        markDirty(GlassDirtyFields.BackgroundColor)
+      }
+    }
+
+  /**
    * Glass tint applied to the refracted content.
    *
    * There are precedence rules to how this styling property is applied:
@@ -656,6 +679,9 @@ internal abstract class GlassRuntimeState {
     }
     if (old.fresnelExponent != new.fresnelExponent) {
       markDirty(GlassDirtyFields.FresnelExponent)
+    }
+    if (old.backgroundColor != new.backgroundColor) {
+      markDirty(GlassDirtyFields.BackgroundColor)
     }
     if (old.tint != new.tint) {
       markDirty(GlassDirtyFields.Tint)

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStageInvalidation.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStageInvalidation.kt
@@ -5,6 +5,7 @@ package dev.chrisbanes.haze.glass
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import dev.chrisbanes.haze.HazeEffectInputSnapshot
 import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
 
@@ -81,19 +82,22 @@ internal class GlassRuntimeSourceSnapshot(
   val layerSize: Size,
   val layerOffset: Offset,
   val inputSnapshot: HazeEffectInputSnapshot,
+  val backgroundColor: Color = Color.Transparent,
 ) {
   override fun equals(other: Any?): Boolean =
     other is GlassRuntimeSourceSnapshot &&
       captureScale == other.captureScale &&
       layerSize == other.layerSize &&
       layerOffset == other.layerOffset &&
-      inputSnapshot == other.inputSnapshot
+      inputSnapshot == other.inputSnapshot &&
+      backgroundColor == other.backgroundColor
 
   override fun hashCode(): Int {
     var result = captureScale.hashCode()
     result = 31 * result + layerSize.hashCode()
     result = 31 * result + layerOffset.hashCode()
-    return 31 * result + inputSnapshot.hashCode()
+    result = 31 * result + inputSnapshot.hashCode()
+    return 31 * result + backgroundColor.hashCode()
   }
 }
 
@@ -104,6 +108,7 @@ internal data class GlassRuntimeSourceState(
 
 internal fun HazeEffectRuntimeDrawScope.resolveGlassRuntimeSourceState(
   captureScale: Float,
+  backgroundColor: Color,
   previousSnapshot: GlassRuntimeSourceSnapshot? = null,
 ): GlassRuntimeSourceState = resolveGlassRuntimeSourceState(
   captureScale = captureScale,
@@ -111,6 +116,7 @@ internal fun HazeEffectRuntimeDrawScope.resolveGlassRuntimeSourceState(
   layerOffset = layerOffset,
   hasDrawableInput = hasDrawableInput,
   inputSnapshot = inputSnapshot,
+  backgroundColor = backgroundColor,
   previousSnapshot = previousSnapshot,
 )
 
@@ -120,6 +126,7 @@ internal fun resolveGlassRuntimeSourceState(
   layerOffset: Offset,
   hasDrawableInput: Boolean,
   inputSnapshot: HazeEffectInputSnapshot?,
+  backgroundColor: Color = Color.Transparent,
   previousSnapshot: GlassRuntimeSourceSnapshot? = null,
 ): GlassRuntimeSourceState {
   if (!hasDrawableInput) return GlassRuntimeSourceState(false, null)
@@ -129,6 +136,7 @@ internal fun resolveGlassRuntimeSourceState(
     layerSize = layerSize,
     layerOffset = layerOffset,
     inputSnapshot = currentInputSnapshot,
+    backgroundColor = backgroundColor,
   )
   return GlassRuntimeSourceState(
     hasDrawableSource = true,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -219,6 +219,12 @@ public class GlassStyleScope internal constructor(
     writes += { ambientResponse = validated }
   }
 
+  /** Sets any specified color, including transparent, composited behind the captured input. */
+  public fun backgroundColor(color: Color) {
+    require(color.isSpecified) { "backgroundColor must be specified" }
+    writes += { backgroundColor = color }
+  }
+
   /** Sets any specified tint, including transparent, applied to refracted content. */
   public fun tint(color: Color) {
     require(color.isSpecified) { "tint must be specified" }
@@ -351,6 +357,7 @@ internal class GlassStyleValues(
   var optics: GlassOptics = GlassDefaults.optics,
   var specularIntensity: Float = GlassDefaults.specularIntensity,
   var ambientResponse: Float = GlassDefaults.ambientResponse,
+  var backgroundColor: Color = GlassDefaults.backgroundColor,
   var tint: Color = GlassDefaults.tint,
   var edgeSoftness: Dp = GlassDefaults.edgeSoftness,
   var lightPosition: Alignment = Alignment.Center,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -410,6 +410,7 @@ internal class RuntimeShaderGlassDelegate(
         )
         val sourceState = context.resolveGlassRuntimeSourceState(
           captureScale = params.coordinates.scaleFactor,
+          backgroundColor = params.backgroundColor,
           previousSnapshot = lastSuccessfulSourceSnapshot,
         )
         val shouldRecordSource = sourceState.hasDrawableSource && (
@@ -994,7 +995,7 @@ internal class RuntimeShaderGlassDelegate(
       layerSize = context.layerSize,
       layerOffset = context.layerOffset,
       existingLayer = layers.source,
-      backgroundColor = Color.Transparent,
+      backgroundColor = params.backgroundColor,
     )?.also {
       layers.source = it
       sourceRecordCount++

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -413,6 +413,13 @@ internal class RuntimeShaderGlassDelegate(
           backgroundColor = params.backgroundColor,
           previousSnapshot = lastSuccessfulSourceSnapshot,
         )
+        if (
+          !sourceState.hasDrawableSource &&
+          lastSuccessfulSourceSnapshot?.backgroundColor != params.backgroundColor
+        ) {
+          clearRetainedOutput()
+          return
+        }
         val shouldRecordSource = sourceState.hasDrawableSource && (
           sourceState.snapshot == null ||
             sourceState.snapshot != lastSuccessfulSourceSnapshot ||

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectKeysTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectKeysTest.kt
@@ -317,6 +317,7 @@ class GlassRenderEffectKeysTest {
     specularIntensity = 0.5f,
     depth = 1f,
     ambientResponse = 0.5f,
+    backgroundColor = Color.Transparent,
     tint = Color.Transparent,
     edgeSoftnessPx = 4f,
     blurRadiusPx = 20f,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderParamsTest.kt
@@ -1384,6 +1384,7 @@ class GlassRenderParamsTest {
     specularIntensity = 1f,
     depth = depth,
     ambientResponse = 1f,
+    backgroundColor = GlassDefaults.backgroundColor,
     tint = GlassDefaults.tint,
     edgeSoftnessPx = 1f,
     blurRadiusPx = blurRadiusPx,

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStageInvalidationTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStageInvalidationTest.kt
@@ -5,6 +5,7 @@ package dev.chrisbanes.haze.glass
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
@@ -323,6 +324,7 @@ class GlassStageInvalidationTest {
     assertThat(snapshot(layerSize = Size(120f, 80f))).isNotEqualTo(base)
     assertThat(snapshot(layerOffset = Offset(8f, 2f))).isNotEqualTo(base)
     assertThat(snapshot(inputSnapshot = TestInputSnapshot(2))).isNotEqualTo(base)
+    assertThat(snapshot(backgroundColor = Color.White)).isNotEqualTo(base)
   }
 
   @Test
@@ -377,12 +379,14 @@ class GlassStageInvalidationTest {
     layerSize: Size = Size(100f, 80f),
     layerOffset: Offset = Offset.Zero,
     inputSnapshot: HazeEffectInputSnapshot = TestInputSnapshot(1),
+    backgroundColor: Color = Color.Transparent,
   ) = resolveGlassRuntimeSourceState(
     captureScale = captureScale,
     layerSize = layerSize,
     layerOffset = layerOffset,
     hasDrawableInput = true,
     inputSnapshot = inputSnapshot,
+    backgroundColor = backgroundColor,
   ).snapshot!!
 
   private data class TestInputSnapshot(val value: Int) : HazeEffectInputSnapshot

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassStyleTest.kt
@@ -337,9 +337,11 @@ class GlassStyleTest {
   @Test
   fun styleChain_appliesWritesInOrder() {
     val style = GlassStyle {
+      backgroundColor(Color.Red)
       tint(Color.Red)
       alpha(0.25f)
     }.then {
+      backgroundColor(Color.Green)
       tint(Color.Blue)
       alpha(0.75f)
     }
@@ -349,6 +351,7 @@ class GlassStyleTest {
       explicitStyle = style,
     )
 
+    assertThat(resolved.backgroundColor).isEqualTo(Color.Green)
     assertThat(resolved.tint).isEqualTo(Color.Blue)
     assertThat(resolved.alpha).isEqualTo(0.75f)
   }
@@ -485,11 +488,20 @@ class GlassStyleTest {
   }
 
   @Test
+  fun backgroundColor_rejectsUnspecifiedAtConstruction() {
+    assertFailure { GlassStyle { backgroundColor(Color.Unspecified) } }.apply {
+      isInstanceOf<IllegalArgumentException>()
+      hasMessage("backgroundColor must be specified")
+    }
+  }
+
+  @Test
   fun defaults_constructThroughTheValidatedStyleSurface() {
     val values = resolveGlassStyleValues(GlassStyle, GlassDefaults.style)
 
     assertThat(values.specularIntensity).isEqualTo(GlassDefaults.specularIntensity)
     assertThat(values.ambientResponse).isEqualTo(GlassDefaults.ambientResponse)
+    assertThat(values.backgroundColor).isEqualTo(GlassDefaults.backgroundColor)
     assertThat(values.tint).isEqualTo(GlassDefaults.tint)
     assertThat(values.edgeSoftness).isEqualTo(GlassDefaults.edgeSoftness)
     assertThat(values.chromaticAberrationStrength)

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -217,6 +218,31 @@ class FallbackGlassDelegateTest {
   }
 
   @Test
+  fun backgroundColor_compositesBehindCapturedContent() = runComposeUiTest {
+    val effect = GlassRuntimeEffect().apply {
+      backgroundColor = Color.White
+      tint = Color.Transparent
+      specularIntensity = 0f
+      ambientResponse = 0f
+      edgeSoftness = 0.dp
+      shape = RoundedCornerShape(0.dp)
+    }
+    val fallback = FallbackGlassDelegate(effect)
+    val visualEffect = FallbackOnlyVisualEffect(effect, fallback)
+
+    setContent {
+      FallbackTestContent(visualEffect) {
+        Box(Modifier.size(40.dp).background(Color.Red))
+      }
+    }
+    waitForIdle()
+
+    val pixels = onNodeWithTag(FALLBACK_TAG).captureToImage().toPixelMap()
+    assertThat(pixels[60, 60]).isEqualTo(Color.Red)
+    assertThat(pixels[10, 10]).isEqualTo(Color.White)
+  }
+
+  @Test
   fun foregroundLighting_drawsOverOpaqueContent() {
     val effect = GlassRuntimeEffect().apply {
       tint = Color.Transparent
@@ -350,7 +376,10 @@ class FallbackGlassDelegateTest {
   }
 
   @Composable
-  private fun FallbackTestContent(fallbackVisualEffect: FallbackOnlyVisualEffect) {
+  private fun FallbackTestContent(
+    fallbackVisualEffect: FallbackOnlyVisualEffect,
+    content: @Composable () -> Unit = {},
+  ) {
     val factory = remember(fallbackVisualEffect) {
       HazeEffectFactory<Unit> { fallbackVisualEffect }
     }
@@ -364,7 +393,10 @@ class FallbackGlassDelegateTest {
           style = Unit,
           sampling = HazeSampling.FullResolution,
         ),
-    )
+      contentAlignment = Alignment.Center,
+    ) {
+      content()
+    }
   }
 }
 

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
@@ -171,6 +171,15 @@ class FallbackGlassDelegateTest {
 
     assertDirectAlphaHalvesContribution(
       effect = GlassRuntimeEffect().apply {
+        backgroundColor = Color.Red
+        tint = Color.Transparent
+        specularIntensity = 0f
+        edgeSoftness = 0.dp
+      },
+      sample = Offset(60f, 60f),
+    )
+    assertDirectAlphaHalvesContribution(
+      effect = GlassRuntimeEffect().apply {
         tint = Color.Red
         specularIntensity = 0f
         edgeSoftness = 0.dp

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/FallbackGlassDelegateTest.kt
@@ -243,6 +243,34 @@ class FallbackGlassDelegateTest {
   }
 
   @Test
+  fun directAlphaDegradation_appliesAlphaToReplayedInput() = runComposeUiTest {
+    val effect = GlassRuntimeEffect().apply {
+      backgroundColor = Color.White
+      tint = Color.Transparent
+      specularIntensity = 0f
+      ambientResponse = 0f
+      edgeSoftness = 0.dp
+      shape = RoundedCornerShape(0.dp)
+    }
+    val fallback = FallbackGlassDelegate(effect)
+    val visualEffect = FallbackOnlyVisualEffect(effect, fallback)
+
+    setContent {
+      FallbackTestContent(visualEffect) {
+        Box(Modifier.size(40.dp).background(Color.Red.copy(alpha = 0.5f)))
+      }
+    }
+    waitForIdle()
+
+    effect.alpha = 0.5f
+    visualEffect.disableGroupPreparation()
+    waitForIdle()
+
+    val pixel = onNodeWithTag(FALLBACK_TAG).captureToImage().toPixelMap()[60, 60]
+    assertThat(pixel.alpha).isLessThan(0.85f)
+  }
+
+  @Test
   fun foregroundLighting_drawsOverOpaqueContent() {
     val effect = GlassRuntimeEffect().apply {
       tint = Color.Transparent

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -590,6 +590,27 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   @Test
+  fun backgroundColorStyleChangeRecordsSource() = runComposeUiTest {
+    val effect = activeDetailEffect()
+    val style = mutableStateOf<GlassStyle>(GlassStyle)
+    setContent { RuntimeGlassTestContent(effect, tag = "glass", style = style.value) }
+    waitForIdle()
+
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
+    val sourceRecordsBeforeChange = delegate.sourceRecordCount
+    val snapshotBeforeChange = checkNotNull(delegate.lastSuccessfulSourceSnapshot)
+
+    style.value = GlassStyle { backgroundColor(Color.White) }
+    waitForIdle()
+
+    assertThat(delegate.sourceRecordCount).isGreaterThan(sourceRecordsBeforeChange)
+    assertThat(checkNotNull(delegate.lastSuccessfulSourceSnapshot).backgroundColor)
+      .isEqualTo(Color.White)
+    assertThat(checkNotNull(delegate.lastSuccessfulSourceSnapshot))
+      .isNotEqualTo(snapshotBeforeChange)
+  }
+
+  @Test
   fun activeDetail_recordsAndSurvivesRetainedSourceGap() = runComposeUiTest {
     val hazeState = HazeState()
     val showSource = mutableStateOf(true)
@@ -918,6 +939,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     effect: GlassRuntimeEffect,
     input: HazeInput = HazeInput.Content,
     sampling: HazeSampling = HazeSampling.FullResolution,
+    style: GlassStyle = effect.style,
   ): Modifier = hazeGlass(
     factory = rendererFactories.getOrPut(effect) {
       HazeEffectFactory {
@@ -925,7 +947,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
       }
     },
     input = input,
-    style = effect.style,
+    style = style,
     sampling = sampling,
     expandLayerBounds = true,
     interactionSource = effect.interactionSource,
@@ -980,6 +1002,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     effect: GlassRuntimeEffect,
     tag: String,
     sampling: HazeSampling = HazeSampling.FullResolution,
+    style: GlassStyle = effect.style,
   ) {
     val hazeState = remember { HazeState() }
     Box(Modifier.size(120.dp)) {
@@ -992,6 +1015,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
             effect = effect,
             input = HazeInput.Sources(hazeState),
             sampling = sampling,
+            style = style,
           ),
       )
     }

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -611,6 +611,56 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   @Test
+  fun backgroundColorStyleChangeDuringSourceGapClearsRetainedOutput() = runComposeUiTest {
+    val hazeState = HazeState()
+    val showSource = mutableStateOf(true)
+    val style = mutableStateOf(GlassStyle { backgroundColor(Color.Red) })
+    val effect = activeDetailEffect()
+
+    setContent {
+      Box(Modifier.size(120.dp)) {
+        if (showSource.value) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .background(Color.Red)
+              .hazeSource(hazeState),
+          )
+        }
+        Box(
+          Modifier
+            .fillMaxSize()
+            .testGlass(
+              effect = effect,
+              input = HazeInput.Sources(hazeState),
+              style = style.value,
+            ),
+        )
+      }
+    }
+
+    waitForIdle()
+    val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
+
+    showSource.value = false
+    waitForIdle()
+    assertThat(delegate.canDrawRetainedOutput()).isTrue()
+
+    style.value = GlassStyle { backgroundColor(Color.Blue) }
+    waitForIdle()
+
+    assertThat(delegate.canDrawRetainedOutput()).isFalse()
+    assertThat(delegate.lastSuccessfulSourceSnapshot).isNull()
+
+    showSource.value = true
+    waitForIdle()
+
+    assertThat(delegate.canDrawRetainedOutput()).isTrue()
+    assertThat(checkNotNull(delegate.lastSuccessfulSourceSnapshot).backgroundColor)
+      .isEqualTo(Color.Blue)
+  }
+
+  @Test
   fun activeDetail_recordsAndSurvivesRetainedSourceGap() = runComposeUiTest {
     val hazeState = HazeState()
     val showSource = mutableStateOf(true)

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassDepthAndroidScreenshotTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/GlassDepthAndroidScreenshotTest.kt
@@ -49,6 +49,11 @@ class GlassDepthAndroidScreenshotTest : ScreenshotTest() {
   }
 
   @Test
+  fun glass_backgroundColorBlursTransparentSource() = runScreenshotTest {
+    assertGlassBackgroundColorBlurInvariant()
+  }
+
+  @Test
   fun glass_refractionDetailPreservesSharpSource() = runScreenshotTest {
     assertGlassRefractionDetailPreservesSharpSourceInvariant()
   }

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInvariantSample.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/GlassInvariantSample.kt
@@ -48,6 +48,7 @@ import assertk.assertions.isTrue
 import dev.chrisbanes.haze.glass.GlassDefaults
 import dev.chrisbanes.haze.glass.GlassOptics
 import dev.chrisbanes.haze.glass.GlassReducedMotionPolicy
+import dev.chrisbanes.haze.glass.GlassStyle
 import dev.chrisbanes.haze.glass.SurfaceProfile
 import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.test.ScreenshotTheme
@@ -594,6 +595,56 @@ internal fun ScreenshotUiTest.assertGlassBlurInvariant() {
   setContent {
     ScreenshotTheme {
       GlassInvariantSample(effect, HazeSampling.FullResolution, shape)
+    }
+  }
+
+  val sharp = captureInvariantSnapshot()
+  effect.updateFixedOptics { copy(blurRadius = 32.dp) }
+  waitForIdle()
+  val blurred = captureInvariantSnapshot()
+
+  assertBlurReducesHighFrequencyEnergy(sharp, blurred, sharp.invariantGeometry().interiorBounds)
+}
+
+internal fun ScreenshotUiTest.assertGlassBackgroundColorBlurInvariant() {
+  val effect = GlassTestConfiguration().apply {
+    style = GlassStyle { backgroundColor(Color.White) }
+    optics = GlassOptics.Fixed(refractionStrength = 0f, depth = 1f, blurRadius = 0.dp)
+    tint = Color.Transparent
+    specularIntensity = 0f
+    ambientResponse = 0f
+    edgeSoftness = 0.dp
+    shape = RoundedCornerShape(0.dp)
+  }
+  setContent {
+    ScreenshotTheme {
+      val hazeState = rememberHazeState()
+      Box(Modifier.fillMaxSize().background(Color.White)) {
+        Canvas(
+          Modifier
+            .align(Alignment.Center)
+            .size(280.dp, 180.dp)
+            .hazeSource(hazeState),
+        ) {
+          for (x in 0 until size.width.toInt() step 12) {
+            drawRect(
+              color = Color.Black,
+              topLeft = Offset(x.toFloat(), 0f),
+              size = Size(6f, size.height),
+            )
+          }
+        }
+        Box(
+          Modifier
+            .align(Alignment.Center)
+            .size(280.dp, 180.dp)
+            .hazeGlass(
+              input = HazeInput.Sources(hazeState),
+              configuration = effect,
+              sampling = HazeSampling.FullResolution,
+            ),
+        )
+      }
     }
   }
 

--- a/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/GlassDepthDesktopScreenshotTest.kt
+++ b/haze-screenshot-tests/src/jvmTest/kotlin/dev/chrisbanes/haze/GlassDepthDesktopScreenshotTest.kt
@@ -40,6 +40,11 @@ class GlassDepthDesktopScreenshotTest : ScreenshotTest() {
   }
 
   @Test
+  fun glass_backgroundColorBlursTransparentSource() = runScreenshotTest {
+    assertGlassBackgroundColorBlurInvariant()
+  }
+
+  @Test
   fun glass_refractionDetailPreservesSharpSource() = runScreenshotTest {
     assertGlassRefractionDetailPreservesSharpSourceInvariant()
   }


### PR DESCRIPTION
## Summary

- add a configurable background color to the Glass style scope
- use that color when capturing transparent sources and in the fallback renderer
- add regression coverage, documentation, API tracking, and changelog notes

## Why

Transparent source content previously blurred against transparent pixels, producing incorrect or missing blur output. The new background color is applied before blur while preserving the existing transparent default.

## Validation

- :haze-glass:jvmTest
- :haze-glass:testAndroidHostTest
- :haze-glass:metalavaCheckCompatibility
- targeted desktop and Android transparent-source screenshot tests
- Spotless checks
- git diff --check

Fixes #1207