### PR TITLE
Guard snapshot observers during teardown

### DIFF
--- a/haze-blur/build.gradle.kts
+++ b/haze-blur/build.gradle.kts
@@ -70,6 +70,18 @@ kotlin {
       }
     }
 
+    named("androidHostTest") {
+      dependencies {
+        implementation(libs.androidx.compose.ui.test.junit4)
+        implementation(libs.compose.material3)
+        implementation(libs.robolectric)
+        implementation(libs.roborazzi.android)
+        implementation(libs.roborazzi.compose)
+        implementation(libs.roborazzi.junit)
+        implementation(projects.internal.screenshotTest)
+      }
+    }
+
     commonTest {
       dependencies {
         implementation(libs.assertk)

--- a/haze-blur/build.gradle.kts
+++ b/haze-blur/build.gradle.kts
@@ -74,11 +74,6 @@ kotlin {
       dependencies {
         implementation(libs.androidx.compose.ui.test.junit4)
         implementation(libs.compose.material3)
-        implementation(libs.robolectric)
-        implementation(libs.roborazzi.android)
-        implementation(libs.roborazzi.compose)
-        implementation(libs.roborazzi.junit)
-        implementation(projects.internal.screenshotTest)
       }
     }
 

--- a/haze-blur/src/androidHostTest/kotlin/dev/chrisbanes/haze/blur/HazeSourceNodeActivityTeardownTest.kt
+++ b/haze-blur/src/androidHostTest/kotlin/dev/chrisbanes/haze/blur/HazeSourceNodeActivityTeardownTest.kt
@@ -3,157 +3,58 @@
 
 package dev.chrisbanes.haze.blur
 
-import android.app.Application
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshots.ObserverHandle
-import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
-import assertk.assertThat
-import assertk.assertions.isTrue
-import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
-import com.github.takahirom.roborazzi.RoborazziRule
-import com.github.takahirom.roborazzi.captureRoboImage
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
-import dev.chrisbanes.haze.test.HazeRoborazziDefaults
-import java.util.concurrent.atomic.AtomicBoolean
+import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 import org.junit.After
-import org.junit.Before
 import org.junit.Rule
-import org.junit.runner.RunWith
-import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
-import org.robolectric.annotation.GraphicsMode
-import org.robolectric.annotation.experimental.LazyApplication
 
-@Config(
-  manifest = Config.NONE,
-  application = Application::class,
-  sdk = [Config.NEWEST_SDK],
-)
-@GraphicsMode(GraphicsMode.Mode.NATIVE)
-@LazyApplication(LazyApplication.LazyLoad.ON)
-@RunWith(ParameterizedRobolectricTestRunner::class)
 @Suppress("DEPRECATION") // This regression specifically covers Compose UI Test v1 teardown.
-class HazeSourceNodeActivityTeardownTest(
-  private val qualifiers: String,
-) {
-
-  private val contentSlotDisposed = AtomicBoolean(false)
-  private val snapshotApplyAfterContentSlotDispose = AtomicBoolean(false)
-  private var snapshotApplyObserver: ObserverHandle? = null
-
-  init {
-    RuntimeEnvironment.setQualifiers(qualifiers)
-  }
+class HazeSourceNodeActivityTeardownTest : ContextTest() {
 
   @get:Rule
   val composeRule = createAndroidComposeRule<ComponentActivity>()
 
-  @get:Rule
-  val roborazziRule = RoborazziRule(
-    composeRule = composeRule,
-    captureRoot = composeRule.onRoot(),
-    options = RoborazziRule.Options(
-      outputDirectoryPath = "screenshots/android",
-      roborazziOptions = HazeRoborazziDefaults.roborazziOptions,
-    ),
-  )
-
-  @Before
-  fun observeTeardownSnapshotApplies() {
-    snapshotApplyObserver = Snapshot.registerApplyObserver { _, _ ->
-      if (contentSlotDisposed.get()) {
-        snapshotApplyAfterContentSlotDispose.set(true)
-      }
-    }
-  }
-
   @After
   fun cleanup() {
-    var closeFailure: Throwable? = null
-    try {
-      composeRule.activityRule.scenario.close()
-    } catch (failure: Throwable) {
-      closeFailure = failure
-      throw failure
-    } finally {
-      println(
-        "Haze teardown probe: contentSlotDisposed=${contentSlotDisposed.get()}, " +
-          "snapshotApplyAfterContentSlotDispose=${snapshotApplyAfterContentSlotDispose.get()}",
-      )
-      snapshotApplyObserver?.dispose()
-      snapshotApplyObserver = null
-      if (closeFailure == null) {
-        assertThat(contentSlotDisposed.get()).isTrue()
-        assertThat(snapshotApplyAfterContentSlotDispose.get()).isTrue()
-      }
-    }
+    composeRule.activityRule.scenario.close()
   }
 
   @Test
   fun activityScenarioClose_withScaffoldSlots_doesNotAccessDetachedNode() {
+    val hazeState = HazeState()
     composeRule.setContent {
-      CompositionLocalProvider(LocalInspectionMode provides true) {
-        MaterialTheme {
-          Surface {
-            val hazeState = remember { HazeState() }
-            Scaffold(
-              topBar = {
-                Box(
-                  Modifier
-                    .fillMaxWidth()
-                    .height(56.dp)
-                    .hazeBlur(
-                      input = HazeInput.Sources(hazeState),
-                      style = HazeBlurStyle { blurRadius(20.dp) },
-                    ),
-                )
-              },
-            ) { padding ->
-              DisposableEffect(Unit) {
-                onDispose { contentSlotDisposed.set(true) }
-              }
-              Box(
-                Modifier
-                  .padding(padding)
-                  .fillMaxSize()
-                  .hazeSource(hazeState),
-              )
-            }
-          }
-        }
+      Scaffold(
+        topBar = {
+          Box(
+            Modifier
+              .fillMaxWidth()
+              .height(56.dp)
+              .hazeBlur(
+                input = HazeInput.Sources(hazeState),
+                style = HazeBlurStyle { blurRadius(20.dp) },
+              ),
+          )
+        },
+      ) {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeSource(hazeState),
+        )
       }
     }
     composeRule.waitForIdle()
-    composeRule.onRoot().captureRoboImage()
-  }
-
-  private companion object {
-    @JvmStatic
-    @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
-    fun deviceQualifiers(): List<Array<String>> = listOf(
-      arrayOf(RobolectricDeviceQualifiers.Pixel5),
-      arrayOf(RobolectricDeviceQualifiers.Pixel7),
-      arrayOf(RobolectricDeviceQualifiers.PixelFold),
-    )
   }
 }

--- a/haze-blur/src/androidHostTest/kotlin/dev/chrisbanes/haze/blur/HazeSourceNodeActivityTeardownTest.kt
+++ b/haze-blur/src/androidHostTest/kotlin/dev/chrisbanes/haze/blur/HazeSourceNodeActivityTeardownTest.kt
@@ -1,0 +1,159 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshots.ObserverHandle
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isTrue
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
+import com.github.takahirom.roborazzi.RoborazziRule
+import com.github.takahirom.roborazzi.captureRoboImage
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.test.HazeRoborazziDefaults
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.annotation.experimental.LazyApplication
+
+@Config(
+  manifest = Config.NONE,
+  application = Application::class,
+  sdk = [Config.NEWEST_SDK],
+)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@LazyApplication(LazyApplication.LazyLoad.ON)
+@RunWith(ParameterizedRobolectricTestRunner::class)
+@Suppress("DEPRECATION") // This regression specifically covers Compose UI Test v1 teardown.
+class HazeSourceNodeActivityTeardownTest(
+  private val qualifiers: String,
+) {
+
+  private val contentSlotDisposed = AtomicBoolean(false)
+  private val snapshotApplyAfterContentSlotDispose = AtomicBoolean(false)
+  private var snapshotApplyObserver: ObserverHandle? = null
+
+  init {
+    RuntimeEnvironment.setQualifiers(qualifiers)
+  }
+
+  @get:Rule
+  val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+  @get:Rule
+  val roborazziRule = RoborazziRule(
+    composeRule = composeRule,
+    captureRoot = composeRule.onRoot(),
+    options = RoborazziRule.Options(
+      outputDirectoryPath = "screenshots/android",
+      roborazziOptions = HazeRoborazziDefaults.roborazziOptions,
+    ),
+  )
+
+  @Before
+  fun observeTeardownSnapshotApplies() {
+    snapshotApplyObserver = Snapshot.registerApplyObserver { _, _ ->
+      if (contentSlotDisposed.get()) {
+        snapshotApplyAfterContentSlotDispose.set(true)
+      }
+    }
+  }
+
+  @After
+  fun cleanup() {
+    var closeFailure: Throwable? = null
+    try {
+      composeRule.activityRule.scenario.close()
+    } catch (failure: Throwable) {
+      closeFailure = failure
+      throw failure
+    } finally {
+      println(
+        "Haze teardown probe: contentSlotDisposed=${contentSlotDisposed.get()}, " +
+          "snapshotApplyAfterContentSlotDispose=${snapshotApplyAfterContentSlotDispose.get()}",
+      )
+      snapshotApplyObserver?.dispose()
+      snapshotApplyObserver = null
+      if (closeFailure == null) {
+        assertThat(contentSlotDisposed.get()).isTrue()
+        assertThat(snapshotApplyAfterContentSlotDispose.get()).isTrue()
+      }
+    }
+  }
+
+  @Test
+  fun activityScenarioClose_withScaffoldSlots_doesNotAccessDetachedNode() {
+    composeRule.setContent {
+      CompositionLocalProvider(LocalInspectionMode provides true) {
+        MaterialTheme {
+          Surface {
+            val hazeState = remember { HazeState() }
+            Scaffold(
+              topBar = {
+                Box(
+                  Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .hazeBlur(
+                      input = HazeInput.Sources(hazeState),
+                      style = HazeBlurStyle { blurRadius(20.dp) },
+                    ),
+                )
+              },
+            ) { padding ->
+              DisposableEffect(Unit) {
+                onDispose { contentSlotDisposed.set(true) }
+              }
+              Box(
+                Modifier
+                  .padding(padding)
+                  .fillMaxSize()
+                  .hazeSource(hazeState),
+              )
+            }
+          }
+        }
+      }
+    }
+    composeRule.waitForIdle()
+    composeRule.onRoot().captureRoboImage()
+  }
+
+  private companion object {
+    @JvmStatic
+    @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
+    fun deviceQualifiers(): List<Array<String>> = listOf(
+      arrayOf(RobolectricDeviceQualifiers.Pixel5),
+      arrayOf(RobolectricDeviceQualifiers.Pixel7),
+      arrayOf(RobolectricDeviceQualifiers.PixelFold),
+    )
+  }
+}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -130,12 +130,20 @@ internal class HazeSourceNode(
   }
 
   private fun enableSnapshotApplyObserver() {
-    if (snapshotApplyObserver != null) return
+    if (snapshotApplyObserver != null || !isAttached) return
+
+    val nodeScope = coroutineScope
 
     // Descendant layer-property changes may not redraw this node, but their snapshot writes
     // still need to refresh effects hosted in another window.
     snapshotApplyObserver = Snapshot.registerApplyObserver { _, _ ->
-      coroutineScope.launch { schedulePreDraw(snapshotApplied = true) }
+      if (!isAttached) return@registerApplyObserver
+
+      nodeScope.launch {
+        if (isAttached) {
+          schedulePreDraw(snapshotApplied = true)
+        }
+      }
     }
   }
 
@@ -145,7 +153,7 @@ internal class HazeSourceNode(
   }
 
   private fun schedulePreDraw(snapshotApplied: Boolean = false) {
-    if (area.preDrawListeners.isEmpty()) return
+    if (!isAttached || area.preDrawListeners.isEmpty()) return
     if (snapshotApplied) {
       snapshotApplyPending = true
     } else {


### PR DESCRIPTION
## Summary

Activity teardown can dispose a Material 3 `Scaffold` content-slot subcomposition before pending snapshot notifications are delivered. Haze's global snapshot apply observer then tried to obtain `Modifier.Node.coroutineScope` from a detached `HazeSourceNode`, causing `This node does not have an owner`.

This change:

- captures the node scope while the source is attached and ignores snapshot callbacks after detach;
- prevents detached nodes from scheduling pre-draw work; and
- adds a minimal Android host regression test with the source and effect in separate `Scaffold` slot subcompositions.

The observer remains active for attached sources, so existing cross-window refresh behaviour is unchanged.

## Test plan

- `./gradlew :haze-blur:testAndroidHostTest :haze:testAndroidHostTest :haze:jvmTest spotlessCheck --no-scan`
