### PR TITLE
Refresh Haze 2 documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.0.0-beta01 <small>2026-08-20</small> { id="2.0.0-beta01" }
 
+### Added
+
+- Added `refractionFoldStrength` to `GlassOptics.Fixed` and the inline `GlassStyle.optics(...)`
+  builder. The optional edge fold reverses local refraction near the Glass boundary without
+  expanding its capture area ([#1236](https://github.com/chrisbanes/haze/pull/1236)).
+- Added CameraX and Kamera samples plus a camera guide. Blur and Glass can process live previews
+  rendered into their Compose source layer; Android `PreviewView` integrations must use
+  `ImplementationMode.COMPATIBLE` ([#1238](https://github.com/chrisbanes/haze/pull/1238)).
+
 ### Changed
 
 - Haze 2 beta finalizes the supported source-selection and Blur contracts. Source predicates now
@@ -24,6 +33,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Haze effects now sample source content correctly through scaled or rotated `graphicsLayer`
   transforms, including transforms applied directly to the effect-bearing composable
   ([#717](https://github.com/chrisbanes/haze/issues/717)).
+- Glass pointer lights now track direct mouse, stylus, and touch input immediately; focus and
+  `InteractionSource`-derived movement still use `interactionPositionAnimationSpec`
+  ([#1234](https://github.com/chrisbanes/haze/pull/1234)).
+- Fixed visible refraction seams on elongated, rounded Glass surfaces
+  ([#1235](https://github.com/chrisbanes/haze/pull/1235)).
+- Glass now preserves captured input when a runtime-shader draw failure falls back in the same
+  frame, including own-content input with a transparent background
+  ([#1230](https://github.com/chrisbanes/haze/pull/1230),
+  [#1231](https://github.com/chrisbanes/haze/pull/1231)).
 
 ### Removed
 
@@ -37,6 +55,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the public core `Poko` marker and `HazeLogger.d(...)` operations from the supported API.
 
 ## 2.0.0-alpha05 <small>2026-08-12</small> { id="2.0.0-alpha05" }
+
+### Added
+
+- Added `HazePerformanceMode` for built-in Blur and Glass. `Default` is adaptive; `Quality`,
+  `Balanced`, `Performance`, and `Fixed(qualityFraction)` select effect-owned profiles. Custom
+  effects continue to use `HazeSampling`
+  ([#1209](https://github.com/chrisbanes/haze/pull/1209),
+  [#1211](https://github.com/chrisbanes/haze/pull/1211)).
+- Added optional `haze-blur-material3` and `haze-glass-material3` artifacts. Their
+  `HazeBlurStyle.Material3()` and `GlassStyle.Material3()` factories use the current
+  `MaterialTheme.colorScheme.surface` without adding a Material dependency to the core effect
+  artifacts ([#1215](https://github.com/chrisbanes/haze/pull/1215)).
 
 ### Changed
 
@@ -137,9 +167,14 @@ is stable.
 - Added declarative hover, focus, and press responses to `GlassStyle`, including localized lighting
   and optics plus configurable transforms and motion on `Modifier.hazeGlass`.
 - Added progressive blur support to Glass.
+- Added `GlassOptics.Adaptive`, the default Glass material that adapts its optical response to a
+  surface's size, aspect ratio, and roundness.
 - Added direct fixed-optics authoring through `GlassStyle { optics(...) }`; keep
   `GlassOptics.Fixed` for reusable or programmatically selected values in
   [#1192](https://github.com/chrisbanes/haze/pull/1192).
+- Added source-selection and retained-output policies to `HazeInput.Sources`. Effects select
+  sources with `HazeSourceSelection` and keep the last frame through temporary source gaps by
+  default; use `HazeSourceRetention.ClearWhenUnavailable` when stale pixels are inappropriate.
 
 ### Changed
 
@@ -186,6 +221,8 @@ is stable.
   [#996](https://github.com/chrisbanes/haze/pull/996). `HazeSourceNode` now refreshes local
   coordinates from every `onPlaced`, and observed area-position reads dirty `HazeEffectNode` area
   offsets so sticky headers blur the currently visible content while scrolling.
+- Fixed source and effect positioning when they are hosted by separate iOS Compose roots
+  ([#978](https://github.com/chrisbanes/haze/pull/978)).
 
 Thanks to [Arda K.](https://github.com/ardakazanci) for
 [#1093](https://github.com/chrisbanes/haze/pull/1093) and

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Modifier.hazeGlass(
     style = GlassStyle {
         backgroundColor(MaterialTheme.colorScheme.surface)
         tint(Color.White.copy(alpha = 0.16f))
-        optics(refractionStrength = 0.8f)
         shape(RoundedCornerShape(20.dp))
     },
 )

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/dev.chrisbanes.haze/haze)](https://search.maven.org/search?q=g:dev.chrisbanes.haze) ![Build status](https://github.com/chrisbanes/haze/actions/workflows/build.yml/badge.svg)
 
-Visual effects (blur and more) for Compose Multiplatform.
+Composable visual effects for Compose Multiplatform.
 
 https://github.com/user-attachments/assets/836dd79a-abdc-4cdc-b27d-baee394c1e26
 
-Haze provides hardware-accelerated visual effects for Compose Multiplatform — Android, iOS, macOS, Desktop, and Web. Built on a modular effect system, it lets you add blur, tint, and custom effects to any composable with a single modifier.
+Haze provides hardware-accelerated visual effects for Compose Multiplatform — Android, iOS, macOS, Desktop, and Web. Its modular Haze 2 API lets you apply source-backed or own-content Blur, refraction-driven Glass, and custom effects with explicit, reusable configuration.
+
+Haze 2.0 is currently in beta. If you are upgrading from Haze 1.x or an earlier Haze 2 prerelease, see the [Haze 2 migration guide](https://chrisbanes.github.io/haze/migrating-2.0/).
 
 ## Platforms
 
@@ -22,17 +24,42 @@ Haze provides hardware-accelerated visual effects for Compose Multiplatform — 
 | macOS | ✅ |
 | Wasm / JS | ✅ |
 
+## Modules
+
+Add the core module and only the effect modules you use. Keep every Haze artifact on the same version.
+
+| Artifact | Purpose |
+|---|---|
+| `haze` | Source capture and the typed custom-effect API. |
+| `haze-blur` | Blur for captured sources or a modifier's own content. |
+| `haze-blur-materials` | Optional ready-made Blur Styles, including `HazeMaterials.thin()`. |
+| `haze-blur-material3` | Optional Compose Material 3 Blur Style factory. |
+| `haze-glass` | Experimental, refraction-driven Glass effect. |
+| `haze-glass-material3` | Optional Compose Material 3 Glass Style factory. |
+
 ## Download
 
 ```kotlin
 dependencies {
+    // Core infrastructure and Blur
     implementation("dev.chrisbanes.haze:haze:<version>")
     implementation("dev.chrisbanes.haze:haze-blur:<version>")
+
+    // Optional: ready-made Blur styles
     implementation("dev.chrisbanes.haze:haze-blur-materials:<version>")
 }
 ```
 
-## Quick start
+For Glass, add the core module and the experimental Glass artifact:
+
+```kotlin
+dependencies {
+    implementation("dev.chrisbanes.haze:haze:<version>")
+    implementation("dev.chrisbanes.haze:haze-glass:<version>")
+}
+```
+
+## Blur
 
 ```kotlin
 val hazeState = rememberHazeState()
@@ -54,6 +81,45 @@ Box {
 }
 ```
 
+`HazeInput.Sources` renders captured `hazeSource` content. Use `HazeInput.Content` to blur the modifier's own content instead. `HazeBlurStyle` is immutable and reusable; use `then` to derive a variation or supply a replacement Style when its appearance changes.
+
+The optional [Blur material presets](https://chrisbanes.github.io/haze/blur/materials/) provide `HazeMaterials.ultraThin()`, `thin()`, `regular()`, `thick()`, and `ultraThick()`. The [`haze-blur-material3` integration](https://chrisbanes.github.io/haze/blur/material3/) provides `HazeBlurStyle.Material3()` for a Style based on the current Material 3 surface.
+
+## Glass
+
+`haze-glass` is an experimental Haze 2 module for material-like Glass: refraction, depth Blur, tint, lighting, highlights, rounded shapes, and optional pointer, focus, and press responses. Glass APIs require `@ExperimentalHazeApi`.
+
+```kotlin
+Modifier.hazeGlass(
+    input = HazeInput.Sources(hazeState),
+    style = GlassStyle {
+        backgroundColor(MaterialTheme.colorScheme.surface)
+        tint(Color.White.copy(alpha = 0.16f))
+        optics(refractionStrength = 0.8f)
+        shape(RoundedCornerShape(20.dp))
+    },
+)
+```
+
+Start with the adaptive defaults, then consult the [Glass guide](https://chrisbanes.github.io/haze/effects/glass/) for optics, interaction, retention, and platform fallback behavior. Add `haze-glass-material3` to use `GlassStyle.Material3()` with your current Material 3 surface color.
+
+## Performance
+
+Built-in Blur and Glass use `HazePerformanceMode.Default`, which is adaptive. Begin with that setting and measure a release-like build on representative devices before selecting `Quality`, `Balanced`, `Performance`, or `Fixed(...)`. Custom effects keep the separate `HazeSampling` policy. See the [performance guide](https://chrisbanes.github.io/haze/performance/) for the decision framework and effect-specific guidance.
+
+## Camera and platform views
+
+Blur and Glass can process a live camera preview when its pixels are drawn in the same Compose graphics layer as `hazeSource`. On Android, CameraX requires `PreviewView.ImplementationMode.COMPATIBLE`; a `SurfaceView` cannot be captured. The [camera guide](https://chrisbanes.github.io/haze/scenarios/camera/) covers CameraX, Kamera, and the same constraint for video and other platform views.
+
+## Learn more
+
+- [Haze documentation](https://chrisbanes.github.io/haze/)
+- [Blur guide](https://chrisbanes.github.io/haze/blur/)
+- [Glass guide](https://chrisbanes.github.io/haze/effects/glass/)
+- [Custom effects](https://chrisbanes.github.io/haze/custom-effects/)
+- [Sample code](https://github.com/chrisbanes/haze/tree/main/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample)
+- [Haze 2 migration guide](https://chrisbanes.github.io/haze/migrating-2.0/)
+
 ## License
 
 ```
@@ -71,5 +137,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
-
-Full documentation: https://chrisbanes.github.io/haze


### PR DESCRIPTION
## Summary
- refresh the README for Haze 2 modules, Blur, Glass, performance, and camera guidance
- reconcile every 2.0.0 release section in the changelog with shipped public APIs and user-visible fixes

## Validation
- git diff --check