### PR TITLE
Add Glass counterparts to samples

### DIFF
--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BaselineProfileGenerator.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BaselineProfileGenerator.kt
@@ -21,9 +21,6 @@ class BaselineProfileGenerator {
     pressHome()
     startActivityAndWait()
 
-    // Force enable blurring
-    device.setBlurEnabled(true)
-
     // Scroll down several times
     device.navigateToImagesList()
     device.repeatedScrolls("lazy_column")

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BaselineProfileGenerator.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BaselineProfileGenerator.kt
@@ -9,6 +9,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+private const val FORCE_BLUR_EXTRA = "dev.chrisbanes.haze.sample.android.FORCE_BLUR"
+
 @RunWith(AndroidJUnit4::class)
 class BaselineProfileGenerator {
   @get:Rule
@@ -19,7 +21,9 @@ class BaselineProfileGenerator {
     packageName = "dev.chrisbanes.haze.sample.android",
   ) {
     pressHome()
-    startActivityAndWait()
+    startActivityAndWait { intent ->
+      intent.putExtra(FORCE_BLUR_EXTRA, true)
+    }
 
     // Scroll down several times
     device.navigateToImagesList()

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
@@ -53,7 +53,6 @@ class BenchmarkTest {
       iterations = DEFAULT_ITERATIONS,
       setupBlock = {
         startActivityAndWait()
-        device.setBlurEnabled(true)
         device.navigateToScaffoldWithEquivalentStyleChurn()
       },
     ) {

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
@@ -36,14 +36,6 @@ internal fun <R> UiDevice.wait(condition: SearchCondition<R>, timeout: Duration)
   return wait(condition, timeout.inWholeMilliseconds)
 }
 
-internal fun UiDevice.setBlurEnabled(enabled: Boolean) {
-  val checkbox = waitForObject(By.res("blur_enabled"))
-  if (checkbox.isChecked != enabled) {
-    checkbox.click()
-    waitForIdle()
-  }
-}
-
 internal fun UiDevice.navigateToImagesList() {
   findSampleListItem(By.res("Images List")).click()
   waitForIdle()

--- a/sample/android/src/main/kotlin/dev/chrisbanes/haze/sample/android/MainActivity.kt
+++ b/sample/android/src/main/kotlin/dev/chrisbanes/haze/sample/android/MainActivity.kt
@@ -9,13 +9,18 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import dev.chrisbanes.haze.sample.Samples
 
+private const val FORCE_BLUR_EXTRA = "dev.chrisbanes.haze.sample.android.FORCE_BLUR"
+
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
 
     setContent {
-      Samples(appTitle = title.toString())
+      Samples(
+        appTitle = title.toString(),
+        forceBlur = intent.getBooleanExtra(FORCE_BLUR_EXTRA, false),
+      )
     }
   }
 }

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/SamplesAndroidTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/SamplesAndroidTest.kt
@@ -1,0 +1,18 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.chrisbanes.haze.test.ContextTest
+import kotlin.test.Test
+
+class SamplesAndroidTest : ContextTest() {
+  @Test
+  fun exoPlayer_exposesBothBuiltInEffects() {
+    assertThat(AndroidExoPlayer.effects).isEqualTo(
+      listOf(SampleEffect.Blur, SampleEffect.Glass),
+    )
+  }
+}

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSample.kt
@@ -117,7 +117,7 @@ private fun BlurProfilingScene(
   Box(modifier = modifier.fillMaxSize()) {
     ScaffoldSample(
       navController = navController,
-      blurEnabled = true,
+      effect = SampleEffect.Blur,
       performanceMode = scenario.performanceMode,
       sourceOffset = sourceOffset,
       profilingDrawProgress = profilingDrawProgress,

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/ExoPlayerSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/ExoPlayerSample.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -17,19 +18,25 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import dev.chrisbanes.haze.sample.shared.R
 
 @Composable
-fun ExoPlayerSample(blurEnabled: Boolean) {
+@OptIn(ExperimentalHazeApi::class)
+fun ExoPlayerSample(effect: SampleEffect) {
   val hazeState = rememberHazeState()
 
   val context = LocalContext.current
@@ -65,16 +72,35 @@ fun ExoPlayerSample(blurEnabled: Boolean) {
         .hazeSource(hazeState),
     )
 
-    val style = HazeMaterials.ultraThin()
+    val shape = RoundedCornerShape(16.dp)
+    val glassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.14f)
 
     Spacer(
       Modifier
         .fillMaxSize(0.5f)
         .align(Alignment.Center)
-        .clip(MaterialTheme.shapes.large)
-        .hazeBlur(
-          input = HazeInput.Sources(hazeState),
-          style = style.then { blurEnabled(blurEnabled) },
+        .then(
+          when (effect) {
+            SampleEffect.Blur ->
+              Modifier
+                .clip(shape)
+                .hazeBlur(
+                  input = HazeInput.Sources(hazeState),
+                  style = HazeMaterials.ultraThin(),
+                )
+
+            SampleEffect.Glass ->
+              Modifier
+                .hazeGlass(
+                  input = HazeInput.Sources(hazeState),
+                  style = GlassStyle {
+                    tint(glassTint)
+                    shape(shape)
+                    optics(GlassOptics.Adaptive)
+                  },
+                )
+                .clip(shape)
+          },
         ),
     )
   }

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/Samples.android.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/Samples.android.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.remember
 internal val AndroidGlassProfiling = Sample(
   route = "glass-profiling",
   title = "Glass — Profiling",
+  effects = listOf(SampleEffect.Glass),
 ) { navController, _ ->
   GlassProfilingSampleContent(
     state = remember { GlassProfilingState() },
@@ -18,6 +19,7 @@ internal val AndroidGlassProfiling = Sample(
 internal val AndroidBlurProfiling = Sample(
   route = "blur-profiling",
   title = "Blur — Profiling",
+  effects = listOf(SampleEffect.Blur),
 ) { navController, _ ->
   BlurProfilingSampleContent(
     state = remember { BlurProfilingState() },
@@ -29,16 +31,21 @@ internal val AndroidBlurProfiling = Sample(
 internal val AndroidBlurStyleChurn = Sample(
   route = "blur-style-churn",
   title = "Blur — Equivalent Style Churn",
-) { navController, blurEnabled ->
+  effects = listOf(SampleEffect.Blur),
+) { navController, _ ->
   ScaffoldSample(
     navController = navController,
-    blurEnabled = blurEnabled,
+    effect = SampleEffect.Blur,
     mode = ScaffoldSampleMode.StyleChurn,
   )
 }
 
-val AndroidExoPlayer = Sample("exo-player", "ExoPlayer") { _, blurEnabled ->
-  ExoPlayerSample(blurEnabled)
+val AndroidExoPlayer = Sample(
+  route = "exo-player",
+  title = "ExoPlayer",
+  effects = listOf(SampleEffect.Blur, SampleEffect.Glass),
+) { _, effect ->
+  ExoPlayerSample(effect)
 }
 
 actual val Samples: List<Sample> = buildList {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
@@ -35,15 +36,19 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
-fun BottomSheet(navController: NavHostController, blurEnabled: Boolean) {
+fun BottomSheet(navController: NavHostController, effect: SampleEffect) {
   var imageIndex by remember { mutableIntStateOf(0) }
 
   Scaffold(
@@ -96,12 +101,26 @@ fun BottomSheet(navController: NavHostController, blurEnabled: Boolean) {
         // Instead, we add it below
         dragHandle = null,
       ) {
-        val style = HazeMaterials.thin()
+        val sheetShape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
+        val glassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.14f)
         Column(
           modifier = Modifier
-            .hazeBlur(
-              input = HazeInput.Sources(hazeState),
-              style = style.then { blurEnabled(blurEnabled) },
+            .then(
+              when (effect) {
+                SampleEffect.Blur -> Modifier.hazeBlur(
+                  input = HazeInput.Sources(hazeState),
+                  style = HazeMaterials.thin(),
+                )
+
+                SampleEffect.Glass -> Modifier.hazeGlass(
+                  input = HazeInput.Sources(hazeState),
+                  style = GlassStyle {
+                    tint(glassTint)
+                    shape(sheetShape)
+                    optics(GlassOptics.Adaptive)
+                  },
+                )
+              },
             )
             .height(400.dp)
             .fillMaxWidth(),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
@@ -5,38 +5,57 @@ package dev.chrisbanes.haze.sample
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
-import dev.chrisbanes.haze.blur.HazeBlurDefaults
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.HazeColorEffect
 import dev.chrisbanes.haze.blur.hazeBlur
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 
 @Composable
+@OptIn(ExperimentalHazeApi::class)
 fun CreditCardSample(
   navController: NavHostController,
-  blurEnabled: Boolean = HazeBlurDefaults.blurEnabled(),
+  effect: SampleEffect = SampleEffect.Blur,
 ) {
-  val cardStyle = HazeBlurStyle {
-    blurEnabled(blurEnabled)
-    backgroundColor(Color.Black)
-    colorEffects(listOf(HazeColorEffect.tint(Color.Yellow.copy(alpha = 0.4f))))
-    blurRadius(8.dp)
-    noiseFactor(HazeBlurDefaults.noiseFactor)
-  }
-
   CreditCardScene(onNavigateUp = navController::navigateUp) { hazeState, modifier, shape, zIndex ->
     Box(
       modifier = modifier
         .hazeSource(hazeState, zIndex = zIndex)
-        .clip(shape)
-        .hazeBlur(
-          input = HazeInput.Sources(hazeState),
-          style = cardStyle,
+        .then(
+          when (effect) {
+            SampleEffect.Blur ->
+              Modifier
+                .clip(shape)
+                .hazeBlur(
+                  input = HazeInput.Sources(hazeState),
+                  style = HazeBlurStyle {
+                    backgroundColor(Color.Black)
+                    colorEffects(listOf(HazeColorEffect.tint(Color.Yellow.copy(alpha = 0.4f))))
+                    blurRadius(8.dp)
+                  },
+                )
+
+            SampleEffect.Glass ->
+              Modifier
+                .hazeGlass(
+                  input = HazeInput.Sources(hazeState),
+                  style = GlassStyle {
+                    tint(Color.Yellow.copy(alpha = 0.18f))
+                    shape(shape)
+                    optics(GlassOptics.Adaptive)
+                  },
+                )
+                .clip(shape)
+          },
         ),
     ) {
       DefaultCreditCardContents()

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ContentBlurring.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ContentBlurring.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
@@ -33,6 +34,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
@@ -41,15 +43,19 @@ import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
 import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
 fun ContentBlurring(
   navController: NavHostController,
-  blurEnabled: Boolean,
+  effect: SampleEffect,
 ) {
   var imageIndex by remember { mutableIntStateOf(0) }
 
@@ -77,7 +83,7 @@ fun ContentBlurring(
   ) {
     var clipEnabled by remember { mutableStateOf(true) }
 
-    val style = HazeMaterials.ultraThin()
+    val glassShape = RoundedCornerShape(24.dp)
 
     Box(Modifier.fillMaxSize()) {
       val context = LocalPlatformContext.current
@@ -92,34 +98,55 @@ fun ContentBlurring(
         contentScale = ContentScale.Crop,
         contentDescription = null,
         modifier = Modifier
-          .hazeBlur(
-            input = HazeInput.Content,
-            style = style.then {
-              blurEnabled(blurEnabled)
-              backgroundColor(Color.Transparent)
-              blurredEdgeTreatment(
-                when {
-                  clipEnabled -> BlurredEdgeTreatment.Rectangle
-                  else -> BlurredEdgeTreatment.Unbounded
+          .then(
+            when (effect) {
+              SampleEffect.Blur -> Modifier.hazeBlur(
+                input = HazeInput.Content,
+                style = HazeMaterials.ultraThin().then {
+                  backgroundColor(Color.Transparent)
+                  blurredEdgeTreatment(
+                    when {
+                      clipEnabled -> BlurredEdgeTreatment.Rectangle
+                      else -> BlurredEdgeTreatment.Unbounded
+                    },
+                  )
+                  blurRadius(100.dp)
                 },
               )
-              blurRadius(100.dp)
+
+              SampleEffect.Glass ->
+                Modifier
+                  .hazeGlass(
+                    input = HazeInput.Content,
+                    style = GlassStyle {
+                      tint(Color.White.copy(alpha = 0.14f))
+                      shape(glassShape)
+                      optics(GlassOptics.Adaptive)
+                    },
+                  )
+                  .clip(glassShape)
             },
           )
           .align(Alignment.Center)
           .size(300.dp),
       )
 
-      Column(
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-        modifier = Modifier
-          .padding(bottom = 16.dp)
-          .windowInsetsPadding(WindowInsets.navigationBars)
-          .align(Alignment.BottomCenter),
-      ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-          Text("Clipped:", modifier = Modifier.padding(end = 8.dp))
-          Switch(checked = clipEnabled, onCheckedChange = { clipEnabled = it })
+      if (effect == SampleEffect.Blur) {
+        Column(
+          verticalArrangement = Arrangement.spacedBy(4.dp),
+          modifier = Modifier
+            .padding(bottom = 16.dp)
+            .windowInsetsPadding(WindowInsets.navigationBars)
+            .align(Alignment.BottomCenter),
+        ) {
+          Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Clipped:", modifier = Modifier.padding(end = 8.dp))
+            Switch(
+              checked = clipEnabled,
+              onCheckedChange = { clipEnabled = it },
+              modifier = Modifier.testTag("content_blur_clipped"),
+            )
+          }
         }
       }
     }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CreditCardScene.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CreditCardScene.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -50,7 +49,7 @@ internal fun CreditCardScene(
   card: @Composable BoxScope.(
     hazeState: HazeState,
     modifier: Modifier,
-    shape: Shape,
+    shape: RoundedCornerShape,
     zIndex: Float,
   ) -> Unit,
 ) {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CustomVisualEffectSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CustomVisualEffectSample.kt
@@ -82,7 +82,6 @@ private val LocalSparklePhase = compositionLocalOf { 0f }
 @Composable
 fun CustomVisualEffectSample(
   navController: NavHostController,
-  blurEnabled: Boolean,
 ) {
   val hazeState = rememberHazeState()
   var selectedSparkIndex by remember { mutableIntStateOf(0) }
@@ -190,7 +189,7 @@ fun CustomVisualEffectSample(
               style = SparkStyle(
                 color = SparkOptions[selectedSparkIndex].color,
                 alpha = sparkAlpha,
-                enabled = blurEnabled,
+                enabled = true,
                 sparkleEnabled = sparkleEnabled,
               ),
             ),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Card
@@ -37,16 +38,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavHostController
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
-fun DialogSample(navController: NavHostController, blurEnabled: Boolean) {
+fun DialogSample(navController: NavHostController, effect: SampleEffect) {
   Scaffold(
     modifier = Modifier.fillMaxSize(),
     topBar = {
@@ -64,6 +69,8 @@ fun DialogSample(navController: NavHostController, blurEnabled: Boolean) {
   ) { innerPadding ->
     val hazeState = rememberHazeState()
     var showDialog by remember { mutableStateOf(false) }
+    val dialogShape = RoundedCornerShape(28.dp)
+    val glassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.12f)
 
     if (showDialog) {
       Dialog(onDismissRequest = { showDialog = false }) {
@@ -71,18 +78,30 @@ fun DialogSample(navController: NavHostController, blurEnabled: Boolean) {
           modifier = Modifier
             .fillMaxWidth()
             .fillMaxHeight(fraction = .5f),
-          shape = MaterialTheme.shapes.extraLarge,
+          shape = dialogShape,
           // We can't use Haze tint with dialogs, as the tint will display a scrim over the
           // background content. Instead we need to set a translucent background on the
           // dialog content.
           color = MaterialTheme.colorScheme.surface.copy(alpha = 0.2f),
           contentColor = MaterialTheme.colorScheme.onSurface,
         ) {
-          val style = HazeMaterials.regular()
           Box(
-            Modifier.hazeBlur(
-              input = HazeInput.Sources(hazeState),
-              style = style.then { blurEnabled(blurEnabled) },
+            Modifier.then(
+              when (effect) {
+                SampleEffect.Blur -> Modifier.hazeBlur(
+                  input = HazeInput.Sources(hazeState),
+                  style = HazeMaterials.regular(),
+                )
+
+                SampleEffect.Glass -> Modifier.hazeGlass(
+                  input = HazeInput.Sources(hazeState),
+                  style = GlassStyle {
+                    tint(glassTint)
+                    shape(dialogShape)
+                    optics(GlassOptics.Adaptive)
+                  },
+                )
+              },
             ),
           ) {
             // empty

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
@@ -29,15 +29,19 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
-fun ImagesList(navController: NavHostController, blurEnabled: Boolean) {
+fun ImagesList(navController: NavHostController, effect: SampleEffect) {
   MaterialTheme {
     Scaffold(
       topBar = {
@@ -81,15 +85,34 @@ fun ImagesList(navController: NavHostController, blurEnabled: Boolean) {
                   .fillMaxSize(),
               )
 
-              val style = HazeMaterials.thin()
+              val shape = RoundedCornerShape(4.dp)
+              val glassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.14f)
               Box(
                 modifier = Modifier
                   .fillMaxSize(0.8f)
                   .align(Alignment.Center)
-                  .clip(RoundedCornerShape(4.dp))
-                  .hazeBlur(
-                    input = HazeInput.Sources(hazeState),
-                    style = style.then { blurEnabled(blurEnabled) },
+                  .then(
+                    when (effect) {
+                      SampleEffect.Blur ->
+                        Modifier
+                          .clip(shape)
+                          .hazeBlur(
+                            input = HazeInput.Sources(hazeState),
+                            style = HazeMaterials.thin(),
+                          )
+
+                      SampleEffect.Glass ->
+                        Modifier
+                          .hazeGlass(
+                            input = HazeInput.Sources(hazeState),
+                            style = GlassStyle {
+                              tint(glassTint)
+                              shape(shape)
+                              optics(GlassOptics.Adaptive)
+                            },
+                          )
+                          .clip(shape)
+                    },
                   ),
               ) {
                 Text(

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/LayerTransformations.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/LayerTransformations.kt
@@ -29,9 +29,13 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.blur.HazeBlurStyle
 import dev.chrisbanes.haze.blur.hazeBlur
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.math.PI
@@ -39,8 +43,9 @@ import kotlin.math.cos
 import kotlin.math.sin
 
 @Composable
+@OptIn(ExperimentalHazeApi::class)
 fun LayerTransformations(
-  blurEnabled: Boolean,
+  effect: SampleEffect,
   topOffset: DpOffset = DpOffset.Zero,
 ) {
   val hazeState = rememberHazeState()
@@ -101,11 +106,21 @@ fun LayerTransformations(
           translationY = (radiusPx * sin(theta)).toFloat()
         }
         .align(Alignment.Center)
-        .hazeBlur(
-          input = HazeInput.Sources(hazeState),
-          style = HazeBlurStyle {
-            blurEnabled(blurEnabled)
-            blurRadius(20.dp)
+        .then(
+          when (effect) {
+            SampleEffect.Blur -> Modifier.hazeBlur(
+              input = HazeInput.Sources(hazeState),
+              style = HazeBlurStyle { blurRadius(20.dp) },
+            )
+
+            SampleEffect.Glass -> Modifier.hazeGlass(
+              input = HazeInput.Sources(hazeState),
+              style = GlassStyle {
+                tint(Color.White.copy(alpha = 0.14f))
+                shape(androidx.compose.foundation.shape.RoundedCornerShape(16.dp))
+                optics(GlassOptics.Adaptive)
+              },
+            )
           },
         )
         .padding(16.dp),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Refresh
@@ -32,15 +33,19 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
-fun ListOverImage(navController: NavHostController, blurEnabled: Boolean) {
+fun ListOverImage(navController: NavHostController, effect: SampleEffect) {
   var imageIndex by remember { mutableIntStateOf(0) }
 
   MaterialTheme {
@@ -91,14 +96,28 @@ fun ListOverImage(navController: NavHostController, blurEnabled: Boolean) {
                 .fillParentMaxWidth()
                 .height(160.dp),
             ) {
-              val style = HazeMaterials.thin()
+              val shape = RoundedCornerShape(16.dp)
+              val glassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.14f)
               Box(
                 modifier = Modifier
                   .fillMaxSize()
                   .padding(horizontal = 24.dp)
-                  .hazeBlur(
-                    input = HazeInput.Sources(hazeState),
-                    style = style.then { blurEnabled(blurEnabled) },
+                  .then(
+                    when (effect) {
+                      SampleEffect.Blur -> Modifier.hazeBlur(
+                        input = HazeInput.Sources(hazeState),
+                        style = HazeMaterials.thin(),
+                      )
+
+                      SampleEffect.Glass -> Modifier.hazeGlass(
+                        input = HazeInput.Sources(hazeState),
+                        style = GlassStyle {
+                          tint(glassTint)
+                          shape(shape)
+                          optics(GlassOptics.Adaptive)
+                        },
+                      )
+                    },
                   ),
               ) {
                 Text(

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -32,6 +33,9 @@ import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazePerformanceMode
 import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
@@ -41,11 +45,13 @@ import dev.chrisbanes.haze.rememberHazeState
   ExperimentalFoundationApi::class,
 )
 @Composable
-fun ListWithStickyHeaders(navController: NavHostController, blurEnabled: Boolean) {
+fun ListWithStickyHeaders(navController: NavHostController, effect: SampleEffect) {
   val hazeState = rememberHazeState()
   val listState = rememberLazyListState()
 
-  val style = HazeMaterials.regular(MaterialTheme.colorScheme.surface)
+  val blurStyle = HazeMaterials.regular(MaterialTheme.colorScheme.surface)
+  val glassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.16f)
+  val glassShape = RoundedCornerShape(0.dp)
 
   Scaffold(
     topBar = {
@@ -74,10 +80,24 @@ fun ListWithStickyHeaders(navController: NavHostController, blurEnabled: Boolean
           Box(
             modifier = Modifier
               .fillMaxWidth()
-              .hazeBlur(
-                input = HazeInput.Sources(hazeState),
-                style = style.then { blurEnabled(blurEnabled) },
-                performanceMode = HazePerformanceMode.Adaptive,
+              .then(
+                when (effect) {
+                  SampleEffect.Blur -> Modifier.hazeBlur(
+                    input = HazeInput.Sources(hazeState),
+                    style = blurStyle,
+                    performanceMode = HazePerformanceMode.Adaptive,
+                  )
+
+                  SampleEffect.Glass -> Modifier.hazeGlass(
+                    input = HazeInput.Sources(hazeState),
+                    style = GlassStyle {
+                      tint(glassTint)
+                      shape(glassShape)
+                      optics(GlassOptics.Adaptive)
+                    },
+                    performanceMode = HazePerformanceMode.Adaptive,
+                  )
+                },
               ),
           ) {
             Text("Header: $group", modifier = Modifier.padding(16.dp))

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -22,12 +23,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import coil3.compose.AsyncImage
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.blur.HazeBlurStyle
@@ -35,11 +38,15 @@ import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.CupertinoMaterials
 import dev.chrisbanes.haze.blur.materials.FluentMaterials
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
+@OptIn(ExperimentalHazeApi::class)
 @Composable
-fun MaterialsSample(navController: NavHostController, blurEnabled: Boolean) {
+fun MaterialsSample(navController: NavHostController, effect: SampleEffect) {
   val hazeState = rememberHazeState()
 
   Box {
@@ -52,106 +59,193 @@ fun MaterialsSample(navController: NavHostController, blurEnabled: Boolean) {
         .fillMaxSize(),
     )
 
-    Column(
-      verticalArrangement = Arrangement.spacedBy(24.dp),
-      modifier = Modifier
-        .fillMaxSize()
-        .verticalScroll(rememberScrollState())
-        .padding(24.dp),
+    if (effect == SampleEffect.Blur) {
+      Column(
+        verticalArrangement = Arrangement.spacedBy(24.dp),
+        modifier = Modifier
+          .fillMaxSize()
+          .verticalScroll(rememberScrollState())
+          .padding(24.dp),
+      ) {
+        Spacer(Modifier.height(400.dp))
+
+        Card {
+          Text(
+            text = "HazeMaterials - Light",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(16.dp),
+          )
+        }
+
+        SamplesTheme(useDarkColors = false) {
+          HazeMaterialsRow(
+            hazeState = hazeState,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        Card(modifier = Modifier.padding(top = 24.dp)) {
+          Text(
+            text = "HazeMaterials - Dark",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(16.dp),
+          )
+        }
+
+        SamplesTheme(useDarkColors = true) {
+          HazeMaterialsRow(
+            hazeState = hazeState,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        Card(modifier = Modifier.padding(top = 24.dp)) {
+          Text(
+            text = "CupertinoMaterials - Light",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(16.dp),
+          )
+        }
+
+        SamplesTheme(useDarkColors = false) {
+          CupertinoMaterialsRow(
+            hazeState = hazeState,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        Card {
+          Text(
+            text = "CupertinoMaterials - Dark",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(16.dp),
+          )
+        }
+
+        SamplesTheme(useDarkColors = true) {
+          CupertinoMaterialsRow(
+            hazeState = hazeState,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        Card(modifier = Modifier.padding(top = 24.dp)) {
+          Text(
+            text = "FluentMaterials - Light",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(16.dp),
+          )
+        }
+
+        SamplesTheme(useDarkColors = false) {
+          FluentMaterialsRow(
+            hazeState = hazeState,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        Card {
+          Text(
+            text = "FluentMaterials - Dark",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(16.dp),
+          )
+        }
+
+        SamplesTheme(useDarkColors = true) {
+          FluentMaterialsRow(
+            hazeState = hazeState,
+            modifier = Modifier.fillMaxWidth(),
+          )
+        }
+
+        Spacer(Modifier.height(400.dp))
+      }
+    } else {
+      GlassMaterialsContent(hazeState = hazeState)
+    }
+  }
+}
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalHazeApi::class)
+@Composable
+private fun GlassMaterialsContent(hazeState: HazeState) {
+  Column(
+    verticalArrangement = Arrangement.spacedBy(24.dp),
+    modifier = Modifier
+      .fillMaxSize()
+      .verticalScroll(rememberScrollState())
+      .padding(24.dp),
+  ) {
+    Spacer(Modifier.height(400.dp))
+    Card {
+      Text(
+        text = "Adaptive Glass",
+        style = MaterialTheme.typography.titleLarge,
+        modifier = Modifier.padding(16.dp),
+      )
+    }
+    FlowRow(
+      horizontalArrangement = Arrangement.spacedBy(16.dp),
+      verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-      Spacer(Modifier.height(400.dp))
+      GlassMaterialsCard(
+        name = "Warm",
+        hazeState = hazeState,
+        tint = Color(0xFFFFD9A8).copy(alpha = 0.18f),
+      )
+      GlassMaterialsCard(
+        name = "Cool",
+        hazeState = hazeState,
+        tint = Color(0xFFA8D8FF).copy(alpha = 0.18f),
+      )
+      GlassMaterialsCard(
+        name = "Mint",
+        hazeState = hazeState,
+        tint = Color(0xFFA8F2D1).copy(alpha = 0.18f),
+      )
+      GlassMaterialsCard(
+        name = "Violet",
+        hazeState = hazeState,
+        tint = Color(0xFFD8C0FF).copy(alpha = 0.18f),
+      )
+    }
+    Spacer(Modifier.height(400.dp))
+  }
+}
 
-      Card {
-        Text(
-          text = "HazeMaterials - Light",
-          style = MaterialTheme.typography.titleLarge,
-          modifier = Modifier.padding(16.dp),
+@OptIn(ExperimentalHazeApi::class)
+@Composable
+private fun GlassMaterialsCard(
+  name: String,
+  hazeState: HazeState,
+  tint: Color,
+  modifier: Modifier = Modifier,
+) {
+  val shape = RoundedCornerShape(24.dp)
+  Card(
+    shape = shape,
+    colors = CardDefaults.cardColors(
+      containerColor = Color.Transparent,
+      contentColor = MaterialTheme.colorScheme.onSurface,
+    ),
+    modifier = modifier.size(160.dp),
+  ) {
+    Box(
+      Modifier
+        .fillMaxSize()
+        .hazeGlass(
+          input = HazeInput.Sources(hazeState),
+          style = GlassStyle {
+            this.tint(tint)
+            shape(shape)
+            optics(GlassOptics.Adaptive)
+          },
         )
-      }
-
-      SamplesTheme(useDarkColors = false) {
-        HazeMaterialsRow(
-          hazeState = hazeState,
-          modifier = Modifier.fillMaxWidth(),
-        )
-      }
-
-      Card(modifier = Modifier.padding(top = 24.dp)) {
-        Text(
-          text = "HazeMaterials - Dark",
-          style = MaterialTheme.typography.titleLarge,
-          modifier = Modifier.padding(16.dp),
-        )
-      }
-
-      SamplesTheme(useDarkColors = true) {
-        HazeMaterialsRow(
-          hazeState = hazeState,
-          modifier = Modifier.fillMaxWidth(),
-        )
-      }
-
-      Card(modifier = Modifier.padding(top = 24.dp)) {
-        Text(
-          text = "CupertinoMaterials - Light",
-          style = MaterialTheme.typography.titleLarge,
-          modifier = Modifier.padding(16.dp),
-        )
-      }
-
-      SamplesTheme(useDarkColors = false) {
-        CupertinoMaterialsRow(
-          hazeState = hazeState,
-          modifier = Modifier.fillMaxWidth(),
-        )
-      }
-
-      Card {
-        Text(
-          text = "CupertinoMaterials - Dark",
-          style = MaterialTheme.typography.titleLarge,
-          modifier = Modifier.padding(16.dp),
-        )
-      }
-
-      SamplesTheme(useDarkColors = true) {
-        CupertinoMaterialsRow(
-          hazeState = hazeState,
-          modifier = Modifier.fillMaxWidth(),
-        )
-      }
-
-      Card(modifier = Modifier.padding(top = 24.dp)) {
-        Text(
-          text = "FluentMaterials - Light",
-          style = MaterialTheme.typography.titleLarge,
-          modifier = Modifier.padding(16.dp),
-        )
-      }
-
-      SamplesTheme(useDarkColors = false) {
-        FluentMaterialsRow(
-          hazeState = hazeState,
-          modifier = Modifier.fillMaxWidth(),
-        )
-      }
-
-      Card {
-        Text(
-          text = "FluentMaterials - Dark",
-          style = MaterialTheme.typography.titleLarge,
-          modifier = Modifier.padding(16.dp),
-        )
-      }
-
-      SamplesTheme(useDarkColors = true) {
-        FluentMaterialsRow(
-          hazeState = hazeState,
-          modifier = Modifier.fillMaxWidth(),
-        )
-      }
-
-      Spacer(Modifier.height(400.dp))
+        .clip(shape)
+        .padding(16.dp),
+    ) {
+      Text(name)
     }
   }
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/PopupSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/PopupSample.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Card
@@ -37,16 +38,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.navigation.NavHostController
+import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import kotlin.time.Duration.Companion.seconds
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
-fun PopupSample(navController: NavHostController, blurEnabled: Boolean) {
+fun PopupSample(navController: NavHostController, effect: SampleEffect) {
   Scaffold(
     modifier = Modifier.fillMaxSize(),
     topBar = {
@@ -64,6 +69,8 @@ fun PopupSample(navController: NavHostController, blurEnabled: Boolean) {
   ) { innerPadding ->
     val hazeState = rememberHazeState()
     var showPopup by remember { mutableStateOf(false) }
+    val popupShape = RoundedCornerShape(28.dp)
+    val glassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.12f)
 
     if (showPopup) {
       Popup(onDismissRequest = { showPopup = false }) {
@@ -71,18 +78,30 @@ fun PopupSample(navController: NavHostController, blurEnabled: Boolean) {
           modifier = Modifier
             .fillMaxWidth()
             .fillMaxHeight(fraction = .5f),
-          shape = MaterialTheme.shapes.extraLarge,
+          shape = popupShape,
           // We can't use Haze tint with dialogs, as the tint will display a scrim over the
           // background content. Instead we need to set a translucent background on the
           // dialog content.
           color = MaterialTheme.colorScheme.surface.copy(alpha = 0.2f),
           contentColor = MaterialTheme.colorScheme.onSurface,
         ) {
-          val style = HazeMaterials.regular()
           Box(
-            Modifier.hazeBlur(
-              input = HazeInput.Sources(hazeState),
-              style = style.then { blurEnabled(blurEnabled) },
+            Modifier.then(
+              when (effect) {
+                SampleEffect.Blur -> Modifier.hazeBlur(
+                  input = HazeInput.Sources(hazeState),
+                  style = HazeMaterials.regular(),
+                )
+
+                SampleEffect.Glass -> Modifier.hazeGlass(
+                  input = HazeInput.Sources(hazeState),
+                  style = GlassStyle {
+                    tint(glassTint)
+                    shape(popupShape)
+                    optics(GlassOptics.Adaptive)
+                  },
+                )
+              },
             ),
           ) {
             // empty

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,6 +43,8 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazePerformanceMode
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
 
 expect val Samples: List<Sample>
 
@@ -328,6 +331,7 @@ fun Samples(
   appTitle: String,
   navController: NavHostController = rememberNavController(),
   samples: List<Sample> = Samples,
+  forceBlur: Boolean = false,
 ) {
   val coilPlatformContext = LocalPlatformContext.current
   LaunchedEffect(coilPlatformContext) {
@@ -339,24 +343,34 @@ fun Samples(
       .forEach { imageLoader.enqueue(it) }
   }
 
-  SamplesTheme {
-    NavHost(
-      navController = navController,
-      startDestination = SAMPLES_ROUTE,
-      modifier = Modifier.testTagsAsResourceId(true),
-    ) {
-      composable(SAMPLES_ROUTE) {
-        val sortedSamples = remember { samples.sortedBy(Sample::title) }
-        SamplesList(
-          appTitle = appTitle,
-          samples = sortedSamples,
-          navController = navController,
-        )
-      }
+  val localBlurStyle = remember(forceBlur) {
+    if (forceBlur) {
+      HazeBlurStyle.then { blurEnabled(true) }
+    } else {
+      HazeBlurStyle
+    }
+  }
 
-      samples.forEach { sample ->
-        composable(sample.route) {
-          SampleDestination(sample = sample, navController = navController)
+  SamplesTheme {
+    CompositionLocalProvider(LocalHazeBlurStyle provides localBlurStyle) {
+      NavHost(
+        navController = navController,
+        startDestination = SAMPLES_ROUTE,
+        modifier = Modifier.testTagsAsResourceId(true),
+      ) {
+        composable(SAMPLES_ROUTE) {
+          val sortedSamples = remember { samples.sortedBy(Sample::title) }
+          SamplesList(
+            appTitle = appTitle,
+            samples = sortedSamples,
+            navController = navController,
+          )
+        }
+
+        samples.forEach { sample ->
+          composable(sample.route) {
+            SampleDestination(sample = sample, navController = navController)
+          }
         }
       }
     }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
@@ -5,15 +5,19 @@ package dev.chrisbanes.haze.sample
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.darkColorScheme
@@ -25,8 +29,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -36,11 +42,15 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazePerformanceMode
-import dev.chrisbanes.haze.blur.HazeBlurDefaults
 
 expect val Samples: List<Sample>
 
 private const val SAMPLES_ROUTE = "samples"
+
+enum class SampleEffect(val label: String) {
+  Blur("Blur"),
+  Glass("Glass"),
+}
 
 @OptIn(ExperimentalHazeApi::class)
 val CommonSamples: List<Sample> = listOf(
@@ -73,20 +83,32 @@ val CommonSamples: List<Sample> = listOf(
 class Sample(
   val route: String,
   val title: String,
-  val content: @Composable (NavHostController, Boolean) -> Unit,
+  val effects: List<SampleEffect> = listOf(SampleEffect.Blur),
+  val content: @Composable (NavHostController, SampleEffect) -> Unit,
 ) {
+  init {
+    require(effects.isNotEmpty())
+  }
+
   companion object {
-    val Scaffold = Sample("scaffold", "Scaffold") { navController, blurEnabled ->
-      ScaffoldSample(navController = navController, blurEnabled = blurEnabled)
+    private val BuiltInEffects = listOf(SampleEffect.Blur, SampleEffect.Glass)
+
+    val Scaffold = Sample(
+      route = "scaffold",
+      title = "Scaffold",
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      ScaffoldSample(navController = navController, effect = effect)
     }
 
     val ScaffoldAdaptive = Sample(
       route = "scaffold-adaptive",
       title = "Scaffold (adaptive)",
-    ) { navController, blurEnabled ->
+      effects = BuiltInEffects,
+    ) { navController, effect ->
       ScaffoldSample(
         navController = navController,
-        blurEnabled = blurEnabled,
+        effect = effect,
         performanceMode = HazePerformanceMode.Adaptive,
       )
     }
@@ -94,10 +116,11 @@ class Sample(
     val ScaffoldQuality = Sample(
       route = "scaffold-quality",
       title = "Scaffold (quality)",
-    ) { navController, blurEnabled ->
+      effects = BuiltInEffects,
+    ) { navController, effect ->
       ScaffoldSample(
         navController = navController,
-        blurEnabled = blurEnabled,
+        effect = effect,
         performanceMode = HazePerformanceMode.Quality,
       )
     }
@@ -105,10 +128,11 @@ class Sample(
     val ScaffoldBalanced = Sample(
       route = "scaffold-balanced",
       title = "Scaffold (balanced)",
-    ) { navController, blurEnabled ->
+      effects = BuiltInEffects,
+    ) { navController, effect ->
       ScaffoldSample(
         navController = navController,
-        blurEnabled = blurEnabled,
+        effect = effect,
         performanceMode = HazePerformanceMode.Balanced,
       )
     }
@@ -116,10 +140,11 @@ class Sample(
     val ScaffoldPerformance = Sample(
       route = "scaffold-performance",
       title = "Scaffold (performance)",
-    ) { navController, blurEnabled ->
+      effects = BuiltInEffects,
+    ) { navController, effect ->
       ScaffoldSample(
         navController = navController,
-        blurEnabled = blurEnabled,
+        effect = effect,
         performanceMode = HazePerformanceMode.Performance,
       )
     }
@@ -127,10 +152,11 @@ class Sample(
     val ScaffoldProgressive = Sample(
       route = "scaffold-progressive",
       title = "Scaffold (progressive blur)",
-    ) { navController, blurEnabled ->
+      effects = BuiltInEffects,
+    ) { navController, effect ->
       ScaffoldSample(
         navController = navController,
-        blurEnabled = blurEnabled,
+        effect = effect,
         mode = ScaffoldSampleMode.Progressive,
       )
     }
@@ -138,10 +164,11 @@ class Sample(
     val ScaffoldProgressiveQuality = Sample(
       route = "scaffold-progressive-quality",
       title = "Scaffold (progressive blur, quality)",
-    ) { navController, blurEnabled ->
+      effects = BuiltInEffects,
+    ) { navController, effect ->
       ScaffoldSample(
         navController = navController,
-        blurEnabled = blurEnabled,
+        effect = effect,
         mode = ScaffoldSampleMode.Progressive,
         performanceMode = HazePerformanceMode.Quality,
       )
@@ -150,10 +177,11 @@ class Sample(
     val ScaffoldMasked = Sample(
       route = "scaffold-masked",
       title = "Scaffold (masked)",
-    ) { navController, blurEnabled ->
+      effects = BuiltInEffects,
+    ) { navController, effect ->
       ScaffoldSample(
         navController = navController,
-        blurEnabled = blurEnabled,
+        effect = effect,
         mode = ScaffoldSampleMode.Mask,
       )
     }
@@ -161,80 +189,124 @@ class Sample(
     val ScaffoldMaskedQuality = Sample(
       route = "scaffold-masked-quality",
       title = "Scaffold (masked, quality)",
-    ) { navController, blurEnabled ->
+      effects = BuiltInEffects,
+    ) { navController, effect ->
       ScaffoldSample(
         navController = navController,
-        blurEnabled = blurEnabled,
+        effect = effect,
         mode = ScaffoldSampleMode.Mask,
         performanceMode = HazePerformanceMode.Quality,
       )
     }
 
-    val CreditCard = Sample("credit-card", "Credit Card") { navController, blurEnabled ->
-      CreditCardSample(navController = navController, blurEnabled = blurEnabled)
+    val CreditCard = Sample(
+      route = "credit-card",
+      title = "Credit Card",
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      CreditCardSample(navController = navController, effect = effect)
     }
 
-    val ImageList = Sample("images-list", "Images List") { navController, blurEnabled ->
-      ImagesList(navController = navController, blurEnabled = blurEnabled)
+    val ImageList = Sample(
+      route = "images-list",
+      title = "Images List",
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      ImagesList(navController = navController, effect = effect)
     }
 
-    val ListOverImage = Sample("list-over-image", "List over Image") { navController, blurEnabled ->
-      ListOverImage(navController, blurEnabled)
+    val ListOverImage = Sample(
+      route = "list-over-image",
+      title = "List over Image",
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      ListOverImage(navController, effect)
     }
 
-    val Dialog = Sample("dialog", "Dialog") { navController, blurEnabled ->
-      DialogSample(navController, blurEnabled)
+    val Dialog = Sample(
+      route = "dialog",
+      title = "Dialog",
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      DialogSample(navController, effect)
     }
 
-    val Popup = Sample("popup", "Popup") { navController, blurEnabled ->
-      PopupSample(navController, blurEnabled)
+    val Popup = Sample(
+      route = "popup",
+      title = "Popup",
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      PopupSample(navController, effect)
     }
 
-    val Materials = Sample("materials", "Materials") { navController, blurEnabled ->
-      MaterialsSample(navController, blurEnabled)
+    val Materials = Sample(
+      route = "materials",
+      title = "Materials",
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      MaterialsSample(navController, effect)
     }
 
     val ListWithStickyHeaders = Sample(
       route = "list-with-sticky-headers",
       title = "List with Sticky Headers",
-    ) { navController, blurEnabled ->
-      ListWithStickyHeaders(navController, blurEnabled)
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      ListWithStickyHeaders(navController, effect)
     }
 
-    val BottomSheet = Sample("bottom-sheet", "Bottom Sheet") { navController, blurEnabled ->
-      BottomSheet(navController, blurEnabled)
+    val BottomSheet = Sample(
+      route = "bottom-sheet",
+      title = "Bottom Sheet",
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      BottomSheet(navController, effect)
     }
 
     val ContentBlurring = Sample(
       route = "content-blurring",
       title = "Content Blurring",
-    ) { navController, blurEnabled ->
-      ContentBlurring(navController, blurEnabled)
+      effects = BuiltInEffects,
+    ) { navController, effect ->
+      ContentBlurring(navController, effect)
     }
 
     val CustomVisualEffect = Sample(
       route = "custom-visual-effect",
       title = "Custom VisualEffect",
-    ) { navController, blurEnabled ->
-      CustomVisualEffectSample(navController, blurEnabled)
+    ) { navController, effect ->
+      CustomVisualEffectSample(navController)
     }
 
     val LayerTransformations = Sample(
       route = "layer-transformations",
       title = "Layer Transformations",
-    ) { _, blurEnabled ->
-      LayerTransformations(blurEnabled = blurEnabled)
+      effects = BuiltInEffects,
+    ) { _, effect ->
+      LayerTransformations(effect = effect)
     }
 
-    val GlassProduct = Sample("glass-product", "Glass — Product") { navController, _ ->
+    val GlassProduct = Sample(
+      route = "glass-product",
+      title = "Glass — Product",
+      effects = listOf(SampleEffect.Glass),
+    ) { navController, _ ->
       GlassProductSample(navController = navController)
     }
 
-    val GlassPlayground = Sample("glass-playground", "Glass — Playground") { navController, _ ->
+    val GlassPlayground = Sample(
+      route = "glass-playground",
+      title = "Glass — Playground",
+      effects = listOf(SampleEffect.Glass),
+    ) { navController, _ ->
       GlassPlaygroundSample(navController = navController)
     }
 
-    val GlassLab = Sample("glass-lab", "Glass — Lab") { navController, _ ->
+    val GlassLab = Sample(
+      route = "glass-lab",
+      title = "Glass — Lab",
+      effects = listOf(SampleEffect.Glass),
+    ) { navController, _ ->
       GlassLabSample(navController = navController)
     }
   }
@@ -267,8 +339,6 @@ fun Samples(
       .forEach { imageLoader.enqueue(it) }
   }
 
-  var blurEnabled by rememberSaveable { mutableStateOf(HazeBlurDefaults.blurEnabled()) }
-
   SamplesTheme {
     NavHost(
       navController = navController,
@@ -281,15 +351,61 @@ fun Samples(
           appTitle = appTitle,
           samples = sortedSamples,
           navController = navController,
-          forceBlurEnabled = blurEnabled,
-          onForceBlurChanged = { blurEnabled = it },
         )
       }
 
       samples.forEach { sample ->
         composable(sample.route) {
-          sample.content(navController, blurEnabled)
+          SampleDestination(sample = sample, navController = navController)
         }
+      }
+    }
+  }
+}
+
+@Composable
+internal fun SampleDestination(
+  sample: Sample,
+  navController: NavHostController,
+) {
+  var selectedEffectName by rememberSaveable(sample.route) {
+    mutableStateOf(sample.effects.first().name)
+  }
+  val selectedEffect = sample.effects.firstOrNull { it.name == selectedEffectName }
+    ?: sample.effects.first()
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    sample.content(navController, selectedEffect)
+
+    if (sample.effects.size > 1) {
+      SampleEffectPicker(
+        effects = sample.effects,
+        selectedEffect = selectedEffect,
+        onEffectSelected = { selectedEffectName = it.name },
+        modifier = Modifier
+          .align(Alignment.TopEnd)
+          .padding(top = 80.dp, end = 16.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun SampleEffectPicker(
+  effects: List<SampleEffect>,
+  selectedEffect: SampleEffect,
+  onEffectSelected: (SampleEffect) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  SingleChoiceSegmentedButtonRow(modifier = modifier.testTag("sample_effect_picker")) {
+    effects.forEachIndexed { index, effect ->
+      SegmentedButton(
+        selected = effect == selectedEffect,
+        onClick = { onEffectSelected(effect) },
+        shape = SegmentedButtonDefaults.itemShape(index = index, count = effects.size),
+        modifier = Modifier.testTag("sample_effect_${effect.name.lowercase()}"),
+      ) {
+        Text(effect.label)
       }
     }
   }
@@ -301,23 +417,12 @@ private fun SamplesList(
   appTitle: String,
   samples: List<Sample>,
   navController: NavHostController,
-  forceBlurEnabled: Boolean = false,
-  onForceBlurChanged: (Boolean) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   Scaffold(
     topBar = {
       TopAppBar(
         title = { Text(text = appTitle) },
-        actions = {
-          Text("Blur enabled:")
-          Checkbox(
-            checked = forceBlurEnabled,
-            onCheckedChange = onForceBlurChanged,
-            modifier = Modifier
-              .testTag("blur_enabled"),
-          )
-        },
         modifier = Modifier.fillMaxWidth(),
       )
     },

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Call
@@ -33,6 +34,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -54,6 +56,9 @@ import dev.chrisbanes.haze.HazePerformanceMode
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.blur.hazeBlur
 import dev.chrisbanes.haze.blur.materials.HazeMaterials
+import dev.chrisbanes.haze.glass.GlassOptics
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 
@@ -71,7 +76,7 @@ enum class ScaffoldSampleMode {
 @Composable
 fun ScaffoldSample(
   navController: NavHostController,
-  blurEnabled: Boolean,
+  effect: SampleEffect = SampleEffect.Blur,
   mode: ScaffoldSampleMode = ScaffoldSampleMode.Default,
   performanceMode: HazePerformanceMode = HazePerformanceMode.Default,
   sourceOffset: (() -> Float)? = null,
@@ -111,12 +116,21 @@ fun ScaffoldSample(
       }
     } ?: modifier
   }
+  val glassTint = MaterialTheme.colorScheme.surface.copy(alpha = 0.16f)
+  val progressive = HazeProgressive.verticalGradient(
+    startIntensity = 1f,
+    endIntensity = 0f,
+  )
 
   Scaffold(
     topBar = {
-      val currentStyle = style ?: HazeMaterials.regular(MaterialTheme.colorScheme.surface)
+      val currentBlurStyle = style ?: HazeMaterials.regular(MaterialTheme.colorScheme.surface)
       LargeTopAppBar(
-        title = { },
+        title = {
+          if (effect == SampleEffect.Glass && mode == ScaffoldSampleMode.Mask) {
+            Text("Glass shaped boundary")
+          }
+        },
         navigationIcon = {
           IconButton(
             onClick = navController::navigateUp,
@@ -134,37 +148,49 @@ fun ScaffoldSample(
             profilingDrawProgress?.invoke()
             drawContent()
           }
-          .hazeBlur(
-            input = HazeInput.Sources(hazeState),
-            performanceMode = performanceMode,
-            style = currentStyle.then {
-              blurEnabled(blurEnabled)
-              when (mode) {
-                ScaffoldSampleMode.Default -> Unit
-                ScaffoldSampleMode.Progressive -> {
-                  progressive(
-                    HazeProgressive.verticalGradient(
-                      startIntensity = 1f,
-                      endIntensity = 0f,
-                    ),
+          .then(
+            when (effect) {
+              SampleEffect.Blur -> Modifier.hazeBlur(
+                input = HazeInput.Sources(hazeState),
+                performanceMode = performanceMode,
+                style = currentBlurStyle.then {
+                  when (mode) {
+                    ScaffoldSampleMode.Default -> Unit
+                    ScaffoldSampleMode.Progressive -> progressive(progressive)
+                    ScaffoldSampleMode.Mask -> mask(Brush.easedVerticalGradient(EaseIn))
+                    ScaffoldSampleMode.StyleChurn -> {
+                      alpha(1f + checkNotNull(styleChurnPhase).value * 0f)
+                    }
+                  }
+                },
+              )
+
+              SampleEffect.Glass -> Modifier.hazeGlass(
+                input = HazeInput.Sources(hazeState),
+                performanceMode = performanceMode,
+                style = GlassStyle {
+                  tint(glassTint)
+                  shape(
+                    when (mode) {
+                      ScaffoldSampleMode.Mask -> RoundedCornerShape(24.dp)
+                      else -> RoundedCornerShape(0.dp)
+                    },
                   )
-                }
-
-                ScaffoldSampleMode.Mask -> {
-                  mask(Brush.easedVerticalGradient(EaseIn))
-                }
-
-                ScaffoldSampleMode.StyleChurn -> {
-                  alpha(1f + checkNotNull(styleChurnPhase).value * 0f)
-                }
-              }
+                  optics(
+                    when (mode) {
+                      ScaffoldSampleMode.Progressive -> GlassOptics.Fixed(progressive = progressive)
+                      else -> GlassOptics.Adaptive
+                    },
+                  )
+                },
+              )
             },
           )
           .fillMaxWidth(),
       )
     },
     bottomBar = {
-      val currentStyle = style ?: HazeMaterials.regular(MaterialTheme.colorScheme.surface)
+      val currentBlurStyle = style ?: HazeMaterials.regular(MaterialTheme.colorScheme.surface)
       var selectedIndex by remember { mutableIntStateOf(0) }
       AnimatedVisibility(
         visible = showNavigationBar,
@@ -179,14 +205,27 @@ fun ScaffoldSample(
               profilingDrawProgress?.invoke()
               drawContent()
             }
-            .hazeBlur(
-              input = HazeInput.Sources(hazeState),
-              performanceMode = performanceMode,
-              style = currentStyle.then {
-                blurEnabled(blurEnabled)
-                if (mode == ScaffoldSampleMode.StyleChurn) {
-                  alpha(1f + checkNotNull(styleChurnPhase).value * 0f)
-                }
+            .then(
+              when (effect) {
+                SampleEffect.Blur -> Modifier.hazeBlur(
+                  input = HazeInput.Sources(hazeState),
+                  performanceMode = performanceMode,
+                  style = currentBlurStyle.then {
+                    if (mode == ScaffoldSampleMode.StyleChurn) {
+                      alpha(1f + checkNotNull(styleChurnPhase).value * 0f)
+                    }
+                  },
+                )
+
+                SampleEffect.Glass -> Modifier.hazeGlass(
+                  input = HazeInput.Sources(hazeState),
+                  performanceMode = performanceMode,
+                  style = GlassStyle {
+                    tint(glassTint)
+                    shape(RoundedCornerShape(0.dp))
+                    optics(GlassOptics.Adaptive)
+                  },
+                )
               },
             )
             .fillMaxWidth(),

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/CreditCardSamplesTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/CreditCardSamplesTest.kt
@@ -14,10 +14,20 @@ import kotlin.test.Test
 @OptIn(ExperimentalTestApi::class)
 class CreditCardSamplesTest : ContextTest() {
   @Test
-  fun creditCardSample_keepsBenchmarkCardTag() = runComposeUiTest {
+  fun creditCardSample_keepsBenchmarkCardTagForBlur() = runComposeUiTest {
     setContent {
       val navController = rememberNavController()
-      CreditCardSample(navController = navController, blurEnabled = false)
+      CreditCardSample(navController = navController)
+    }
+
+    onNodeWithTag("credit_card_2").assertIsDisplayed()
+  }
+
+  @Test
+  fun creditCardSample_keepsBenchmarkCardTagForGlass() = runComposeUiTest {
+    setContent {
+      val navController = rememberNavController()
+      CreditCardSample(navController = navController, effect = SampleEffect.Glass)
     }
 
     onNodeWithTag("credit_card_2").assertIsDisplayed()

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
@@ -5,8 +5,12 @@ package dev.chrisbanes.haze.sample
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.navigation.compose.rememberNavController
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import dev.chrisbanes.haze.test.ContextTest
@@ -51,6 +55,35 @@ class SamplesTest : ContextTest() {
   }
 
   @Test
+  fun commonBuiltInSamples_exposeBothBuiltInEffects() {
+    val comparisonSamples = listOf(
+      Sample.Scaffold,
+      Sample.ScaffoldAdaptive,
+      Sample.ScaffoldQuality,
+      Sample.ScaffoldBalanced,
+      Sample.ScaffoldPerformance,
+      Sample.ScaffoldProgressive,
+      Sample.ScaffoldProgressiveQuality,
+      Sample.ScaffoldMasked,
+      Sample.ScaffoldMaskedQuality,
+      Sample.CreditCard,
+      Sample.ImageList,
+      Sample.ListOverImage,
+      Sample.Dialog,
+      Sample.Popup,
+      Sample.Materials,
+      Sample.ListWithStickyHeaders,
+      Sample.BottomSheet,
+      Sample.ContentBlurring,
+      Sample.LayerTransformations,
+    )
+
+    assertThat(comparisonSamples.map(Sample::effects)).isEqualTo(
+      List(comparisonSamples.size) { listOf(SampleEffect.Blur, SampleEffect.Glass) },
+    )
+  }
+
+  @Test
   fun samplesList_replacesOldGlassEntriesWithShowcaseSuite() = runComposeUiTest {
     setContent {
       Samples(
@@ -70,5 +103,48 @@ class SamplesTest : ContextTest() {
     onNodeWithTag("Glass — Lab").assertIsDisplayed()
     onNodeWithTag("Glass").assertDoesNotExist()
     onNodeWithTag("Glass (Debug)").assertDoesNotExist()
+  }
+
+  @Test
+  fun creditCard_exposesALocalBlurAndGlassChoice() = runComposeUiTest {
+    setContent {
+      SampleDestination(
+        sample = Sample.CreditCard,
+        navController = rememberNavController(),
+      )
+    }
+
+    onNodeWithTag("sample_effect_picker").assertIsDisplayed()
+    onNodeWithTag("sample_effect_blur").assertIsDisplayed().assertIsSelected()
+    onNodeWithTag("sample_effect_glass").performClick().assertIsSelected()
+    onNodeWithTag("sample_effect_blur").assertIsNotSelected()
+    onNodeWithTag("credit_card_2").assertIsDisplayed()
+    onNodeWithTag("blur_enabled").assertDoesNotExist()
+  }
+
+  @Test
+  fun glassScaffold_keepsItsGridContent() = runComposeUiTest {
+    setContent {
+      SampleDestination(
+        sample = Sample.Scaffold,
+        navController = rememberNavController(),
+      )
+    }
+
+    onNodeWithTag("sample_effect_glass").performClick()
+    onNodeWithTag("lazy_grid").assertIsDisplayed()
+  }
+
+  @Test
+  fun glassContentBlurring_omitsTheBlurOnlyClippedControl() = runComposeUiTest {
+    setContent {
+      SampleDestination(
+        sample = Sample.ContentBlurring,
+        navController = rememberNavController(),
+      )
+    }
+
+    onNodeWithTag("sample_effect_glass").performClick()
+    onNodeWithTag("content_blur_clipped").assertDoesNotExist()
   }
 }


### PR DESCRIPTION
Closes #1216

## What changed

- Adds a local, accessible Blur/Glass selector to every built-in Blur teaching recipe, including Android ExoPlayer.
- Keeps each recipe directly copyable with explicit `hazeBlur` and `hazeGlass` branches and recipe-local Glass styles.
- Preserves specialized behavior for Scaffold performance modes, Content Blurring, Materials, source-backed video, and custom effects.
- Removes the obsolete baseline-profile Blur-enable automation and adds shared/Android-host coverage.

## Why

The samples previously taught only the Blur version of these recipes. Developers now have an equivalent Glass implementation at the same seam without a generic abstraction obscuring the code they should copy.

## Developer impact

Each comparison route defaults to Blur and lets developers switch locally to Glass. Dedicated Glass showcases, profiling routes, and custom effects remain effect-specific.

## Validation

- `./gradlew --no-scan :sample:shared:jvmTest :sample:shared:testAndroidHostTest :internal:benchmark:compileBenchmarkReleaseKotlin`
- `./gradlew --no-scan --max-workers=1 build`
