### PR TITLE
Make Glass pointer tracking immediate

### DIFF
--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -302,6 +302,10 @@ Modifier
   )
 ```
 
+Direct mouse, stylus, and touch positions track immediately.
+`interactionPositionAnimationSpec` controls movement to focus and `InteractionSource`-derived
+positions.
+
 Keep the visual response in `GlassStyle`, and pass each element's interaction source and behavior
 options to `hazeGlass`. The same Style can be reused without sharing interaction state.
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassDefaults.kt
@@ -6,6 +6,7 @@ package dev.chrisbanes.haze.glass
 import androidx.compose.animation.core.FiniteAnimationSpec
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -20,7 +21,7 @@ public object GlassDefaults {
   /** Default light radius recorded by [style] as a fraction of the material's shortest side. */
   public const val interactionLightRadiusFraction: Float = 0.7f
 
-  /** Default animation recorded by [style] when the interaction light moves to a new position. */
+  /** Default animation used for focus and [InteractionSource]-derived positions. */
   public val positionAnimationSpec: FiniteAnimationSpec<Offset> = spring(
     dampingRatio = 1f,
     stiffness = Spring.StiffnessMedium,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteractionController.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteractionController.kt
@@ -284,13 +284,14 @@ internal class GlassInteractionController(
   fun onPointerEvent(event: PointerEvent, size: Size) {
     if (disposed) return
     val hasDrawableSize = size.isDrawable()
+    var directPosition: Offset? = null
 
     val primaryChange = primaryPointerId?.let { id ->
       event.changes.firstOrNull { it.id == id }
     }
     if (primaryChange?.isConsumed == true && primaryChange.positionChangedIgnoreConsumed()) {
       if (hasDrawableSize) {
-        primaryChange.position.validOrNull()?.let { rawPosition = it.clampTo(size) }
+        directPosition = captureRawPosition(primaryChange.position, size)
       }
       cancelRawPress()
     }
@@ -317,13 +318,13 @@ internal class GlassInteractionController(
         primaryPointerId = change.id
         rawPressed = true
         if (hasDrawableSize) {
-          change.position.validOrNull()?.let { rawPosition = it.clampTo(size) }
+          directPosition = captureRawPosition(change.position, size)
         }
       }
     } else {
       event.changes.firstOrNull { it.id == primaryPointerId }?.let { change ->
         if (hasDrawableSize) {
-          change.position.validOrNull()?.let { rawPosition = it.clampTo(size) }
+          directPosition = captureRawPosition(change.position, size)
         }
         if (change.changedToUpIgnoreConsumed()) {
           primaryPointerId = null
@@ -332,7 +333,7 @@ internal class GlassInteractionController(
       }
     }
 
-    updateSignalsAndPosition(size)
+    updateSignalsAndPosition(size, directPosition)
   }
 
   fun cancelPointerInput(size: Size) {
@@ -414,6 +415,9 @@ internal class GlassInteractionController(
     positionJob = null
   }
 
+  private fun captureRawPosition(position: Offset, size: Size): Offset? =
+    position.validOrNull()?.clampTo(size)?.also { rawPosition = it }
+
   private fun cancelRawPress() {
     primaryPointerId = null
     rawPressed = false
@@ -426,12 +430,12 @@ internal class GlassInteractionController(
       ?.validOrNull()
   }
 
-  private fun updateSignalsAndPosition(size: Size) {
+  private fun updateSignalsAndPosition(size: Size, directPosition: Offset? = null) {
     updateSignals(currentSignals)
-    updatePositionForCurrentInputs(size)
+    updatePositionForCurrentInputs(size, directPosition)
   }
 
-  private fun updatePositionForCurrentInputs(size: Size) {
+  private fun updatePositionForCurrentInputs(size: Size, directPosition: Offset? = null) {
     if (!size.isDrawable()) return
     when {
       rawPressed -> retargetPosition(
@@ -442,10 +446,11 @@ internal class GlassInteractionController(
         (sourcePosition ?: rawPosition ?: size.center).clampTo(size),
       )
       rawHovered -> retargetPosition(
-        target = (hoverPosition ?: size.center).clampTo(size),
-        immediate = hoverPosition != null,
+        target = (directPosition ?: hoverPosition ?: size.center).clampTo(size),
+        immediate = directPosition != null || hoverPosition != null,
       )
       sourceHovers.isNotEmpty() || sourceFocuses.isNotEmpty() -> updatePosition(size.center)
+      directPosition != null -> retargetPosition(directPosition, immediate = true)
       else -> updatePosition((hoverPosition ?: rawPosition ?: size.center).clampTo(size))
     }
   }

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteractionController.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassInteractionController.kt
@@ -433,14 +433,21 @@ internal class GlassInteractionController(
 
   private fun updatePositionForCurrentInputs(size: Size) {
     if (!size.isDrawable()) return
-    val target = when {
-      rawPressed -> rawPosition ?: sourcePosition ?: size.center
-      sourcePresses.isNotEmpty() -> sourcePosition ?: rawPosition ?: size.center
-      rawHovered -> hoverPosition ?: size.center
-      sourceHovers.isNotEmpty() || sourceFocuses.isNotEmpty() -> size.center
-      else -> hoverPosition ?: rawPosition ?: size.center
+    when {
+      rawPressed -> retargetPosition(
+        target = (rawPosition ?: sourcePosition ?: size.center).clampTo(size),
+        immediate = rawPosition != null,
+      )
+      sourcePresses.isNotEmpty() -> updatePosition(
+        (sourcePosition ?: rawPosition ?: size.center).clampTo(size),
+      )
+      rawHovered -> retargetPosition(
+        target = (hoverPosition ?: size.center).clampTo(size),
+        immediate = hoverPosition != null,
+      )
+      sourceHovers.isNotEmpty() || sourceFocuses.isNotEmpty() -> updatePosition(size.center)
+      else -> updatePosition((hoverPosition ?: rawPosition ?: size.center).clampTo(size))
     }
-    updatePosition(target.clampTo(size))
   }
 
   private fun retarget(
@@ -512,7 +519,11 @@ internal class GlassInteractionController(
     scaleY.snapTo(targets.scaleY)
   }
 
-  private fun retargetPosition(target: Offset, force: Boolean = false) {
+  private fun retargetPosition(
+    target: Offset,
+    force: Boolean = false,
+    immediate: Boolean = false,
+  ) {
     if (!hasInitialPositionTarget) {
       hasInitialPositionTarget = true
       positionTarget = target
@@ -523,13 +534,13 @@ internal class GlassInteractionController(
       }
       return
     }
-    if (!force && target == positionTarget) return
+    if (!force && target == positionTarget && (!immediate || position.value == target)) return
     positionTarget = target
     positionJob?.cancel()
     positionJob = scope.launch(
       if (configuration.forceFullMotion) FullMotionDurationScale else EmptyCoroutineContext,
     ) {
-      if (configuration.reducedMotion || !hasFrameClock) {
+      if (immediate || configuration.reducedMotion || !hasFrameClock) {
         position.snapTo(target)
         invalidateDraw()
       } else {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassStyle.kt
@@ -6,6 +6,7 @@
 package dev.chrisbanes.haze.glass
 
 import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.ProvidableCompositionLocal
@@ -160,7 +161,9 @@ public class GlassStyleScope internal constructor(
   }
 
   /**
-   * Sets the animation used when the interaction light moves to a new position.
+   * Sets the animation used for focus and [InteractionSource]-derived positions.
+   *
+   * Direct mouse, stylus, and touch input tracks immediately.
    *
    * This presentation is replayed into fresh animation state owned by each consuming node.
    */

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
@@ -197,6 +197,26 @@ class GlassInteractionControllerTest : ContextTest() {
   }
 
   @Test
+  fun touchMove_tracksLatestPointerOnNextFrame() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val effect = GlassRuntimeEffect().apply {
+      testPressResponse()
+      interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
+      style = GlassStyle { interactionPositionAnimationSpec(tween(1_000)) }
+    }
+    setTaggedEffectContent(effect)
+    mainClock.advanceTimeByFrame()
+
+    onNodeWithTag("glass").performTouchInput {
+      down(Offset(20f, 30f))
+      moveTo(Offset(80f, 70f))
+    }
+    mainClock.advanceTimeByFrame()
+
+    assertThat(renderState(effect).position).isEqualTo(Offset(80f, 70f))
+  }
+
+  @Test
   fun rawInput_primaryUpAtZeroSizeClearsActivePress() = runComposeUiTest {
     val effect = reducedPressEffect()
     var size by mutableStateOf(100.dp)
@@ -320,6 +340,52 @@ class GlassInteractionControllerTest : ContextTest() {
     waitForIdle()
     assertThat(renderState(effect).lightingIntensity).isEqualTo(0f)
     assertThat(renderState(effect).position).isEqualTo(Offset(30f, 40f))
+  }
+
+  @Test
+  fun mouseHoverMove_tracksLatestPointerOnNextFrame() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val effect = GlassRuntimeEffect().apply {
+      testHoverResponse()
+      interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
+      style = GlassStyle { interactionPositionAnimationSpec(tween(1_000)) }
+    }
+    setTaggedEffectContent(effect)
+    mainClock.advanceTimeByFrame()
+
+    onNodeWithTag("glass").performMouseInput {
+      enter(Offset(50f, 50f))
+      moveTo(Offset(90f, 50f))
+    }
+    mainClock.advanceTimeByFrame()
+
+    assertThat(renderState(effect).position).isEqualTo(Offset(90f, 50f))
+  }
+
+  @Test
+  fun mouseHoverAtSyntheticTarget_cancelsInFlightAnimation() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val effect = GlassRuntimeEffect().apply {
+      testHoverResponse()
+      interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
+      style = GlassStyle { interactionPositionAnimationSpec(tween(1_000)) }
+    }
+    setTaggedEffectContent(effect)
+    mainClock.advanceTimeByFrame()
+    val controller = checkNotNull(runtime(effect).interactionControllerForTest)
+
+    onNodeWithTag("glass").performMouseInput { enter(Offset(10f, 50f)) }
+    mainClock.advanceTimeByFrame()
+    onNodeWithTag("glass").performMouseInput { exit() }
+    controller.updatePosition(Offset(50f, 50f))
+    mainClock.advanceTimeBy(200)
+    assertThat(renderState(effect).position.x).isGreaterThan(10f)
+    assertThat(renderState(effect).position.x).isLessThan(50f)
+
+    onNodeWithTag("glass").performMouseInput { enter(Offset(50f, 50f)) }
+    mainClock.advanceTimeByFrame()
+
+    assertThat(renderState(effect).position).isEqualTo(Offset(50f, 50f))
   }
 
   @Test

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassInteractionControllerTest.kt
@@ -217,6 +217,27 @@ class GlassInteractionControllerTest : ContextTest() {
   }
 
   @Test
+  fun touchUp_tracksLatestPointerOnNextFrame() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    val effect = GlassRuntimeEffect().apply {
+      testPressResponse()
+      interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full
+      style = GlassStyle { interactionPositionAnimationSpec(tween(1_000)) }
+    }
+    setTaggedEffectContent(effect)
+    mainClock.advanceTimeByFrame()
+
+    onNodeWithTag("glass").performTouchInput {
+      down(Offset(20f, 30f))
+      updatePointerTo(0, Offset(80f, 70f))
+      up()
+    }
+    mainClock.advanceTimeByFrame()
+
+    assertThat(renderState(effect).position).isEqualTo(Offset(80f, 70f))
+  }
+
+  @Test
   fun rawInput_primaryUpAtZeroSizeClearsActivePress() = runComposeUiTest {
     val effect = reducedPressEffect()
     var size by mutableStateOf(100.dp)


### PR DESCRIPTION
## Summary

- make direct mouse, stylus, and touch positions track on the next rendered frame without interpolation
- retain `interactionPositionAnimationSpec` for focus and `InteractionSource`-derived movement
- document the behavior boundary and add mouse, touch, and in-flight synthetic-animation regressions

## Why

Glass routed every pointer-coordinate update through the configured position spring. During continuous hover or touch movement, the interaction light therefore chased the pointer instead of tracking it in real time. Direct pointer input now snaps through the existing controller state, while synthetic repositioning keeps its configured animation.

## Validation

- `./gradlew --no-scan :haze-glass:jvmTest :haze-glass:testAndroidHostTest :haze-glass:spotlessCheck`
- `git diff --check`
- `review-and-simplify-changes`
- `ponytail-review`