### PR TITLE
Add Material 3 style factories

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,9 @@ No renderer or lifecycle object can be shared between Glass nodes.
 - **haze** — core state, source capture, and typed custom-effect orchestration
 - **haze-blur** — blur effect implementation
 - **haze-blur-materials** — reusable blur presets
+- **haze-blur-material3** — optional Compose Material 3 Blur Style factory
 - **haze-glass** — Glass effect implementation
+- **haze-glass-material3** — optional Compose Material 3 Glass Style factory
 - **haze-utils** — shared platform rendering utilities
 
 Effect modules can keep platform-specific renderer internals behind their own `expect`/`actual`

--- a/docs/blur/index.md
+++ b/docs/blur/index.md
@@ -71,7 +71,8 @@ The appearance of the blur effect is controlled through the [HazeBlurStyle](../a
 - **Tint**: Applies a color overlay for contrast
 - **Noise**: Adds visual texture
 
-Pre-built styles are available in the [materials](materials.md) guide.
+Opinionated pre-built styles are available in the [material presets](materials.md) guide. To adapt
+the current Compose Material 3 theme into a Blur Style, see the [Material 3 integration](material3.md).
 
 ## Performance
 
@@ -80,5 +81,6 @@ Blur can be a resource-intensive effect. See the [Performance](../performance.md
 ## Next Steps
 
 - [Blur Usage Guide](usage.md) - Comprehensive usage patterns and features
-- [Materials](materials.md) - Pre-built blur styles
+- [Material presets](materials.md) - Opinionated pre-built Blur Styles
+- [Material 3 integration](material3.md) - Adapt a Compose Material 3 theme into a Blur Style
 - [Performance Tips](../performance.md) - Optimization techniques

--- a/docs/blur/material3.md
+++ b/docs/blur/material3.md
@@ -1,0 +1,32 @@
+# Material 3 integration
+
+The `haze-blur-material3` artifact adapts the current Compose Material 3 theme into a Blur Style.
+It is a theme integration rather than a catalog of opinionated material presets; for those, see
+[Blur material presets](materials.md).
+
+```kotlin
+dependencies {
+  implementation("dev.chrisbanes.haze:haze-blur-material3:<version>")
+}
+```
+
+`HazeBlurStyle.Material3()` uses `MaterialTheme.colorScheme.surface` as its default container
+color. Pass `containerColor` to use a different color. When supplied, its block runs afterward, so
+a one-off Style can override that background without adding an implicit color effect:
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Sources(hazeState),
+  style = HazeBlurStyle.Material3 {
+    blurRadius(12.dp)
+  },
+)
+```
+
+Use the returned Style with `LocalHazeBlurStyle` to provide a Material 3 background to a subtree:
+
+```kotlin
+CompositionLocalProvider(LocalHazeBlurStyle provides HazeBlurStyle.Material3()) {
+  // Blur modifiers in this subtree inherit the Material 3 surface background.
+}
+```

--- a/docs/blur/materials.md
+++ b/docs/blur/materials.md
@@ -1,12 +1,16 @@
-# Blur materials
+# Blur material presets
 
-The `haze-blur-materials` artifact provides replayable Blur Styles for common design systems:
+The `haze-blur-materials` artifact provides opinionated, replayable Blur Style presets for Haze,
+Cupertino, and Fluent designs:
 
 ```kotlin
 dependencies {
   implementation("dev.chrisbanes.haze:haze-blur-materials:<version>")
 }
 ```
+
+For a minimal Style that follows the current Compose Material 3 theme, use the separate
+[Material 3 integration](material3.md).
 
 ## Material
 

--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -20,6 +20,40 @@ dependencies {
 For unreleased changes, follow the [snapshot build instructions](../using-snapshot-version.md) and
 use the same snapshot version for both artifacts.
 
+### Material 3
+
+Add the optional Material 3 integration when a Glass surface should use the current theme surface
+color:
+
+```kotlin
+dependencies {
+  implementation("dev.chrisbanes.haze:haze-glass-material3:<version>")
+}
+```
+
+`GlassStyle.Material3()` uses `MaterialTheme.colorScheme.surface` as its default container color.
+Pass `containerColor` to use a different color. Supply a replacement Style through recomposition
+when the theme changes. It deliberately leaves the tint unset unless you pass one, so it never
+derives a tint from `LocalContentColor`.
+
+```kotlin
+Modifier.hazeGlass(
+  input = HazeInput.Sources(hazeState),
+  style = GlassStyle.Material3(tint = Color.White.copy(alpha = 0.16f)) {
+    optics(refractionStrength = 0.8f)
+  },
+)
+```
+
+The factory writes its container color and optional tint before its block, allowing the block to
+override either value. It also works as a subtree default:
+
+```kotlin
+CompositionLocalProvider(LocalGlassStyle provides GlassStyle.Material3()) {
+  // Glass modifiers in this subtree inherit the Material 3 surface background.
+}
+```
+
 ### Built-in material
 
 Start with the default `GlassOptics.Adaptive` material. It adjusts to the surface's size and shape,

--- a/haze-blur-material3/api/api.txt
+++ b/haze-blur-material3/api/api.txt
@@ -1,0 +1,9 @@
+// Signature format: 4.0
+package dev.chrisbanes.haze.blur.material3 {
+
+  public final class BlurMaterial3Kt {
+    method @KotlinOnly @androidx.compose.runtime.Composable public static dev.chrisbanes.haze.blur.HazeBlurStyle Material3(dev.chrisbanes.haze.blur.HazeBlurStyle.Companion, optional androidx.compose.ui.graphics.Color containerColor);
+    method @KotlinOnly @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable public static dev.chrisbanes.haze.blur.HazeBlurStyle Material3(dev.chrisbanes.haze.blur.HazeBlurStyle.Companion, optional androidx.compose.ui.graphics.Color containerColor, kotlin.jvm.functions.Function1<dev.chrisbanes.haze.blur.HazeBlurStyleScope,kotlin.Unit> block);
+  }
+
+}

--- a/haze-blur-material3/build.gradle.kts
+++ b/haze-blur-material3/build.gradle.kts
@@ -1,0 +1,49 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+
+import dev.chrisbanes.gradle.addDefaultHazeTargets
+
+plugins {
+  id("dev.chrisbanes.android.library")
+  id("dev.chrisbanes.kotlin.multiplatform")
+  id("dev.chrisbanes.compose")
+  id("org.jetbrains.dokka")
+  id("com.vanniktech.maven.publish")
+  id("dev.chrisbanes.metalava")
+}
+
+kotlin {
+  android {
+    namespace = "dev.chrisbanes.haze.blur.material3"
+
+    withHostTest {}
+  }
+
+  addDefaultHazeTargets(project)
+  explicitApi()
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.hazeBlur)
+        implementation(libs.compose.material3)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(kotlin("test"))
+        implementation(libs.assertk)
+        implementation(libs.compose.ui.test)
+        implementation(projects.internal.contextTest)
+      }
+    }
+
+    jvmTest {
+      dependencies {
+        implementation(compose.desktop.currentOs)
+      }
+    }
+  }
+}

--- a/haze-blur-material3/gradle.properties
+++ b/haze-blur-material3/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=haze-blur-material3
+POM_NAME=Haze Blur Material 3

--- a/haze-blur-material3/src/commonMain/kotlin/dev/chrisbanes/haze/blur/material3/BlurMaterial3.kt
+++ b/haze-blur-material3/src/commonMain/kotlin/dev/chrisbanes/haze/blur/material3/BlurMaterial3.kt
@@ -1,0 +1,42 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur.material3
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.HazeBlurStyleScope
+
+/**
+ * Creates a Blur Style with a Material 3 surface background.
+ *
+ * The default [containerColor] comes from the current [MaterialTheme]. The returned Style is
+ * reused while that color is unchanged.
+ */
+@Composable
+public fun HazeBlurStyle.Companion.Material3(
+  containerColor: Color = MaterialTheme.colorScheme.surface,
+): HazeBlurStyle = remember(containerColor) {
+  HazeBlurStyle { backgroundColor(containerColor) }
+}
+
+/**
+ * Creates a Blur Style with a Material 3 surface background and additional Style writes.
+ *
+ * The default [containerColor] comes from the current [MaterialTheme]. The supplied color is
+ * recorded before [block], so the block can override it without changing unrelated inherited
+ * Style writes.
+ */
+@Composable
+@ReadOnlyComposable
+public fun HazeBlurStyle.Companion.Material3(
+  containerColor: Color = MaterialTheme.colorScheme.surface,
+  block: HazeBlurStyleScope.() -> Unit,
+): HazeBlurStyle = HazeBlurStyle {
+  backgroundColor(containerColor)
+  block()
+}

--- a/haze-blur-material3/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/material3/BlurMaterial3Test.kt
+++ b/haze-blur-material3/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/material3/BlurMaterial3Test.kt
@@ -1,0 +1,126 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur.material3
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSameInstanceAs
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.HazeColorEffect
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
+import dev.chrisbanes.haze.blur.hazeBlur
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class BlurMaterial3Test {
+
+  @Test
+  fun material3_capturesThemeSurfaceAndRecomposesWithReplacementStyle() = runComposeUiTest {
+    val colorScheme = mutableStateOf(lightColorScheme(surface = Color.Red))
+
+    setContent {
+      MaterialTheme(colorScheme = colorScheme.value) {
+        BlurMaterial3Content(HazeBlurStyle.Material3())
+      }
+    }
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Red)
+
+    colorScheme.value = lightColorScheme(surface = Color.Blue)
+    waitForIdle()
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Blue)
+  }
+
+  @Test
+  fun material3_withoutBlockReusesStyleAcrossUnrelatedRecompositions() = runComposeUiTest {
+    val recomposed = mutableStateOf(false)
+    lateinit var initialStyle: HazeBlurStyle
+    lateinit var recomposedStyle: HazeBlurStyle
+
+    setContent {
+      val style = HazeBlurStyle.Material3()
+      val isRecomposed = recomposed.value
+      SideEffect {
+        if (isRecomposed) recomposedStyle = style else initialStyle = style
+      }
+      BlurMaterial3Content(style)
+    }
+
+    recomposed.value = true
+    waitForIdle()
+
+    assertThat(recomposedStyle).isSameInstanceAs(initialStyle)
+  }
+
+  @Test
+  fun material3_explicitAndBlockBackgroundsOverrideThemeSurface() = runComposeUiTest {
+    val blockOverridesBackground = mutableStateOf(false)
+
+    setContent {
+      MaterialTheme(colorScheme = lightColorScheme(surface = Color.Blue)) {
+        BlurMaterial3Content(
+          HazeBlurStyle.Material3(containerColor = Color.Red) {
+            if (blockOverridesBackground.value) backgroundColor(Color.Green)
+          },
+        )
+      }
+    }
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Red)
+
+    blockOverridesBackground.value = true
+    waitForIdle()
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Green)
+  }
+
+  @Test
+  fun material3_preservesCompositionLocalColorEffects() = runComposeUiTest {
+    val localStyle = HazeBlurStyle {
+      colorEffects(listOf(HazeColorEffect.tint(Color.Blue)))
+    }
+
+    setContent {
+      MaterialTheme(colorScheme = lightColorScheme(surface = Color.Red)) {
+        CompositionLocalProvider(LocalHazeBlurStyle provides localStyle) {
+          BlurMaterial3Content(HazeBlurStyle.Material3())
+        }
+      }
+    }
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Blue)
+  }
+}
+
+@Composable
+private fun BlurMaterial3Content(style: HazeBlurStyle) {
+  Box(
+    Modifier
+      .size(40.dp)
+      .testTag("material")
+      .hazeBlur(
+        input = HazeInput.Content,
+        style = style,
+      ),
+  )
+}

--- a/haze-glass-material3/api/api.txt
+++ b/haze-glass-material3/api/api.txt
@@ -1,0 +1,9 @@
+// Signature format: 4.0
+package dev.chrisbanes.haze.glass.material3 {
+
+  public final class GlassMaterial3Kt {
+    method @KotlinOnly @androidx.compose.runtime.Composable @dev.chrisbanes.haze.ExperimentalHazeApi public static dev.chrisbanes.haze.glass.GlassStyle Material3(dev.chrisbanes.haze.glass.GlassStyle.Companion, optional androidx.compose.ui.graphics.Color containerColor, optional androidx.compose.ui.graphics.Color? tint);
+    method @KotlinOnly @androidx.compose.runtime.Composable @androidx.compose.runtime.ReadOnlyComposable @dev.chrisbanes.haze.ExperimentalHazeApi public static dev.chrisbanes.haze.glass.GlassStyle Material3(dev.chrisbanes.haze.glass.GlassStyle.Companion, optional androidx.compose.ui.graphics.Color containerColor, optional androidx.compose.ui.graphics.Color? tint, kotlin.jvm.functions.Function1<dev.chrisbanes.haze.glass.GlassStyleScope,kotlin.Unit> block);
+  }
+
+}

--- a/haze-glass-material3/build.gradle.kts
+++ b/haze-glass-material3/build.gradle.kts
@@ -1,0 +1,53 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+
+import dev.chrisbanes.gradle.addDefaultHazeTargets
+
+plugins {
+  id("dev.chrisbanes.android.library")
+  id("dev.chrisbanes.kotlin.multiplatform")
+  id("dev.chrisbanes.compose")
+  id("org.jetbrains.dokka")
+  id("com.vanniktech.maven.publish")
+  id("dev.chrisbanes.metalava")
+}
+
+kotlin {
+  android {
+    namespace = "dev.chrisbanes.haze.glass.material3"
+
+    withHostTest {}
+  }
+
+  addDefaultHazeTargets(project)
+  explicitApi()
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.hazeGlass)
+        implementation(libs.compose.material3)
+      }
+    }
+
+    commonTest {
+      dependencies {
+        implementation(kotlin("test"))
+        implementation(libs.assertk)
+        implementation(libs.compose.ui.test)
+        implementation(projects.internal.contextTest)
+      }
+    }
+
+    jvmTest {
+      dependencies {
+        implementation(compose.desktop.currentOs)
+      }
+    }
+  }
+
+  compilerOptions {
+    optIn.add("dev.chrisbanes.haze.ExperimentalHazeApi")
+  }
+}

--- a/haze-glass-material3/gradle.properties
+++ b/haze-glass-material3/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=haze-glass-material3
+POM_NAME=Haze Glass Material 3

--- a/haze-glass-material3/src/commonMain/kotlin/dev/chrisbanes/haze/glass/material3/GlassMaterial3.kt
+++ b/haze-glass-material3/src/commonMain/kotlin/dev/chrisbanes/haze/glass/material3/GlassMaterial3.kt
@@ -1,0 +1,53 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass.material3
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.GlassStyleScope
+
+/**
+ * Creates a Glass Style with a Material 3 surface background and optional tint.
+ *
+ * The default [containerColor] comes from the current [MaterialTheme]. A null [tint] omits the
+ * tint write, preserving any inherited tint. The returned Style is reused while [containerColor]
+ * and [tint] are unchanged.
+ */
+@Composable
+@ExperimentalHazeApi
+public fun GlassStyle.Companion.Material3(
+  containerColor: Color = MaterialTheme.colorScheme.surface,
+  tint: Color? = null,
+): GlassStyle = remember(containerColor, tint) {
+  GlassStyle {
+    backgroundColor(containerColor)
+    if (tint != null) tint(tint)
+  }
+}
+
+/**
+ * Creates a Glass Style with a Material 3 surface background, optional tint, and additional
+ * Style writes.
+ *
+ * The default [containerColor] comes from the current [MaterialTheme]. A null [tint] omits the
+ * tint write, preserving any inherited tint. The supplied values are recorded before [block], so
+ * the block can override them without changing unrelated inherited Style writes.
+ */
+@Composable
+@ReadOnlyComposable
+@ExperimentalHazeApi
+public fun GlassStyle.Companion.Material3(
+  containerColor: Color = MaterialTheme.colorScheme.surface,
+  tint: Color? = null,
+  block: GlassStyleScope.() -> Unit,
+): GlassStyle = GlassStyle {
+  backgroundColor(containerColor)
+  if (tint != null) tint(tint)
+  block()
+}

--- a/haze-glass-material3/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/material3/GlassMaterial3Test.kt
+++ b/haze-glass-material3/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/material3/GlassMaterial3Test.kt
@@ -1,0 +1,129 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass.material3
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSameInstanceAs
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.LocalGlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
+import kotlin.test.Test
+
+@OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
+class GlassMaterial3Test {
+
+  @Test
+  fun material3_capturesThemeSurfaceAndRecomposesWithReplacementStyle() = runComposeUiTest {
+    val colorScheme = mutableStateOf(lightColorScheme(surface = Color.Red))
+
+    setContent {
+      MaterialTheme(colorScheme = colorScheme.value) {
+        GlassMaterial3Content(GlassStyle.Material3())
+      }
+    }
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Red)
+
+    colorScheme.value = lightColorScheme(surface = Color.Blue)
+    waitForIdle()
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Blue)
+  }
+
+  @Test
+  fun material3_withoutBlockReusesStyleAcrossUnrelatedRecompositions() = runComposeUiTest {
+    val recomposed = mutableStateOf(false)
+    lateinit var initialStyle: GlassStyle
+    lateinit var recomposedStyle: GlassStyle
+
+    setContent {
+      val style = GlassStyle.Material3()
+      val isRecomposed = recomposed.value
+      SideEffect {
+        if (isRecomposed) recomposedStyle = style else initialStyle = style
+      }
+      GlassMaterial3Content(style)
+    }
+
+    recomposed.value = true
+    waitForIdle()
+
+    assertThat(recomposedStyle).isSameInstanceAs(initialStyle)
+  }
+
+  @Test
+  fun material3_explicitAndBlockWritesOverrideEarlierWrites() = runComposeUiTest {
+    val blockOverridesTint = mutableStateOf(false)
+
+    setContent {
+      MaterialTheme(colorScheme = lightColorScheme(surface = Color.Green)) {
+        GlassMaterial3Content(
+          GlassStyle.Material3(containerColor = Color.Red, tint = Color.Blue) {
+            if (blockOverridesTint.value) tint(Color.Yellow)
+          },
+        )
+      }
+    }
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Blue)
+
+    blockOverridesTint.value = true
+    waitForIdle()
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Yellow)
+  }
+
+  @Test
+  fun material3_nullTintPreservesLocalTintWithoutReadingContentColor() = runComposeUiTest {
+    val localStyle = GlassStyle { tint(Color.Blue) }
+
+    setContent {
+      MaterialTheme(colorScheme = lightColorScheme(surface = Color.Red)) {
+        CompositionLocalProvider(
+          LocalGlassStyle provides localStyle,
+          LocalContentColor provides Color.Green,
+        ) {
+          GlassMaterial3Content(GlassStyle.Material3(tint = null))
+        }
+      }
+    }
+
+    assertThat(onNodeWithTag("material").captureToImage().toPixelMap()[20, 20]).isEqualTo(Color.Blue)
+  }
+}
+
+@OptIn(ExperimentalHazeApi::class)
+@Composable
+private fun GlassMaterial3Content(style: GlassStyle) {
+  Box(
+    Modifier
+      .size(40.dp)
+      .testTag("material")
+      .hazeGlass(
+        input = HazeInput.Content,
+        style = style,
+      ),
+  )
+}

--- a/internal/dokka/build.gradle.kts
+++ b/internal/dokka/build.gradle.kts
@@ -21,7 +21,9 @@ kotlin {
 dependencies {
   dokka(projects.haze)
   dokka(projects.hazeBlur)
+  dokka(projects.hazeBlurMaterial3)
   dokka(projects.hazeGlass)
+  dokka(projects.hazeGlassMaterial3)
   dokka(projects.hazeMaterials)
   dokka(projects.hazeUtils)
 }

--- a/kotlin-js-store/package-lock.json
+++ b/kotlin-js-store/package-lock.json
@@ -12,8 +12,12 @@
         "packages/haze-root-haze-test",
         "packages/haze-root-haze-blur",
         "packages/haze-root-haze-blur-test",
+        "packages/haze-root-haze-blur-material3",
+        "packages/haze-root-haze-blur-material3-test",
         "packages/haze-root-haze-glass",
         "packages/haze-root-haze-glass-test",
+        "packages/haze-root-haze-glass-material3",
+        "packages/haze-root-haze-glass-material3-test",
         "packages/haze-root-haze-materials",
         "packages/haze-root-haze-materials-test",
         "packages/haze-root-haze-utils",
@@ -2393,12 +2397,28 @@
       "resolved": "packages/haze-root-haze-blur",
       "link": true
     },
+    "node_modules/haze-root-haze-blur-material3": {
+      "resolved": "packages/haze-root-haze-blur-material3",
+      "link": true
+    },
+    "node_modules/haze-root-haze-blur-material3-test": {
+      "resolved": "packages/haze-root-haze-blur-material3-test",
+      "link": true
+    },
     "node_modules/haze-root-haze-blur-test": {
       "resolved": "packages/haze-root-haze-blur-test",
       "link": true
     },
     "node_modules/haze-root-haze-glass": {
       "resolved": "packages/haze-root-haze-glass",
+      "link": true
+    },
+    "node_modules/haze-root-haze-glass-material3": {
+      "resolved": "packages/haze-root-haze-glass-material3",
+      "link": true
+    },
+    "node_modules/haze-root-haze-glass-material3-test": {
+      "resolved": "packages/haze-root-haze-glass-material3-test",
       "link": true
     },
     "node_modules/haze-root-haze-glass-test": {
@@ -5454,12 +5474,40 @@
       "version": "0.0.0-unspecified",
       "devDependencies": {}
     },
+    "packages/haze-root-haze-blur-material3": {
+      "version": "0.0.0-unspecified",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
+      "devDependencies": {}
+    },
+    "packages/haze-root-haze-blur-material3-test": {
+      "version": "0.0.0-unspecified",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
+      "devDependencies": {}
+    },
     "packages/haze-root-haze-blur-test": {
       "version": "0.0.0-unspecified",
       "devDependencies": {}
     },
     "packages/haze-root-haze-glass": {
       "version": "0.0.0-unspecified",
+      "devDependencies": {}
+    },
+    "packages/haze-root-haze-glass-material3": {
+      "version": "0.0.0-unspecified",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
+      "devDependencies": {}
+    },
+    "packages/haze-root-haze-glass-material3-test": {
+      "version": "0.0.0-unspecified",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
       "devDependencies": {}
     },
     "packages/haze-root-haze-glass-test": {

--- a/kotlin-js-store/wasm/package-lock.json
+++ b/kotlin-js-store/wasm/package-lock.json
@@ -12,8 +12,12 @@
         "packages/haze-root-haze-test",
         "packages/haze-root-haze-blur",
         "packages/haze-root-haze-blur-test",
+        "packages/haze-root-haze-blur-material3",
+        "packages/haze-root-haze-blur-material3-test",
         "packages/haze-root-haze-glass",
         "packages/haze-root-haze-glass-test",
+        "packages/haze-root-haze-glass-material3",
+        "packages/haze-root-haze-glass-material3-test",
         "packages/haze-root-haze-materials",
         "packages/haze-root-haze-materials-test",
         "packages/haze-root-haze-utils",
@@ -1303,12 +1307,28 @@
       "resolved": "packages/haze-root-haze-blur",
       "link": true
     },
+    "node_modules/haze-root-haze-blur-material3": {
+      "resolved": "packages/haze-root-haze-blur-material3",
+      "link": true
+    },
+    "node_modules/haze-root-haze-blur-material3-test": {
+      "resolved": "packages/haze-root-haze-blur-material3-test",
+      "link": true
+    },
     "node_modules/haze-root-haze-blur-test": {
       "resolved": "packages/haze-root-haze-blur-test",
       "link": true
     },
     "node_modules/haze-root-haze-glass": {
       "resolved": "packages/haze-root-haze-glass",
+      "link": true
+    },
+    "node_modules/haze-root-haze-glass-material3": {
+      "resolved": "packages/haze-root-haze-glass-material3",
+      "link": true
+    },
+    "node_modules/haze-root-haze-glass-material3-test": {
+      "resolved": "packages/haze-root-haze-glass-material3-test",
       "link": true
     },
     "node_modules/haze-root-haze-glass-test": {
@@ -2959,12 +2979,40 @@
       "version": "0.0.0-unspecified",
       "devDependencies": {}
     },
+    "packages/haze-root-haze-blur-material3": {
+      "version": "0.0.0-unspecified",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
+      "devDependencies": {}
+    },
+    "packages/haze-root-haze-blur-material3-test": {
+      "version": "0.0.0-unspecified",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
+      "devDependencies": {}
+    },
     "packages/haze-root-haze-blur-test": {
       "version": "0.0.0-unspecified",
       "devDependencies": {}
     },
     "packages/haze-root-haze-glass": {
       "version": "0.0.0-unspecified",
+      "devDependencies": {}
+    },
+    "packages/haze-root-haze-glass-material3": {
+      "version": "0.0.0-unspecified",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
+      "devDependencies": {}
+    },
+    "packages/haze-root-haze-glass-material3-test": {
+      "version": "0.0.0-unspecified",
+      "dependencies": {
+        "@js-joda/core": "3.2.0"
+      },
       "devDependencies": {}
     },
     "packages/haze-root-haze-glass-test": {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,8 @@ nav:
   - "Blur":
     - "Overview": blur/index.md
     - "Usage": blur/usage.md
-    - "Materials": blur/materials.md
+    - "Material presets": blur/materials.md
+    - "Material 3 integration": blur/material3.md
     - "FAQs": blur/faq.md
     - "Platforms": blur/platforms.md
   - "Glass":

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -105,7 +105,9 @@ rootProject.name = "haze-root"
 include(
   ":haze",
   ":haze-blur",
+  ":haze-blur-material3",
   ":haze-glass",
+  ":haze-glass-material3",
   ":haze-utils",
   ":haze-materials",
   ":haze-screenshot-tests",


### PR DESCRIPTION
## Summary

- publish optional `haze-blur-material3` and `haze-glass-material3` multiplatform artifacts
- add Material 3 Style factories that default to `MaterialTheme.colorScheme.surface`, with an optional explicit Glass tint
- reuse no-block Styles across unrelated recompositions while keeping block-taking factories dynamic
- add public JVM rendering and recomposition tests, Metalava signatures, package locks, and focused documentation
- separate Blur material-preset documentation from the Material 3 theme integration

The dedicated artifacts keep Compose Material 3 out of the core Blur and Glass modules while giving applications a small theme adapter.

Closes #1210

## Validation

- `./gradlew --no-scan :haze-blur-material3:check :haze-glass-material3:check`
- `./gradlew --no-scan :haze-blur-material3:spotlessCheck :haze-glass-material3:spotlessCheck`
- `git diff --check`
- final review-and-simplify and ponytail-review passes

`mkdocs build --strict` parsed the updated navigation and links, but could not finish locally because the social-card plugin could not resolve `fonts.google.com`.