### PR TITLE
Refresh cross-window Haze captures

### DIFF
--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/DialogBlurInputRefreshInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/DialogBlurInputRefreshInstrumentationTest.kt
@@ -1,0 +1,119 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazePerformanceMode
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class DialogBlurInputRefreshInstrumentationTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun dialogBlur_updatesWhenNestedSourceLayerChanges() {
+    val hazeState = HazeState()
+    val overlayAlpha = mutableFloatStateOf(1f)
+    val showDialog = mutableStateOf(true)
+
+    composeTestRule.setContent {
+      Box(
+        Modifier
+          .fillMaxSize()
+          .hazeSource(hazeState)
+          .background(Color.Blue),
+      ) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .graphicsLayer { alpha = overlayAlpha.floatValue }
+            .background(Color.Red),
+        )
+      }
+
+      if (showDialog.value) {
+        Dialog(onDismissRequest = {}) {
+          Box(
+            Modifier
+              .size(160.dp)
+              .testTag(DIALOG_EFFECT_TAG)
+              .hazeBlur(
+                input = HazeInput.Sources(hazeState),
+                style = HazeBlurStyle {
+                  blurRadius(8.dp)
+                  noiseFactor(0f)
+                  backgroundColor(Color.Transparent)
+                  colorEffects(emptyList())
+                  fallbackColorEffect(HazeColorEffect.tint(Color.Transparent))
+                },
+                performanceMode = HazePerformanceMode.Quality,
+              ),
+          )
+        }
+      }
+    }
+    composeTestRule.waitForIdle()
+
+    val before = composeTestRule.captureDialogCenterPixel()
+    assertThat(before.red, "initial dialog red channel").isGreaterThan(before.blue)
+
+    composeTestRule.mainClock.autoAdvance = false
+    composeTestRule.runOnIdle { overlayAlpha.floatValue = 0f }
+    composeTestRule.advanceCrossWindowFrames()
+
+    val after = composeTestRule.captureDialogCenterPixel()
+    assertThat(after.blue, "updated dialog blue channel").isGreaterThan(after.red)
+
+    composeTestRule.runOnIdle { overlayAlpha.floatValue = 1f }
+    composeTestRule.advanceCrossWindowFrames()
+
+    val restored = composeTestRule.captureDialogCenterPixel()
+    assertThat(restored.red, "restored dialog red channel").isGreaterThan(restored.blue)
+
+    composeTestRule.runOnIdle { showDialog.value = false }
+    composeTestRule.advanceCrossWindowFrames()
+    composeTestRule.runOnIdle { overlayAlpha.floatValue = 0f }
+    composeTestRule.advanceCrossWindowFrames()
+  }
+
+  private fun androidx.compose.ui.test.junit4.AndroidComposeTestRule<*, *>.advanceCrossWindowFrames() {
+    mainClock.advanceTimeByFrame()
+    mainClock.advanceTimeByFrame()
+    waitForIdle()
+  }
+
+  private fun androidx.compose.ui.test.junit4.AndroidComposeTestRule<*, *>.captureDialogCenterPixel(): Color {
+    val pixels = onNodeWithTag(DIALOG_EFFECT_TAG).captureToImage().toPixelMap()
+    return pixels[pixels.width / 2, pixels.height / 2]
+  }
+
+  private companion object {
+    const val DIALOG_EFFECT_TAG = "dialog_effect"
+  }
+}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -152,11 +152,24 @@ internal fun HazeArea.reset() {
 
 internal class OnPreDrawListener(
   private val effectWindowId: () -> Any?,
-  private val onPreDraw: () -> Unit,
+  private val onPreDraw: (invalidateInputCapture: Boolean) -> Unit,
 ) {
   fun needsSnapshotApplyObservation(area: HazeArea): Boolean = area.windowId != effectWindowId()
 
-  operator fun invoke() = onPreDraw()
+  operator fun invoke(invalidateInputCapture: Boolean) = onPreDraw(invalidateInputCapture)
+}
+
+internal fun HazeArea.notifyPreDrawListeners(
+  regularPreDraw: Boolean,
+  snapshotApplied: Boolean,
+) {
+  preDrawListeners.forEach { listener ->
+    val invalidateInputCapture =
+      snapshotApplied && listener.needsSnapshotApplyObservation(this)
+    if (regularPreDraw || invalidateInputCapture) {
+      listener(invalidateInputCapture)
+    }
+  }
 }
 
 /**

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -150,8 +150,13 @@ internal fun HazeArea.reset() {
   contentDrawing = false
 }
 
-internal fun interface OnPreDrawListener {
-  operator fun invoke()
+internal class OnPreDrawListener(
+  private val effectWindowId: () -> Any?,
+  private val onPreDraw: () -> Unit,
+) {
+  fun needsSnapshotApplyObservation(area: HazeArea): Boolean = area.windowId != effectWindowId()
+
+  operator fun invoke() = onPreDraw()
 }
 
 /**

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -365,8 +365,8 @@ internal class HazeEffectNode(
   private val areaPreDrawListener by lazy(LazyThreadSafetyMode.NONE) {
     OnPreDrawListener(
       effectWindowId = { windowId },
-      onPreDraw = {
-        inputCaptureGeneration++
+      onPreDraw = { invalidateInputCapture ->
+        if (invalidateInputCapture) inputCaptureGeneration++
         if (!needsPreDrawInvalidation) {
           needsPreDrawInvalidation = true
           invalidateHazeDraw(HazeInvalidationReason.PreDraw)

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -108,6 +108,7 @@ internal class HazeEffectNode(
   private var needsContentInvalidation = false
   private var hasRenderedTypedSourceOutput = false
   private var lastInputSnapshot: HazeEffectInputSnapshotImpl? = null
+  private var inputCaptureGeneration = 0L
   private var isDrawing = false
   private var lastKnownCoordinates: LayoutCoordinates? = null
   private var sourceSelectionSnapshotObserver: SnapshotStateObserver? = null
@@ -362,12 +363,16 @@ internal class HazeEffectNode(
 
   private var retainOutputWhenSourceUnavailable: Boolean = true
   private val areaPreDrawListener by lazy(LazyThreadSafetyMode.NONE) {
-    OnPreDrawListener {
-      if (!needsPreDrawInvalidation) {
-        needsPreDrawInvalidation = true
-        invalidateHazeDraw(HazeInvalidationReason.PreDraw)
-      }
-    }
+    OnPreDrawListener(
+      effectWindowId = { windowId },
+      onPreDraw = {
+        inputCaptureGeneration++
+        if (!needsPreDrawInvalidation) {
+          needsPreDrawInvalidation = true
+          invalidateHazeDraw(HazeInvalidationReason.PreDraw)
+        }
+      },
+    )
   }
 
   internal fun update() {
@@ -1030,7 +1035,9 @@ internal class HazeEffectNode(
   }
 
   internal fun inputSnapshot(): HazeEffectInputSnapshot? {
-    lastInputSnapshot?.takeIf { it.matches(this) }?.let { return it }
+    lastInputSnapshot
+      ?.takeIf { it.matches(this, inputCaptureGeneration) }
+      ?.let { return it }
     val snapshots = ArrayList<HazeEffectInputSnapshotEntry>(areas.size)
     val effectPosition = position
     for (area in areas) {
@@ -1053,7 +1060,7 @@ internal class HazeEffectNode(
     }
     return snapshots
       .takeIf { it.isNotEmpty() }
-      ?.let(::HazeEffectInputSnapshotImpl)
+      ?.let { HazeEffectInputSnapshotImpl(it, inputCaptureGeneration) }
       .also { lastInputSnapshot = it }
   }
 
@@ -1093,8 +1100,11 @@ private class HazeEffectPointerInputNode(
 
 private class HazeEffectInputSnapshotImpl(
   private val entries: List<HazeEffectInputSnapshotEntry>,
+  private val captureGeneration: Long,
 ) : HazeEffectInputSnapshot {
-  fun matches(node: HazeEffectNode): Boolean {
+  fun matches(node: HazeEffectNode, captureGeneration: Long): Boolean {
+    if (this.captureGeneration != captureGeneration) return false
+
     val effectPosition = node.position
     var drawableIndex = 0
     for (area in node.areas) {
@@ -1124,9 +1134,11 @@ private class HazeEffectInputSnapshotImpl(
   }
 
   override fun equals(other: Any?): Boolean =
-    other is HazeEffectInputSnapshotImpl && entries == other.entries
+    other is HazeEffectInputSnapshotImpl &&
+      captureGeneration == other.captureGeneration &&
+      entries == other.entries
 
-  override fun hashCode(): Int = entries.hashCode()
+  override fun hashCode(): Int = 31 * entries.hashCode() + captureGeneration.hashCode()
 }
 
 private class HazeEffectInputSnapshotEntry(

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -92,6 +92,8 @@ internal class HazeSourceNode(
   private var lastCoordinates: LayoutCoordinates? = null
 
   private var preDrawJob: Job? = null
+  private var regularPreDrawPending = false
+  private var snapshotApplyPending = false
   private var snapshotApplyObserver: ObserverHandle? = null
 
   /**
@@ -133,7 +135,7 @@ internal class HazeSourceNode(
     // Descendant layer-property changes may not redraw this node, but their snapshot writes
     // still need to refresh effects hosted in another window.
     snapshotApplyObserver = Snapshot.registerApplyObserver { _, _ ->
-      coroutineScope.launch { schedulePreDraw() }
+      coroutineScope.launch { schedulePreDraw(snapshotApplied = true) }
     }
   }
 
@@ -142,8 +144,13 @@ internal class HazeSourceNode(
     snapshotApplyObserver = null
   }
 
-  private fun schedulePreDraw() {
+  private fun schedulePreDraw(snapshotApplied: Boolean = false) {
     if (area.preDrawListeners.isEmpty()) return
+    if (snapshotApplied) {
+      snapshotApplyPending = true
+    } else {
+      regularPreDrawPending = true
+    }
     if (preDrawJob?.isActive != true) {
       preDrawJob = launchPreDraw()
     }
@@ -152,12 +159,21 @@ internal class HazeSourceNode(
   private fun launchPreDraw(): Job = coroutineScope.launch {
     withFrameNanos {
       HazeLogger.d(TAG) { "onPreDraw" }
-      area.preDrawListeners.forEach(OnPreDrawListener::invoke)
+      val regularPreDraw = regularPreDrawPending
+      val snapshotApplied = snapshotApplyPending
+      regularPreDrawPending = false
+      snapshotApplyPending = false
+      area.notifyPreDrawListeners(
+        regularPreDraw = regularPreDraw,
+        snapshotApplied = snapshotApplied,
+      )
     }
   }
 
   private fun disablePreDrawListener() {
     disableSnapshotApplyObserver()
+    regularPreDrawPending = false
+    snapshotApplyPending = false
     preDrawJob?.cancel()
     preDrawJob = null
   }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -5,6 +5,7 @@
 
 package dev.chrisbanes.haze
 
+import androidx.compose.runtime.snapshots.ObserverHandle
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
@@ -91,6 +92,7 @@ internal class HazeSourceNode(
   private var lastCoordinates: LayoutCoordinates? = null
 
   private var preDrawJob: Job? = null
+  private var snapshotApplyObserver: ObserverHandle? = null
 
   /**
    * We manually invalidate when things have changed
@@ -117,6 +119,31 @@ internal class HazeSourceNode(
   }
 
   private fun enablePreDrawListener() {
+    if (area.preDrawListeners.any { it.needsSnapshotApplyObservation(area) }) {
+      enableSnapshotApplyObserver()
+    } else {
+      disableSnapshotApplyObserver()
+    }
+    schedulePreDraw()
+  }
+
+  private fun enableSnapshotApplyObserver() {
+    if (snapshotApplyObserver != null) return
+
+    // Descendant layer-property changes may not redraw this node, but their snapshot writes
+    // still need to refresh effects hosted in another window.
+    snapshotApplyObserver = Snapshot.registerApplyObserver { _, _ ->
+      coroutineScope.launch { schedulePreDraw() }
+    }
+  }
+
+  private fun disableSnapshotApplyObserver() {
+    snapshotApplyObserver?.dispose()
+    snapshotApplyObserver = null
+  }
+
+  private fun schedulePreDraw() {
+    if (area.preDrawListeners.isEmpty()) return
     if (preDrawJob?.isActive != true) {
       preDrawJob = launchPreDraw()
     }
@@ -130,6 +157,7 @@ internal class HazeSourceNode(
   }
 
   private fun disablePreDrawListener() {
+    disableSnapshotApplyObserver()
     preDrawJob?.cancel()
     preDrawJob = null
   }
@@ -238,6 +266,7 @@ internal class HazeSourceNode(
 
   override fun onDetach() {
     HazeLogger.d(TAG) { "onDetach. Removing HazeArea: $area" }
+    disablePreDrawListener()
     area.reset()
     area.releaseLayer()
     state.removeArea(area)
@@ -245,6 +274,7 @@ internal class HazeSourceNode(
 
   override fun onReset() {
     HazeLogger.d(TAG) { "onReset. Resetting HazeArea: $area" }
+    disablePreDrawListener()
     area.releaseLayer()
     area.reset()
   }

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazePreDrawListenerTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazePreDrawListenerTest.kt
@@ -1,0 +1,66 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import kotlin.test.Test
+
+class HazePreDrawListenerTest {
+
+  @Test
+  fun snapshotApply_notifiesOnlyCrossWindowListener() {
+    val area = HazeArea().apply { windowId = SOURCE_WINDOW }
+    val sameWindowInvalidations = mutableListOf<Boolean>()
+    val crossWindowInvalidations = mutableListOf<Boolean>()
+    area.preDrawListeners += listener(SOURCE_WINDOW, sameWindowInvalidations)
+    area.preDrawListeners += listener(EFFECT_WINDOW, crossWindowInvalidations)
+
+    area.notifyPreDrawListeners(regularPreDraw = false, snapshotApplied = true)
+
+    assertThat(sameWindowInvalidations).containsExactly()
+    assertThat(crossWindowInvalidations).containsExactly(true)
+  }
+
+  @Test
+  fun regularPreDraw_notifiesEveryListenerWithoutInvalidatingCapture() {
+    val area = HazeArea().apply { windowId = SOURCE_WINDOW }
+    val sameWindowInvalidations = mutableListOf<Boolean>()
+    val crossWindowInvalidations = mutableListOf<Boolean>()
+    area.preDrawListeners += listener(SOURCE_WINDOW, sameWindowInvalidations)
+    area.preDrawListeners += listener(EFFECT_WINDOW, crossWindowInvalidations)
+
+    area.notifyPreDrawListeners(regularPreDraw = true, snapshotApplied = false)
+
+    assertThat(sameWindowInvalidations).containsExactly(false)
+    assertThat(crossWindowInvalidations).containsExactly(false)
+  }
+
+  @Test
+  fun combinedPreDraw_invalidatesOnlyCrossWindowCapture() {
+    val area = HazeArea().apply { windowId = SOURCE_WINDOW }
+    val sameWindowInvalidations = mutableListOf<Boolean>()
+    val crossWindowInvalidations = mutableListOf<Boolean>()
+    area.preDrawListeners += listener(SOURCE_WINDOW, sameWindowInvalidations)
+    area.preDrawListeners += listener(EFFECT_WINDOW, crossWindowInvalidations)
+
+    area.notifyPreDrawListeners(regularPreDraw = true, snapshotApplied = true)
+
+    assertThat(sameWindowInvalidations).containsExactly(false)
+    assertThat(crossWindowInvalidations).containsExactly(true)
+  }
+
+  private fun listener(
+    windowId: Any,
+    invalidations: MutableList<Boolean>,
+  ): OnPreDrawListener = OnPreDrawListener(
+    effectWindowId = { windowId },
+    onPreDraw = invalidations::add,
+  )
+
+  private companion object {
+    val SOURCE_WINDOW = Any()
+    val EFFECT_WINDOW = Any()
+  }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/RecompositionLoopTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/RecompositionLoopTest.kt
@@ -92,7 +92,7 @@ class RecompositionLoopTest : ContextTest() {
   }
 
   @Test
-  fun openingDialogWithSharedStateAndHostEffect_doesNotInfiniteLoop() = runComposeUiTest {
+  fun openingAndClosingDialogWithSharedStateAndHostEffect_doesNotInfiniteLoop() = runComposeUiTest {
     val hazeState = HazeState()
     val showDialog = mutableStateOf(false)
     val detector = LivelockDetector()
@@ -131,6 +131,10 @@ class RecompositionLoopTest : ContextTest() {
     showDialog.value = true
 
     awaitIdleWithTimeout("after opening dialog with shared HazeState")
+
+    showDialog.value = false
+
+    awaitIdleWithTimeout("after closing dialog with shared HazeState")
   }
 
   @Test

--- a/haze/src/iosTest/kotlin/dev/chrisbanes/haze/HazeComposeUIViewTest.ios.kt
+++ b/haze/src/iosTest/kotlin/dev/chrisbanes/haze/HazeComposeUIViewTest.ios.kt
@@ -5,9 +5,12 @@ package dev.chrisbanes.haze
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
@@ -18,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
 import kotlin.test.Test
 import platform.UIKit.UIView
@@ -64,6 +68,77 @@ class HazeComposeUIViewTest {
         windowId = effectWindowId,
       ),
     ).isEqualTo(HazePositionStrategy.Screen)
+  }
+
+  @Test
+  fun crossUIViewEffect_refreshesWhenNestedSourceLayerChanges() = runComposeUiTest {
+    val hazeState = HazeState()
+    val overlayAlpha = mutableFloatStateOf(1f)
+    val factory = InputSnapshotRecordingRendererFactory()
+    val sourceView = UIView()
+    val effectView = UIView()
+    var sourceWindowId: Any? = null
+    var effectWindowId: Any? = null
+
+    setContent {
+      CompositionLocalProvider(LocalUIView provides sourceView) {
+        Box(
+          Modifier
+            .size(100.dp)
+            .captureWindowId { sourceWindowId = it }
+            .hazeSource(hazeState),
+        ) {
+          Spacer(
+            Modifier
+              .fillMaxSize()
+              .graphicsLayer { alpha = overlayAlpha.floatValue },
+          )
+        }
+      }
+
+      CompositionLocalProvider(LocalUIView provides effectView) {
+        Spacer(
+          Modifier
+            .size(100.dp)
+            .captureWindowId { effectWindowId = it }
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Sources(hazeState),
+              style = Unit,
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val renderer = factory.renderer
+    val initialSnapshot = renderer.snapshots.last()
+    val initialContentVersion = hazeState.areas.single().contentVersion
+    assertThat(sourceWindowId).isSameInstanceAs(sourceView)
+    assertThat(effectWindowId).isSameInstanceAs(effectView)
+    assertThat(effectWindowId).isNotSameInstanceAs(sourceWindowId)
+
+    overlayAlpha.floatValue = 0f
+    waitForIdle()
+
+    assertThat(hazeState.areas.single().contentVersion).isEqualTo(initialContentVersion)
+    assertThat(renderer.snapshots.last()).isNotSameInstanceAs(initialSnapshot)
+  }
+}
+
+private class InputSnapshotRecordingRendererFactory : HazeEffectFactory<Unit> {
+  val renderer = InputSnapshotRecordingRenderer()
+
+  override fun createRenderer(): HazeEffectRenderer<Unit> = renderer
+}
+
+@OptIn(InternalHazeApi::class)
+private class InputSnapshotRecordingRenderer : HazeEffectRenderer<Unit> {
+  val snapshots = mutableListOf<HazeEffectInputSnapshot?>()
+
+  override fun HazeEffectDrawScope.draw(style: Unit) {
+    snapshots += (this as HazeEffectRuntimeDrawScope).inputSnapshot
+    drawInput()
   }
 }
 


### PR DESCRIPTION
Fixes #1240

## Summary

- re-arm source pre-draw pulses from snapshot writes while a Haze effect is hosted in a different window
- include an effect-local capture generation in the opaque input snapshot so Blur and retained Glass recapture changed descendant layers
- preserve same-window input reuse, including the legacy Android pre-draw path
- add a real Android `Dialog` regression test and extend dialog dismissal/livelock coverage

## Root cause

A descendant `graphicsLayer` property change can update the source window without re-recording the outer Haze source layer. Its `contentVersion` therefore remains unchanged, so an effect in another window reuses a stale captured input. A permanent frame loop fixes the pixels but prevents static dialogs from becoming idle; this change instead schedules one frame pulse per snapshot application while a cross-window listener exists.

## Validation

- `./gradlew build --no-scan` — 1,881 tasks across all modules/platforms
- `./gradlew :haze:jvmTest --tests dev.chrisbanes.haze.RecompositionLoopTest :haze-blur:jvmTest --tests dev.chrisbanes.haze.blur.RenderEffectBlurVisualEffectDelegateTrimMemoryTest --no-scan`
- `./gradlew :haze-blur:pixel6Api34AndroidDeviceTest -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.blur.DialogBlurInputRefreshInstrumentationTest --no-scan`
- `./gradlew :haze:compileKotlinIosSimulatorArm64 spotlessCheck --no-scan`