### PR TITLE
Force blur for style churn benchmark

### DIFF
--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BaselineProfileGenerator.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BaselineProfileGenerator.kt
@@ -9,8 +9,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-private const val FORCE_BLUR_EXTRA = "dev.chrisbanes.haze.sample.android.FORCE_BLUR"
-
 @RunWith(AndroidJUnit4::class)
 class BaselineProfileGenerator {
   @get:Rule

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
@@ -52,7 +52,9 @@ class BenchmarkTest {
       startupMode = StartupMode.WARM,
       iterations = DEFAULT_ITERATIONS,
       setupBlock = {
-        startActivityAndWait()
+        startActivityAndWait { intent ->
+          intent.putExtra(FORCE_BLUR_EXTRA, true)
+        }
         device.navigateToScaffoldWithEquivalentStyleChurn()
       },
     ) {

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
@@ -16,6 +16,8 @@ import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+internal const val FORCE_BLUR_EXTRA = "dev.chrisbanes.haze.sample.android.FORCE_BLUR"
+
 internal fun UiDevice.waitForObject(
   selector: BySelector,
   timeout: Duration = 15.seconds,


### PR DESCRIPTION
## What changed

- Starts the equivalent style-churn macrobenchmark with the private force-Blur launch extra.
- Shares the benchmark-only extra name with baseline-profile generation.

## Why

On API 30, Blur is disabled by default. The benchmark must explicitly enable it so it measures the intended Blur style-update path rather than the scrim fallback.

## Validation

- `./gradlew --no-scan :internal:benchmark:spotlessCheck :internal:benchmark:compileBenchmarkReleaseKotlin`
