### PR TITLE
Group samples by visual effect

### DIFF
--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
@@ -39,27 +39,27 @@ internal fun <R> UiDevice.wait(condition: SearchCondition<R>, timeout: Duration)
 }
 
 internal fun UiDevice.navigateToImagesList() {
-  findSampleListItem(By.res("Images List")).click()
+  findBlurSampleListItem(By.res("Images List")).click()
   waitForIdle()
 }
 
 internal fun UiDevice.navigateToScaffold() {
-  findSampleListItem(By.res("Scaffold")).click()
+  findBlurSampleListItem(By.res("Scaffold")).click()
   waitForIdle()
 }
 
 internal fun UiDevice.navigateToScaffoldWithEquivalentStyleChurn() {
-  findSampleListItem(By.res("Blur — Equivalent Style Churn")).click()
+  findBlurSampleListItem(By.res("Blur — Equivalent Style Churn")).click()
   waitForIdle()
 }
 
 internal fun UiDevice.navigateToCreditCard() {
-  findSampleListItem(By.res("Credit Card")).click()
+  findBlurSampleListItem(By.res("Credit Card")).click()
   waitForIdle()
 }
 
 internal fun UiDevice.navigateToBlurProfiling(scenarioId: String) {
-  findSampleListItem(By.res("Blur — Profiling")).click()
+  findBlurSampleListItem(By.res("Blur — Profiling")).click()
   waitForObject(By.res("blur_profiling_picker"))
     .apply { setGestureMarginPercentage(0.1f) }
     .scrollUntil(
@@ -92,7 +92,7 @@ internal fun UiDevice.runBlurProfilingScenario(scenarioId: String) {
 }
 
 internal fun UiDevice.navigateToGlassProduct() {
-  findSampleListItem(By.res("Glass — Product")).click()
+  findGlassSampleListItem(By.res("Glass — Product")).click()
   waitForObject(By.res("glass_product_page_0"))
 }
 
@@ -102,7 +102,7 @@ internal fun UiDevice.advanceGlassProduct() {
 }
 
 internal fun UiDevice.navigateToGlassPlayground() {
-  findSampleListItem(By.res("Glass — Playground")).click()
+  findGlassSampleListItem(By.res("Glass — Playground")).click()
   waitForObject(By.res("glass_playground_loop_1"), timeout = 20.seconds)
 }
 
@@ -113,7 +113,7 @@ internal fun UiDevice.measureFullGlassPlaygroundLoop() {
 }
 
 internal fun UiDevice.navigateToGlassProfiling(scenarioId: String) {
-  findSampleListItem(By.res("Glass — Profiling")).click()
+  findGlassSampleListItem(By.res("Glass — Profiling")).click()
   waitForObject(By.res("glass_profiling_picker"))
     .apply { setGestureMarginPercentage(0.1f) }
     .scrollUntil(
@@ -165,7 +165,14 @@ private fun UiDevice.waitForProfilingObject(
 private const val GLASS_PROFILING_MEASURE_MILLIS = 3_250L
 private const val BLUR_PROFILING_MEASURE_MILLIS = 3_250L
 
-internal fun UiDevice.findSampleListItem(selector: BySelector): UiObject2 {
+private fun UiDevice.findBlurSampleListItem(selector: BySelector): UiObject2 =
+  findSampleListItem(effect = "blur", selector = selector)
+
+private fun UiDevice.findGlassSampleListItem(selector: BySelector): UiObject2 =
+  findSampleListItem(effect = "glass", selector = selector)
+
+private fun UiDevice.findSampleListItem(effect: String, selector: BySelector): UiObject2 {
+  waitForObject(By.res("sample_effect_$effect")).click()
   return waitForObject(By.res("sample_list"))
     .apply { setGestureMarginPercentage(0.1f) }
     .scrollUntil(Direction.DOWN, Until.findObject(selector))

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/UiAutomator.kt
@@ -172,8 +172,11 @@ private fun UiDevice.findGlassSampleListItem(selector: BySelector): UiObject2 =
   findSampleListItem(effect = "glass", selector = selector)
 
 private fun UiDevice.findSampleListItem(effect: String, selector: BySelector): UiObject2 {
-  waitForObject(By.res("sample_effect_$effect")).click()
-  return waitForObject(By.res("sample_list"))
+  val sampleList = findObject(By.res("sample_list")) ?: run {
+    waitForObject(By.res("sample_effect_$effect")).click()
+    waitForObject(By.res("sample_list"))
+  }
+  return sampleList
     .apply { setGestureMarginPercentage(0.1f) }
     .scrollUntil(Direction.DOWN, Until.findObject(selector))
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
@@ -9,7 +9,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -371,6 +375,7 @@ fun Samples(
             SamplesList(
               appTitle = "$appTitle — ${effect.label}",
               samples = effectSamples,
+              onNavigateUp = navController::navigateUp,
               onSampleSelected = { selected ->
                 navController.navigate(selected.route(effect))
               },
@@ -431,6 +436,7 @@ internal fun EffectList(
 internal fun SamplesList(
   appTitle: String,
   samples: List<Sample>,
+  onNavigateUp: () -> Unit,
   onSampleSelected: (Sample) -> Unit,
   modifier: Modifier = Modifier,
 ) {
@@ -438,6 +444,14 @@ internal fun SamplesList(
     topBar = {
       TopAppBar(
         title = { Text(text = appTitle) },
+        navigationIcon = {
+          IconButton(
+            onClick = onNavigateUp,
+            modifier = Modifier.testTag("sample_list_back"),
+          ) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+          }
+        },
         modifier = Modifier.fillMaxWidth(),
       )
     },

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
@@ -5,19 +5,14 @@ package dev.chrisbanes.haze.sample
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.darkColorScheme
@@ -25,15 +20,9 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -53,6 +42,14 @@ private const val SAMPLES_ROUTE = "samples"
 enum class SampleEffect(val label: String) {
   Blur("Blur"),
   Glass("Glass"),
+}
+
+private fun SampleEffect.route(): String = "$SAMPLES_ROUTE/${name.lowercase()}"
+
+private fun Sample.route(effect: SampleEffect): String = "$route/${effect.name.lowercase()}"
+
+internal fun List<Sample>.forEffect(effect: SampleEffect): List<Sample> = filter {
+  effect in it.effects
 }
 
 @OptIn(ExperimentalHazeApi::class)
@@ -359,17 +356,37 @@ fun Samples(
         modifier = Modifier.testTagsAsResourceId(true),
       ) {
         composable(SAMPLES_ROUTE) {
-          val sortedSamples = remember { samples.sortedBy(Sample::title) }
-          SamplesList(
+          EffectList(
             appTitle = appTitle,
-            samples = sortedSamples,
-            navController = navController,
+            effects = SampleEffect.entries.toList(),
+            onEffectSelected = { effect -> navController.navigate(effect.route()) },
           )
         }
 
+        SampleEffect.entries.forEach { effect ->
+          composable(effect.route()) {
+            val effectSamples = remember(samples, effect) {
+              samples.forEffect(effect).sortedBy(Sample::title)
+            }
+            SamplesList(
+              appTitle = "$appTitle — ${effect.label}",
+              samples = effectSamples,
+              onSampleSelected = { selected ->
+                navController.navigate(selected.route(effect))
+              },
+            )
+          }
+        }
+
         samples.forEach { sample ->
-          composable(sample.route) {
-            SampleDestination(sample = sample, navController = navController)
+          sample.effects.forEach { effect ->
+            composable(sample.route(effect)) {
+              SampleDestination(
+                sample = sample,
+                effect = effect,
+                navController = navController,
+              )
+            }
           }
         }
       }
@@ -380,46 +397,43 @@ fun Samples(
 @Composable
 internal fun SampleDestination(
   sample: Sample,
+  effect: SampleEffect,
   navController: NavHostController,
 ) {
-  var selectedEffectName by rememberSaveable(sample.route) {
-    mutableStateOf(sample.effects.first().name)
-  }
-  val selectedEffect = sample.effects.firstOrNull { it.name == selectedEffectName }
-    ?: sample.effects.first()
-
-  Box(modifier = Modifier.fillMaxSize()) {
-    sample.content(navController, selectedEffect)
-
-    if (sample.effects.size > 1) {
-      SampleEffectPicker(
-        effects = sample.effects,
-        selectedEffect = selectedEffect,
-        onEffectSelected = { selectedEffectName = it.name },
-        modifier = Modifier
-          .align(Alignment.TopEnd)
-          .padding(top = 80.dp, end = 16.dp),
-      )
-    }
-  }
+  sample.content(navController, effect)
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SampleEffectPicker(
+internal fun EffectList(
+  appTitle: String,
   effects: List<SampleEffect>,
-  selectedEffect: SampleEffect,
   onEffectSelected: (SampleEffect) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  SingleChoiceSegmentedButtonRow(modifier = modifier.testTag("sample_effect_picker")) {
-    effects.forEachIndexed { index, effect ->
-      SegmentedButton(
-        selected = effect == selectedEffect,
-        onClick = { onEffectSelected(effect) },
-        shape = SegmentedButtonDefaults.itemShape(index = index, count = effects.size),
-        modifier = Modifier.testTag("sample_effect_${effect.name.lowercase()}"),
-      ) {
-        Text(effect.label)
+  Scaffold(
+    topBar = {
+      TopAppBar(
+        title = { Text(text = appTitle) },
+        modifier = Modifier.fillMaxWidth(),
+      )
+    },
+    modifier = modifier,
+  ) { contentPadding ->
+    LazyColumn(
+      modifier = Modifier
+        .testTag("sample_effect_list")
+        .fillMaxSize(),
+      contentPadding = contentPadding,
+    ) {
+      items(effects) { effect ->
+        ListItem(
+          headlineContent = { Text(text = effect.label) },
+          modifier = Modifier
+            .fillMaxWidth()
+            .testTag("sample_effect_${effect.name.lowercase()}")
+            .clickable { onEffectSelected(effect) },
+        )
       }
     }
   }
@@ -427,10 +441,10 @@ private fun SampleEffectPicker(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SamplesList(
+internal fun SamplesList(
   appTitle: String,
   samples: List<Sample>,
-  navController: NavHostController,
+  onSampleSelected: (Sample) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   Scaffold(
@@ -454,7 +468,7 @@ private fun SamplesList(
           modifier = Modifier
             .fillMaxWidth()
             .testTag(sample.title)
-            .clickable { navController.navigate(sample.route) },
+            .clickable { onSampleSelected(sample) },
         )
       }
     }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
@@ -381,26 +381,13 @@ fun Samples(
         samples.forEach { sample ->
           sample.effects.forEach { effect ->
             composable(sample.route(effect)) {
-              SampleDestination(
-                sample = sample,
-                effect = effect,
-                navController = navController,
-              )
+              sample.content(navController, effect)
             }
           }
         }
       }
     }
   }
-}
-
-@Composable
-internal fun SampleDestination(
-  sample: Sample,
-  effect: SampleEffect,
-  navController: NavHostController,
-) {
-  sample.content(navController, effect)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
@@ -8,13 +8,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotSelected
-import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.navigation.compose.rememberNavController
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
@@ -30,12 +29,23 @@ class SamplesTest : ContextTest() {
   }
 
   @Test
-  fun commonSamples_containsOnlyThreeGlassGalleryDestinations() {
+  fun commonSamples_hasDedicatedGlassGalleryDestinations() {
     assertThat(
       CommonSamples.map(Sample::title).filter { "Glass" in it },
     ).isEqualTo(
       listOf("Glass — Product", "Glass — Playground", "Glass — Lab"),
     )
+  }
+
+  @Test
+  fun commonSamples_catalogsIncludeCustomVisualEffectAndGlassShowcases() {
+    assertThat(CommonSamples.forEffect(SampleEffect.Blur).map(Sample::title))
+      .contains("Custom VisualEffect")
+    assertThat(CommonSamples.forEffect(SampleEffect.Glass).size).isEqualTo(22)
+    val glassTitles = CommonSamples.forEffect(SampleEffect.Glass).map(Sample::title)
+    assertThat(glassTitles).contains("Glass — Product")
+    assertThat(glassTitles).contains("Glass — Playground")
+    assertThat(glassTitles).contains("Glass — Lab")
   }
 
   @Test
@@ -87,7 +97,7 @@ class SamplesTest : ContextTest() {
   }
 
   @Test
-  fun samplesList_replacesOldGlassEntriesWithShowcaseSuite() = runComposeUiTest {
+  fun samples_startsWithEffectCategories() = runComposeUiTest {
     setContent {
       Samples(
         appTitle = "Haze Samples",
@@ -100,16 +110,55 @@ class SamplesTest : ContextTest() {
       )
     }
 
-    onNodeWithTag("Credit Card").assertIsDisplayed()
-    onNodeWithTag("Glass — Product").assertIsDisplayed()
-    onNodeWithTag("Glass — Playground").assertIsDisplayed()
-    onNodeWithTag("Glass — Lab").assertIsDisplayed()
-    onNodeWithTag("Glass").assertDoesNotExist()
-    onNodeWithTag("Glass (Debug)").assertDoesNotExist()
+    onNodeWithTag("sample_effect_blur").assertIsDisplayed()
+    onNodeWithTag("sample_effect_glass").assertIsDisplayed()
+    onNodeWithTag("Credit Card").assertDoesNotExist()
   }
 
   @Test
-  fun sampleDestination_switchesLocalEffect() = runComposeUiTest {
+  fun effectList_selectsGlassCategory() = runComposeUiTest {
+    var selectedEffect: SampleEffect? = null
+    setContent {
+      EffectList(
+        appTitle = "Haze Samples",
+        effects = SampleEffect.entries.toList(),
+        onEffectSelected = { selectedEffect = it },
+      )
+    }
+
+    onNodeWithTag("sample_effect_glass").performClick()
+    runOnIdle {
+      assertThat(selectedEffect).isEqualTo(SampleEffect.Glass)
+    }
+  }
+
+  @Test
+  fun samplesForEffect_keepsSharedAndEffectSpecificSamplesSeparate() {
+    val sharedSample = Sample(
+      route = "shared",
+      title = "Shared sample",
+      effects = listOf(SampleEffect.Blur, SampleEffect.Glass),
+    ) { _, _ -> }
+    val blurOnlySample = Sample(
+      route = "blur-only",
+      title = "Blur-only sample",
+    ) { _, _ -> }
+    val glassOnlySample = Sample(
+      route = "glass-only",
+      title = "Glass-only sample",
+      effects = listOf(SampleEffect.Glass),
+    ) { _, _ -> }
+
+    val samples = listOf(sharedSample, blurOnlySample, glassOnlySample)
+
+    assertThat(samples.forEffect(SampleEffect.Blur).map(Sample::title))
+      .isEqualTo(listOf("Shared sample", "Blur-only sample"))
+    assertThat(samples.forEffect(SampleEffect.Glass).map(Sample::title))
+      .isEqualTo(listOf("Shared sample", "Glass-only sample"))
+  }
+
+  @Test
+  fun sampleDestination_usesItsEffectRoute() = runComposeUiTest {
     val sample = Sample(
       route = "effect-picker",
       title = "Effect picker",
@@ -124,15 +173,11 @@ class SamplesTest : ContextTest() {
     setContent {
       SampleDestination(
         sample = sample,
+        effect = SampleEffect.Glass,
         navController = rememberNavController(),
       )
     }
 
-    onNodeWithTag("sample_effect_picker").assertIsDisplayed()
-    onNodeWithTag("sample_effect_blur").assertIsDisplayed().assertIsSelected()
-    onNodeWithTag("selected_effect_blur").assertIsDisplayed()
-    onNodeWithTag("sample_effect_glass").performClick().assertIsSelected()
-    onNodeWithTag("sample_effect_blur").assertIsNotSelected()
     onNodeWithTag("selected_effect_glass").assertIsDisplayed()
     onNodeWithTag("selected_effect_blur").assertDoesNotExist()
   }
@@ -142,11 +187,11 @@ class SamplesTest : ContextTest() {
     setContent {
       SampleDestination(
         sample = Sample.Scaffold,
+        effect = SampleEffect.Glass,
         navController = rememberNavController(),
       )
     }
 
-    onNodeWithTag("sample_effect_glass").performClick()
     onNodeWithTag("lazy_grid").assertIsDisplayed()
   }
 
@@ -155,11 +200,11 @@ class SamplesTest : ContextTest() {
     setContent {
       SampleDestination(
         sample = Sample.ContentBlurring,
+        effect = SampleEffect.Glass,
         navController = rememberNavController(),
       )
     }
 
-    onNodeWithTag("sample_effect_glass").performClick()
     onNodeWithTag("content_blur_clipped").assertDoesNotExist()
   }
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
@@ -158,7 +158,7 @@ class SamplesTest : ContextTest() {
   }
 
   @Test
-  fun sampleDestination_usesItsEffectRoute() = runComposeUiTest {
+  fun sampleContent_usesItsEffectRoute() = runComposeUiTest {
     val sample = Sample(
       route = "effect-picker",
       title = "Effect picker",
@@ -171,11 +171,7 @@ class SamplesTest : ContextTest() {
     }
 
     setContent {
-      SampleDestination(
-        sample = sample,
-        effect = SampleEffect.Glass,
-        navController = rememberNavController(),
-      )
+      sample.content(rememberNavController(), SampleEffect.Glass)
     }
 
     onNodeWithTag("selected_effect_glass").assertIsDisplayed()
@@ -185,11 +181,7 @@ class SamplesTest : ContextTest() {
   @Test
   fun glassScaffold_keepsItsGridContent() = runComposeUiTest {
     setContent {
-      SampleDestination(
-        sample = Sample.Scaffold,
-        effect = SampleEffect.Glass,
-        navController = rememberNavController(),
-      )
+      Sample.Scaffold.content(rememberNavController(), SampleEffect.Glass)
     }
 
     onNodeWithTag("lazy_grid").assertIsDisplayed()
@@ -198,11 +190,7 @@ class SamplesTest : ContextTest() {
   @Test
   fun glassContentBlurring_omitsTheBlurOnlyClippedControl() = runComposeUiTest {
     setContent {
-      SampleDestination(
-        sample = Sample.ContentBlurring,
-        effect = SampleEffect.Glass,
-        navController = rememberNavController(),
-      )
+      Sample.ContentBlurring.content(rememberNavController(), SampleEffect.Glass)
     }
 
     onNodeWithTag("content_blur_clipped").assertDoesNotExist()

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.rememberNavController
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isEqualTo
+import assertk.assertions.isTrue
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 
@@ -129,6 +130,24 @@ class SamplesTest : ContextTest() {
     onNodeWithTag("sample_effect_glass").performClick()
     runOnIdle {
       assertThat(selectedEffect).isEqualTo(SampleEffect.Glass)
+    }
+  }
+
+  @Test
+  fun samplesList_navigatesUp() = runComposeUiTest {
+    var navigatedUp = false
+    setContent {
+      SamplesList(
+        appTitle = "Haze Samples — Blur",
+        samples = emptyList(),
+        onNavigateUp = { navigatedUp = true },
+        onSampleSelected = {},
+      )
+    }
+
+    onNodeWithTag("sample_list_back").performClick()
+    runOnIdle {
+      assertThat(navigatedUp).isTrue()
     }
   }
 


### PR DESCRIPTION
## Summary

- organize the gallery into Blur and Glass catalogs
- list all shared samples in each catalog and retain the three Glass-only showcases
- remove the per-screen effect picker

## Validation

- `./gradlew check --no-scan`
- `./gradlew :sample:shared:jvmTest --tests dev.chrisbanes.haze.sample.SamplesTest --no-scan`
- `git diff --check`

## Reviews

- `review-and-simplify-changes`
- `ponytail-review`