### PR TITLE
Improve snapshot documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ site/
 docs/api
 docs/sample
 docs/changelog.md
+docs/javascripts/snapshot-metadata.xml
 
 # Ignore baseline profile files in samples
 sample/**/generated

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,4 +68,3 @@ limitations under the License.
 ```
 
 [compose]: https://developer.android.com/jetpack/compose
-[snap]: https://oss.sonatype.org/content/repositories/snapshots/dev/chrisbanes/haze/

--- a/docs/javascripts/snapshot-version.js
+++ b/docs/javascripts/snapshot-version.js
@@ -1,0 +1,36 @@
+(() => {
+  const scriptUrl = document.currentScript?.src
+  if (scriptUrl == null) return
+
+  const versionElements = document.querySelectorAll("[data-haze-snapshot-version]")
+  if (versionElements.length === 0) return
+
+  const metadataUrl = new URL("snapshot-metadata.xml", scriptUrl)
+
+  async function displaySnapshotVersion() {
+    try {
+      const response = await fetch(metadataUrl, { cache: "no-cache" })
+      if (!response.ok) return
+
+      const metadata = new DOMParser().parseFromString(
+        await response.text(),
+        "application/xml",
+      )
+      if (metadata.querySelector("parsererror") != null) return
+
+      const version = metadata.querySelector("metadata > versioning > latest")?.textContent?.trim()
+      if (version == null || !/^[0-9A-Za-z][0-9A-Za-z._+-]*-SNAPSHOT$/.test(version)) return
+
+      versionElements.forEach((element) => {
+        element.textContent = version
+      })
+      document.querySelectorAll("[data-haze-snapshot-version-container]").forEach((element) => {
+        element.hidden = false
+      })
+    } catch {
+      // The static metadata link remains available if the generated file cannot be read.
+    }
+  }
+
+  void displaySnapshotVersion()
+})()

--- a/docs/using-snapshot-version.md
+++ b/docs/using-snapshot-version.md
@@ -2,6 +2,11 @@
 
 If you would like to depend on the cutting edge version of the library, you can use the [snapshot versions][snap] that are published to
 [Sonatype Central Repository](https://central.sonatype.org/)'s snapshot repository. These are updated on every commit to `main`.
+All Haze artifacts from a snapshot build use the same version.
+
+<p data-haze-snapshot-version-container hidden aria-live="polite">
+  Current snapshot version: <code data-haze-snapshot-version></code>
+</p>
 
 To do so:
 
@@ -12,13 +17,16 @@ repositories {
 }
 
 dependencies {
-    // Check the latest SNAPSHOT version from the link above
+    // Replace XXX-SNAPSHOT with the latest version from the metadata link above.
     // Core infrastructure (required)
     implementation("dev.chrisbanes.haze:haze:XXX-SNAPSHOT")
 
     // For blur effects (most users will need this)
     implementation("dev.chrisbanes.haze:haze-blur:XXX-SNAPSHOT")
+
+    // For Glass effects
+    implementation("dev.chrisbanes.haze:haze-glass:XXX-SNAPSHOT")
 }
 ```
 
- [snap]: https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/dev/chrisbanes/haze/haze/
+[snap]: https://central.sonatype.com/repository/maven-snapshots/dev/chrisbanes/haze/haze/maven-metadata.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,9 @@ extra:
     provider: mike
     alias: true
 
+extra_javascript:
+  - javascripts/snapshot-version.js
+
 validation:
   unrecognized_links: warn
   anchors: warn

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 ./gradlew \
+    --no-scan \
     :internal:dokka:dokkaGenerate \
     :sample:web:wasmJsBrowserDistribution \
     :sample:web:jsBrowserDistribution
@@ -14,5 +15,23 @@ cp -r sample/web/build/dist/wasmJs/productionExecutable/ docs/sample/wasm/
 cp -r sample/web/build/dist/js/productionExecutable/ docs/sample/js/
 
 cp CHANGELOG.md docs/changelog.md
+
+snapshot_version="$(sed -n 's/^VERSION_NAME=//p' gradle.properties)"
+case "$snapshot_version" in
+  ''|*[!0-9A-Za-z._+-]*)
+    echo "Invalid VERSION_NAME: $snapshot_version"
+    exit 1
+    ;;
+esac
+
+mkdir -p docs/javascripts
+printf '%s\n' \
+  '<?xml version="1.0" encoding="UTF-8"?>' \
+  '<metadata>' \
+  '  <versioning>' \
+  "    <latest>$snapshot_version</latest>" \
+  '  </versioning>' \
+  '</metadata>' \
+  > docs/javascripts/snapshot-metadata.xml
 
 mkdocs $@


### PR DESCRIPTION
## Summary

- document the `haze-glass` snapshot dependency and link to Maven metadata
- display the current snapshot version from build-generated, same-origin XML
- disable Build Scans in the documentation build

## Why

Sonatype's metadata endpoint does not allow browser cross-origin reads, and the snapshot guide omitted the Glass dependency. The documentation build now emits metadata that the site can read directly.

## Validation

- `./scripts/build_docs.sh build`
- `node --check docs/javascripts/snapshot-version.js`
- `sh -n scripts/build_docs.sh`
- `git diff --check`