### PR TITLE
Optimize equivalent Blur Style updates

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |
@@ -105,7 +105,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Install dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   input-pixel fractions must be remeasured before selecting `Fixed(qualityFraction)`.
   `HazeSampling` remains the generic contract for custom effects
   ([#1206](https://github.com/chrisbanes/haze/issues/1206)).
+- Blur avoids redundant modifier updates when independently recreated `HazeBlurStyle` programs
+  are equivalent.
 
 ### Fixed
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -80,7 +80,9 @@ val style = HazeBlurStyle {
 
 Resolution replays `HazeBlurDefaults.style`, `LocalHazeBlurStyle`, and the explicit Style in order.
 The last write wins, and every evaluation starts fresh. Styles contain no mutable renderer or
-platform state and can be shared by concurrent modifiers.
+platform state and can be shared by concurrent modifiers. Style programs with identical ordered
+writes and equal values are structurally equal, so recreating the same program during recomposition
+does not update the modifier node; provide a replacement Style when a configured value changes.
 
 ## Typed custom effects
 

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyle.kt
@@ -32,7 +32,9 @@ public val LocalHazeBlurStyle: ProvidableCompositionLocal<HazeBlurStyle> =
  * An opaque, stateless, and shareable program of Blur Style writes.
  *
  * A Style never owns renderer or platform resources. Calling [then] creates a new Style whose
- * writes replay after this one, so the last write to each property wins.
+ * writes replay after this one, so the last write to each property wins. Values retained by a Style
+ * must be immutable after construction; lists passed to [HazeBlurStyleScope.colorEffects] are
+ * snapshotted. Provide a replacement Style when a value changes.
  */
 @Immutable
 public sealed interface HazeBlurStyle {
@@ -60,12 +62,13 @@ public sealed interface HazeBlurStyle {
 }
 
 @Immutable
+@Poko
 private class RecordedHazeBlurStyle(
-  private val writes: List<HazeBlurStyleScope.() -> Unit>,
+  private val writes: List<HazeBlurStyleWrite>,
 ) : HazeBlurStyle {
   fun replay(scope: HazeBlurStyleScope) {
     for (write in writes) {
-      scope.write()
+      write.replay(scope)
     }
   }
 
@@ -203,54 +206,92 @@ public sealed interface HazeBlurStyleScope {
   public fun blurredEdgeTreatment(treatment: BlurredEdgeTreatment)
 }
 
+private enum class HazeBlurStyleProperty {
+  BlurEnabled,
+  BlurRadius,
+  NoiseFactor,
+  BackgroundColor,
+  ColorEffects,
+  FallbackColorEffect,
+  Alpha,
+  Mask,
+  Progressive,
+  BlurredEdgeTreatment,
+}
+
+@Poko
+private class HazeBlurStyleWrite(
+  private val property: HazeBlurStyleProperty,
+  private val value: Any?,
+) {
+  @Suppress("UNCHECKED_CAST")
+  fun replay(scope: HazeBlurStyleScope) {
+    with(scope) {
+      when (property) {
+        HazeBlurStyleProperty.BlurEnabled -> blurEnabled(value as Boolean)
+        HazeBlurStyleProperty.BlurRadius -> blurRadius(value as Dp)
+        HazeBlurStyleProperty.NoiseFactor -> noiseFactor(value as Float)
+        HazeBlurStyleProperty.BackgroundColor -> backgroundColor(value as Color)
+        HazeBlurStyleProperty.ColorEffects -> colorEffects(value as List<HazeColorEffect>)
+        HazeBlurStyleProperty.FallbackColorEffect ->
+          fallbackColorEffect(value as HazeColorEffect)
+        HazeBlurStyleProperty.Alpha -> alpha(value as Float)
+        HazeBlurStyleProperty.Mask -> mask(value as Brush?)
+        HazeBlurStyleProperty.Progressive -> progressive(value as HazeProgressive?)
+        HazeBlurStyleProperty.BlurredEdgeTreatment ->
+          blurredEdgeTreatment(value as BlurredEdgeTreatment)
+      }
+    }
+  }
+}
+
 private fun recordWrites(
   block: HazeBlurStyleScope.() -> Unit,
-): List<HazeBlurStyleScope.() -> Unit> = buildList {
+): List<HazeBlurStyleWrite> = buildList {
   RecordingHazeBlurStyleScope(this).block()
 }
 
 private class RecordingHazeBlurStyleScope(
-  private val writes: MutableList<HazeBlurStyleScope.() -> Unit>,
+  private val writes: MutableList<HazeBlurStyleWrite>,
 ) : HazeBlurStyleScope {
   override fun blurEnabled(enabled: Boolean) {
-    writes += { blurEnabled(enabled) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.BlurEnabled, enabled)
   }
 
   override fun blurRadius(radius: Dp) {
-    writes += { blurRadius(radius) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.BlurRadius, radius)
   }
 
   override fun noiseFactor(factor: Float) {
-    writes += { noiseFactor(factor) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.NoiseFactor, factor)
   }
 
   override fun backgroundColor(color: Color) {
-    writes += { backgroundColor(color) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.BackgroundColor, color)
   }
 
   override fun colorEffects(effects: List<HazeColorEffect>) {
-    val snapshot = effects.toList()
-    writes += { colorEffects(snapshot) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.ColorEffects, effects.toList())
   }
 
   override fun fallbackColorEffect(effect: HazeColorEffect) {
-    writes += { fallbackColorEffect(effect) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.FallbackColorEffect, effect)
   }
 
   override fun alpha(alpha: Float) {
-    writes += { alpha(alpha) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.Alpha, alpha)
   }
 
   override fun mask(mask: Brush?) {
-    writes += { mask(mask) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.Mask, mask)
   }
 
   override fun progressive(progressive: HazeProgressive?) {
-    writes += { progressive(progressive) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.Progressive, progressive)
   }
 
   override fun blurredEdgeTreatment(treatment: BlurredEdgeTreatment) {
-    writes += { blurredEdgeTreatment(treatment) }
+    writes += HazeBlurStyleWrite(HazeBlurStyleProperty.BlurredEdgeTreatment, treatment)
   }
 }
 

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyleTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/HazeBlurStyleTest.kt
@@ -15,6 +15,7 @@ import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isSameInstanceAs
 import dev.chrisbanes.haze.HazeProgressive
 import kotlin.test.Test
@@ -25,6 +26,38 @@ class HazeBlurStyleTest {
   @Test
   fun defaultStyle_isShared() {
     assertThat(HazeBlurDefaults.style).isSameInstanceAs(HazeBlurDefaults.style)
+  }
+
+  @Test
+  fun equivalentStylePrograms_areEqual() {
+    val first = HazeBlurStyle {
+      blurEnabled(true)
+      blurRadius(24.dp)
+      backgroundColor(Color.Black)
+      colorEffects(listOf(HazeColorEffect.tint(Color.Red)))
+      alpha(0.8f)
+    }.then {
+      noiseFactor(0.2f)
+    }
+    val second = HazeBlurStyle {
+      blurEnabled(true)
+      blurRadius(24.dp)
+      backgroundColor(Color.Black)
+      colorEffects(listOf(HazeColorEffect.tint(Color.Red)))
+      alpha(0.8f)
+    }.then {
+      noiseFactor(0.2f)
+    }
+
+    assertThat(first).isEqualTo(second)
+  }
+
+  @Test
+  fun differentStylePrograms_areNotEqual() {
+    val first = HazeBlurStyle { blurRadius(24.dp) }
+    val second = HazeBlurStyle { blurRadius(25.dp) }
+
+    assertThat(first).isNotEqualTo(second)
   }
 
   @Test

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze
 
+import android.os.SystemClock
 import androidx.benchmark.macro.FrameTimingMetric
 import androidx.benchmark.macro.StartupMode
 import androidx.benchmark.macro.junit4.MacrobenchmarkRule
@@ -42,6 +43,23 @@ class BenchmarkTest {
 
   @Test
   fun blurSourceUpdateAdaptive() = measureBlurProfilingScenario("source_update_adaptive")
+
+  @Test
+  fun scaffoldEquivalentStyleChurn() {
+    benchmarkRule.measureRepeated(
+      packageName = APP_PACKAGE,
+      metrics = listOf(FrameTimingMetric()),
+      startupMode = StartupMode.WARM,
+      iterations = DEFAULT_ITERATIONS,
+      setupBlock = {
+        startActivityAndWait()
+        device.setBlurEnabled(true)
+        device.navigateToScaffoldWithEquivalentStyleChurn()
+      },
+    ) {
+      SystemClock.sleep(STYLE_CHURN_MEASURE_MILLIS)
+    }
+  }
 
   @Test
   fun blurSourceUpdateQuality() = measureBlurProfilingScenario("source_update_quality")
@@ -94,3 +112,5 @@ class BenchmarkTest {
     }
   }
 }
+
+private const val STYLE_CHURN_MEASURE_MILLIS = 3_250L

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
@@ -54,6 +54,11 @@ internal fun UiDevice.navigateToScaffold() {
   waitForIdle()
 }
 
+internal fun UiDevice.navigateToScaffoldWithEquivalentStyleChurn() {
+  findSampleListItem(By.res("Blur — Equivalent Style Churn")).click()
+  waitForIdle()
+}
+
 internal fun UiDevice.navigateToCreditCard() {
   findSampleListItem(By.res("Credit Card")).click()
   waitForIdle()

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/Samples.android.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/Samples.android.kt
@@ -26,6 +26,17 @@ internal val AndroidBlurProfiling = Sample(
   )
 }
 
+internal val AndroidBlurStyleChurn = Sample(
+  route = "blur-style-churn",
+  title = "Blur — Equivalent Style Churn",
+) { navController, blurEnabled ->
+  ScaffoldSample(
+    navController = navController,
+    blurEnabled = blurEnabled,
+    mode = ScaffoldSampleMode.StyleChurn,
+  )
+}
+
 val AndroidExoPlayer = Sample("exo-player", "ExoPlayer") { _, blurEnabled ->
   ExoPlayerSample(blurEnabled)
 }
@@ -34,5 +45,6 @@ actual val Samples: List<Sample> = buildList {
   addAll(CommonSamples)
   add(AndroidExoPlayer)
   add(AndroidBlurProfiling)
+  add(AndroidBlurStyleChurn)
   add(AndroidGlassProfiling)
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -5,6 +5,12 @@ package dev.chrisbanes.haze.sample
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.EaseIn
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
@@ -55,6 +61,7 @@ enum class ScaffoldSampleMode {
   Default,
   Progressive,
   Mask,
+  StyleChurn,
 }
 
 @OptIn(
@@ -75,11 +82,39 @@ fun ScaffoldSample(
   val showNavigationBar by remember(gridState) {
     derivedStateOf { gridState.firstVisibleItemIndex == 0 }
   }
+  // The benchmark reads a changing value while resolving to the same Style on every frame.
+  val styleChurnPhase = if (mode == ScaffoldSampleMode.StyleChurn) {
+    rememberInfiniteTransition(label = "Blur style churn").animateFloat(
+      initialValue = 0f,
+      targetValue = 1f,
+      animationSpec = infiniteRepeatable(
+        animation = tween(durationMillis = 1_000, easing = LinearEasing),
+        repeatMode = RepeatMode.Reverse,
+      ),
+      label = "Blur style churn phase",
+    )
+  } else {
+    null
+  }
 
-  val style = HazeMaterials.regular(MaterialTheme.colorScheme.surface)
+  val style = if (mode == ScaffoldSampleMode.StyleChurn) {
+    null
+  } else {
+    HazeMaterials.regular(MaterialTheme.colorScheme.surface)
+  }
+  val scaffoldModifier = Modifier.fillMaxSize().let { modifier ->
+    styleChurnPhase?.let { phase ->
+      modifier.graphicsLayer {
+        // Keep a constant RenderThread workload so frame metrics remain comparable when the
+        // equivalent style update is suppressed.
+        translationX = phase.value
+      }
+    } ?: modifier
+  }
 
   Scaffold(
     topBar = {
+      val currentStyle = style ?: HazeMaterials.regular(MaterialTheme.colorScheme.surface)
       LargeTopAppBar(
         title = { },
         navigationIcon = {
@@ -102,7 +137,7 @@ fun ScaffoldSample(
           .hazeBlur(
             input = HazeInput.Sources(hazeState),
             performanceMode = performanceMode,
-            style = style.then {
+            style = currentStyle.then {
               blurEnabled(blurEnabled)
               when (mode) {
                 ScaffoldSampleMode.Default -> Unit
@@ -118,6 +153,10 @@ fun ScaffoldSample(
                 ScaffoldSampleMode.Mask -> {
                   mask(Brush.easedVerticalGradient(EaseIn))
                 }
+
+                ScaffoldSampleMode.StyleChurn -> {
+                  alpha(1f + checkNotNull(styleChurnPhase).value * 0f)
+                }
               }
             },
           )
@@ -125,6 +164,7 @@ fun ScaffoldSample(
       )
     },
     bottomBar = {
+      val currentStyle = style ?: HazeMaterials.regular(MaterialTheme.colorScheme.surface)
       var selectedIndex by remember { mutableIntStateOf(0) }
       AnimatedVisibility(
         visible = showNavigationBar,
@@ -142,13 +182,18 @@ fun ScaffoldSample(
             .hazeBlur(
               input = HazeInput.Sources(hazeState),
               performanceMode = performanceMode,
-              style = style.then { blurEnabled(blurEnabled) },
+              style = currentStyle.then {
+                blurEnabled(blurEnabled)
+                if (mode == ScaffoldSampleMode.StyleChurn) {
+                  alpha(1f + checkNotNull(styleChurnPhase).value * 0f)
+                }
+              },
             )
             .fillMaxWidth(),
         )
       }
     },
-    modifier = Modifier.fillMaxSize(),
+    modifier = scaffoldModifier,
   ) { contentPadding ->
     LazyVerticalGrid(
       state = gridState,


### PR DESCRIPTION
## Summary

- Make independently recreated Blur Style programs with identical ordered writes and equal values compare structurally.
- Avoid redundant modifier-node updates when a Blur Style is rebuilt without changing its configured values.
- Add an Android-only style-churn Macrobenchmark scenario and document the immutable retained-value contract.

## Root cause

Recorded Blur Styles previously retained DSL lambdas. New, otherwise identical Style instances therefore compared unequal and caused modifier updates during recomposition.

## Validation

- `./gradlew :haze-blur:jvmTest :sample:shared:compileAndroidMain :internal:benchmark:compileBenchmarkReleaseKotlin spotlessCheck --no-scan`
- `mkdocs build --no-strict --site-dir /private/tmp/haze-docs-preview`
- Paired 16-iteration Pixel 6 Macrobenchmark/Perfetto artifacts captured before the review cleanup: the candidate produced zero exact modifier-element updates, versus a baseline median of 408.
- Final device benchmark smoke was blocked by the phone's secure lock screen before it reached the sample UI.