### PR TITLE
Restore macosArm64 target support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
 
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v7
@@ -39,8 +39,12 @@ jobs:
           gradle-home-cache-excludes: |
             caches/build-cache-1
 
-      - name: Compile iOS arm64 target and run simulator tests
-        run: ./gradlew compileKotlinIosArm64 iosSimulatorArm64Test -Phaze.enableAppleTests
+      - name: Compile Apple targets, run iOS simulator and macOS host tests, link macOS sample
+        run: >
+          ./gradlew
+          compileKotlinIosArm64 iosSimulatorArm64Test
+          macosArm64Test :sample:macos:linkDebugExecutableMacosArm64
+          -Phaze.enableAppleTests
         env:
           ORG_GRADLE_PROJECT_remoteBuildCacheUrl: ${{ secrets.GRADLE_REMOTE_CACHE_URL }}
           ORG_GRADLE_PROJECT_remoteBuildCacheUsername: ${{ secrets.GRADLE_REMOTE_CACHE_USERNAME }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,9 @@ run faster: `./gradlew assembleDebug testDebug` for library artifacts,
 
 ## Coding Style & Naming Conventions
 
-All Kotlin sources use the default JetBrains style (four-space indentation, trailing commas where
-helpful). Spotless with ktlint enforces formatting; run `./gradlew spotlessApply` before committing.
+All Kotlin sources use the ktlint `intellij_idea` code style with two-space indentation, as
+configured in `.editorconfig`, and trailing commas where helpful. Spotless with ktlint enforces
+formatting; run `./gradlew spotlessApply` before committing.
 Keep public packages under `dev.chrisbanes.haze.*` and follow PascalCase for composables, camelCase
 for parameters, and `*Defaults` naming for reusable configuration containers.
 For internal or private value types, prefer `@Poko` over `data class`. Configure modules that use

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Glass can now composite transparent captured content onto an explicit background before
   refraction and blur using `GlassStyle.backgroundColor`
   ([#1207](https://github.com/chrisbanes/haze/issues/1207)).
+- Restored the `macosArm64` target across every published module, along with the `sample/macos`
+  app. The target was published in `2.0.0-alpha03` and dropped from `2.0.0-alpha04` in
+  [#1002](https://github.com/chrisbanes/haze/pull/1002).
 
 ## 2.0.0-alpha04 <small>2026-08-08</small> { id="2.0.0-alpha04" }
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Visual effects (blur and more) for Compose Multiplatform.
 
 https://github.com/user-attachments/assets/836dd79a-abdc-4cdc-b27d-baee394c1e26
 
-Haze provides hardware-accelerated visual effects for Compose Multiplatform — Android, iOS, Desktop, and Web. Built on a modular effect system, it lets you add blur, tint, and custom effects to any composable with a single modifier.
+Haze provides hardware-accelerated visual effects for Compose Multiplatform — Android, iOS, macOS, Desktop, and Web. Built on a modular effect system, it lets you add blur, tint, and custom effects to any composable with a single modifier.
 
 ## Platforms
 
@@ -19,6 +19,7 @@ Haze provides hardware-accelerated visual effects for Compose Multiplatform — 
 | Android | ✅ |
 | Desktop (JVM) | ✅ |
 | iOS | ✅ |
+| macOS | ✅ |
 | Wasm / JS | ✅ |
 
 ## Download

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,7 @@ subprojects {
         "coil-core-iossimulatorarm64",
         "coil-core-js",
         "coil-core-jvm",
+        "coil-core-macosarm64",
         "coil-core-wasm-js",
       ).forEach { module ->
         withModule("io.coil-kt.coil3:$module") {

--- a/docs/blur/platforms.md
+++ b/docs/blur/platforms.md
@@ -99,6 +99,10 @@ Desktop JVM is a Compose Multiplatform target which is built upon [Skiko][skiko]
 
 iOS is a Compose Multiplatform target which is built upon [Skiko][skiko], so see the [Skiko](#skiko) docs below.
 
+## macOS
+
+macOS is a Compose Multiplatform target which is built upon [Skiko][skiko], so see the [Skiko](#skiko) docs below.
+
 ## Web
 
 Compose for Web is based on Kotlin/Wasm, and is a Compose Multiplatform target which is built upon [Skiko][skiko], so see the [Skiko](#skiko) docs below.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Haze is built with [Compose Multiplatform](https://www.jetbrains.com/lp/compose-
 | Android       | ✅               |
 | Desktop (JVM) | ✅               |
 | iOS           | ✅               |
+| macOS         | ✅               |
 | Wasm          | ✅               |
 | JS/Canvas     | ✅               |
 

--- a/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/KotlinMultiplatformConventionPlugin.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/KotlinMultiplatformConventionPlugin.kt
@@ -58,15 +58,24 @@ class KotlinMultiplatformConventionPlugin : Plugin<Project> {
   }
 }
 
+/**
+ * Whether the Apple (iOS + macOS) Kotlin/Native targets are configured for this build.
+ *
+ * Non-Apple hosts cannot build them, so CI opts out with `-Phaze.disableAppleTargets`.
+ */
+val Project.appleTargetsEnabled: Boolean
+  get() = !providers.gradleProperty("haze.disableAppleTargets").isPresent
+
 fun KotlinMultiplatformExtension.addDefaultHazeTargets(
   project: Project,
   withSkikoMain: Boolean = false,
 ) {
   jvm()
 
-  if (!project.providers.gradleProperty("haze.disableAppleTargets").isPresent) {
+  if (project.appleTargetsEnabled) {
     iosArm64()
     iosSimulatorArm64()
+    macosArm64()
   }
 
   @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
@@ -82,8 +91,9 @@ fun KotlinMultiplatformExtension.addDefaultHazeTargets(
     val skikoMain = sourceSets.maybeCreate("skikoMain").apply {
       dependsOn(sourceSets.getByName("commonMain"))
     }
-    if (!project.providers.gradleProperty("haze.disableAppleTargets").isPresent) {
-      sourceSets.getByName("iosMain").dependsOn(skikoMain)
+    if (project.appleTargetsEnabled) {
+      // appleMain is the common parent of iosMain and macosMain, both of which render via Skiko.
+      sourceSets.getByName("appleMain").dependsOn(skikoMain)
     }
     sourceSets.getByName("jvmMain").dependsOn(skikoMain)
     sourceSets.getByName("wasmJsMain").dependsOn(skikoMain)

--- a/haze/src/macosMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.macos.kt
+++ b/haze/src/macosMain/kotlin/dev/chrisbanes/haze/TrimMemoryCallback.macos.kt
@@ -1,0 +1,17 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.lifecycle.Lifecycle
+import kotlinx.coroutines.DisposableHandle
+
+/**
+ * AppKit has no equivalent of UIKit's `UIApplicationDidReceiveMemoryWarningNotification`, so macOS
+ * follows the desktop targets and trims on lifecycle stop instead.
+ */
+internal actual fun registerTrimMemoryCallback(
+  context: PlatformContext,
+  lifecycle: Lifecycle?,
+  callback: (TrimMemoryLevel) -> Unit,
+): DisposableHandle = registerLifecycleTrimMemoryCallback(lifecycle, callback)

--- a/haze/src/macosTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.macos.kt
+++ b/haze/src/macosTest/kotlin/dev/chrisbanes/haze/LifecycleTrimMemoryTestPlatform.macos.kt
@@ -1,0 +1,6 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal actual val supportsLifecycleTrimMemoryCallbacks: Boolean = true

--- a/sample/macos/build.gradle.kts
+++ b/sample/macos/build.gradle.kts
@@ -1,0 +1,35 @@
+// Copyright 2023, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+
+plugins {
+  id("dev.chrisbanes.kotlin.multiplatform")
+  id("dev.chrisbanes.compose")
+}
+
+kotlin {
+  macosArm64 {
+    binaries.executable {
+      entryPoint = "dev.chrisbanes.haze.sample.main"
+    }
+  }
+
+  sourceSets {
+    macosMain {
+      dependencies {
+        implementation(projects.sample.shared)
+      }
+    }
+  }
+}
+
+compose.desktop {
+  nativeApplication {
+    targets(kotlin.macosArm64())
+
+    distributions {
+      packageName = "HazeSample"
+      packageVersion = "1.0.0"
+    }
+  }
+}

--- a/sample/macos/src/macosMain/kotlin/dev/chrisbanes/haze/sample/Main.kt
+++ b/sample/macos/src/macosMain/kotlin/dev/chrisbanes/haze/sample/Main.kt
@@ -1,0 +1,26 @@
+// Copyright 2023, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample
+
+import androidx.compose.ui.window.Window
+import platform.AppKit.NSApplication
+import platform.AppKit.NSApplicationActivationPolicy
+import platform.AppKit.NSApplicationDelegateProtocol
+import platform.darwin.NSObject
+
+fun main() {
+  val nsApplication = NSApplication.sharedApplication()
+  nsApplication.setActivationPolicy(NSApplicationActivationPolicy.NSApplicationActivationPolicyRegular)
+  nsApplication.delegate = object : NSObject(), NSApplicationDelegateProtocol {
+    override fun applicationShouldTerminateAfterLastWindowClosed(sender: NSApplication): Boolean {
+      return true
+    }
+  }
+  Window(
+    title = "Haze Sample",
+  ) {
+    Samples("Haze Samples")
+  }
+  nsApplication.run()
+}

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -3,7 +3,9 @@
 
 
 import dev.chrisbanes.gradle.addDefaultHazeTargets
+import dev.chrisbanes.gradle.appleTargetsEnabled
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.konan.target.Family
 
 plugins {
   id("dev.chrisbanes.android.library")
@@ -71,8 +73,8 @@ kotlin {
       }
     }
 
-    if (!project.providers.gradleProperty("haze.disableAppleTargets").isPresent) {
-      iosMain {
+    if (project.appleTargetsEnabled) {
+      appleMain {
         dependencies {
           implementation(libs.ktor.darwin)
         }
@@ -117,12 +119,16 @@ kotlin {
     }
   }
 
-  targets.withType<KotlinNativeTarget>().configureEach {
-    binaries.framework {
-      isStatic = true
-      baseName = "HazeSamplesKt"
+  // Only iOS consumes this framework, via the Xcode sample project. :sample:macos links the
+  // klib directly, so macosArm64 must not build a framework that nothing reads.
+  targets.withType<KotlinNativeTarget>()
+    .matching { it.konanTarget.family == Family.IOS }
+    .configureEach {
+      binaries.framework {
+        isStatic = true
+        baseName = "HazeSamplesKt"
+      }
     }
-  }
 }
 
 poko {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -121,3 +121,8 @@ include(
   ":sample:desktop",
   ":sample:web",
 )
+
+// Kotlin/Native macOS executables can only be built on an Apple host.
+if (!providers.gradleProperty("haze.disableAppleTargets").isPresent) {
+  include(":sample:macos")
+}


### PR DESCRIPTION
## Summary

- Restore `macosArm64()` in `addDefaultHazeTargets`, and hang `skikoMain` off `appleMain` so both `iosMain` and `macosMain` inherit it.
- Add the one missing `actual`, `registerTrimMemoryCallback` for macOS, plus its `macosTest` platform flag.
- Restore the `:sample:macos` module and its settings include, and move `ktor.darwin` from `iosMain` to `appleMain` in `:sample:shared`.
- Keep the shared `HazeSamplesKt` framework iOS-only, so `macosArm64` does not link a framework that nothing consumes.
- Exclude the duplicate Skiko dependency from `coil-core-macosarm64`, matching the existing iOS/JS/JVM/Wasm entries.
- Cover the target in the `mac_build` CI job, and document it in the changelog, README and platform docs.

Affected modules: `gradle/build-logic`, `haze`, `sample/shared` and the new `sample/macos`, plus root Gradle config, CI and docs. No public API change.

## Why

`macosArm64` shipped in [2.0.0-alpha03](https://github.com/chrisbanes/haze/releases/tag/2.0.0-alpha03) but disappeared in [2.0.0-alpha04](https://github.com/chrisbanes/haze/releases/tag/2.0.0-alpha04). It was dropped by the build-warning cleanup in #1002, which removed the target, the `:sample:macos` module and the `macosMain` sample sources, but didn't seem to mention any of it in the PR description. I had seen some clear messaging back in the [2.0.0-alpha01](https://github.com/chrisbanes/haze/releases/tag/2.0.0-alpha01) release notes relating to dropping support for `iosX64` and `macosX64` targets (in line with CMP deprecations), so I found it strange that `macosArm64` support had been dropped in `2.0.0-alpha04`.

I figured the change might have been unintentional, since it wasn't mentioned, and was bundled with the above mentioned changes. I also noticed that removal wasn't complete: `haze/src/macosMain/Utils.macos.kt` and `internal/context-test/src/macosMain/ContextTest.kt` were left behind as dead source sets, and `org.jetbrains.compose.experimental.macos.enabled` appears to still set in `gradle.properties`.

## Developer impact

On an Apple host, `./gradlew build` now also links and runs a macOS host test binary for `haze-blur`, `haze-glass`, `haze-materials` and `sample:shared`. Only `:haze` gates native tests behind `-Phaze.enableAppleTests`, so this matches the existing ungated `iosSimulatorArm64Test` behaviour in those same modules rather than introducing a new pattern. The `mac_build` timeout moves from 30 to 45 minutes to absorb the added compile, link and test work.

## Validation

- `./gradlew compileKotlinMacosArm64 :sample:macos:linkDebugExecutableMacosArm64`
- `./gradlew :haze:macosArm64Test :haze-blur:macosArm64Test :haze-glass:macosArm64Test :haze-materials:macosArm64Test :sample:shared:macosArm64Test -Phaze.enableAppleTests` (446 tests, 0 failures, 0 skipped)
- `./gradlew :sample:macos:createDistributableNativeDebugMacosArm64` produces `HazeSample.app`. I ran it briefly with the AppKit run loop and sample frames on the stack, and `otool -L` confirms AppKit and Metal were linked
- `./gradlew :sample:shared:assemble --dry-run` lists only the four iOS framework link tasks, with no `linkDebugFrameworkMacosArm64`
- `./gradlew :sample:shared:help :haze:help -Phaze.disableAppleTargets` (the non-Apple CI path still configures)
- `./gradlew metalavaCheckCompatibility checkPublicApiDocumentation`
- `./gradlew spotlessApply` (no changes)