### PR TITLE
Fetch published snapshot metadata

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,7 +6,17 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - '**.md'
+      - 'docs/**'
   pull_request:
+  workflow_run:
+    workflows:
+      - Build
+    types:
+      - completed
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:
@@ -34,12 +44,15 @@ permissions:
 
 jobs:
   build_docs:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: macos-26
     env:
       DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup JDK
         uses: actions/setup-java@v5
@@ -77,7 +90,7 @@ jobs:
   deploy_docs:
     runs-on: macos-26
     needs: build_docs
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_run' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -86,6 +99,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -23,4 +23,4 @@ curl --fail --location --silent --show-error \
   --output docs/javascripts/snapshot-metadata.xml \
   https://central.sonatype.com/repository/maven-snapshots/dev/chrisbanes/haze/haze/maven-metadata.xml
 
-mkdocs $@
+mkdocs "$@"

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -eu
+
 ./gradlew \
     --no-scan \
     :internal:dokka:dokkaGenerate \
@@ -16,22 +18,9 @@ cp -r sample/web/build/dist/js/productionExecutable/ docs/sample/js/
 
 cp CHANGELOG.md docs/changelog.md
 
-snapshot_version="$(sed -n 's/^VERSION_NAME=//p' gradle.properties)"
-case "$snapshot_version" in
-  ''|*[!0-9A-Za-z._+-]*)
-    echo "Invalid VERSION_NAME: $snapshot_version"
-    exit 1
-    ;;
-esac
-
 mkdir -p docs/javascripts
-printf '%s\n' \
-  '<?xml version="1.0" encoding="UTF-8"?>' \
-  '<metadata>' \
-  '  <versioning>' \
-  "    <latest>$snapshot_version</latest>" \
-  '  </versioning>' \
-  '</metadata>' \
-  > docs/javascripts/snapshot-metadata.xml
+curl --fail --location --silent --show-error \
+  --output docs/javascripts/snapshot-metadata.xml \
+  https://central.sonatype.com/repository/maven-snapshots/dev/chrisbanes/haze/haze/maven-metadata.xml
 
 mkdocs $@


### PR DESCRIPTION
## Summary

- fetch the published Haze snapshot metadata when building the documentation site
- make the docs build fail fast when generation or metadata retrieval fails

## Why

Follow-up to #1213. Release documentation previously embedded its tagged, non-snapshot version, so the snapshot-version display was hidden on the `latest` site. The generated same-origin XML now always reflects the published snapshot repository.

## Validation

- `./scripts/build_docs.sh build`
- `sh -n scripts/build_docs.sh`
- `node --check docs/javascripts/snapshot-version.js`
- `git diff --check`