### PR TITLE
Stabilize sample effect picker test

### DIFF
--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
@@ -3,6 +3,9 @@
 
 package dev.chrisbanes.haze.sample
 
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
@@ -106,20 +109,32 @@ class SamplesTest : ContextTest() {
   }
 
   @Test
-  fun creditCard_exposesALocalBlurAndGlassChoice() = runComposeUiTest {
+  fun sampleDestination_switchesLocalEffect() = runComposeUiTest {
+    val sample = Sample(
+      route = "effect-picker",
+      title = "Effect picker",
+      effects = listOf(SampleEffect.Blur, SampleEffect.Glass),
+    ) { _, effect ->
+      Text(
+        text = "Selected ${effect.label}",
+        modifier = Modifier.testTag("selected_effect_${effect.name.lowercase()}"),
+      )
+    }
+
     setContent {
       SampleDestination(
-        sample = Sample.CreditCard,
+        sample = sample,
         navController = rememberNavController(),
       )
     }
 
     onNodeWithTag("sample_effect_picker").assertIsDisplayed()
     onNodeWithTag("sample_effect_blur").assertIsDisplayed().assertIsSelected()
+    onNodeWithTag("selected_effect_blur").assertIsDisplayed()
     onNodeWithTag("sample_effect_glass").performClick().assertIsSelected()
     onNodeWithTag("sample_effect_blur").assertIsNotSelected()
-    onNodeWithTag("credit_card_2").assertIsDisplayed()
-    onNodeWithTag("blur_enabled").assertDoesNotExist()
+    onNodeWithTag("selected_effect_glass").assertIsDisplayed()
+    onNodeWithTag("selected_effect_blur").assertDoesNotExist()
   }
 
   @Test


### PR DESCRIPTION
## Summary

- test `SampleDestination`'s local Blur/Glass selection with a lightweight visible sample fixture
- retain the direct Credit Card Blur and Glass tests as renderer coverage

## Why

The previous picker test switched three live source-backed Credit Card effects from Blur to Glass. On Linux JVM CI, Compose `waitForIdle` intermittently never quiesced after the switch, causing `UncompletedCoroutinesError` (#1222). The picker contract does not require the renderer; isolating it removes the incidental Skiko/Haze idle dependency without weakening the effect-selection assertions.

## Validation

- `./gradlew :sample:shared:jvmTest --tests dev.chrisbanes.haze.sample.SamplesTest.sampleDestination_switchesLocalEffect --tests 'dev.chrisbanes.haze.sample.CreditCardSamplesTest.*' --no-scan --stacktrace`
- five forced fresh executions of the picker test
- `./gradlew :sample:shared:allTests --no-scan --console=plain`
- `./gradlew :sample:shared:spotlessCheck --no-scan --console=plain`