### PR TITLE
Add native backdrop backend for Android 17 QPR2

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,3 +41,16 @@ _Avoid_: Size step, size threshold
 An optical parameter value that is either fixed for every Glass surface size or smoothly
 interpolated across two or more ordered optical size points.
 _Avoid_: Size response, blur profile, adaptive optics
+
+**Backdrop input**:
+The `HazeInput.Backdrop` intent to consume all pixels drawn earlier in the same window. A native
+renderer may consume those current-window pixels when it is eligible; source capture is the
+portable fallback. Backdrop input cannot select individual Haze sources, include later drawing, or
+cross a dialog, popup, or other window boundary.
+_Avoid_: Backdrop source, native backdrop guarantee
+
+**Sources input**:
+The `HazeInput.Sources` input that consumes pixels captured by associated `hazeSource` modifiers.
+It preserves explicit source selection and retained-output policies, including the semantics needed
+for cross-window alignment or exact source ownership.
+_Avoid_: Source backdrop, implicit backdrop

--- a/docs/adr/0009-use-opt-in-android-window-backdrops.md
+++ b/docs/adr/0009-use-opt-in-android-window-backdrops.md
@@ -1,0 +1,37 @@
+---
+status: accepted
+---
+
+# Use opt-in Android window backdrops
+
+Haze will expose `HazeInput.Backdrop(fallback: HazeInput.Sources)` as an experimental input. On a
+supported hardware-accelerated Android window, built-in effects may filter pixels already drawn
+behind the effect through a dedicated `RenderNode`. The fallback is mandatory and remains the
+authoritative result on older Android releases, other platforms, unsupported renderers, and after
+native setup or drawing fails.
+
+Backdrop input is not another source-selection policy. It samples the combined earlier pixels in
+the current window surface; it cannot select individual Haze sources, include later drawing, or
+cross a dialog, popup, or window boundary. Callers that require those semantics continue to use
+`HazeInput.Sources` directly.
+
+Core owns attachment-scoped backend selection, geometry, clipping, transforms, draw ordering, and
+fallback capture demand. A missing capability, unavailable canvas, unusable root effect, or native
+failure selects source fallback until the modifier node detaches. A healthy native node neither
+allocates nor records its fallback source layers. This keeps fallback reliable without charging
+the native path for dormant capture work.
+
+The Android platform renderer is gated on the full 37.2 SDK version and hardware acceleration,
+not major API 37 alone. Its backend and built-in renderer capability remain internal; callers
+cannot select a backend or supply a custom backdrop root effect through the supported public API.
+
+## Consequences
+
+Existing `HazeInput.Sources` and `HazeInput.Content` behavior is unchanged. Blur and Glass retain
+ownership of their complete platform effect graphs and may opt into the internal capability only
+when their styling can be represented without weakening their public contract. A native-to-source
+transition may take one frame, but known failures are not retried every frame.
+
+[ADR-0003](0003-use-one-android-fused-glass-renderer.md) remains authoritative for source-backed
+Android Glass. Backdrop is an explicit input exception: it may reuse the fused effect graph, but it
+must not replace or simplify the retained source-backed renderer.

--- a/docs/adr/0009-use-opt-in-android-window-backdrops.md
+++ b/docs/adr/0009-use-opt-in-android-window-backdrops.md
@@ -1,5 +1,6 @@
 ---
-status: accepted
+status: superseded
+superseded_by: 0010-adopt-backdrop-as-the-adaptive-haze-input
 ---
 
 # Use opt-in Android window backdrops

--- a/docs/adr/0010-adopt-backdrop-as-the-adaptive-haze-input.md
+++ b/docs/adr/0010-adopt-backdrop-as-the-adaptive-haze-input.md
@@ -1,0 +1,55 @@
+---
+status: accepted
+supersedes: 0009-use-opt-in-android-window-backdrops
+---
+
+# Adopt Backdrop as the adaptive Haze input
+
+`HazeInput.Sources` remains the exact source-capture input. `HazeInput.Backdrop` is the normal
+input for a built-in Blur or Glass surface whose intent is to consume the pixels already drawn
+behind it in the current window:
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Backdrop(hazeState),
+)
+```
+
+The native path samples the combined earlier pixels in the same window surface. It cannot select
+individual Haze sources, include later drawing, or cross a dialog, popup, or other window boundary.
+When the native path is unavailable, Haze uses `Backdrop`'s source fallback. The fallback's
+`fallbackSelection` and `fallbackRetention` options apply only to that source-capture path; they
+do not filter native window pixels.
+
+## Eligibility and fallback
+
+`HazeFeatureFlags.isPlatformBackdropEnabled` is an experimental process-wide switch. It is
+`false` by default. Set it before attaching the Haze effect nodes that should observe the switch:
+
+```kotlin
+HazeFeatureFlags.isPlatformBackdropEnabled = true
+```
+
+The switch makes the platform renderer eligible; it does not force native rendering. Built-in
+effect support, the Android full 37.2 SDK gate, the current window and canvas, native setup, and
+native drawing must all succeed. Unsupported platforms, incompatible effects, software canvases,
+and setup or draw failures use source fallback. A known unavailable or failed native path remains
+sticky until that modifier node detaches. Existing attached nodes keep the value observed at
+attachment; a later attachment reads the current value.
+
+The current implementation is experimental and has not established physical Android 37.2
+acceptance or a performance result. Those remain release gates. The rollout is deliberately
+staged: after acceptance a later release may enable the default, retain `false` temporarily as a
+regression escape hatch, and then remove the flag.
+
+## Diagnostics and consequences
+
+Enable `HazeLogger.enabled` while diagnosing selection and fallback messages. Native draw work is
+also marked by the `HazeBackdrop.draw` trace section. These are diagnostics, not a public backend
+selection or status API.
+
+On a healthy native attachment, Haze does not record dormant source layers. A native-to-source
+transition may take one frame, and source fallback remains responsible for portable rendering and
+retained-output behavior. [ADR-0009](0009-use-opt-in-android-window-backdrops.md) records the
+earlier wrapper-based decision and remains unchanged as historical context; this ADR supersedes
+its public input shape.

--- a/docs/adr/0010-adopt-backdrop-as-the-adaptive-haze-input.md
+++ b/docs/adr/0010-adopt-backdrop-as-the-adaptive-haze-input.md
@@ -17,9 +17,9 @@ Modifier.hazeBlur(
 
 The native path samples the combined earlier pixels in the same window surface. It cannot select
 individual Haze sources, include later drawing, or cross a dialog, popup, or other window boundary.
-When the native path is unavailable, Haze uses `Backdrop`'s source fallback. The fallback's
-`fallbackSelection` and `fallbackRetention` options apply only to that source-capture path; they
-do not filter native window pixels.
+When the native path is unavailable, Haze uses `Backdrop`'s `fallback` source input. Its
+selection and retention policies apply only to that source-capture path; they do not filter native
+window pixels.
 
 ## Eligibility and fallback
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,8 +41,11 @@ Modifier.hazeEffect(
 ```
 
 `HazeInput.Sources` selects content captured by `hazeSource`; `HazeInput.Content` selects the
-modifier's own content. Source selection, retained-output privacy, sampling, and layer expansion
-remain core policies rather than effect-specific mutable configuration.
+modifier's own content. Experimental `HazeInput.Backdrop` lets supported built-in effects request
+the combined earlier pixels in the current Android window while carrying a mandatory Sources
+fallback. It is not a source-selection mode and cannot cross a window boundary. Source selection,
+retained-output privacy, sampling, and layer expansion remain core policies rather than
+effect-specific mutable configuration.
 
 ## Semantic renderer scopes
 
@@ -72,6 +75,13 @@ Reads are observed in the phase where they occur:
 - renderer replacement and disposal;
 - draw and bounds invalidation.
 
+For Backdrop input, core also owns the attachment-scoped native/fallback decision, full Android
+minor-SDK and hardware-canvas gate, backdrop geometry and clipping, draw ordering, and dormant
+fallback capture demand. Blur and Glass own their platform root-effect graphs; no backend or
+platform effect is public. A native failure becomes sticky source fallback after at most one
+transition frame. [ADR-0009](adr/0009-use-opt-in-android-window-backdrops.md) records this exception
+to the ordinary source-capture path.
+
 Those details are intentionally absent from the public typed renderer scopes.
 
 ## Built-in Blur
@@ -97,6 +107,11 @@ input requires replacing the Style through recomposition.
 
 The old public effect, renderer, cache, grouped sentinel values, and `glassEffect` DSL are removed.
 No renderer or lifecycle object can be shared between Glass nodes.
+
+On supported Backdrop input, Glass reuses the Android fused effect graph with compositor input and
+keeps only independent rim and interaction-lighting foreground layers. It does not replace the
+source-backed renderer established by
+[ADR-0003](adr/0003-use-one-android-fused-glass-renderer.md).
 
 ## Modules
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,12 +40,13 @@ Modifier.hazeEffect(
 )
 ```
 
-`HazeInput.Sources` selects content captured by `hazeSource`; `HazeInput.Content` selects the
-modifier's own content. Experimental `HazeInput.Backdrop` lets supported built-in effects request
-the combined earlier pixels in the current Android window while carrying a mandatory Sources
-fallback. It is not a source-selection mode and cannot cross a window boundary. Source selection,
-retained-output privacy, sampling, and layer expansion remain core policies rather than
-effect-specific mutable configuration.
+`HazeInput.Backdrop(state)` is the normal built-in input for the intent to consume all pixels drawn
+earlier in the current window. Its `fallbackSelection` and `fallbackRetention` options configure
+only the source-capture fallback. `HazeInput.Sources` selects content captured by `hazeSource`,
+while `HazeInput.Content` selects the modifier's own content. Backdrop input is not a
+source-selection mode: it cannot select individual sources, include later drawing, or cross a
+window boundary. Source selection, retained-output privacy, sampling, and layer expansion remain
+core policies rather than effect-specific mutable configuration.
 
 ## Semantic renderer scopes
 
@@ -75,11 +76,14 @@ Reads are observed in the phase where they occur:
 - renderer replacement and disposal;
 - draw and bounds invalidation.
 
-For Backdrop input, core also owns the attachment-scoped native/fallback decision, full Android
-minor-SDK and hardware-canvas gate, backdrop geometry and clipping, draw ordering, and dormant
-fallback capture demand. Blur and Glass own their platform root-effect graphs; no backend or
-platform effect is public. A native failure becomes sticky source fallback after at most one
-transition frame. [ADR-0009](adr/0009-use-opt-in-android-window-backdrops.md) records this exception
+For Backdrop input, core also snapshots `HazeFeatureFlags.isPlatformBackdropEnabled` when the
+modifier node attaches, then owns the native/fallback decision, full Android minor-SDK and
+hardware-canvas gate, backdrop geometry and clipping, draw ordering, and dormant fallback capture
+demand. The flag makes native rendering eligible; it does not guarantee it. A native failure
+becomes sticky source fallback after at most one transition frame. `HazeLogger.enabled` exposes
+selection and fallback messages, and native work is marked by the `HazeBackdrop.draw` trace
+section. Blur and Glass own their platform root-effect graphs; no backend or platform effect is
+public. [ADR-0010](adr/0010-adopt-backdrop-as-the-adaptive-haze-input.md) records this exception
 to the ordinary source-capture path.
 
 Those details are intentionally absent from the public typed renderer scopes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,8 +41,8 @@ Modifier.hazeEffect(
 ```
 
 `HazeInput.Backdrop(state)` is the normal built-in input for the intent to consume all pixels drawn
-earlier in the current window. Its `fallbackSelection` and `fallbackRetention` options configure
-only the source-capture fallback. `HazeInput.Sources` selects content captured by `hazeSource`,
+earlier in the current window. Its `fallback` source input configures only the source-capture
+fallback. `HazeInput.Sources` selects content captured by `hazeSource`,
 while `HazeInput.Content` selects the modifier's own content. Backdrop input is not a
 source-selection mode: it cannot select individual sources, include later drawing, or cross a
 window boundary. Source selection, retained-output privacy, sampling, and layer expansion remain

--- a/docs/blur/faq.md
+++ b/docs/blur/faq.md
@@ -28,7 +28,7 @@ Box(
 ) {
   Box(
     Modifier.hazeBlur(
-      input = HazeInput.Sources(hazeState),
+      input = HazeInput.Backdrop(hazeState),
       style = HazeBlurStyle { blurRadius(blurRadius) },
     ),
   )
@@ -50,6 +50,17 @@ For most platforms we can use on [RenderEffects][rendereffect] to implement the 
 ## What versions of Android does Haze work on?
 
 See the [Platforms](platforms.md) page for a detailed run down of what is supported on various platforms.
+
+## When should I use Backdrop instead of Sources?
+
+Use `HazeInput.Backdrop(hazeState)` for ordinary built-in Blur when the intent is to consume all
+pixels drawn earlier in the same window. It has source capture as a portable fallback. Use
+`HazeInput.Sources(hazeState)` when you need exact source selection, cross-window alignment, or a
+retained-output policy that governs the actual input. Backdrop's fallback options do not filter
+native window pixels.
+The native path is currently experimental, disabled by default, and only eligible after the flag is
+set before attachment; eligibility is not a guarantee. See the [Blur usage](usage.md) guide for
+fallback and diagnostic details.
 
  [rendereffect]: https://developer.android.com/reference/android/graphics/RenderEffect
  [layer-outsets]: https://developer.android.com/reference/kotlin/androidx/compose/ui/graphics/LayerOutsets

--- a/docs/blur/index.md
+++ b/docs/blur/index.md
@@ -54,7 +54,7 @@ Box {
 
     TopAppBar(
         modifier = Modifier.hazeBlur(
-            input = HazeInput.Sources(hazeState),
+            input = HazeInput.Backdrop(hazeState),
             style = style,
         ),
     )

--- a/docs/blur/material3.md
+++ b/docs/blur/material3.md
@@ -16,7 +16,7 @@ a one-off Style can override that background without adding an implicit color ef
 
 ```kotlin
 Modifier.hazeBlur(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = HazeBlurStyle.Material3 {
     blurRadius(12.dp)
   },

--- a/docs/blur/materials.md
+++ b/docs/blur/materials.md
@@ -18,7 +18,7 @@ For a minimal Style that follows the current Compose Material 3 theme, use the s
 
 ```kotlin
 Modifier.hazeBlur(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = HazeMaterials.thin(),
 )
 ```
@@ -29,7 +29,7 @@ Modifier.hazeBlur(
 
 ```kotlin
 Modifier.hazeBlur(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = CupertinoMaterials.regular(),
 )
 ```
@@ -40,7 +40,7 @@ Modifier.hazeBlur(
 
 ```kotlin
 Modifier.hazeBlur(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = FluentMaterials.acrylicDefault(),
 )
 ```

--- a/docs/blur/usage.md
+++ b/docs/blur/usage.md
@@ -11,8 +11,8 @@ own Content input. All modes use the typed `hazeBlur` modifier and the same repl
 | Exact source ownership or selection | `HazeInput.Sources(hazeState)` | Pixels captured by selected `hazeSource` modifiers. |
 | Blur the modifier's own content | `HazeInput.Content` | Content drawn by the modifier's composable. |
 
-Use `Backdrop` for the usual built-in Blur case. Its `fallbackSelection` and `fallbackRetention`
-options apply only if source capture is needed; they do not filter the native window backdrop.
+Use `Backdrop` for the usual built-in Blur case. Its `fallback` source input applies only if
+source capture is needed; it does not filter the native window backdrop.
 
 ## Source-backed Blur
 

--- a/docs/blur/usage.md
+++ b/docs/blur/usage.md
@@ -53,6 +53,30 @@ Image(
 )
 ```
 
+## Android window-backdrop Blur
+
+On a hardware-accelerated Android 37.2 window, experimental `HazeInput.Backdrop` can blur the
+combined pixels already drawn behind the modifier without recording a Haze source for that healthy
+native consumer:
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Backdrop(
+    fallback = HazeInput.Sources(hazeState),
+  ),
+  style = HazeMaterials.thin(),
+)
+```
+
+This is same-window, previous-pixel ordering—not selected-source capture. It cannot see later draw
+operations or pixels from another dialog, popup, or window. Native sampling stays at compositor
+resolution; `HazePerformanceMode` does not downsample that input. On older Android releases, other
+platforms, a software canvas, or after native setup/draw failure, the modifier uses the mandatory
+Sources fallback. That decision is sticky until detachment and the transition may take one frame.
+
+Use `HazeInput.Sources` when its selection, cross-window, or retention semantics are required. See
+[ADR-0009](../adr/0009-use-opt-in-android-window-backdrops.md) for the complete boundary.
+
 ## Enabling Blur
 
 Blur is enabled by default only where Haze considers the platform implementation reliable. To

--- a/docs/blur/usage.md
+++ b/docs/blur/usage.md
@@ -1,7 +1,18 @@
 # Blur usage
 
-Blur works with either source-backed content or the modifier's own content. Both modes use the
-typed `hazeBlur` modifier and the same replayable Style.
+Blur works with a current-window Backdrop input, exact captured Sources input, or the modifier's
+own Content input. All modes use the typed `hazeBlur` modifier and the same replayable Style.
+
+## Choosing the input
+
+| Requirement | Input | What it consumes |
+| --- | --- | --- |
+| Normal built-in Blur behind content | `HazeInput.Backdrop(hazeState)` | All earlier pixels in the same window, with source capture as fallback. |
+| Exact source ownership or selection | `HazeInput.Sources(hazeState)` | Pixels captured by selected `hazeSource` modifiers. |
+| Blur the modifier's own content | `HazeInput.Content` | Content drawn by the modifier's composable. |
+
+Use `Backdrop` for the usual built-in Blur case. Its `fallbackSelection` and `fallbackRetention`
+options apply only if source capture is needed; they do not filter the native window backdrop.
 
 ## Source-backed Blur
 
@@ -55,27 +66,36 @@ Image(
 
 ## Android window-backdrop Blur
 
-On a hardware-accelerated Android 37.2 window, experimental `HazeInput.Backdrop` can blur the
-combined pixels already drawn behind the modifier without recording a Haze source for that healthy
-native consumer:
+`HazeInput.Backdrop` is portable, while its native path is an experimental eligibility path. Set
+the process-wide flag before attaching the effect nodes that should observe it:
 
 ```kotlin
+HazeFeatureFlags.isPlatformBackdropEnabled = true
+
 Modifier.hazeBlur(
-  input = HazeInput.Backdrop(
-    fallback = HazeInput.Sources(hazeState),
-  ),
+  input = HazeInput.Backdrop(hazeState),
   style = HazeMaterials.thin(),
 )
 ```
 
-This is same-window, previous-pixel ordering—not selected-source capture. It cannot see later draw
-operations or pixels from another dialog, popup, or window. Native sampling stays at compositor
-resolution; `HazePerformanceMode` does not downsample that input. On older Android releases, other
-platforms, a software canvas, or after native setup/draw failure, the modifier uses the mandatory
-Sources fallback. That decision is sticky until detachment and the transition may take one frame.
+The current default is `false`. `true` makes native rendering eligible, not guaranteed: built-in
+effect support, the full Android 37.2 gate, the window and canvas, native setup, and the draw must
+all succeed. This is same-window, previous-pixel ordering—not selected-source capture. It cannot
+see later draw operations or pixels from another dialog, popup, or window. Native sampling stays
+at compositor resolution; `HazePerformanceMode` does not downsample that input. On older Android
+releases, other platforms, a software canvas, or after native setup/draw failure, the modifier uses
+the configured source fallback. That decision is sticky until detachment and the transition may
+take one frame. Changing the flag affects later attachments only, and healthy native consumers do
+not record fallback source layers.
 
-Use `HazeInput.Sources` when its selection, cross-window, or retention semantics are required. See
-[ADR-0009](../adr/0009-use-opt-in-android-window-backdrops.md) for the complete boundary.
+Set `HazeLogger.enabled = true` for selection and fallback messages. The native draw is marked by
+the `HazeBackdrop.draw` trace section. These diagnostics do not establish a performance result;
+physical Android 37.2 acceptance is still pending. A later release may flip the default, retain a
+temporary `false` escape hatch, and then remove the experimental flag.
+
+Use `HazeInput.Sources` when its exact selection, cross-window, or retention semantics must govern
+the actual input. See
+[ADR-0010](../adr/0010-adopt-backdrop-as-the-adaptive-haze-input.md) for the complete boundary.
 
 ## Enabling Blur
 
@@ -84,7 +104,7 @@ override that decision, write `blurEnabled` in a Style:
 
 ```kotlin
 Modifier.hazeBlur(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = HazeBlurStyle {
     blurEnabled(true)
   },

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -36,6 +36,8 @@ Typed effects always declare what they consume:
 
 - `HazeInput.Sources(hazeState)` consumes captured source content.
 - `HazeInput.Content` consumes the modifier's own content.
+- `HazeInput.Backdrop(fallback)` opts built-in Blur or Glass into supported Android window-backdrop
+  rendering, with a mandatory `HazeInput.Sources` fallback.
 
 Source-backed input also declares retention:
 
@@ -48,6 +50,31 @@ HazeInput.Sources(
 
 `KeepLastFrame` smooths temporary source gaps. `ClearWhenUnavailable` clears retained output as
 soon as no selected source is drawable.
+
+### Android window backdrops
+
+`HazeInput.Backdrop` is experimental and currently uses the native path only on a
+hardware-accelerated Android 37.2 window. It filters the combined pixels already drawn earlier in
+the same window surface. It cannot select individual Haze sources, include content drawn later,
+or cross a dialog, popup, or window boundary.
+
+```kotlin
+Modifier.hazeBlur(
+  input = HazeInput.Backdrop(
+    fallback = HazeInput.Sources(hazeState),
+  ),
+)
+```
+
+Native backdrop sampling uses compositor resolution rather than the effect's source-capture scale.
+If the platform, canvas, built-in effect, or native draw is unavailable, that modifier switches to
+its source fallback for the rest of the attachment. The switch may take one frame; a known-bad
+native path is not retried every frame. Healthy native-only consumers do not cause their dormant
+fallback sources to record.
+
+Use `HazeInput.Sources` directly when source selection, cross-window alignment, retention policy,
+or stable support on older platforms is required. See
+[ADR-0009](adr/0009-use-opt-in-android-window-backdrops.md) for the backend decision.
 
 ## Typed Blur
 

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -34,10 +34,24 @@ val selection = HazeSourceSelection.Behind
 
 Typed effects always declare what they consume:
 
-- `HazeInput.Sources(hazeState)` consumes captured source content.
-- `HazeInput.Content` consumes the modifier's own content.
-- `HazeInput.Backdrop(fallback)` opts built-in Blur or Glass into supported Android window-backdrop
-  rendering, with a mandatory `HazeInput.Sources` fallback.
+| Intent | Input | Semantics |
+| --- | --- | --- |
+| Pixels already behind a built-in effect | `HazeInput.Backdrop(hazeState)` | Current-window, earlier-pixel intent with source capture as the portable fallback. |
+| Exact captured Haze sources | `HazeInput.Sources(hazeState)` | Explicit source selection and retained-output policies. |
+| The modifier's own content | `HazeInput.Content` | Foreground or own-content effect input. |
+
+Use `HazeInput.Backdrop(hazeState)` for ordinary built-in Blur and Glass surfaces. Its
+`fallbackSelection` and `fallbackRetention` options configure only the source fallback; they do
+not select or filter native window pixels:
+
+```kotlin
+Modifier.hazeGlass(
+  input = HazeInput.Backdrop(
+    state = hazeState,
+    fallbackRetention = HazeSourceRetention.ClearWhenUnavailable,
+  ),
+)
+```
 
 Source-backed input also declares retention:
 
@@ -53,28 +67,38 @@ soon as no selected source is drawable.
 
 ### Android window backdrops
 
-`HazeInput.Backdrop` is experimental and currently uses the native path only on a
-hardware-accelerated Android 37.2 window. It filters the combined pixels already drawn earlier in
-the same window surface. It cannot select individual Haze sources, include content drawn later,
-or cross a dialog, popup, or window boundary.
+`HazeInput.Backdrop` is a stable, portable input contract. Its native path is currently eligible
+only when the experimental process flag is enabled, the built-in effect supports it, and the
+modifier is attached to a hardware-accelerated Android 37.2 window. The native renderer filters
+the combined pixels already drawn earlier in the same window surface. It cannot select individual
+Haze sources, include content drawn later, or cross a dialog, popup, or window boundary.
 
 ```kotlin
+// Set this before the effect node is attached.
+HazeFeatureFlags.isPlatformBackdropEnabled = true
+
 Modifier.hazeBlur(
-  input = HazeInput.Backdrop(
-    fallback = HazeInput.Sources(hazeState),
-  ),
+  input = HazeInput.Backdrop(hazeState),
 )
 ```
 
-Native backdrop sampling uses compositor resolution rather than the effect's source-capture scale.
-If the platform, canvas, built-in effect, or native draw is unavailable, that modifier switches to
-its source fallback for the rest of the attachment. The switch may take one frame; a known-bad
-native path is not retried every frame. Healthy native-only consumers do not cause their dormant
-fallback sources to record.
+The flag defaults to `false`, and `true` means eligible rather than guaranteed. Native backdrop
+sampling uses compositor resolution rather than the effect's source-capture scale. If the platform,
+window, canvas, built-in effect, native setup, or native draw is unavailable, that modifier switches
+to its configured source fallback for the rest of the attachment. The switch may take one frame;
+a known-bad native path is not retried every frame. Healthy native-only consumers do not cause
+their dormant fallback sources to record. Changing the flag affects later attachments only.
 
-Use `HazeInput.Sources` directly when source selection, cross-window alignment, retention policy,
-or stable support on older platforms is required. See
-[ADR-0009](adr/0009-use-opt-in-android-window-backdrops.md) for the backend decision.
+For diagnostics, set `HazeLogger.enabled = true` to see backdrop selection and fallback messages.
+Native work is marked by the `HazeBackdrop.draw` trace section. No performance claim is implied by
+native eligibility; physical Android 37.2 acceptance remains a separate release gate. Later
+releases may enable the flag by default, retain a temporary `false` escape hatch, and then remove
+the experimental flag.
+
+Use `HazeInput.Sources` directly when exact source selection, cross-window alignment, or a
+retention policy that must govern the actual input rather than only the fallback is required. See
+[ADR-0010](adr/0010-adopt-backdrop-as-the-adaptive-haze-input.md) for the input and rollout
+decision.
 
 ## Typed Blur
 
@@ -82,7 +106,7 @@ Blur has an ordinary typed modifier:
 
 ```kotlin
 Modifier.hazeBlur(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = HazeMaterials.thin(),
   performanceMode = HazePerformanceMode.Adaptive,
   expandLayerBounds = true,
@@ -165,7 +189,9 @@ captured.
 
 ## Background and foreground effects
 
-Source-backed effects render captured content from elsewhere in the hierarchy:
+For the normal built-in case, use Backdrop input to consume earlier pixels in the current window.
+Use Sources when the example needs exact captured-source semantics, as in this source-ordering
+example:
 
 ```kotlin
 Box {
@@ -217,7 +243,7 @@ fun HazeExample() {
 fun Foreground() {
   Text(
     modifier = Modifier.hazeBlur(
-      input = HazeInput.Sources(LocalHazeState.current),
+      input = HazeInput.Backdrop(LocalHazeState.current),
     ),
   )
 }
@@ -225,8 +251,9 @@ fun Foreground() {
 
 ## Overlapping effects
 
-One composable can both consume lower sources and become a source for a higher effect. Give each
-source an explicit `zIndex`:
+One composable can both consume lower sources and become a source for a higher effect. This example
+deliberately uses Sources because the exact source ordering matters. Give each source an explicit
+`zIndex`:
 
 ```kotlin
 Box {

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -40,15 +40,17 @@ Typed effects always declare what they consume:
 | Exact captured Haze sources | `HazeInput.Sources(hazeState)` | Explicit source selection and retained-output policies. |
 | The modifier's own content | `HazeInput.Content` | Foreground or own-content effect input. |
 
-Use `HazeInput.Backdrop(hazeState)` for ordinary built-in Blur and Glass surfaces. Its
-`fallbackSelection` and `fallbackRetention` options configure only the source fallback; they do
-not select or filter native window pixels:
+Use `HazeInput.Backdrop(hazeState)` for ordinary built-in Blur and Glass surfaces. Its `fallback`
+source input configures only the source fallback; it does not select or filter native window
+pixels:
 
 ```kotlin
 Modifier.hazeGlass(
   input = HazeInput.Backdrop(
-    state = hazeState,
-    fallbackRetention = HazeSourceRetention.ClearWhenUnavailable,
+    HazeInput.Sources(
+      state = hazeState,
+      retention = HazeSourceRetention.ClearWhenUnavailable,
+    ),
   ),
 )
 ```

--- a/docs/custom-effects.md
+++ b/docs/custom-effects.md
@@ -56,6 +56,9 @@ factory is replaced or the node detaches.
 ## Draw source-backed input
 
 Use an explicit `HazeInput.Sources` when the effect consumes content captured by `hazeSource`:
+This is deliberate for custom effects: `Backdrop` is the built-in Blur and Glass input contract,
+and a generic factory does not receive the platform window-backdrop capability. `Sources` keeps
+the captured-source selection and retention semantics visible at the call site.
 
 ```kotlin
 val hazeState = rememberHazeState()

--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -44,7 +44,7 @@ val clear = GlassStyle.clear.material3(tint = Color.White.copy(alpha = 0.16f))
 
 ```kotlin
 Modifier.hazeGlass(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = GlassStyle.Material3(tint = Color.White.copy(alpha = 0.16f)) {
     optics(refractionStrength = 0.8f)
   },
@@ -75,7 +75,7 @@ they do not promise pixel parity with another system.
 
 ```kotlin
 Modifier.hazeGlass(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = GlassStyle.clear.material3(tint = Color.White.copy(alpha = 0.12f)),
 )
 ```
@@ -186,7 +186,7 @@ when one element needs to differ.
 Box(
   Modifier
     .size(180.dp)
-    .hazeGlass(input = HazeInput.Sources(hazeState))
+    .hazeGlass(input = HazeInput.Backdrop(hazeState)),
 )
 ```
 
@@ -285,14 +285,15 @@ Modifier.hazeGlass(
 
 ### Android window-backdrop Glass
 
-Experimental `HazeInput.Backdrop` lets Glass use the combined pixels already drawn earlier in a
-hardware-accelerated Android 37.2 window:
+`HazeInput.Backdrop` is the normal Glass input when the surface should consume the combined pixels
+already drawn earlier in the current window. Its native path is experimental and eligible only
+after setting the process-wide flag before the effect node attaches:
 
 ```kotlin
+HazeFeatureFlags.isPlatformBackdropEnabled = true
+
 Modifier.hazeGlass(
-  input = HazeInput.Backdrop(
-    fallback = HazeInput.Sources(hazeState),
-  ),
+  input = HazeInput.Backdrop(hazeState),
   style = GlassStyle.regular,
 )
 ```
@@ -303,14 +304,26 @@ and authored alpha, shape, and material transforms keep their normal ordering. I
 a source or fused-output layer while healthy.
 
 Backdrop input samples the current window's combined earlier pixels. It cannot select a Haze
-source, include content drawn later, or cross a dialog, popup, or window boundary. Unsupported
-platforms, an unavailable native graph, or a native failure select the mandatory Sources fallback
-for the rest of that attachment; the transition may take one frame.
+source, include content drawn later, or cross a dialog, popup, or window boundary. The
+`fallbackSelection` and `fallbackRetention` options on `HazeInput.Backdrop` configure only its
+source fallback; they do not filter native window pixels. The current flag default is `false`, and
+`true` means eligible rather than guaranteed: the built-in effect, full Android 37.2 gate, window,
+canvas, native graph setup, and draw must all succeed. Unsupported platforms or a native failure
+select the source fallback for the rest of that attachment; the transition may take one frame.
+Changing the flag affects later attachments only, and healthy native rendering does not retain or
+record source layers.
 
-Use Sources directly when source selection, cross-window alignment, or retained-output behavior is
-part of the requirement. [ADR-0009](../adr/0009-use-opt-in-android-window-backdrops.md) defines the
-opt-in backend, while [ADR-0003](../adr/0003-use-one-android-fused-glass-renderer.md) remains
-authoritative for source-backed Android Glass.
+Set `HazeLogger.enabled = true` to inspect selection and fallback messages. Native work is marked
+by the `HazeBackdrop.draw` trace section. This is diagnostic information, not a performance claim;
+physical Android 37.2 acceptance remains a separate release gate. A later release may enable the
+flag by default, retain a temporary `false` escape hatch, and then remove the experimental flag.
+
+Use Sources directly when exact source selection, cross-window alignment, or retained-output
+behavior must govern the actual input rather than only the fallback.
+[ADR-0010](../adr/0010-adopt-backdrop-as-the-adaptive-haze-input.md)
+defines the input and rollout, while
+[ADR-0003](../adr/0003-use-one-android-fused-glass-renderer.md) remains authoritative for
+source-backed Android Glass.
 
 You can select a literal optical configuration when the built-in material does not fit the design:
 
@@ -359,7 +372,7 @@ not add click handling, focusability, semantics, or keyboard/D-pad activation.
 
 ```kotlin
 Modifier.hazeGlass(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = GlassStyle {
     pressed {
       lightingIntensity(1f)
@@ -397,7 +410,7 @@ Modifier
   .clickable(interactionSource = interactionSource, indication = null) { onClick() }
   .focusable(interactionSource = interactionSource)
   .hazeGlass(
-    input = HazeInput.Sources(hazeState),
+    input = HazeInput.Backdrop(hazeState),
     style = interactionStyle,
     interactionSource = interactionSource,
     interactionTransformTarget = GlassTransformTarget.MaterialAndContent,
@@ -445,7 +458,7 @@ Box(
   Modifier
     .size(180.dp)
     .hazeGlass(
-      input = HazeInput.Sources(hazeState),
+      input = HazeInput.Backdrop(hazeState),
       style = GlassStyle {
         tint(Color.White.copy(alpha = 0.16f))
         optics(

--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -304,9 +304,9 @@ and authored alpha, shape, and material transforms keep their normal ordering. I
 a source or fused-output layer while healthy.
 
 Backdrop input samples the current window's combined earlier pixels. It cannot select a Haze
-source, include content drawn later, or cross a dialog, popup, or window boundary. The
-`fallbackSelection` and `fallbackRetention` options on `HazeInput.Backdrop` configure only its
-source fallback; they do not filter native window pixels. The current flag default is `false`, and
+source, include content drawn later, or cross a dialog, popup, or window boundary. The `fallback`
+source input on `HazeInput.Backdrop` configures only its source fallback; it does not filter native
+window pixels. The current flag default is `false`, and
 `true` means eligible rather than guaranteed: the built-in effect, full Android 37.2 gate, window,
 canvas, native graph setup, and draw must all succeed. Unsupported platforms or a native failure
 select the source fallback for the rest of that attachment; the transition may take one frame.

--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -283,6 +283,35 @@ Modifier.hazeGlass(
 )
 ```
 
+### Android window-backdrop Glass
+
+Experimental `HazeInput.Backdrop` lets Glass use the combined pixels already drawn earlier in a
+hardware-accelerated Android 37.2 window:
+
+```kotlin
+Modifier.hazeGlass(
+  input = HazeInput.Backdrop(
+    fallback = HazeInput.Sources(hazeState),
+  ),
+  style = GlassStyle.regular,
+)
+```
+
+The native path reuses Glass's fused blur, depth, refraction, detail, chromatic, tint, and tone
+graph at compositor resolution. Rim and interaction lighting remain independent foreground draws,
+and authored alpha, shape, and material transforms keep their normal ordering. It does not retain
+a source or fused-output layer while healthy.
+
+Backdrop input samples the current window's combined earlier pixels. It cannot select a Haze
+source, include content drawn later, or cross a dialog, popup, or window boundary. Unsupported
+platforms, an unavailable native graph, or a native failure select the mandatory Sources fallback
+for the rest of that attachment; the transition may take one frame.
+
+Use Sources directly when source selection, cross-window alignment, or retained-output behavior is
+part of the requirement. [ADR-0009](../adr/0009-use-opt-in-android-window-backdrops.md) defines the
+opt-in backend, while [ADR-0003](../adr/0003-use-one-android-fused-glass-renderer.md) remains
+authoritative for source-backed Android Glass.
+
 You can select a literal optical configuration when the built-in material does not fit the design:
 
 ```kotlin

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -131,10 +131,20 @@ specific retained-output policy that governs the actual input:
 | Exact captured-source semantics | `HazeInput.Sources(hazeState)` |
 | Modifier's own content | `HazeInput.Content` |
 
-Early beta builds accepted a branch-only `Backdrop` wrapper with a nested `fallback` Sources
-input. That constructor is removed; replace it with `HazeInput.Backdrop(state)`. If you need to
-customize the portable fallback, use `fallbackSelection` and `fallbackRetention` on `Backdrop`.
-Those options do not filter native window pixels.
+Use `HazeInput.Backdrop(state)` for the default source fallback. If you need to customize the
+portable fallback, pass a `HazeInput.Sources` value to `Backdrop`:
+
+```kotlin
+HazeInput.Backdrop(
+  HazeInput.Sources(
+    state = state,
+    selection = HazeSourceSelection.All,
+    retention = HazeSourceRetention.ClearWhenUnavailable,
+  ),
+)
+```
+
+The fallback source input does not filter native window pixels.
 
 These values are modifier structure, not Style:
 

--- a/docs/migrating-2.0.md
+++ b/docs/migrating-2.0.md
@@ -112,7 +112,7 @@ After:
 
 ```kotlin
 Modifier.hazeBlur(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = HazeMaterials.thin(),
 )
 ```
@@ -120,6 +120,21 @@ Modifier.hazeBlur(
 Customize a preset with `then`, not `copy`.
 
 ## Migrate input and rendering policy
+
+For ordinary built-in Blur and Glass, use the current-window Backdrop input. Keep
+`HazeInput.Sources` when the effect needs exact source selection, cross-window alignment, or a
+specific retained-output policy that governs the actual input:
+
+| Requirement | Input |
+| --- | --- |
+| Normal built-in surface behind content | `HazeInput.Backdrop(hazeState)` |
+| Exact captured-source semantics | `HazeInput.Sources(hazeState)` |
+| Modifier's own content | `HazeInput.Content` |
+
+Early beta builds accepted a branch-only `Backdrop` wrapper with a nested `fallback` Sources
+input. That constructor is removed; replace it with `HazeInput.Backdrop(state)`. If you need to
+customize the portable fallback, use `fallbackSelection` and `fallbackRetention` on `Backdrop`.
+Those options do not filter native window pixels.
 
 These values are modifier structure, not Style:
 
@@ -134,6 +149,16 @@ Modifier.hazeBlur(
   expandLayerBounds = false,
 )
 ```
+
+The native Backdrop path is experimental and disabled by default. Set
+`HazeFeatureFlags.isPlatformBackdropEnabled = true` before the relevant effect nodes attach. The
+flag makes native rendering eligible rather than guaranteed, and changing it affects later
+attachments only. Unsupported platforms, incompatible effects, software canvases, native setup,
+or draw failures use sticky source fallback until detachment. Enable `HazeLogger.enabled` for
+selection/fallback messages and inspect the `HazeBackdrop.draw` trace section when diagnosing a
+native draw. No performance result is implied; physical Android 37.2 acceptance remains pending.
+Later releases may enable the default, retain a temporary `false` escape hatch, and then remove
+the flag.
 
 `HazePerformanceMode.Default` points to `Adaptive` for built-in Blur and Glass. Use `Adaptive` to pin that policy,
 `Quality`, `Balanced`, or `Performance` for its named profiles, or `Fixed(qualityFraction)` for an
@@ -180,7 +205,7 @@ generated API reference for property-specific ranges.
 | `GlassStyleConfiguration`, `GlassRenderer`, `GlassRendererCache`, and lifecycle or retention hooks | removed with no public replacement |
 | effect-owned hover, focus, press, light-radius, and light-position animation presentation | property writes inside `GlassStyle { … }` |
 | effect-owned interaction source, transform target/pivot, and reduced-motion policy | explicit `Modifier.hazeGlass` arguments owned by each node |
-| implicit source/content | explicit `HazeInput.Sources` or `HazeInput.Content` |
+| implicit source/content | explicit `HazeInput.Backdrop`, `HazeInput.Sources`, or `HazeInput.Content` |
 | `GlassOptics.Absolute` and `GlassOptics.Fixed` | `GlassOptics` with fixed `OpticalSizeValue` values; this is an intentional source break with no alias or compatibility bridge |
 | `GlassOptics.Adaptive` used as a complete Style | `GlassStyle.regular` |
 | `GlassOptics.Adaptive` supplied through `optics(...)` | `optics(GlassDefaults.optics)` |
@@ -217,7 +242,7 @@ val glassStyle = GlassStyle {
 }
 
 Modifier.hazeGlass(
-  input = HazeInput.Sources(hazeState),
+  input = HazeInput.Backdrop(hazeState),
   style = glassStyle,
   performanceMode = HazePerformanceMode.Adaptive,
   expandLayerBounds = true,
@@ -307,7 +332,8 @@ and `then`.
    `dev.chrisbanes.haze.blur.materials`.
 3. Replace `Modifier.haze(...)` with `Modifier.hazeSource(...)`.
 4. Replace Blur-configuring `hazeEffect` blocks with `hazeBlur`, choosing
-   `HazeInput.Sources(state)` or `HazeInput.Content`.
+   `HazeInput.Backdrop(state)` for ordinary built-in surfaces, `HazeInput.Sources(state)` for
+   exact captured-source semantics, or `HazeInput.Content` for own-content Blur.
 5. Move Blur properties into `HazeBlurStyle { ... }`, changing property assignments into Style
    functions. Use `then` instead of `copy` when customizing a preset.
 6. Move built-in Blur input-scale choices to `HazePerformanceMode`: map the previous default to

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -13,7 +13,7 @@ Scaffold(
     TopAppBar(
       colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent),
       modifier = Modifier.hazeBlur(
-        input = HazeInput.Sources(hazeState),
+        input = HazeInput.Backdrop(hazeState),
         style = style,
       ),
     )
@@ -22,7 +22,7 @@ Scaffold(
     NavigationBar(
       containerColor = Color.Transparent,
       modifier = Modifier.hazeBlur(
-        input = HazeInput.Sources(hazeState),
+        input = HazeInput.Backdrop(hazeState),
         style = style,
       ),
     ) {
@@ -56,7 +56,7 @@ LazyColumn {
   stickyHeader {
     Header(
       modifier = Modifier.hazeBlur(
-        input = HazeInput.Sources(hazeState),
+        input = HazeInput.Backdrop(hazeState),
         style = style,
         performanceMode = HazePerformanceMode.Adaptive,
       ),
@@ -96,10 +96,10 @@ val quiet = base.then {
 }
 
 TopAppBar(
-  modifier = Modifier.hazeBlur(HazeInput.Sources(hazeState), quiet),
+  modifier = Modifier.hazeBlur(HazeInput.Backdrop(hazeState), quiet),
 )
 BottomAppBar(
-  modifier = Modifier.hazeBlur(HazeInput.Sources(hazeState), quiet),
+  modifier = Modifier.hazeBlur(HazeInput.Backdrop(hazeState), quiet),
 )
 ```
 

--- a/docs/scenarios/camera.md
+++ b/docs/scenarios/camera.md
@@ -3,6 +3,10 @@
 Haze can apply Blur and Glass to a live camera preview when the preview pixels are drawn into the
 same Compose graphics layer that contains `hazeSource`.
 
+This example intentionally uses `HazeInput.Sources`: camera and video integrations need explicit
+captured-source semantics, and a platform surface can sit outside the current window's earlier
+Compose pixels. `HazeInput.Backdrop` cannot cross that surface or window boundary.
+
 ```kotlin
 val hazeState = rememberHazeState()
 

--- a/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/Android.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/Android.kt
@@ -4,6 +4,7 @@
 package dev.chrisbanes.gradle
 
 import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.CompileSdkSpec
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.dsl.TestExtension
@@ -16,7 +17,7 @@ import org.gradle.kotlin.dsl.configure
 
 fun Project.configureAndroidApplication() {
   extensions.configure<ApplicationExtension> {
-    compileSdk = Versions.COMPILE_SDK
+    compileSdk { configureHazeCompileSdk() }
 
     defaultConfig {
       minSdk = Versions.MIN_SDK
@@ -34,7 +35,7 @@ fun Project.configureAndroidApplication() {
 
 fun Project.configureAndroidLibrary() {
   extensions.configure<LibraryExtension> {
-    compileSdk = Versions.COMPILE_SDK
+    compileSdk { configureHazeCompileSdk() }
 
     defaultConfig {
       minSdk = Versions.MIN_SDK
@@ -53,7 +54,7 @@ fun Project.configureKotlinMultiplatformAndroidLibrary() {
   kotlin {
     targets.configureEach {
       if (this is KotlinMultiplatformAndroidLibraryTarget) {
-        compileSdk = Versions.COMPILE_SDK
+        compileSdk { configureHazeCompileSdk() }
         minSdk = Versions.MIN_SDK
       }
     }
@@ -70,7 +71,7 @@ fun Project.configureKotlinMultiplatformAndroidLibrary() {
 
 fun Project.configureAndroidTest() {
   extensions.configure<TestExtension> {
-    compileSdk = Versions.COMPILE_SDK
+    compileSdk { configureHazeCompileSdk() }
 
     defaultConfig {
       minSdk = Versions.MIN_SDK
@@ -84,6 +85,12 @@ fun Project.configureAndroidTest() {
   }
 
   configureAndroidComponents()
+}
+
+private fun CompileSdkSpec.configureHazeCompileSdk() {
+  version = release(Versions.COMPILE_SDK) {
+    minorApiLevel = Versions.COMPILE_SDK_MINOR
+  }
 }
 
 private fun Project.configureAndroidComponents() {

--- a/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/Versions.kt
+++ b/gradle/build-logic/convention/src/main/kotlin/dev/chrisbanes/gradle/Versions.kt
@@ -5,6 +5,7 @@ package dev.chrisbanes.gradle
 
 object Versions {
   const val COMPILE_SDK = 37
+  const val COMPILE_SDK_MINOR = 2
   const val MIN_SDK = 23
   const val TARGET_SDK = 37
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,8 @@ androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", versi
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "androidx-media3" }
 androidx-profileinstaller = "androidx.profileinstaller:profileinstaller:1.4.1"
 androidx-test-ext-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-ext-junit" }
+androidx-test-core = "androidx.test:core:1.7.0"
+androidx-test-runner = "androidx.test:runner:1.7.0"
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.4.0"
 
 androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "jetpack-compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,7 @@ androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "andr
 androidx-profileinstaller = "androidx.profileinstaller:profileinstaller:1.4.1"
 androidx-test-ext-junit = { module = "androidx.test.ext:junit-ktx", version.ref = "androidx-test-ext-junit" }
 androidx-test-core = "androidx.test:core:1.7.0"
+androidx-test-espresso-core = "androidx.test.espresso:espresso-core:3.7.0"
 androidx-test-runner = "androidx.test:runner:1.7.0"
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.4.0"
 

--- a/haze-blur/build.gradle.kts
+++ b/haze-blur/build.gradle.kts
@@ -63,8 +63,10 @@ kotlin {
       dependencies {
         implementation(libs.assertk)
         implementation(libs.androidx.activity)
+        implementation(libs.androidx.activity.compose)
         implementation(libs.androidx.compose.ui.test.junit4)
         implementation(libs.androidx.compose.ui.test.manifest)
+        implementation(libs.androidx.test.runner)
         implementation(libs.compose.foundation)
         implementation(projects.internal.contextTest) {
           exclude(group = "org.robolectric", module = "robolectric")

--- a/haze-blur/build.gradle.kts
+++ b/haze-blur/build.gradle.kts
@@ -66,6 +66,7 @@ kotlin {
         implementation(libs.androidx.activity.compose)
         implementation(libs.androidx.compose.ui.test.junit4)
         implementation(libs.androidx.compose.ui.test.manifest)
+        implementation(libs.androidx.test.espresso.core)
         implementation(libs.androidx.test.runner)
         implementation(libs.compose.foundation)
         implementation(projects.internal.contextTest) {

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropFallbackInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropFallbackInstrumentationTest.kt
@@ -1,0 +1,93 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.filters.SdkSuppress
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+import org.junit.Rule
+import org.junit.Test
+
+@SdkSuppress(maxSdkVersion = 36)
+@OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class)
+class BlurBackdropFallbackInstrumentationTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun unsupportedPlatform_usesSourcesFallback() {
+    val fallbackState = HazeState()
+
+    composeTestRule.setContent {
+      Box(Modifier.fillMaxSize().background(Color.White)) {
+        Box(
+          Modifier
+            .align(Alignment.Center)
+            .size(width = 200.dp, height = 100.dp)
+            .hazeSource(fallbackState)
+            .background(Color.Black),
+        ) {
+          Box(
+            Modifier
+              .align(Alignment.CenterEnd)
+              .size(width = 100.dp, height = 100.dp)
+              .background(Color.White),
+          )
+        }
+        Box(
+          Modifier
+            .align(Alignment.Center)
+            .size(width = 200.dp, height = 100.dp)
+            .testTag(EFFECT_TAG)
+            .hazeBlur(
+              input = HazeInput.Backdrop(HazeInput.Sources(fallbackState)),
+              style = HazeBlurStyle {
+                blurRadius(14.dp)
+                noiseFactor(0f)
+                colorEffects(emptyList())
+              },
+            ),
+        )
+      }
+    }
+    composeTestRule.waitForIdle()
+
+    val pixels = composeTestRule.onNodeWithTag(EFFECT_TAG).captureToImage().toPixelMap()
+    val centerX = pixels.width / 2
+    val centerY = pixels.height / 2
+    val blackInterior = pixels[centerX - 60, centerY].red
+    val blackNearEdge = pixels[centerX - 3, centerY].red
+    val whiteNearEdge = pixels[centerX + 3, centerY].red
+    val whiteInterior = pixels[centerX + 60, centerY].red
+
+    assertThat(blackNearEdge - blackInterior, "Fallback softens the black side")
+      .isGreaterThan(0.05f)
+    assertThat(whiteInterior - whiteNearEdge, "Fallback softens the white side")
+      .isGreaterThan(0.05f)
+  }
+
+  private companion object {
+    const val EFFECT_TAG = "effect"
+  }
+}

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropFallbackInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropFallbackInstrumentationTest.kt
@@ -22,9 +22,12 @@ import androidx.test.filters.SdkSuppress
 import assertk.assertThat
 import assertk.assertions.isGreaterThan
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeFeatureFlags
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -32,8 +35,21 @@ import org.junit.Test
 @OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class)
 class BlurBackdropFallbackInstrumentationTest {
 
+  private var previousPlatformBackdropEnabled = false
+
   @get:Rule
   val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Before
+  fun setUp() {
+    previousPlatformBackdropEnabled = HazeFeatureFlags.isPlatformBackdropEnabled
+    HazeFeatureFlags.isPlatformBackdropEnabled = false
+  }
+
+  @After
+  fun tearDown() {
+    HazeFeatureFlags.isPlatformBackdropEnabled = previousPlatformBackdropEnabled
+  }
 
   @Test
   fun unsupportedPlatform_usesSourcesFallback() {
@@ -61,7 +77,7 @@ class BlurBackdropFallbackInstrumentationTest {
             .size(width = 200.dp, height = 100.dp)
             .testTag(EFFECT_TAG)
             .hazeBlur(
-              input = HazeInput.Backdrop(HazeInput.Sources(fallbackState)),
+              input = HazeInput.Backdrop(fallbackState),
               style = HazeBlurStyle {
                 blurRadius(14.dp)
                 noiseFactor(0f)

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropInstrumentationTest.kt
@@ -29,6 +29,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isLessThan
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeFeatureFlags
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
@@ -44,16 +45,23 @@ class BlurBackdropInstrumentationTest {
 
   private lateinit var activityScenario: ActivityScenario<ComponentActivity>
   private lateinit var activity: ComponentActivity
+  private var previousPlatformBackdropEnabled = false
 
   @Before
   fun setUp() {
+    previousPlatformBackdropEnabled = HazeFeatureFlags.isPlatformBackdropEnabled
+    HazeFeatureFlags.isPlatformBackdropEnabled = true
     activityScenario = ActivityScenario.launch(ComponentActivity::class.java)
     activityScenario.onActivity { activity = it }
   }
 
   @After
   fun tearDown() {
-    activityScenario.close()
+    try {
+      activityScenario.close()
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previousPlatformBackdropEnabled
+    }
   }
 
   @Test
@@ -86,7 +94,7 @@ class BlurBackdropInstrumentationTest {
               .align(Alignment.Center)
               .size(width = 200.dp, height = 100.dp)
               .hazeBlur(
-                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                input = HazeInput.Backdrop(emptyFallbackState),
                 style = HazeBlurStyle {
                   blurRadius(14.dp)
                   noiseFactor(0f)
@@ -142,7 +150,7 @@ class BlurBackdropInstrumentationTest {
               .align(Alignment.Center)
               .size(width = 200.dp, height = 100.dp)
               .hazeBlur(
-                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                input = HazeInput.Backdrop(emptyFallbackState),
                 style = HazeBlurStyle {
                   blurRadius(radius.value)
                   noiseFactor(0f)
@@ -203,7 +211,7 @@ class BlurBackdropInstrumentationTest {
               .align(Alignment.Center)
               .size(width = 200.dp, height = 100.dp)
               .hazeBlur(
-                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                input = HazeInput.Backdrop(emptyFallbackState),
                 style = HazeBlurStyle {
                   blurRadius(14.dp)
                   noiseFactor(0f)
@@ -263,7 +271,7 @@ class BlurBackdropInstrumentationTest {
               .align(Alignment.Center)
               .size(100.dp)
               .hazeBlur(
-                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                input = HazeInput.Backdrop(emptyFallbackState),
                 style = HazeBlurStyle {
                   blurRadius(0.dp)
                   noiseFactor(0f)

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropInstrumentationTest.kt
@@ -1,0 +1,374 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import android.graphics.Bitmap
+import android.graphics.Color as AndroidColor
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.HazeState
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalHazeApi::class)
+class BlurBackdropInstrumentationTest {
+
+  private lateinit var activityScenario: ActivityScenario<ComponentActivity>
+  private lateinit var activity: ComponentActivity
+
+  @Before
+  fun setUp() {
+    activityScenario = ActivityScenario.launch(ComponentActivity::class.java)
+    activityScenario.onActivity { activity = it }
+  }
+
+  @After
+  fun tearDown() {
+    activityScenario.close()
+  }
+
+  @Test
+  fun backdropInput_blursWindowPixelsWithoutFallbackSources() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    val emptyFallbackState = HazeState()
+    val drawReady = CountDownLatch(1)
+
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .background(Color.Black),
+          ) {
+            Box(
+              Modifier
+                .align(Alignment.CenterEnd)
+                .size(width = 100.dp, height = 100.dp)
+                .background(Color.White),
+            )
+          }
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .hazeBlur(
+                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                style = HazeBlurStyle {
+                  blurRadius(14.dp)
+                  noiseFactor(0f)
+                  colorEffects(emptyList())
+                },
+              )
+              .drawWithContent {
+                drawContent()
+                drawReady.countDown()
+              },
+          )
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Blur presented its first draw")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    val bitmap = activity.copyWindow()
+    val density = Density(activity.resources.displayMetrics.density)
+    bitmap.assertCenterEdgeSoftened(density)
+  }
+
+  @Test
+  fun backdropInput_rebuildsRootEffectAfterStyleChange() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    val emptyFallbackState = HazeState()
+    val radius = mutableStateOf(0.dp)
+    val initialDraw = CountDownLatch(1)
+    val updatedDraw = CountDownLatch(1)
+
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .background(Color.Black),
+          ) {
+            Box(
+              Modifier
+                .align(Alignment.CenterEnd)
+                .size(width = 100.dp, height = 100.dp)
+                .background(Color.White),
+            )
+          }
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .hazeBlur(
+                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                style = HazeBlurStyle {
+                  blurRadius(radius.value)
+                  noiseFactor(0f)
+                  colorEffects(emptyList())
+                },
+              )
+              .drawWithContent {
+                drawContent()
+                if (radius.value == 0.dp) initialDraw.countDown() else updatedDraw.countDown()
+              },
+          )
+        }
+      }
+    }
+    assertThat(initialDraw.await(5, TimeUnit.SECONDS), "Identity effect presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    activity.copyWindow().assertCenterEdgeSharp(
+      Density(activity.resources.displayMetrics.density),
+    )
+
+    radius.value = 14.dp
+    assertThat(updatedDraw.await(5, TimeUnit.SECONDS), "Updated blur effect presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    activity.copyWindow().assertCenterEdgeSoftened(
+      Density(activity.resources.displayMetrics.density),
+    )
+  }
+
+  @Test
+  fun backdropInput_preservesProgressiveBlur() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    val emptyFallbackState = HazeState()
+    val drawReady = CountDownLatch(1)
+
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .background(Color.Black),
+          ) {
+            Box(
+              Modifier
+                .align(Alignment.CenterEnd)
+                .size(width = 100.dp, height = 100.dp)
+                .background(Color.White),
+            )
+          }
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .hazeBlur(
+                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                style = HazeBlurStyle {
+                  blurRadius(14.dp)
+                  noiseFactor(0f)
+                  colorEffects(emptyList())
+                  progressive(
+                    HazeProgressive.verticalGradient(
+                      startIntensity = 1f,
+                      endIntensity = 0f,
+                    ),
+                  )
+                },
+              )
+              .drawWithContent {
+                drawContent()
+                drawReady.countDown()
+              },
+          )
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Progressive Blur presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    val bitmap = activity.copyWindow()
+    val density = Density(activity.resources.displayMetrics.density)
+    val topY = bitmap.height / 2 - 30.dp.roundToPx(density)
+    val bottomY = bitmap.height / 2 + 48.dp.roundToPx(density)
+    bitmap.assertEdgeSoftened(density, topY)
+    assertThat(
+      bitmap.blackEdgeSoftening(density, topY) -
+        bitmap.blackEdgeSoftening(density, bottomY),
+      "Progressive Blur is materially stronger at the authored start",
+    ).isGreaterThan(0.08f)
+  }
+
+  @Test
+  fun backdropInput_preservesTintAndAlpha() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    val emptyFallbackState = HazeState()
+    val drawReady = CountDownLatch(1)
+
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(100.dp)
+              .background(Color.Black),
+          )
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(100.dp)
+              .hazeBlur(
+                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                style = HazeBlurStyle {
+                  blurRadius(0.dp)
+                  noiseFactor(0f)
+                  colorEffects(listOf(HazeColorEffect.tint(Color.Red)))
+                  alpha(0.5f)
+                },
+              )
+              .drawWithContent {
+                drawContent()
+                drawReady.countDown()
+              },
+          )
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Tinted Blur presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    val pixel = activity.copyWindow().let { bitmap ->
+      bitmap.getPixel(bitmap.width / 2, bitmap.height / 2)
+    }
+    assertThat(AndroidColor.red(pixel) / 255f, "Tint is grouped by effect alpha")
+      .isGreaterThan(0.4f)
+    assertThat(AndroidColor.red(pixel) / 255f, "Tint is grouped by effect alpha")
+      .isLessThan(0.6f)
+    assertThat(AndroidColor.green(pixel) / 255f, "Tint preserves the black backdrop")
+      .isLessThan(0.05f)
+  }
+
+  private fun ComponentActivity.copyWindow(): Bitmap {
+    val bitmap = Bitmap.createBitmap(
+      window.decorView.width,
+      window.decorView.height,
+      Bitmap.Config.ARGB_8888,
+    )
+    val latch = CountDownLatch(1)
+    var result = PixelCopy.ERROR_UNKNOWN
+    PixelCopy.request(window, bitmap, { copyResult ->
+      result = copyResult
+      latch.countDown()
+    }, Handler(Looper.getMainLooper()))
+    assertThat(latch.await(5, TimeUnit.SECONDS), "Window PixelCopy completed").isEqualTo(true)
+    assertThat(result, "Window PixelCopy result").isEqualTo(PixelCopy.SUCCESS)
+    return bitmap
+  }
+
+  private companion object {
+    fun isBackdropSdkSupported(): Boolean {
+      val fullSdkInt = if (Build.VERSION.SDK_INT < 36) {
+        Build.VERSION.SDK_INT * 100_000
+      } else {
+        runCatching {
+          Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
+        }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
+      }
+      return fullSdkInt >= 3_700_002 ||
+        (fullSdkInt == 3_700_001 && Build.VERSION.PREVIEW_SDK_INT == 3_723)
+    }
+  }
+}
+
+private fun Bitmap.red(x: Int, y: Int): Float {
+  val pixel = getPixel(x.coerceIn(0, width - 1), y.coerceIn(0, height - 1))
+  return AndroidColor.red(pixel) / 255f
+}
+
+private fun Bitmap.assertCenterEdgeSoftened(density: Density) {
+  assertEdgeSoftened(density, height / 2)
+}
+
+private fun Bitmap.assertEdgeSoftened(density: Density, y: Int) {
+  val centerX = width / 2
+  val whiteNearEdge = red(centerX + 3.dp.roundToPx(density), y)
+  val whiteInterior = red(centerX + 60.dp.roundToPx(density), y)
+
+  assertThat(blackEdgeSoftening(density, y), "Blur softens the black side")
+    .isGreaterThan(0.05f)
+  assertThat(whiteInterior - whiteNearEdge, "Blur softens the white side")
+    .isGreaterThan(0.05f)
+}
+
+private fun Bitmap.blackEdgeSoftening(density: Density, y: Int): Float {
+  val centerX = width / 2
+  val blackInterior = red(centerX - 60.dp.roundToPx(density), y)
+  val blackNearEdge = red(centerX - 3.dp.roundToPx(density), y)
+  return blackNearEdge - blackInterior
+}
+
+private fun Bitmap.assertCenterEdgeSharp(density: Density) {
+  assertEdgeSharp(density, height / 2)
+}
+
+private fun Bitmap.assertEdgeSharp(density: Density, y: Int) {
+  val centerX = width / 2
+  val blackInterior = red(centerX - 60.dp.roundToPx(density), y)
+  val blackNearEdge = red(centerX - 3.dp.roundToPx(density), y)
+  val whiteNearEdge = red(centerX + 3.dp.roundToPx(density), y)
+  val whiteInterior = red(centerX + 60.dp.roundToPx(density), y)
+
+  assertThat(blackNearEdge - blackInterior, "Identity keeps the black side sharp")
+    .isLessThan(0.02f)
+  assertThat(whiteInterior - whiteNearEdge, "Identity keeps the white side sharp")
+    .isLessThan(0.02f)
+}
+
+private fun androidx.compose.ui.unit.Dp.roundToPx(density: Density): Int =
+  kotlin.math.round(value * density.density).toInt()

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropInstrumentationTest.kt
@@ -316,12 +316,13 @@ class BlurBackdropInstrumentationTest {
       val fullSdkInt = if (Build.VERSION.SDK_INT < 36) {
         Build.VERSION.SDK_INT * 100_000
       } else {
-        runCatching {
-          Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
-        }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
+        Build.VERSION.SDK_INT_FULL
       }
-      return fullSdkInt >= 3_700_002 ||
-        (fullSdkInt == 3_700_001 && Build.VERSION.PREVIEW_SDK_INT == 3_723)
+      return fullSdkInt >= Build.VERSION_CODES_FULL.CINNAMON_BUN_2 ||
+        (
+          fullSdkInt == Build.VERSION_CODES_FULL.CINNAMON_BUN_1 &&
+            Build.VERSION.PREVIEW_SDK_INT == 3_723
+          )
     }
   }
 }

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropInstrumentationTest.kt
@@ -15,12 +15,18 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.test.core.app.ActivityScenario
 import androidx.test.platform.app.InstrumentationRegistry
@@ -33,8 +39,10 @@ import dev.chrisbanes.haze.HazeFeatureFlags
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
 import org.junit.After
 import org.junit.Assume.assumeTrue
 import org.junit.Before
@@ -249,6 +257,269 @@ class BlurBackdropInstrumentationTest {
   }
 
   @Test
+  fun backdropInput_clearsClipWhenChangedToUnbounded() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    val fallbackState = HazeState()
+    val unboundedStyle = mutableStateOf(false)
+    val effectSize = mutableStateOf(100.dp)
+    var drawReady = CountDownLatch(1)
+
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .background(Color.Black),
+          ) {
+            Box(
+              Modifier
+                .align(Alignment.CenterEnd)
+                .size(width = 100.dp, height = 100.dp)
+                .background(Color.White),
+            )
+          }
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(effectSize.value)
+              .hazeBlur(
+                input = HazeInput.Backdrop(fallbackState),
+                style = HazeBlurStyle {
+                  blurRadius(14.dp)
+                  noiseFactor(0f)
+                  colorEffects(emptyList())
+                  blurredEdgeTreatment(
+                    if (unboundedStyle.value) {
+                      BlurredEdgeTreatment.Unbounded
+                    } else {
+                      BlurredEdgeTreatment.Rectangle
+                    },
+                  )
+                },
+              )
+              .drawWithContent {
+                drawContent()
+                drawReady.countDown()
+              },
+          )
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Bounded Blur presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    val density = Density(activity.resources.displayMetrics.density)
+    val bounded = activity.copyWindow()
+    fun sampleOutsideTop(bitmap: Bitmap, size: Dp): Float {
+      val centerX = bitmap.width / 2
+      val centerY = bitmap.height / 2
+      val outsideTop = centerY - size.roundToPx(density) / 2 - 3.dp.roundToPx(density)
+      return bitmap.red(centerX, outsideTop)
+    }
+
+    drawReady = CountDownLatch(1)
+    unboundedStyle.value = true
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Unbounded Blur presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    val unboundedFrame = activity.copyWindow()
+    assertThat(
+      abs(
+        sampleOutsideTop(unboundedFrame, 100.dp) - sampleOutsideTop(bounded, 100.dp),
+      ),
+      "Removing the clip changes the expanded edge",
+    ).isGreaterThan(0.02f)
+
+    drawReady = CountDownLatch(1)
+    effectSize.value = 120.dp
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Resized unbounded Blur presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    val resized = activity.copyWindow()
+    assertThat(
+      abs(
+        sampleOutsideTop(unboundedFrame, 100.dp) - sampleOutsideTop(resized, 120.dp),
+      ),
+      "Unbounded resize updates the expanded edge",
+    ).isGreaterThan(0.01f)
+
+    drawReady = CountDownLatch(1)
+    unboundedStyle.value = false
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Restored bounded Blur presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    val restored = activity.copyWindow()
+
+    fun captureFreshControl(unbounded: Boolean, size: Dp, generation: Int): Bitmap {
+      val freshDraw = CountDownLatch(1)
+      activityScenario.onActivity { controlledActivity ->
+        controlledActivity.setContent {
+          ClipTransitionScene(
+            unbounded = unbounded,
+            effectSize = size,
+            drawReady = freshDraw,
+            generation = generation,
+          )
+        }
+      }
+      assertThat(freshDraw.await(5, TimeUnit.SECONDS), "Fresh clip control presented")
+        .isEqualTo(true)
+      InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+      return activity.copyWindow()
+    }
+    val freshUnbounded100 = captureFreshControl(true, 100.dp, generation = 1)
+    val freshUnbounded120 = captureFreshControl(true, 120.dp, generation = 2)
+    val freshBounded120 = captureFreshControl(false, 120.dp, generation = 3)
+    assertThat(
+      abs(sampleOutsideTop(unboundedFrame, 100.dp) - sampleOutsideTop(freshUnbounded100, 100.dp)),
+      "Unbounded 100dp transition matches a fresh attachment",
+    ).isLessThan(0.03f)
+    assertThat(
+      abs(sampleOutsideTop(resized, 120.dp) - sampleOutsideTop(freshUnbounded120, 120.dp)),
+      "Unbounded 120dp transition matches a fresh attachment",
+    ).isLessThan(0.03f)
+    assertThat(
+      abs(sampleOutsideTop(restored, 120.dp) - sampleOutsideTop(freshBounded120, 120.dp)),
+      "Bounded 120dp transition matches a fresh attachment",
+    ).isLessThan(0.03f)
+    assertThat(
+      abs(
+        sampleOutsideTop(freshUnbounded120, 120.dp) -
+          sampleOutsideTop(freshBounded120, 120.dp),
+      ),
+      "Fresh clipped and unclipped 120dp controls differ outside the effect bounds",
+    ).isGreaterThan(0.02f)
+    unboundedFrame.recycle()
+    resized.recycle()
+    restored.recycle()
+    bounded.recycle()
+    freshUnbounded100.recycle()
+    freshUnbounded120.recycle()
+    freshBounded120.recycle()
+  }
+
+  @Test
+  fun backdropInput_offscreenAncestorsPreserveInput() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    AncestorMode.entries.forEach { mode ->
+      val native = renderOffscreenScene(mode, nativeEnabled = true)
+      val fallback = renderOffscreenScene(mode, nativeEnabled = false)
+      val density = Density(activity.resources.displayMetrics.density)
+      native.assertCenterEdgeSoftened(density)
+      fallback.assertCenterEdgeSoftened(density)
+      val sampleX = native.width / 2 + 3.dp.roundToPx(density)
+      val sampleY = native.height / 2
+      assertThat(
+        abs(native.red(sampleX, sampleY) - fallback.red(sampleX, sampleY)),
+        "${mode.name} native/fallback edge agreement",
+      ).isLessThan(0.12f)
+      native.recycle()
+      fallback.recycle()
+    }
+  }
+
+  private fun renderOffscreenScene(
+    mode: AncestorMode,
+    nativeEnabled: Boolean,
+  ): Bitmap {
+    HazeFeatureFlags.isPlatformBackdropEnabled = nativeEnabled
+    val captureState = HazeState()
+    val ancestorState = HazeState()
+    val drawReady = CountDownLatch(1)
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        key(mode to nativeEnabled) {
+          Box(Modifier.fillMaxSize().background(Color.White)) {
+            Box(
+              Modifier
+                .align(Alignment.Center)
+                .size(width = 200.dp, height = 100.dp)
+                .hazeSource(captureState)
+                .background(Color.Black),
+            ) {
+              Box(
+                Modifier
+                  .align(Alignment.CenterEnd)
+                  .size(width = 100.dp, height = 100.dp)
+                  .background(Color.White),
+              )
+            }
+            Box(
+              Modifier
+                .align(Alignment.Center)
+                .size(width = 200.dp, height = 100.dp)
+                .then(
+                  if (mode == AncestorMode.EnclosingCapture) {
+                    Modifier.hazeSource(ancestorState)
+                  } else {
+                    Modifier
+                  },
+                ),
+            ) {
+              Box(
+                Modifier
+                  .fillMaxSize()
+                  .then(
+                    when (mode) {
+                      AncestorMode.Normal -> Modifier
+                      AncestorMode.Alpha -> Modifier.graphicsLayer { alpha = 0.5f }
+                      AncestorMode.Offscreen -> Modifier.graphicsLayer {
+                        compositingStrategy = CompositingStrategy.Offscreen
+                      }
+                      AncestorMode.EnclosingCapture -> Modifier
+                    },
+                  )
+                  .hazeBlur(
+                    input = HazeInput.Backdrop(captureState),
+                    style = HazeBlurStyle {
+                      blurRadius(14.dp)
+                      noiseFactor(0f)
+                      colorEffects(emptyList())
+                    },
+                  )
+                  .drawWithContent {
+                    drawContent()
+                    drawReady.countDown()
+                  },
+              )
+            }
+            if (mode == AncestorMode.EnclosingCapture) {
+              Box(
+                Modifier
+                  .size(1.dp)
+                  .background(Color.Transparent)
+                  .hazeBlur(
+                    input = HazeInput.Sources(ancestorState),
+                    style = HazeBlurStyle { blurRadius(0.dp) },
+                  ),
+              )
+            }
+          }
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "${mode.name} scene presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    return activity.copyWindow()
+  }
+
+  private enum class AncestorMode {
+    Normal,
+    Alpha,
+    Offscreen,
+    EnclosingCapture,
+  }
+
+  @Test
   fun backdropInput_preservesTintAndAlpha() {
     assumeTrue(
       "HazeInput.Backdrop requires Android 37.2 or the matching preview",
@@ -331,6 +602,53 @@ class BlurBackdropInstrumentationTest {
           fullSdkInt == Build.VERSION_CODES_FULL.CINNAMON_BUN_1 &&
             Build.VERSION.PREVIEW_SDK_INT == 3_723
           )
+    }
+  }
+}
+
+@Composable
+private fun ClipTransitionScene(
+  unbounded: Boolean,
+  effectSize: Dp,
+  drawReady: CountDownLatch,
+  generation: Int,
+) {
+  key(generation) {
+    val fallbackState = dev.chrisbanes.haze.rememberHazeState()
+    Box(Modifier.fillMaxSize().background(Color.White)) {
+      Box(
+        Modifier
+          .align(Alignment.Center)
+          .size(width = 200.dp, height = 100.dp)
+          .background(Color.Black),
+      ) {
+        Box(
+          Modifier
+            .align(Alignment.CenterEnd)
+            .size(width = 100.dp, height = 100.dp)
+            .background(Color.White),
+        )
+      }
+      Box(
+        Modifier
+          .align(Alignment.Center)
+          .size(effectSize)
+          .hazeBlur(
+            input = HazeInput.Backdrop(fallbackState),
+            style = HazeBlurStyle {
+              blurRadius(14.dp)
+              noiseFactor(0f)
+              colorEffects(emptyList())
+              blurredEdgeTreatment(
+                if (unbounded) BlurredEdgeTreatment.Unbounded else BlurredEdgeTreatment.Rectangle,
+              )
+            },
+          )
+          .drawWithContent {
+            drawContent()
+            drawReady.countDown()
+          },
+      )
     }
   }
 }

--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegate.android.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegate.android.kt
@@ -18,6 +18,7 @@ import dev.chrisbanes.haze.HazeLogger
 import dev.chrisbanes.haze.HazeProgressive as RootHazeProgressive
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.asBrush
+import dev.chrisbanes.haze.asComposeRenderEffect
 import dev.chrisbanes.haze.withGraphicsLayer
 
 @OptIn(InternalHazeApi::class)
@@ -33,11 +34,13 @@ internal actual fun RenderEffectBlurVisualEffectDelegate.drawProgressiveEffect(
 ) {
   if (USE_RUNTIME_SHADER && Build.VERSION.SDK_INT >= 33) {
     with(drawScope) {
-      contentLayer.renderEffect = blurVisualEffect.getOrCreateRenderEffect(
-        context = context,
-        inputScale = inputScale,
-        progressive = progressive,
-      )
+      contentLayer.renderEffect = blurVisualEffect
+        .getOrCreateRenderEffect(
+          context = context,
+          inputScale = inputScale,
+          progressive = progressive,
+        )
+        .asComposeRenderEffect()
       contentLayer.alpha = blurVisualEffect.alpha
 
       // Finally draw the layer
@@ -58,12 +61,14 @@ internal actual fun RenderEffectBlurVisualEffectDelegate.drawProgressiveEffect(
   } else {
     // Otherwise draw the masked blur over its input, preserving unblurred regions.
     with(drawScope) {
-      contentLayer.renderEffect = blurVisualEffect.getOrCreateRenderEffect(
-        context = context,
-        inputScale = inputScale,
-        mask = progressive.asBrush(),
-        retainInputWhenMasked = progressive is RootHazeProgressive.LinearGradient,
-      )
+      contentLayer.renderEffect = blurVisualEffect
+        .getOrCreateRenderEffect(
+          context = context,
+          inputScale = inputScale,
+          mask = progressive.asBrush(),
+          retainInputWhenMasked = progressive is RootHazeProgressive.LinearGradient,
+        )
+        .asComposeRenderEffect()
       contentLayer.alpha = blurVisualEffect.alpha
 
       // Finally draw the layer
@@ -93,15 +98,17 @@ private fun RenderEffectBlurVisualEffectDelegate.drawLinearGradientProgressiveEf
         "drawLinearGradientProgressiveEffectUsingLayers. mask=$mask, intensity=$intensity"
       }
 
-      layer.renderEffect = blurVisualEffect.getOrCreateRenderEffect(
-        context = context,
-        inputScale = inputScale,
-        blurRadius = blurRadius * intensity,
-        noiseFactor = noiseFactor,
-        colorEffects = colorEffects.orEmpty(),
-        colorEffectsAlphaModulate = intensity,
-        mask = mask,
-      )
+      layer.renderEffect = blurVisualEffect
+        .getOrCreateRenderEffect(
+          context = context,
+          inputScale = inputScale,
+          blurRadius = blurRadius * intensity,
+          noiseFactor = noiseFactor,
+          colorEffects = colorEffects.orEmpty(),
+          colorEffectsAlphaModulate = intensity,
+          mask = mask,
+        )
+        .asComposeRenderEffect()
       layer.alpha = blurVisualEffect.alpha
 
       // Since we included a border around the content, we need to translate so that

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffect.kt
@@ -11,9 +11,9 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.ui.graphics.Shader
 import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
@@ -22,7 +22,6 @@ import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.PlatformContext
 import dev.chrisbanes.haze.PlatformRenderEffect
 import dev.chrisbanes.haze.asBrush
-import dev.chrisbanes.haze.asComposeRenderEffect
 import dev.chrisbanes.haze.blendForeground
 import dev.chrisbanes.haze.createBlendColorFilter
 import dev.chrisbanes.haze.createBlendRenderEffect
@@ -32,6 +31,7 @@ import dev.chrisbanes.haze.createOffsetRenderEffect
 import dev.chrisbanes.haze.createProgressiveBlurRenderEffect
 import dev.chrisbanes.haze.createShaderRenderEffect
 import dev.chrisbanes.haze.isRuntimeShaderRenderEffectSupported
+import dev.chrisbanes.haze.then
 import dev.chrisbanes.haze.toPlatformColorFilter
 
 @RequiresApi(31)
@@ -39,7 +39,7 @@ internal fun createRenderEffect(
   context: PlatformContext,
   density: Density,
   params: RenderEffectParams,
-): RenderEffect {
+): PlatformRenderEffect {
   val blurRadius = params.blurRadius * params.scale
   require(blurRadius >= 0.dp) { "blurRadius needs to be equal or greater than 0.dp" }
   val size = ceil(params.contentSize * params.scale)
@@ -48,22 +48,41 @@ internal fun createRenderEffect(
   val blurRadiusPx = params.resolveBlurRadiusPx(density)
   val progressiveShader = params.progressive?.asBrush()?.toShader(size)
 
+  val input: PlatformRenderEffect? = if (
+    params.backgroundColor.isSpecified && params.backgroundColor.alpha > 0f
+  ) {
+    Brush.linearGradient(listOf(params.backgroundColor, params.backgroundColor))
+      .toShader(size)
+      ?.let(::createShaderRenderEffect)
+      ?.let { background ->
+        createBlendRenderEffect(
+          blendMode = BlendMode.SrcOver,
+          background = background,
+          foreground = createOffsetRenderEffect(0f, 0f),
+        )
+      }
+  } else {
+    null
+  }
+
   val blur = if (progressiveShader != null && isRuntimeShaderRenderEffectSupported()) {
     // If we've been provided with a progressive/gradient blur shader, we need to use
     // our custom blur via a runtime shader (requires runtime shader support)
-    createProgressiveBlurRenderEffect(
+    val progressive = createProgressiveBlurRenderEffect(
       blurRadiusPx = blurRadiusPx,
       size = size,
       offset = offset,
       mask = progressiveShader,
     )
+    input?.then(progressive) ?: progressive
   } else {
     // Platform-specific blur creation
     createBlurRenderEffect(
       radiusX = blurRadiusPx,
       radiusY = blurRadiusPx,
       tileMode = params.blurTileMode,
-    ) ?: createOffsetRenderEffect(0f, 0f)
+      input = input,
+    ) ?: input ?: createOffsetRenderEffect(0f, 0f)
   }
 
   val combinedNoiseTintEffect = params.combinedNoiseTintColor()?.let { tintColor ->
@@ -107,7 +126,7 @@ internal fun createRenderEffect(
     masked
   }
 
-  return result.asComposeRenderEffect()
+  return result
 }
 
 internal fun Float.hasVisibleNoise(): Boolean = this > 0f

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
@@ -24,6 +24,7 @@ import dev.chrisbanes.haze.HazeProgressive as RootHazeProgressive
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.Poko
 import dev.chrisbanes.haze.TrimMemoryLevel
+import dev.chrisbanes.haze.asComposeRenderEffect
 import kotlin.math.ceil
 
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
@@ -179,7 +180,9 @@ internal class RenderEffectBlurVisualEffectDelegate(
     // This ensures that changes coming from either the effect itself OR the hosting node
     // (e.g., size, layer offset, input scale, etc.) will be reflected without relying on
     // the effect's local dirty flags only.
-    renderEffect = blurVisualEffect.getOrCreateRenderEffect(context, inputScale = scaleFactor)
+    renderEffect = blurVisualEffect
+      .getOrCreateRenderEffect(context, inputScale = scaleFactor)
+      .asComposeRenderEffect()
   }
 
   @Poko

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -148,7 +148,7 @@ internal class BlurVisualEffect :
       if (delegate !is RenderEffectBlurVisualEffectDelegate) return null
 
       HazeEffectBackdrop(
-        effect = getOrCreateRenderEffect(
+        platformEffect = getOrCreateRenderEffect(
           context = this,
           inputScale = BlurInputScalePolicy.NONE_SCALE,
           backgroundColor = backgroundColor,

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -152,6 +152,7 @@ internal class BlurVisualEffect :
           context = this,
           inputScale = BlurInputScalePolicy.NONE_SCALE,
           backgroundColor = backgroundColor,
+          progressive = progressive,
         ),
         alpha = alpha,
       )

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffect.kt
@@ -14,16 +14,17 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Dp
 import dev.chrisbanes.haze.Bitmask
+import dev.chrisbanes.haze.HazeEffectBackdrop
 import dev.chrisbanes.haze.HazeEffectDrawScope
 import dev.chrisbanes.haze.HazeEffectInputSnapshot
 import dev.chrisbanes.haze.HazeEffectLayoutScope
 import dev.chrisbanes.haze.HazeEffectLifecycleScope
 import dev.chrisbanes.haze.HazeEffectRenderer
+import dev.chrisbanes.haze.HazeEffectRendererBackdrop
 import dev.chrisbanes.haze.HazeEffectRendererDrawHooks
 import dev.chrisbanes.haze.HazeEffectRendererLifecycle
 import dev.chrisbanes.haze.HazeEffectRendererRetainedOutput
@@ -33,6 +34,7 @@ import dev.chrisbanes.haze.HazePerformanceMode
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.PlatformRenderEffect
 import dev.chrisbanes.haze.Poko
 import dev.chrisbanes.haze.TrimMemoryLevel
 
@@ -50,6 +52,7 @@ private class BlurAdaptiveUpdateKey(
 @OptIn(InternalHazeApi::class)
 internal class BlurVisualEffect :
   HazeEffectRenderer<BlurConfiguration>,
+  HazeEffectRendererBackdrop<BlurConfiguration>,
   HazeEffectRendererLifecycle<BlurConfiguration>,
   HazeEffectRendererDrawHooks<BlurConfiguration>,
   HazeEffectRendererRetainedOutput {
@@ -59,7 +62,8 @@ internal class BlurVisualEffect :
   private var needsDelegateSelection: Boolean = true
   private var needsLayerBoundsInvalidation: Boolean = false
   private val inputScalePolicy = BlurInputScalePolicy()
-  internal val renderEffectCache = LruCache<RenderEffectCacheKey, RenderEffect>(maxSize = 50)
+  internal val renderEffectCache =
+    LruCache<RenderEffectCacheKey, PlatformRenderEffect>(maxSize = 50)
 
   internal var dirtyTracker: Bitmask by mutableStateOf(Bitmask())
     private set
@@ -133,6 +137,26 @@ internal class BlurVisualEffect :
     }
     with(this as DrawScope) {
       selectDelegateForDraw(this@prepareDraw)
+    }
+  }
+
+  override fun HazeEffectRuntimeDrawScope.backdropEffect(
+    style: BlurConfiguration,
+  ): HazeEffectBackdrop? {
+    return try {
+      with(this as DrawScope) { selectDelegateForDraw(this@backdropEffect) }
+      if (delegate !is RenderEffectBlurVisualEffectDelegate) return null
+
+      HazeEffectBackdrop(
+        effect = getOrCreateRenderEffect(
+          context = this,
+          inputScale = BlurInputScalePolicy.NONE_SCALE,
+          backgroundColor = backgroundColor,
+        ),
+        alpha = alpha,
+      )
+    } finally {
+      resetDirtyTracker()
     }
   }
 

--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtils.kt
@@ -8,7 +8,7 @@ package dev.chrisbanes.haze.blur
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
@@ -19,6 +19,7 @@ import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
 import dev.chrisbanes.haze.HazeLogger
 import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.PlatformRenderEffect
 import dev.chrisbanes.haze.Poko
 import dev.chrisbanes.haze.trace
 
@@ -38,13 +39,14 @@ internal fun BlurVisualEffect.getOrCreateRenderEffect(
   noiseFactor: Float = this.noiseFactor,
   colorEffects: List<HazeColorEffect> = this.colorEffects.orEmpty(),
   colorEffectsAlphaModulate: Float = 1f,
+  backgroundColor: Color = Color.Transparent,
   contentSize: Size = context.size,
   contentOffset: Offset = context.layerOffset,
   mask: Brush? = this.mask,
   retainInputWhenMasked: Boolean = false,
   progressive: HazeProgressive? = null,
   blurTileMode: TileMode = calculateBlurTileMode(),
-): RenderEffect? = trace("HazeEffectNode-getOrCreateRenderEffect") {
+): PlatformRenderEffect = trace("HazeEffectNode-getOrCreateRenderEffect") {
   getOrCreateRenderEffect(
     context = context,
     params = RenderEffectParams(
@@ -53,6 +55,7 @@ internal fun BlurVisualEffect.getOrCreateRenderEffect(
       scale = inputScale,
       colorEffects = colorEffects,
       colorEffectsAlphaModulate = colorEffectsAlphaModulate,
+      backgroundColor = backgroundColor,
       contentSize = contentSize,
       contentOffset = contentOffset,
       mask = mask,
@@ -76,6 +79,7 @@ internal class RenderEffectParams(
   val contentOffset: Offset,
   val colorEffects: List<HazeColorEffect> = emptyList(),
   val colorEffectsAlphaModulate: Float = 1f,
+  val backgroundColor: Color = Color.Transparent,
   val mask: Brush? = null,
   val retainInputWhenMasked: Boolean = false,
   val progressive: HazeProgressive? = null,
@@ -91,6 +95,7 @@ internal class RenderEffectCacheKey(
   val contentOffset: Offset,
   val colorEffects: List<HazeColorEffect>,
   val colorEffectsAlphaModulate: Float,
+  val backgroundColor: Color,
   val mask: Brush?,
   val retainInputWhenMasked: Boolean,
   val progressive: HazeProgressive?,
@@ -116,6 +121,7 @@ internal fun RenderEffectParams.renderEffectCacheKey(density: Density): RenderEf
     contentOffset = if (usesContentOffset) contentOffset else Offset.Zero,
     colorEffects = colorEffects,
     colorEffectsAlphaModulate = colorEffectsAlphaModulate,
+    backgroundColor = backgroundColor,
     mask = mask,
     retainInputWhenMasked = retainInputWhenMasked,
     progressive = progressive,
@@ -127,7 +133,7 @@ internal fun RenderEffectParams.renderEffectCacheKey(density: Density): RenderEf
 private fun BlurVisualEffect.getOrCreateRenderEffect(
   context: HazeEffectRuntimeDrawScope,
   params: RenderEffectParams,
-): RenderEffect? {
+): PlatformRenderEffect {
   HazeLogger.d(BlurVisualEffect.TAG) { "getOrCreateRenderEffect: $params" }
   val density = context.requireDensity()
   val cacheKey = params.renderEffectCacheKey(density)

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropRenderEffectTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurBackdropRenderEffectTest.kt
@@ -1,0 +1,18 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import dev.chrisbanes.haze.HazeEffectRendererBackdrop
+import kotlin.test.Test
+
+class BlurBackdropRenderEffectTest {
+
+  @Test
+  fun blurRenderer_exposesBuiltInBackdropCapability() {
+    assertThat(HazeBlurFactory.createRenderer())
+      .isInstanceOf<HazeEffectRendererBackdrop<*>>()
+  }
+}

--- a/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtilsTest.kt
+++ b/haze-blur/src/commonTest/kotlin/dev/chrisbanes/haze/blur/BlurVisualEffectUtilsTest.kt
@@ -111,6 +111,16 @@ class BlurVisualEffectUtilsTest {
   }
 
   @Test
+  fun renderEffectCacheKey_tracksBackdropBackgroundColor() {
+    val density = Density(2f)
+
+    assertThat(renderEffectParams(backgroundColor = Color.Red).renderEffectCacheKey(density))
+      .isNotEqualTo(
+        renderEffectParams(backgroundColor = Color.Blue).renderEffectCacheKey(density),
+      )
+  }
+
+  @Test
   fun renderEffectCacheKey_canonicalizesDisabledNoise() {
     val density = Density(2f)
     val key = renderEffectParams(noiseFactor = 0f).renderEffectCacheKey(density)
@@ -136,6 +146,7 @@ class BlurVisualEffectUtilsTest {
     noiseFactor: Float = 0.15f,
     contentSize: Size = Size(640f, 480f),
     contentOffset: Offset = Offset(8f, 4f),
+    backgroundColor: Color = Color.Transparent,
     mask: Brush? = null,
     progressive: HazeProgressive? = null,
   ) = RenderEffectParams(
@@ -145,6 +156,7 @@ class BlurVisualEffectUtilsTest {
     contentSize = contentSize,
     contentOffset = contentOffset,
     colorEffects = colorEffects,
+    backgroundColor = backgroundColor,
     mask = mask,
     progressive = progressive,
     blurTileMode = TileMode.Clamp,

--- a/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegateTrimMemoryTest.kt
+++ b/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegateTrimMemoryTest.kt
@@ -1,7 +1,10 @@
 // Copyright 2026, Christopher Banes and the Haze project contributors
 // SPDX-License-Identifier: Apache-2.0
 
-@file:OptIn(dev.chrisbanes.haze.InternalHazeApi::class)
+@file:OptIn(
+  androidx.compose.ui.InternalComposeUiApi::class,
+  dev.chrisbanes.haze.InternalHazeApi::class,
+)
 
 package dev.chrisbanes.haze.blur
 
@@ -15,19 +18,26 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.SkiaGraphicsContext
+import androidx.compose.ui.graphics.asComposeRenderEffect
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.HazeEffectInputSnapshot
 import dev.chrisbanes.haze.HazeEffectLifecycleScope
 import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
 import dev.chrisbanes.haze.HazePerformanceMode
+import dev.chrisbanes.haze.HazeProgressive
 import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.PlatformContext
@@ -249,6 +259,70 @@ class RenderEffectBlurVisualEffectDelegateTrimMemoryTest {
 
     assertThat(context.inputCaptureCount).isEqualTo(2)
   }
+
+  @Test
+  fun backdropEffect_forwardsProgressiveStyleToTheRootRenderEffect() {
+    val effect = BlurVisualEffect()
+    val context = RecordingDrawContext(recordedSize = Size(100f, 100f))
+
+    fun render(style: HazeBlurStyle): Pair<Float, Float> {
+      val configuration = BlurConfiguration(style, HazePerformanceMode.Quality)
+      effect.update(BlurLifecycleScope, configuration, HazeSampling.FullResolution)
+      context.render { with(effect) { with(context) { prepareDraw(configuration) } } }
+      var backdrop: dev.chrisbanes.haze.HazeEffectBackdrop? = null
+      context.render {
+        backdrop = with(effect) { with(context) { backdropEffect(configuration) } }
+      }
+
+      val graphicsContext = SkiaGraphicsContext()
+      val inputLayer = graphicsContext.createGraphicsLayer()
+      inputLayer.record(
+        density = Density(1f),
+        layoutDirection = LayoutDirection.Ltr,
+        size = IntSize(100, 100),
+      ) {
+        drawRect(Color.Black, size = Size(50f, 100f))
+        drawRect(Color.White, topLeft = Offset(50f, 0f), size = Size(50f, 100f))
+      }
+      inputLayer.renderEffect = checkNotNull(backdrop).getPlatformEffect().asComposeRenderEffect()
+      val output = ImageBitmap(100, 100)
+      CanvasDrawScope().draw(
+        density = Density(1f),
+        layoutDirection = LayoutDirection.Ltr,
+        canvas = Canvas(output),
+        size = Size(100f, 100f),
+      ) {
+        drawLayer(inputLayer)
+      }
+      graphicsContext.releaseGraphicsLayer(inputLayer)
+
+      val pixels = output.toPixelMap()
+      fun edgeSoftening(y: Int): Float = (51..60).map { pixels[it, y].red }.average().toFloat()
+      return edgeSoftening(20) to edgeSoftening(80)
+    }
+
+    val forward = render(
+      HazeBlurStyle {
+        blurRadius(14.dp)
+        noiseFactor(0f)
+        colorEffects(emptyList())
+        progressive(HazeProgressive.verticalGradient(startIntensity = 1f, endIntensity = 0f))
+      },
+    )
+    val reversed = render(
+      HazeBlurStyle {
+        blurRadius(14.dp)
+        noiseFactor(0f)
+        colorEffects(emptyList())
+        progressive(HazeProgressive.verticalGradient(startIntensity = 0f, endIntensity = 1f))
+      },
+    )
+
+    assertThat(forward.second - forward.first)
+      .isGreaterThan(0.03f)
+    assertThat(reversed.first - reversed.second)
+      .isGreaterThan(0.03f)
+  }
 }
 
 private fun Any.setPrivateField(name: String, value: Any?) {
@@ -306,13 +380,14 @@ private data object BlurLifecycleScope : HazeEffectLifecycleScope {
 @OptIn(InternalComposeUiApi::class, InternalHazeApi::class)
 private class RecordingDrawContext(
   private val drawScope: CanvasDrawScope = CanvasDrawScope(),
+  private val recordedSize: Size = Size(10f, 10f),
 ) : HazeEffectRuntimeDrawScope, DrawScope by drawScope {
   private val graphicsContext = RecordingGraphicsContext()
 
   var inputCaptureCount = 0
     private set
 
-  override val modifierSize: Size = Size(10f, 10f)
+  override val modifierSize: Size = recordedSize
   override val modifierBounds: Rect = Rect(Offset.Zero, modifierSize)
   override var sampling: HazeSampling = HazeSampling.FullResolution
   override var layerSize: Size = modifierSize
@@ -327,7 +402,7 @@ private class RecordingDrawContext(
     drawScope.draw(
       density = Density(1f),
       layoutDirection = LayoutDirection.Ltr,
-      canvas = Canvas(ImageBitmap(10, 10)),
+      canvas = Canvas(ImageBitmap(recordedSize.width.toInt(), recordedSize.height.toInt())),
       size = modifierSize,
       block = block,
     )

--- a/haze-blur/src/skikoMain/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegate.skiko.kt
+++ b/haze-blur/src/skikoMain/kotlin/dev/chrisbanes/haze/blur/RenderEffectBlurVisualEffectDelegate.skiko.kt
@@ -8,7 +8,10 @@ import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
 import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.InternalHazeApi
+import dev.chrisbanes.haze.asComposeRenderEffect
 
+@OptIn(InternalHazeApi::class)
 internal actual fun RenderEffectBlurVisualEffectDelegate.drawProgressiveEffect(
   drawScope: DrawScope,
   progressive: HazeProgressive,
@@ -16,11 +19,13 @@ internal actual fun RenderEffectBlurVisualEffectDelegate.drawProgressiveEffect(
   context: HazeEffectRuntimeDrawScope,
   inputScale: Float,
 ) = with(drawScope) {
-  contentLayer.renderEffect = blurVisualEffect.getOrCreateRenderEffect(
-    context = context,
-    inputScale = inputScale,
-    progressive = progressive,
-  )
+  contentLayer.renderEffect = blurVisualEffect
+    .getOrCreateRenderEffect(
+      context = context,
+      inputScale = inputScale,
+      progressive = progressive,
+    )
+    .asComposeRenderEffect()
   contentLayer.alpha = blurVisualEffect.alpha
 
   // Finally draw the layer

--- a/haze-glass/build.gradle.kts
+++ b/haze-glass/build.gradle.kts
@@ -17,9 +17,25 @@ plugins {
 kotlin {
   android {
     namespace = "dev.chrisbanes.haze.glass"
+    androidResources.enable = true
 
     withHostTest {
       isIncludeAndroidResources = true
+    }
+
+    withDeviceTest {
+      instrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+      @Suppress("UnstableApiUsage")
+      managedDevices {
+        localDevices {
+          create("pixel6Api34") {
+            device = "Pixel 6"
+            sdkVersion = 34
+            systemImageSource = "aosp_atd"
+          }
+        }
+      }
     }
   }
 
@@ -43,6 +59,16 @@ kotlin {
         implementation(libs.assertk)
         implementation(libs.compose.ui.test)
         implementation(projects.internal.contextTest)
+      }
+    }
+
+    named("androidDeviceTest") {
+      dependencies {
+        implementation(libs.assertk)
+        implementation(libs.androidx.activity.compose)
+        implementation(libs.androidx.compose.ui.test.junit4)
+        implementation(libs.androidx.compose.ui.test.manifest)
+        implementation(libs.androidx.test.runner)
       }
     }
 

--- a/haze-glass/build.gradle.kts
+++ b/haze-glass/build.gradle.kts
@@ -68,6 +68,7 @@ kotlin {
         implementation(libs.androidx.activity.compose)
         implementation(libs.androidx.compose.ui.test.junit4)
         implementation(libs.androidx.compose.ui.test.manifest)
+        implementation(libs.androidx.test.espresso.core)
         implementation(libs.androidx.test.runner)
       }
     }

--- a/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropFallbackInstrumentationTest.kt
+++ b/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropFallbackInstrumentationTest.kt
@@ -1,0 +1,110 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.filters.SdkSuppress
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+import org.junit.Rule
+import org.junit.Test
+
+@SdkSuppress(maxSdkVersion = 36)
+@OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class)
+class GlassBackdropFallbackInstrumentationTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun unsupportedPlatform_usesSourcesFallback() {
+    val fallbackState = HazeState()
+
+    composeTestRule.setContent {
+      Box(Modifier.fillMaxSize().background(Color.White)) {
+        Box(
+          Modifier
+            .align(Alignment.Center)
+            .size(width = 200.dp, height = 100.dp)
+            .hazeSource(fallbackState)
+            .background(Color.Black),
+        ) {
+          Box(
+            Modifier
+              .align(Alignment.CenterEnd)
+              .size(width = 100.dp, height = 100.dp)
+              .background(Color.White),
+          )
+        }
+        Box(
+          Modifier
+            .align(Alignment.Center)
+            .size(width = 200.dp, height = 100.dp)
+            .testTag(EFFECT_TAG)
+            .hazeGlass(
+              input = HazeInput.Backdrop(HazeInput.Sources(fallbackState)),
+              style = GlassStyle.regular.then {
+                optics(
+                  GlassOptics(
+                    refractionStrength = 0f,
+                    refractionHeightFraction = 0f,
+                    refractionDisplacement = 0.dp,
+                    depth = OpticalSizeValue.Fixed(1f),
+                    blurRadius = OpticalSizeValue.Fixed(14.dp),
+                    refractionDetailIntensity = 0f,
+                  ),
+                )
+                specularIntensity(0f)
+                edgeShadow(Color.Transparent)
+                ambientResponse(0f)
+                backgroundColor(Color.Transparent)
+                tint(Color.Transparent)
+                edgeSoftness(0.dp)
+                chromaticAberrationStrength(0f)
+                contrast(0f)
+                whitePoint(0f)
+                chromaMultiplier(1f)
+              },
+            ),
+        )
+      }
+    }
+    composeTestRule.waitForIdle()
+
+    val pixels = composeTestRule.onNodeWithTag(EFFECT_TAG).captureToImage().toPixelMap()
+    val centerX = pixels.width / 2
+    val centerY = pixels.height / 2
+    val blackInterior = pixels[centerX - 60, centerY].red
+    val blackNearEdge = pixels[centerX - 3, centerY].red
+    val whiteNearEdge = pixels[centerX + 3, centerY].red
+    val whiteInterior = pixels[centerX + 60, centerY].red
+
+    assertThat(blackNearEdge - blackInterior, "Fallback softens the black side")
+      .isGreaterThan(0.05f)
+    assertThat(whiteInterior - whiteNearEdge, "Fallback softens the white side")
+      .isGreaterThan(0.05f)
+  }
+
+  private companion object {
+    const val EFFECT_TAG = "effect"
+  }
+}

--- a/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropFallbackInstrumentationTest.kt
+++ b/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropFallbackInstrumentationTest.kt
@@ -22,9 +22,12 @@ import androidx.test.filters.SdkSuppress
 import assertk.assertThat
 import assertk.assertions.isGreaterThan
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeFeatureFlags
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
+import org.junit.After
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -32,8 +35,21 @@ import org.junit.Test
 @OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class)
 class GlassBackdropFallbackInstrumentationTest {
 
+  private var previousPlatformBackdropEnabled = false
+
   @get:Rule
   val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Before
+  fun setUp() {
+    previousPlatformBackdropEnabled = HazeFeatureFlags.isPlatformBackdropEnabled
+    HazeFeatureFlags.isPlatformBackdropEnabled = false
+  }
+
+  @After
+  fun tearDown() {
+    HazeFeatureFlags.isPlatformBackdropEnabled = previousPlatformBackdropEnabled
+  }
 
   @Test
   fun unsupportedPlatform_usesSourcesFallback() {
@@ -61,7 +77,7 @@ class GlassBackdropFallbackInstrumentationTest {
             .size(width = 200.dp, height = 100.dp)
             .testTag(EFFECT_TAG)
             .hazeGlass(
-              input = HazeInput.Backdrop(HazeInput.Sources(fallbackState)),
+              input = HazeInput.Backdrop(fallbackState),
               style = GlassStyle.regular.then {
                 optics(
                   GlassOptics(

--- a/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
+++ b/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
@@ -34,6 +34,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isLessThan
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeFeatureFlags
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
 import java.util.concurrent.CountDownLatch
@@ -50,16 +51,23 @@ class GlassBackdropInstrumentationTest {
 
   private lateinit var activityScenario: ActivityScenario<ComponentActivity>
   private lateinit var activity: ComponentActivity
+  private var previousPlatformBackdropEnabled = false
 
   @Before
   fun setUp() {
+    previousPlatformBackdropEnabled = HazeFeatureFlags.isPlatformBackdropEnabled
+    HazeFeatureFlags.isPlatformBackdropEnabled = true
     activityScenario = ActivityScenario.launch(ComponentActivity::class.java)
     activityScenario.onActivity { activity = it }
   }
 
   @After
   fun tearDown() {
-    activityScenario.close()
+    try {
+      activityScenario.close()
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previousPlatformBackdropEnabled
+    }
   }
 
   @Test
@@ -92,7 +100,7 @@ class GlassBackdropInstrumentationTest {
               .align(Alignment.Center)
               .size(width = 200.dp, height = 100.dp)
               .hazeGlass(
-                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                input = HazeInput.Backdrop(emptyFallbackState),
                 style = pureBlurGlassStyle(14.dp),
               )
               .drawWithContent {
@@ -153,7 +161,7 @@ class GlassBackdropInstrumentationTest {
               .align(Alignment.Center)
               .size(width = 200.dp, height = 100.dp)
               .hazeGlass(
-                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                input = HazeInput.Backdrop(emptyFallbackState),
                 style = pureBlurGlassStyle(blurRadius.value),
               )
               .drawWithContent {
@@ -205,7 +213,7 @@ class GlassBackdropInstrumentationTest {
                       Modifier
                         .fillMaxSize()
                         .hazeGlass(
-                          input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                          input = HazeInput.Backdrop(emptyFallbackState),
                           style = pureBlurGlassStyle(10.dp),
                         )
                         .drawWithContent {
@@ -265,7 +273,7 @@ class GlassBackdropInstrumentationTest {
               .align(Alignment.Center)
               .size(width = 200.dp, height = 100.dp)
               .hazeGlass(
-                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                input = HazeInput.Backdrop(emptyFallbackState),
                 style = GlassStyle.regular.then {
                   pressed {
                     lightingIntensity(1f)

--- a/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
+++ b/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
@@ -19,12 +19,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.test.core.app.ActivityScenario
@@ -37,6 +40,7 @@ import dev.chrisbanes.haze.ExperimentalHazeApi
 import dev.chrisbanes.haze.HazeFeatureFlags
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -251,6 +255,118 @@ class GlassBackdropInstrumentationTest {
         )
       }
     }
+  }
+
+  @Test
+  fun backdropInput_offscreenAncestorsPreserveInput() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    AncestorMode.entries.forEach { mode ->
+      val native = renderOffscreenScene(mode, nativeEnabled = true)
+      val fallback = renderOffscreenScene(mode, nativeEnabled = false)
+      val density = Density(activity.resources.displayMetrics.density)
+      native.assertCenterEdgeSoftened(density)
+      fallback.assertCenterEdgeSoftened(density)
+      val sampleX = native.width / 2 + 3.dp.roundToPx(density)
+      val sampleY = native.height / 2
+      assertThat(
+        kotlin.math.abs(native.red(sampleX, sampleY) - fallback.red(sampleX, sampleY)),
+        "${mode.name} native/fallback edge agreement",
+      ).isLessThan(0.12f)
+      native.recycle()
+      fallback.recycle()
+    }
+  }
+
+  private fun renderOffscreenScene(
+    mode: AncestorMode,
+    nativeEnabled: Boolean,
+  ): Bitmap {
+    HazeFeatureFlags.isPlatformBackdropEnabled = nativeEnabled
+    val captureState = HazeState()
+    val ancestorState = HazeState()
+    val drawReady = CountDownLatch(1)
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        key(mode to nativeEnabled) {
+          Box(Modifier.fillMaxSize().background(Color.White)) {
+            Box(
+              Modifier
+                .align(Alignment.Center)
+                .size(width = 200.dp, height = 100.dp)
+                .hazeSource(captureState)
+                .background(Color.Black),
+            ) {
+              Box(
+                Modifier
+                  .align(Alignment.CenterEnd)
+                  .size(width = 100.dp, height = 100.dp)
+                  .background(Color.White),
+              )
+            }
+            Box(
+              Modifier
+                .align(Alignment.Center)
+                .size(width = 200.dp, height = 100.dp)
+                .then(
+                  if (mode == AncestorMode.EnclosingCapture) {
+                    Modifier.hazeSource(ancestorState)
+                  } else {
+                    Modifier
+                  },
+                ),
+            ) {
+              Box(
+                Modifier
+                  .fillMaxSize()
+                  .then(
+                    when (mode) {
+                      AncestorMode.Normal -> Modifier
+                      AncestorMode.Alpha -> Modifier.graphicsLayer { alpha = 0.5f }
+                      AncestorMode.Offscreen -> Modifier.graphicsLayer {
+                        compositingStrategy = CompositingStrategy.Offscreen
+                      }
+                      AncestorMode.EnclosingCapture -> Modifier
+                    },
+                  )
+                  .hazeGlass(
+                    input = HazeInput.Backdrop(captureState),
+                    style = pureBlurGlassStyle(14.dp),
+                  )
+                  .drawWithContent {
+                    drawContent()
+                    drawReady.countDown()
+                  },
+              )
+            }
+            if (mode == AncestorMode.EnclosingCapture) {
+              Box(
+                Modifier
+                  .size(1.dp)
+                  .background(Color.Transparent)
+                  .hazeGlass(
+                    input = HazeInput.Sources(ancestorState),
+                    style = pureBlurGlassStyle(0.dp),
+                  ),
+              )
+            }
+          }
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "${mode.name} scene presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    return activity.copyWindow()
+  }
+
+  private enum class AncestorMode {
+    Normal,
+    Alpha,
+    Offscreen,
+    EnclosingCapture,
   }
 
   @Test

--- a/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
+++ b/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
@@ -1,0 +1,264 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass
+
+import android.graphics.Bitmap
+import android.graphics.Color as AndroidColor
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazeState
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalHazeApi::class)
+class GlassBackdropInstrumentationTest {
+
+  private lateinit var activityScenario: ActivityScenario<ComponentActivity>
+  private lateinit var activity: ComponentActivity
+
+  @Before
+  fun setUp() {
+    activityScenario = ActivityScenario.launch(ComponentActivity::class.java)
+    activityScenario.onActivity { activity = it }
+  }
+
+  @After
+  fun tearDown() {
+    activityScenario.close()
+  }
+
+  @Test
+  fun backdropInput_rendersGlassFromWindowPixelsWithoutFallbackSources() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    val emptyFallbackState = HazeState()
+    val drawReady = CountDownLatch(1)
+
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .background(Color.Black),
+          ) {
+            Box(
+              Modifier
+                .align(Alignment.CenterEnd)
+                .size(width = 100.dp, height = 100.dp)
+                .background(Color.White),
+            )
+          }
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .hazeGlass(
+                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                style = pureBlurGlassStyle(14.dp),
+              )
+              .drawWithContent {
+                drawContent()
+                drawReady.countDown()
+              },
+          )
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Glass presented its first draw")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    val bitmap = activity.copyWindow()
+    val density = Density(activity.resources.displayMetrics.density)
+    val centerX = bitmap.width / 2
+    val centerY = bitmap.height / 2
+    val blackInterior = bitmap.red(centerX - 60.dp.roundToPx(density), centerY)
+    val blackNearEdge = bitmap.red(centerX - 3.dp.roundToPx(density), centerY)
+    val whiteNearEdge = bitmap.red(centerX + 3.dp.roundToPx(density), centerY)
+    val whiteInterior = bitmap.red(centerX + 60.dp.roundToPx(density), centerY)
+    assertThat(blackNearEdge - blackInterior, "Glass softens the black side")
+      .isGreaterThan(0.05f)
+    assertThat(whiteInterior - whiteNearEdge, "Glass softens the white side")
+      .isGreaterThan(0.05f)
+  }
+
+  @Test
+  fun backdropInput_rebuildsFusedRootAfterStyleChange() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    val emptyFallbackState = HazeState()
+    val blurRadius = mutableStateOf(0.dp)
+    val initialDraw = CountDownLatch(1)
+    val updatedDraw = CountDownLatch(1)
+
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .background(Color.Black),
+          ) {
+            Box(
+              Modifier
+                .align(Alignment.CenterEnd)
+                .size(width = 100.dp, height = 100.dp)
+                .background(Color.White),
+            )
+          }
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .hazeGlass(
+                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                style = pureBlurGlassStyle(blurRadius.value),
+              )
+              .drawWithContent {
+                drawContent()
+                if (blurRadius.value == 0.dp) initialDraw.countDown() else updatedDraw.countDown()
+              },
+          )
+        }
+      }
+    }
+    assertThat(initialDraw.await(5, TimeUnit.SECONDS), "Identity Glass presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    activity.copyWindow().assertCenterEdgeSharp(
+      Density(activity.resources.displayMetrics.density),
+    )
+
+    blurRadius.value = 14.dp
+    assertThat(updatedDraw.await(5, TimeUnit.SECONDS), "Updated Glass presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    activity.copyWindow().assertCenterEdgeSoftened(
+      Density(activity.resources.displayMetrics.density),
+    )
+  }
+
+  private fun ComponentActivity.copyWindow(): Bitmap {
+    val bitmap = Bitmap.createBitmap(
+      window.decorView.width,
+      window.decorView.height,
+      Bitmap.Config.ARGB_8888,
+    )
+    val latch = CountDownLatch(1)
+    var result = PixelCopy.ERROR_UNKNOWN
+    PixelCopy.request(window, bitmap, { copyResult ->
+      result = copyResult
+      latch.countDown()
+    }, Handler(Looper.getMainLooper()))
+    assertThat(latch.await(5, TimeUnit.SECONDS), "Window PixelCopy completed").isEqualTo(true)
+    assertThat(result, "Window PixelCopy result").isEqualTo(PixelCopy.SUCCESS)
+    return bitmap
+  }
+
+  private companion object {
+    fun pureBlurGlassStyle(blurRadius: androidx.compose.ui.unit.Dp) = GlassStyle.regular.then {
+      optics(
+        GlassOptics(
+          refractionStrength = 0f,
+          refractionHeightFraction = 0f,
+          refractionDisplacement = 0.dp,
+          depth = OpticalSizeValue.Fixed(1f),
+          blurRadius = OpticalSizeValue.Fixed(blurRadius),
+          refractionDetailIntensity = 0f,
+        ),
+      )
+      specularIntensity(0f)
+      edgeShadow(Color.Transparent)
+      ambientResponse(0f)
+      backgroundColor(Color.Transparent)
+      tint(Color.Transparent)
+      edgeSoftness(0.dp)
+      chromaticAberrationStrength(0f)
+      contrast(0f)
+      whitePoint(0f)
+      chromaMultiplier(1f)
+    }
+
+    fun isBackdropSdkSupported(): Boolean {
+      val fullSdkInt = if (Build.VERSION.SDK_INT < 36) {
+        Build.VERSION.SDK_INT * 100_000
+      } else {
+        runCatching {
+          Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
+        }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
+      }
+      return fullSdkInt >= 3_700_002 ||
+        (fullSdkInt == 3_700_001 && Build.VERSION.PREVIEW_SDK_INT == 3_723)
+    }
+  }
+}
+
+private fun Bitmap.red(x: Int, y: Int): Float {
+  val pixel = getPixel(x.coerceIn(0, width - 1), y.coerceIn(0, height - 1))
+  return AndroidColor.red(pixel) / 255f
+}
+
+private fun Bitmap.assertCenterEdgeSoftened(density: Density) {
+  val centerX = width / 2
+  val centerY = height / 2
+  val blackInterior = red(centerX - 60.dp.roundToPx(density), centerY)
+  val blackNearEdge = red(centerX - 3.dp.roundToPx(density), centerY)
+  val whiteNearEdge = red(centerX + 3.dp.roundToPx(density), centerY)
+  val whiteInterior = red(centerX + 60.dp.roundToPx(density), centerY)
+  assertThat(blackNearEdge - blackInterior, "Glass softens the black side")
+    .isGreaterThan(0.05f)
+  assertThat(whiteInterior - whiteNearEdge, "Glass softens the white side")
+    .isGreaterThan(0.05f)
+}
+
+private fun Bitmap.assertCenterEdgeSharp(density: Density) {
+  val centerX = width / 2
+  val centerY = height / 2
+  val blackInterior = red(centerX - 60.dp.roundToPx(density), centerY)
+  val blackNearEdge = red(centerX - 3.dp.roundToPx(density), centerY)
+  val whiteNearEdge = red(centerX + 3.dp.roundToPx(density), centerY)
+  val whiteInterior = red(centerX + 60.dp.roundToPx(density), centerY)
+  assertThat(blackNearEdge - blackInterior, "Identity keeps the black side sharp")
+    .isLessThan(0.02f)
+  assertThat(whiteInterior - whiteNearEdge, "Identity keeps the white side sharp")
+    .isLessThan(0.02f)
+}
+
+private fun androidx.compose.ui.unit.Dp.roundToPx(density: Density): Int =
+  (value * density.density).roundToInt()

--- a/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
+++ b/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
@@ -358,12 +358,13 @@ class GlassBackdropInstrumentationTest {
       val fullSdkInt = if (Build.VERSION.SDK_INT < 36) {
         Build.VERSION.SDK_INT * 100_000
       } else {
-        runCatching {
-          Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
-        }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
+        Build.VERSION.SDK_INT_FULL
       }
-      return fullSdkInt >= 3_700_002 ||
-        (fullSdkInt == 3_700_001 && Build.VERSION.PREVIEW_SDK_INT == 3_723)
+      return fullSdkInt >= Build.VERSION_CODES_FULL.CINNAMON_BUN_2 ||
+        (
+          fullSdkInt == Build.VERSION_CODES_FULL.CINNAMON_BUN_1 &&
+            Build.VERSION.PREVIEW_SDK_INT == 3_723
+          )
     }
   }
 }

--- a/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
+++ b/haze-glass/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropInstrumentationTest.kt
@@ -12,13 +12,18 @@ import android.view.PixelCopy
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
@@ -33,6 +38,7 @@ import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazeState
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.roundToInt
 import org.junit.After
 import org.junit.Assume.assumeTrue
@@ -174,6 +180,139 @@ class GlassBackdropInstrumentationTest {
     )
   }
 
+  @Test
+  fun backdropInput_nineSiblingsRenderIndependently() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    val emptyFallbackState = HazeState()
+    val drawReady = CountDownLatch(9)
+
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.Gray)) {
+          Column(Modifier.align(Alignment.Center)) {
+            repeat(3) {
+              Row {
+                repeat(3) {
+                  Box(Modifier.size(width = 72.dp, height = 48.dp)) {
+                    Row {
+                      Box(Modifier.size(width = 36.dp, height = 48.dp).background(Color.Black))
+                      Box(Modifier.size(width = 36.dp, height = 48.dp).background(Color.White))
+                    }
+                    Box(
+                      Modifier
+                        .fillMaxSize()
+                        .hazeGlass(
+                          input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                          style = pureBlurGlassStyle(10.dp),
+                        )
+                        .drawWithContent {
+                          drawContent()
+                          drawReady.countDown()
+                        },
+                    )
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Nine Glass nodes presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    val bitmap = activity.copyWindow()
+    val density = Density(activity.resources.displayMetrics.density)
+    val gridLeft = bitmap.width / 2 - 108.dp.roundToPx(density)
+    val gridTop = bitmap.height / 2 - 72.dp.roundToPx(density)
+    repeat(3) { row ->
+      repeat(3) { column ->
+        val centerX = gridLeft + (column * 72 + 36).dp.roundToPx(density)
+        val centerY = gridTop + (row * 48 + 24).dp.roundToPx(density)
+        bitmap.assertEdgeSoftened(
+          centerX = centerX,
+          centerY = centerY,
+          density = density,
+          label = "Glass[$row,$column]",
+          interiorDistance = 14.dp,
+          edgeDistance = 2.dp,
+        )
+      }
+    }
+  }
+
+  @Test
+  fun backdropInput_pressedMaterialAndContentTransformScalesChildContent() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isBackdropSdkSupported(),
+    )
+    val emptyFallbackState = HazeState()
+    val interactionSource = MutableInteractionSource()
+    val pressedDrawRequested = AtomicBoolean(false)
+    val initialDraw = CountDownLatch(1)
+    val pressedDraw = CountDownLatch(1)
+
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.Blue)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .hazeGlass(
+                input = HazeInput.Backdrop(HazeInput.Sources(emptyFallbackState)),
+                style = GlassStyle.regular.then {
+                  pressed {
+                    lightingIntensity(1f)
+                    refractionMultiplier(1.5f)
+                    whitePointDelta(0.3f)
+                    scale(0.6f)
+                  }
+                },
+                interactionSource = interactionSource,
+                interactionTransformTarget = GlassTransformTarget.MaterialAndContent,
+                interactionTransformPivot = GlassTransformPivot.Center,
+                interactionReducedMotionPolicy = GlassReducedMotionPolicy.Full,
+              )
+              .drawWithContent {
+                drawContent()
+                if (pressedDrawRequested.get()) pressedDraw.countDown() else initialDraw.countDown()
+              },
+          ) {
+            Box(Modifier.fillMaxSize().background(Color.Red))
+          }
+        }
+      }
+    }
+    assertThat(initialDraw.await(5, TimeUnit.SECONDS), "Unpressed Glass presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+    val density = Density(activity.resources.displayMetrics.density)
+    val sampleX = activity.window.decorView.width / 2 + 80.dp.roundToPx(density)
+    val sampleY = activity.window.decorView.height / 2
+    assertThat(activity.copyWindow().red(sampleX, sampleY), "Unpressed child fills its bounds")
+      .isGreaterThan(0.8f)
+
+    pressedDrawRequested.set(true)
+    assertThat(
+      interactionSource.tryEmit(PressInteraction.Press(Offset.Unspecified)),
+      "Press interaction was accepted",
+    ).isEqualTo(true)
+    assertThat(pressedDraw.await(5, TimeUnit.SECONDS), "Pressed Glass presented")
+      .isEqualTo(true)
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    assertThat(
+      activity.copyWindow().red(sampleX, sampleY),
+      "Pressed material-and-content transform exposes the backdrop at the original edge",
+    ).isLessThan(0.5f)
+  }
+
   private fun ComponentActivity.copyWindow(): Bitmap {
     val bitmap = Bitmap.createBitmap(
       window.decorView.width,
@@ -235,15 +374,31 @@ private fun Bitmap.red(x: Int, y: Int): Float {
 }
 
 private fun Bitmap.assertCenterEdgeSoftened(density: Density) {
-  val centerX = width / 2
-  val centerY = height / 2
-  val blackInterior = red(centerX - 60.dp.roundToPx(density), centerY)
-  val blackNearEdge = red(centerX - 3.dp.roundToPx(density), centerY)
-  val whiteNearEdge = red(centerX + 3.dp.roundToPx(density), centerY)
-  val whiteInterior = red(centerX + 60.dp.roundToPx(density), centerY)
-  assertThat(blackNearEdge - blackInterior, "Glass softens the black side")
+  assertEdgeSoftened(
+    centerX = width / 2,
+    centerY = height / 2,
+    density = density,
+    label = "Glass",
+    interiorDistance = 60.dp,
+    edgeDistance = 3.dp,
+  )
+}
+
+private fun Bitmap.assertEdgeSoftened(
+  centerX: Int,
+  centerY: Int,
+  density: Density,
+  label: String,
+  interiorDistance: androidx.compose.ui.unit.Dp,
+  edgeDistance: androidx.compose.ui.unit.Dp,
+) {
+  val blackInterior = red(centerX - interiorDistance.roundToPx(density), centerY)
+  val blackNearEdge = red(centerX - edgeDistance.roundToPx(density), centerY)
+  val whiteNearEdge = red(centerX + edgeDistance.roundToPx(density), centerY)
+  val whiteInterior = red(centerX + interiorDistance.roundToPx(density), centerY)
+  assertThat(blackNearEdge - blackInterior, "$label softens the black side")
     .isGreaterThan(0.05f)
-  assertThat(whiteInterior - whiteNearEdge, "Glass softens the white side")
+  assertThat(whiteInterior - whiteNearEdge, "$label softens the white side")
     .isGreaterThan(0.05f)
 }
 

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffectAndroidCapabilityTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffectAndroidCapabilityTest.kt
@@ -8,15 +8,19 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.LayoutDirection
 import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
+import assertk.assertions.prop
 import dev.chrisbanes.haze.HazeEffectInputSnapshot
 import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
 import dev.chrisbanes.haze.HazeSampling
@@ -67,6 +71,69 @@ class GlassRuntimeEffectAndroidCapabilityTest {
 
   @Test
   @Config(sdk = [35])
+  fun backdropPreparation_requestsFullResolution() {
+    val effect = GlassRuntimeEffect()
+    val context = AndroidCapabilityContext()
+
+    val decision = effect.prepareRenderBudget(
+      context,
+      runtimeShaderSupported = isRuntimeShaderGlassSupported(),
+      requestedScaleOverride = GlassInputScalePolicy.FULL_RESOLUTION_SCALE,
+    )
+
+    assertThat(decision)
+      .isInstanceOf<GlassRenderBudgetDecision.Runtime>()
+      .prop(GlassRenderBudgetDecision.Runtime::scaleFactor)
+      .isEqualTo(GlassInputScalePolicy.FULL_RESOLUTION_SCALE)
+  }
+
+  @Test
+  @Config(sdk = [35])
+  fun oversizedBackdropForeground_fallsBackInsteadOfDownscaling() {
+    val effect = GlassRuntimeEffect()
+    val context = AndroidCapabilityContext(contextSize = Size(5000f, 5000f))
+
+    val decision = effect.prepareRenderBudget(
+      context,
+      runtimeShaderSupported = isRuntimeShaderGlassSupported(),
+      requestedScaleOverride = GlassInputScalePolicy.FULL_RESOLUTION_SCALE,
+      backdrop = true,
+    )
+
+    assertThat(decision).isEqualTo(
+      GlassRenderBudgetDecision.Fallback(GlassRenderBudgetFallbackReason.ExceedsLimits),
+    )
+  }
+
+  @Test
+  @Config(sdk = [35])
+  fun largeBackdropWithoutForegroundLayers_keepsFullResolution() {
+    val effect = GlassRuntimeEffect(
+      GlassNodeConfiguration(
+        style = GlassStyle {
+          specularIntensity(0f)
+          edgeShadow(Color.Transparent)
+        },
+        interactionSource = null,
+      ),
+    )
+    val context = AndroidCapabilityContext(contextSize = Size(5000f, 5000f))
+
+    val decision = effect.prepareRenderBudget(
+      context,
+      runtimeShaderSupported = isRuntimeShaderGlassSupported(),
+      requestedScaleOverride = GlassInputScalePolicy.FULL_RESOLUTION_SCALE,
+      backdrop = true,
+    )
+
+    assertThat(decision)
+      .isInstanceOf<GlassRenderBudgetDecision.Runtime>()
+      .prop(GlassRenderBudgetDecision.Runtime::scaleFactor)
+      .isEqualTo(GlassInputScalePolicy.FULL_RESOLUTION_SCALE)
+  }
+
+  @Test
+  @Config(sdk = [35])
   fun runtimeEffectFactoryChange_replacesRuntimeDelegate() {
     val effect = GlassRuntimeEffect()
     val context = AndroidCapabilityContext()
@@ -85,13 +152,15 @@ class GlassRuntimeEffectAndroidCapabilityTest {
 }
 
 @OptIn(InternalComposeUiApi::class, InternalHazeApi::class)
-private class AndroidCapabilityContext :
+private class AndroidCapabilityContext(
+  private val contextSize: Size = Size(100f, 100f),
+) :
   HazeEffectRuntimeDrawScope,
   DrawScope by CanvasDrawScope() {
-  override val modifierSize: Size = Size(100f, 100f)
+  override val modifierSize: Size = contextSize
   override val modifierBounds: Rect = Rect(Offset.Zero, modifierSize)
   override val sampling: HazeSampling = HazeSampling.FullResolution
-  override val layerSize: Size = Size(100f, 100f)
+  override val layerSize: Size = contextSize
   override val layerOffset: Offset = Offset.Zero
   override val hasDrawableInput: Boolean = true
   override val inputSnapshot: HazeEffectInputSnapshot = AndroidCapabilityInputSnapshot

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffectAndroidCapabilityTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffectAndroidCapabilityTest.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.glass
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.CompositionLocal
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
@@ -13,9 +14,13 @@ import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import assertk.assertThat
+import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
@@ -130,6 +135,72 @@ class GlassRuntimeEffectAndroidCapabilityTest {
       .isInstanceOf<GlassRenderBudgetDecision.Runtime>()
       .prop(GlassRenderBudgetDecision.Runtime::scaleFactor)
       .isEqualTo(GlassInputScalePolicy.FULL_RESOLUTION_SCALE)
+  }
+
+  @Test
+  @Config(sdk = [35])
+  fun backdropPreparation_preservesFullGraphWithoutCaptureLayers() {
+    val tint = Color.Red.copy(alpha = 0.2f)
+    val background = Color.Blue.copy(alpha = 0.1f)
+    val effect = GlassRuntimeEffect(
+      GlassNodeConfiguration(
+        style = GlassStyle.regular.then {
+          optics(
+            GlassOptics(
+              refractionStrength = 0.8f,
+              refractionHeightFraction = 0.25f,
+              refractionDisplacement = 18.dp,
+              depth = OpticalSizeValue.Fixed(0.5f),
+              blurRadius = OpticalSizeValue.Fixed(16.dp),
+              refractionDetailIntensity = 0.8f,
+            ),
+          )
+          shape(RoundedCornerShape(24.dp))
+          specularIntensity(0.8f)
+          edgeShadow(Color.Black.copy(alpha = 0.2f))
+          edgeSoftness(12.dp)
+          backgroundColor(background)
+          tint(tint)
+          alpha(0.4f)
+          chromaticAberrationStrength(0.35f)
+          chromaticAberrationMode(ChromaticAberrationMode.Full)
+          contrast(0.2f)
+          whitePoint(0.1f)
+          chromaMultiplier(1.2f)
+        },
+        interactionSource = null,
+      ),
+    )
+    val context = AndroidCapabilityContext(contextSize = Size(240f, 160f))
+
+    val decision = effect.prepareRenderBudget(
+      context,
+      runtimeShaderSupported = isRuntimeShaderGlassSupported(),
+      requestedScaleOverride = GlassInputScalePolicy.FULL_RESOLUTION_SCALE,
+      backdrop = true,
+    )
+
+    assertThat(decision).isInstanceOf<GlassRenderBudgetDecision.Runtime>()
+    val prepared = checkNotNull(effect.preparedRender)
+    assertThat(prepared.plan.layers.map { it.kind })
+      .containsExactly(GlassRetainedLayerKind.Rim)
+    assertThat(prepared.groupCompositeSize).isNull()
+    assertThat(prepared.alpha).isEqualTo(0.4f)
+    assertThat(prepared.blurKey).isNotNull()
+    assertThat(prepared.refractionDetailKey).isNotNull()
+    assertThat(prepared.rimKey).isNotNull()
+    assertThat(prepared.params.depth).isEqualTo(0.5f)
+    assertThat(prepared.params.blurRadiusPx).isGreaterThan(0f)
+    assertThat(prepared.params.refractionStrength).isEqualTo(0.8f)
+    assertThat(prepared.params.backgroundColor).isEqualTo(background)
+    assertThat(prepared.params.tint).isEqualTo(tint)
+    assertThat(prepared.params.chromaticAberrationStrength).isEqualTo(0.35f)
+    assertThat(prepared.params.chromaticAberrationMode)
+      .isEqualTo(ChromaticAberrationMode.Full.ordinal.toFloat())
+    assertThat(prepared.params.contrast).isEqualTo(0.2f)
+    assertThat(prepared.params.whitePoint).isEqualTo(0.1f)
+    assertThat(prepared.params.chromaMultiplier).isEqualTo(1.2f)
+    assertThat(prepared.params.cornerRadii).isNotEqualTo(CornerRadii.zero)
   }
 
   @Test

--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -20,16 +20,23 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.AndroidComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.v2.runAndroidComposeUiTest
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -37,6 +44,7 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isNotSameInstanceAs
@@ -44,13 +52,22 @@ import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeEffectDrawScope
 import dev.chrisbanes.haze.HazeEffectFactory
+import dev.chrisbanes.haze.HazeEffectLayoutScope
+import dev.chrisbanes.haze.HazeEffectLifecycleScope
 import dev.chrisbanes.haze.HazeEffectRenderer
+import dev.chrisbanes.haze.HazeEffectRendererDrawHooks
+import dev.chrisbanes.haze.HazeEffectRendererLifecycle
+import dev.chrisbanes.haze.HazeEffectRuntimeDrawScope
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazePerformanceMode
 import dev.chrisbanes.haze.HazeProgressive
+import dev.chrisbanes.haze.HazeSampling
 import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.RuntimeShaderRenderEffectException
+import dev.chrisbanes.haze.TrimMemoryLevel
+import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import dev.chrisbanes.haze.test.ContextTest
@@ -526,6 +543,129 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       assertThat(delegate.rimShader).isSameInstanceAs(rimShader)
       assertThat(delegate.rimEffect).isNotSameInstanceAs(rimEffect)
       assertThat(delegate.layers.rim?.renderEffect).isNotSameInstanceAs(rimLayerEffect)
+    }
+
+  @Test
+  fun repeatedBackdropPreparation_reusesUnchangedRimRecording() =
+    runAndroidComposeUiTest<ComponentActivity> {
+      val effect = animatedStageEffect()
+      val factory = TestGlassRuntimeFactory(effect)
+      var contentSize by mutableStateOf(120.dp)
+      val configuration = GlassNodeConfiguration(
+        style = effect.style,
+        performanceMode = HazePerformanceMode.Quality,
+        interactionSource = effect.interactionSource,
+        interactionTransformTarget = effect.interactionTransformTarget,
+        interactionTransformPivot = effect.interactionTransformPivot,
+        interactionReducedMotionPolicy = effect.interactionReducedMotionPolicy,
+      )
+      setContent {
+        Box(
+          Modifier
+            .size(contentSize)
+            .testTag("direct-glass")
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Content,
+              style = configuration,
+              expandLayerBounds = true,
+            ),
+        ) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .background(Brush.verticalGradient(listOf(Color.Red, Color.Blue))),
+          )
+        }
+      }
+      waitForIdle()
+
+      val renderer = factory.renderer
+
+      fun capturePixels(): FloatArray {
+        val pixels = onNodeWithTag("direct-glass")
+          .captureToImage()
+          .toPixelMap()
+        val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+        assertThat(delegate.layers.source).isNull()
+        assertThat(delegate.layers.optical).isNull()
+        return FloatArray(pixels.width * pixels.height) { index ->
+          pixels[index % pixels.width, index / pixels.width].red
+        }
+      }
+
+      val initialPixels = capturePixels()
+      val delegate = checkNotNull(effect.delegate as? RuntimeShaderGlassDelegate)
+      val firstCount = delegate.rimRecordCount
+      val firstRimLayer = checkNotNull(delegate.layers.rim)
+      assertThat(firstCount).isGreaterThan(0)
+
+      renderer.invalidateDraw()
+      waitForIdle()
+      val repeatedPixels = capturePixels()
+      assertThat(delegate.rimRecordCount).isEqualTo(firstCount)
+      assertThat(delegate.layers.rim).isSameInstanceAs(firstRimLayer)
+      assertThat(repeatedPixels.size).isEqualTo(initialPixels.size)
+
+      effect.ambientResponse = 0.6f
+      renderer.invalidateDraw()
+      waitForIdle()
+      capturePixels()
+      assertThat(delegate.rimRecordCount).isEqualTo(firstCount)
+      assertThat(delegate.layers.rim).isSameInstanceAs(firstRimLayer)
+
+      effect.alpha = 0.75f
+      renderer.invalidateDraw()
+      waitForIdle()
+      capturePixels()
+      assertThat(delegate.rimRecordCount).isEqualTo(firstCount)
+      assertThat(delegate.layers.rim).isSameInstanceAs(firstRimLayer)
+
+      contentSize = 100.dp
+      waitForIdle()
+      val resizedPixels = capturePixels()
+      val resizedCount = delegate.rimRecordCount
+      val resizedRimLayer = checkNotNull(delegate.layers.rim)
+      assertThat(resizedCount).isEqualTo(firstCount + 1)
+      assertThat(resizedRimLayer).isNotSameInstanceAs(firstRimLayer)
+
+      val countBeforeLight = delegate.rimRecordCount
+      val pixelsBeforeLight = resizedPixels
+      effect.lightPosition = exactLightAlignment(Offset(10f, 20f))
+      renderer.invalidateDraw()
+      waitForIdle()
+      val pixelsAfterLight = capturePixels()
+      assertThat(delegate.rimRecordCount).isEqualTo(countBeforeLight + 1)
+      assertThat(delegate.layers.rim).isSameInstanceAs(resizedRimLayer)
+      val maximumPixelDelta = pixelsBeforeLight.indices.maxOf { index ->
+        kotlin.math.abs(pixelsBeforeLight[index] - pixelsAfterLight[index])
+      }
+      assertThat(maximumPixelDelta).isGreaterThan(0.01f)
+
+      val countBeforeDisable = delegate.rimRecordCount
+      effect.specularIntensity = 0f
+      effect.edgeShadow = Color.Transparent
+      renderer.invalidateDraw()
+      waitForIdle()
+      capturePixels()
+      assertThat(delegate.layers.rim).isNull()
+
+      effect.specularIntensity = 1f
+      effect.edgeShadow = Color.Black.copy(alpha = 0.2f)
+      renderer.invalidateDraw()
+      waitForIdle()
+      capturePixels()
+      val recreatedCount = delegate.rimRecordCount
+      val recreatedRimLayer = checkNotNull(delegate.layers.rim)
+      assertThat(recreatedCount).isEqualTo(countBeforeDisable + 1)
+      assertThat(recreatedRimLayer).isNotSameInstanceAs(resizedRimLayer)
+
+      effect.onTrimMemory(TrimMemoryLevel.MODERATE)
+      renderer.invalidateDraw()
+      waitForIdle()
+      capturePixels()
+      assertThat(delegate.rimRecordCount).isEqualTo(recreatedCount + 1)
+      assertThat(delegate.layers.rim).isNotSameInstanceAs(recreatedRimLayer)
     }
 
   @Test
@@ -1065,4 +1205,72 @@ private class FixedGlassRuntimeFactory(
   private val effect: GlassRuntimeEffect,
 ) : HazeEffectFactory<GlassNodeConfiguration> {
   override fun createRenderer(): HazeEffectRenderer<GlassNodeConfiguration> = effect
+}
+
+@OptIn(InternalHazeApi::class)
+private class TestGlassRuntimeFactory(
+  private val effect: GlassRuntimeEffect,
+) : HazeEffectFactory<GlassNodeConfiguration> {
+  lateinit var renderer: TestGlassRuntimeRenderer
+
+  override fun createRenderer(): HazeEffectRenderer<GlassNodeConfiguration> =
+    TestGlassRuntimeRenderer(effect).also { renderer = it }
+}
+
+@OptIn(InternalHazeApi::class)
+private class TestGlassRuntimeRenderer(
+  private val effect: GlassRuntimeEffect,
+) :
+  HazeEffectRenderer<GlassNodeConfiguration>,
+  HazeEffectRendererLifecycle<GlassNodeConfiguration>,
+  HazeEffectRendererDrawHooks<GlassNodeConfiguration> {
+  private var lifecycleScope: HazeEffectLifecycleScope? = null
+
+  override fun attach(scope: HazeEffectLifecycleScope) {
+    lifecycleScope = scope
+    effect.attach(scope)
+  }
+
+  override fun update(
+    scope: HazeEffectLifecycleScope,
+    style: GlassNodeConfiguration,
+    sampling: HazeSampling,
+  ) {
+    effect.update(scope, style, sampling)
+  }
+
+  override fun detach() {
+    lifecycleScope = null
+    effect.detach()
+  }
+
+  override fun HazeEffectDrawScope.draw(style: GlassNodeConfiguration) {
+    drawInput()
+  }
+
+  override fun HazeEffectLayoutScope.calculateLayerBounds(
+    style: GlassNodeConfiguration,
+  ): Rect = with(effect) { calculateLayerBounds(style) }
+
+  override fun HazeEffectRuntimeDrawScope.prepareDraw(style: GlassNodeConfiguration) {
+    checkNotNull(with(effect) { backdropEffect(style) })
+  }
+
+  override fun HazeEffectRuntimeDrawScope.drawForeground(style: GlassNodeConfiguration) {
+    with(effect) { drawForeground(style) }
+  }
+
+  override fun shouldDrawContentBehind(): Boolean = effect.shouldDrawContentBehind()
+
+  override fun shouldClipToNodeBounds(): Boolean = effect.shouldClipToNodeBounds()
+
+  override fun shouldPreferClipToInputBounds(): Boolean = effect.shouldPreferClipToInputBounds()
+
+  override fun onTrimMemory(level: TrimMemoryLevel) {
+    effect.onTrimMemory(level)
+  }
+
+  fun invalidateDraw() {
+    lifecycleScope?.invalidateDraw()
+  }
 }

--- a/haze-glass/src/androidMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectFactory.android.kt
+++ b/haze-glass/src/androidMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectFactory.android.kt
@@ -16,6 +16,7 @@ import dev.chrisbanes.haze.PlatformRenderEffect
 
 @RequiresApi(Build.VERSION_CODES.S)
 internal actual fun createGlassDepthInputRenderEffect(
+  sharp: PlatformRenderEffect?,
   blur: PlatformRenderEffect?,
   depth: Float,
 ): PlatformRenderEffect? {
@@ -39,7 +40,7 @@ internal actual fun createGlassDepthInputRenderEffect(
     }
 
     RenderEffect.createBlendModeEffect(
-      scaledInput(1f - depth),
+      scaledInput(1f - depth, sharp),
       scaledInput(depth, blur),
       BlendMode.PLUS,
     )

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassLayers.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassLayers.kt
@@ -225,6 +225,26 @@ internal class GlassLayers {
     release(GlassRetainedLayerKind.InteractionComposite, graphicsContext)
   }
 
+  fun prepareBackdrop(
+    rim: Boolean,
+    interactionLighting: Boolean,
+    graphicsContext: GraphicsContext,
+  ) {
+    groupAlpha.release(graphicsContext)
+    release(GlassRetainedLayerKind.Source, graphicsContext)
+    releaseBlurred(graphicsContext)
+    releaseDepthMixed(graphicsContext)
+    release(GlassRetainedLayerKind.Optical, graphicsContext)
+    releaseRefractionDetail(graphicsContext)
+    prepareInteraction(
+      optics = false,
+      detail = false,
+      lighting = interactionLighting,
+      graphicsContext = graphicsContext,
+    )
+    if (rim) ensureRim(graphicsContext) else releaseRim(graphicsContext)
+  }
+
   fun release(graphicsContext: GraphicsContext?) {
     groupAlpha.release(graphicsContext)
     RetainedGlassReleaseOrder.forEach { kind ->

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
@@ -4,6 +4,7 @@
 package dev.chrisbanes.haze.glass
 
 import androidx.compose.ui.unit.IntSize
+import dev.chrisbanes.haze.Poko
 
 internal const val MAX_GLASS_LAYER_DIMENSION_PX: Int = 4096
 internal const val MAX_GLASS_RETAINED_PIXELS: Long = 16_777_216L
@@ -39,7 +40,8 @@ internal fun IntSize.fitsGlassLayerBudget(): Boolean =
     height in 1..MAX_GLASS_LAYER_DIMENSION_PX &&
     width.toLong() * height.toLong() <= MAX_GLASS_RETAINED_PIXELS
 
-internal data class GlassRetainedLayerPlan(
+@Poko
+internal class GlassRetainedLayerPlan(
   val layers: List<GlassRetainedLayer>,
   val allowsEmpty: Boolean = false,
 ) {

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudget.kt
@@ -41,6 +41,7 @@ internal fun IntSize.fitsGlassLayerBudget(): Boolean =
 
 internal data class GlassRetainedLayerPlan(
   val layers: List<GlassRetainedLayer>,
+  val allowsEmpty: Boolean = false,
 ) {
   fun retainedPixelCountOrNull(): Long? {
     var total = 0L
@@ -56,7 +57,7 @@ internal data class GlassRetainedLayerPlan(
   }
 
   fun fitsGlassRenderBudget(): Boolean =
-    layers.isNotEmpty() &&
+    (allowsEmpty || layers.isNotEmpty()) &&
       layers.all { it.size.fitsGlassLayerBudget() } &&
       (retainedPixelCountOrNull()?.let { it <= MAX_GLASS_RETAINED_PIXELS } == true)
 }
@@ -214,4 +215,4 @@ private fun GlassRetainedLayerPlan.fallbackDecision(): GlassRenderBudgetDecision
   )
 
 private fun GlassRetainedLayerPlan.isInvalidGeometry(): Boolean =
-  layers.isEmpty() || retainedPixelCountOrNull() == null
+  !allowsEmpty && layers.isEmpty() || retainedPixelCountOrNull() == null

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderParams.kt
@@ -688,6 +688,25 @@ internal fun buildGlassBudgetLayerPlan(
   )
 }
 
+internal fun buildGlassBackdropLayerPlan(
+  sampleSize: IntSize,
+  rimActive: Boolean,
+  interactionPatchSize: IntSize,
+  interactionLightingActive: Boolean,
+): GlassRetainedLayerPlan = GlassRetainedLayerPlan(
+  layers = buildList {
+    if (rimActive) add(GlassRetainedLayer(GlassRetainedLayerKind.Rim, sampleSize))
+    if (
+      interactionLightingActive &&
+      interactionPatchSize.width > 0 &&
+      interactionPatchSize.height > 0
+    ) {
+      add(GlassRetainedLayer(GlassRetainedLayerKind.InteractionLighting, interactionPatchSize))
+    }
+  },
+  allowsEmpty = true,
+)
+
 private fun buildGlassRetainedLayerPlan(
   sampleSize: IntSize,
   blurWorkingSize: IntSize?,

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
@@ -456,7 +456,7 @@ internal class GlassRuntimeEffect() :
         with(runtimeDelegate) { prepareBackdrop(context) }
       } ?: return null
       HazeEffectBackdrop(
-        effect = platformEffect,
+        platformEffect = platformEffect,
         alpha = checkNotNull(preparedRender).alpha,
         materialTransform = currentMaterialTransform(context.modifierSize),
       )

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/GlassRuntimeEffect.kt
@@ -24,12 +24,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.roundToIntSize
 import dev.chrisbanes.haze.Bitmask
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeEffectBackdrop
 import dev.chrisbanes.haze.HazeEffectContentTransform
 import dev.chrisbanes.haze.HazeEffectDrawScope
 import dev.chrisbanes.haze.HazeEffectInputSnapshot
 import dev.chrisbanes.haze.HazeEffectLayoutScope
 import dev.chrisbanes.haze.HazeEffectLifecycleScope
 import dev.chrisbanes.haze.HazeEffectRenderer
+import dev.chrisbanes.haze.HazeEffectRendererBackdrop
 import dev.chrisbanes.haze.HazeEffectRendererDrawHooks
 import dev.chrisbanes.haze.HazeEffectRendererInteraction
 import dev.chrisbanes.haze.HazeEffectRendererLifecycle
@@ -52,6 +54,7 @@ private class GlassPreparedRenderCacheKey(
   val coordinates: GlassCoordinates,
   val interaction: ResolvedGlassInteraction,
   val interactionTopology: GlassInteractionTopology,
+  val backdrop: Boolean,
 )
 
 private class GlassRenderBudgetCacheKey(
@@ -61,6 +64,7 @@ private class GlassRenderBudgetCacheKey(
   val materialSize: Size,
   val interactionTopology: GlassInteractionTopology,
   val interactionRadiusFraction: Float,
+  val backdrop: Boolean,
 )
 
 private class GlassPreparedDrawCacheKey(
@@ -135,6 +139,7 @@ private val IdleInteractionSignals = GlassInteractionSignals()
 internal class GlassRuntimeEffect() :
   GlassRuntimeState(),
   HazeEffectRenderer<GlassNodeConfiguration>,
+  HazeEffectRendererBackdrop<GlassNodeConfiguration>,
   HazeEffectRendererLifecycle<GlassNodeConfiguration>,
   HazeEffectRendererDrawHooks<GlassNodeConfiguration>,
   HazeEffectRendererRetainedOutput,
@@ -430,6 +435,44 @@ internal class GlassRuntimeEffect() :
     }
   }
 
+  override fun HazeEffectRuntimeDrawScope.backdropEffect(
+    style: GlassNodeConfiguration,
+  ): HazeEffectBackdrop? {
+    val context = this
+    return try {
+      val previousBudget = preparedRenderBudget
+      prepareRenderBudget(
+        context = context,
+        runtimeShaderSupported = isRuntimeShaderGlassSupported(),
+        requestedScaleOverride = GlassInputScalePolicy.FULL_RESOLUTION_SCALE,
+        backdrop = true,
+      )
+      if (previousBudget::class != preparedRenderBudget::class) {
+        needsDelegateSelection = true
+      }
+      with(context as DrawScope) { selectDelegateForDraw(context) }
+      val runtimeDelegate = delegate as? RuntimeShaderGlassDelegate ?: return null
+      val platformEffect = with(context as DrawScope) {
+        with(runtimeDelegate) { prepareBackdrop(context) }
+      } ?: return null
+      HazeEffectBackdrop(
+        effect = platformEffect,
+        alpha = checkNotNull(preparedRender).alpha,
+        materialTransform = currentMaterialTransform(context.modifierSize),
+      )
+    } catch (failure: RuntimeShaderRenderEffectException) {
+      runtimeShaderIncompatible = true
+      needsDelegateSelection = true
+      HazeLogger.d(TAG) {
+        "Runtime shader backdrop rendering failed; using source fallback: $failure"
+      }
+      context.invalidateDraw()
+      null
+    } finally {
+      resetDirtyTracker()
+    }
+  }
+
   override fun shouldPrepareDraw(style: GlassNodeConfiguration): Boolean {
     if (alpha != 0f) return true
     resetDirtyTracker()
@@ -711,6 +754,8 @@ internal class GlassRuntimeEffect() :
   private fun resolveGlassRenderPreparation(
     context: HazeEffectRuntimeDrawScope,
     runtimeShaderSupported: Boolean,
+    requestedScaleOverride: Float? = null,
+    backdrop: Boolean = false,
   ): GlassRenderPreparation {
     if (
       !context.modifierSize.isDrawable() || !context.layerSize.isDrawable()
@@ -748,37 +793,48 @@ internal class GlassRuntimeEffect() :
       )
       val interactionLayersActive =
         interactionPatchSize.width > 0 && interactionPatchSize.height > 0
-      buildGlassBudgetLayerPlan(
-        sampleSize = coordinates.sampleSize.roundToIntSize(),
-        groupCompositeSize = resolveGlassGroupCompositeSize(
-          outputSize = outputSize,
-          alpha = style.alpha,
-          interactionLayersActive = interactionLayersActive,
-          interactionTopology = interactionTopology,
-        ),
-        blurRadiusPx = optics.blurRadiusPx * scaleFactor,
-        depth = optics.depth,
-        allowMultiscaleBlur = allowMultiscaleBlur,
-        refractionDetailActive = isGlassRefractionDetailActive(
-          refractionStrength = optics.refractionStrength,
-          refractionScalePx = optics.refractionScalePx * scaleFactor,
-          refractionHeightPx = optics.refractionHeightPx * scaleFactor,
-          edgeSoftnessPx = style.edgeSoftnessPx * scaleFactor,
-          sampleStepPx = 2f * scaleFactor,
-          detailIntensity = optics.refractionDetailIntensity,
-        ),
-        rimActive = style.specularIntensity > 0f || style.edgeShadow.alpha > 0f,
-        interactionPatchSize = interactionPatchSize,
-        interactionOpticsActive = interactionTopology.hasOptics,
-        interactionLightingActive = interactionTopology.hasLighting,
-      )
+      if (backdrop) {
+        buildGlassBackdropLayerPlan(
+          sampleSize = coordinates.sampleSize.roundToIntSize(),
+          rimActive = style.specularIntensity > 0f || style.edgeShadow.alpha > 0f,
+          interactionPatchSize = interactionPatchSize,
+          interactionLightingActive = interactionTopology.hasLighting,
+        )
+      } else {
+        buildGlassBudgetLayerPlan(
+          sampleSize = coordinates.sampleSize.roundToIntSize(),
+          groupCompositeSize = resolveGlassGroupCompositeSize(
+            outputSize = outputSize,
+            alpha = style.alpha,
+            interactionLayersActive = interactionLayersActive,
+            interactionTopology = interactionTopology,
+          ),
+          blurRadiusPx = optics.blurRadiusPx * scaleFactor,
+          depth = optics.depth,
+          allowMultiscaleBlur = allowMultiscaleBlur,
+          refractionDetailActive = isGlassRefractionDetailActive(
+            refractionStrength = optics.refractionStrength,
+            refractionScalePx = optics.refractionScalePx * scaleFactor,
+            refractionHeightPx = optics.refractionHeightPx * scaleFactor,
+            edgeSoftnessPx = style.edgeSoftnessPx * scaleFactor,
+            sampleStepPx = 2f * scaleFactor,
+            detailIntensity = optics.refractionDetailIntensity,
+          ),
+          rimActive = style.specularIntensity > 0f || style.edgeShadow.alpha > 0f,
+          interactionPatchSize = interactionPatchSize,
+          interactionOpticsActive = interactionTopology.hasOptics,
+          interactionLightingActive = interactionTopology.hasLighting,
+        )
+      }
     }
-    val balancedPlan = if (performanceMode === HazePerformanceMode.Adaptive) {
+    val balancedPlan = if (
+      requestedScaleOverride == null && performanceMode === HazePerformanceMode.Adaptive
+    ) {
       buildPlan(GlassInputScalePolicy.BALANCED_SCALE)
     } else {
       null
     }
-    val requestedScale = inputScalePolicy.resolve(
+    val requestedScale = requestedScaleOverride ?: inputScalePolicy.resolve(
       performanceMode = performanceMode,
       balancedPlan = balancedPlan,
     )
@@ -803,17 +859,30 @@ internal class GlassRuntimeEffect() :
       budgetKey.layerSize == context.layerSize &&
       budgetKey.materialSize == context.modifierSize &&
       budgetKey.interactionTopology === interactionTopology &&
-      budgetKey.interactionRadiusFraction == interaction.radiusFraction
+      budgetKey.interactionRadiusFraction == interaction.radiusFraction &&
+      budgetKey.backdrop == backdrop
     ) {
       checkNotNull(budgetCacheDecision)
     } else {
-      resolveGlassRenderBudget(
-        requestedScale = requestedScale,
-        requestedPlan = balancedPlan.takeIf {
-          requestedScale == GlassInputScalePolicy.BALANCED_SCALE
-        },
-        buildPlan = buildPlan,
-      ).also { resolvedDecision ->
+      val resolvedDecision = if (requestedScaleOverride != null) {
+        val forcedPlan = buildPlan(requestedScale)
+        when {
+          forcedPlan.fitsGlassRenderBudget() ->
+            GlassRenderBudgetDecision.Runtime(requestedScale, forcedPlan)
+          forcedPlan.layers.isEmpty() ->
+            GlassRenderBudgetDecision.Fallback(GlassRenderBudgetFallbackReason.InvalidGeometry)
+          else -> GlassRenderBudgetDecision.Fallback(GlassRenderBudgetFallbackReason.ExceedsLimits)
+        }
+      } else {
+        resolveGlassRenderBudget(
+          requestedScale = requestedScale,
+          requestedPlan = balancedPlan.takeIf {
+            requestedScale == GlassInputScalePolicy.BALANCED_SCALE
+          },
+          buildPlan = buildPlan,
+        )
+      }
+      resolvedDecision.also {
         budgetCacheKey = GlassRenderBudgetCacheKey(
           style = style,
           inputScale = requestedScale,
@@ -821,8 +890,9 @@ internal class GlassRuntimeEffect() :
           materialSize = context.modifierSize,
           interactionTopology = interactionTopology,
           interactionRadiusFraction = interaction.radiusFraction,
+          backdrop = backdrop,
         )
-        budgetCacheDecision = resolvedDecision
+        budgetCacheDecision = it
       }
     }
     if (decision !is GlassRenderBudgetDecision.Runtime) {
@@ -844,14 +914,15 @@ internal class GlassRuntimeEffect() :
       style === preparedCacheKey.style &&
       coordinates === preparedCacheKey.coordinates &&
       interaction === preparedCacheKey.interaction &&
-      interactionTopology === preparedCacheKey.interactionTopology
+      interactionTopology === preparedCacheKey.interactionTopology &&
+      preparedCacheKey.backdrop == backdrop
     ) {
       return updateRenderPreparation(decision, checkNotNull(preparedRenderCache))
     }
     val previousStyle = preparedCacheKey?.style
     val previousCoordinates = preparedCacheKey?.coordinates
     val previousInteraction = preparedCacheKey?.interaction
-    val previousPrepared = preparedRenderCache
+    val previousPrepared = preparedRenderCache.takeIf { preparedCacheKey?.backdrop == backdrop }
     val params = if (
       previousStyle != null && previousCoordinates != null && previousPrepared != null &&
       coordinates === previousCoordinates &&
@@ -870,7 +941,7 @@ internal class GlassRuntimeEffect() :
     } else {
       interaction.uniforms(coordinates)
     }
-    val exactPrepared = buildGlassPreparedRender(
+    val sourcePrepared = buildGlassPreparedRender(
       params = params,
       interactionUniforms = interactionUniforms,
       interactionTopology = interactionTopology,
@@ -879,6 +950,19 @@ internal class GlassRuntimeEffect() :
       outputSize = context.modifierSize.roundToIntSize(),
       previous = previousPrepared,
     )
+    val exactPrepared = if (backdrop) {
+      sourcePrepared.copy(
+        plan = buildGlassBackdropLayerPlan(
+          sampleSize = params.coordinates.sampleSize.roundToIntSize(),
+          rimActive = sourcePrepared.rimKey != null,
+          interactionPatchSize = sourcePrepared.interactionPatchSize,
+          interactionLightingActive = sourcePrepared.interactionTopology.hasLighting,
+        ),
+        groupCompositeSize = null,
+      )
+    } else {
+      sourcePrepared
+    }
     if (!exactPrepared.plan.fitsGlassRenderBudget()) {
       val fallback = GlassRenderBudgetDecision.Fallback(
         GlassRenderBudgetFallbackReason.ExceedsLimits,
@@ -903,6 +987,7 @@ internal class GlassRuntimeEffect() :
       coordinates = coordinates,
       interaction = interaction,
       interactionTopology = interactionTopology,
+      backdrop = backdrop,
     )
     preparedRenderCache = prepared
     return updateRenderPreparation(validatedDecision, prepared)
@@ -925,11 +1010,15 @@ internal class GlassRuntimeEffect() :
   internal fun prepareRenderBudget(
     context: HazeEffectRuntimeDrawScope,
     runtimeShaderSupported: Boolean,
+    requestedScaleOverride: Float? = null,
+    backdrop: Boolean = false,
   ): GlassRenderBudgetDecision {
     val previousBudget = preparedRenderBudget
     val preparation = resolveGlassRenderPreparation(
       context = context,
       runtimeShaderSupported = runtimeShaderSupported,
+      requestedScaleOverride = requestedScaleOverride,
+      backdrop = backdrop,
     )
     preparedRenderBudget = preparation.decision
     preparedRender = preparation.prepared

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/HazeGlass.kt
@@ -32,7 +32,8 @@ import dev.chrisbanes.haze.hazeEffect
  * mechanics rather than Style presentation. Recomposition replaces each value completely,
  * including a `null` interaction source.
  *
- * @param input Source-backed content or this modifier's own content.
+ * @param input Source-backed content, this modifier's own content, or an experimental Android
+ * window backdrop with a required source fallback.
  * @param style Explicit appearance applied after defaults and [LocalGlassStyle].
  * @param performanceMode Effect-owned rendering-fidelity policy for this Glass runtime. The
  * default adaptive policy selects one of Glass's validated performance profiles from retained work

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -129,6 +129,8 @@ internal class RuntimeShaderGlassDelegate(
   private var recordedInteractionCompositeDetailRecordCount: Int = -1
   private var recordedInteractionLightingLayer: GraphicsLayer? = null
   private var recordedInteractionLightingSize: IntSize? = null
+  private var recordedRimLayer: GraphicsLayer? = null
+  private var recordedRimKey: GlassRimEffectKey? = null
   internal val layers = GlassLayers()
   private var graphicsContext: GraphicsContext? = null
   private var preparedRender: GlassPreparedRender? = null
@@ -207,6 +209,7 @@ internal class RuntimeShaderGlassDelegate(
       graphicsContext = currentGraphicsContext
       if (layers.scaledSize != scaledSize) {
         layers.release(currentGraphicsContext)
+        clearRimLayerMetadata()
         layers.scaledSize = scaledSize
         clearInteractionLayerMetadata()
         clearRetainedMetadata()
@@ -255,6 +258,7 @@ internal class RuntimeShaderGlassDelegate(
       }
       if (!rimRequired) {
         layers.releaseRim(currentGraphicsContext)
+        clearRimLayerMetadata()
       }
       releaseObsoleteInteractionLayers(
         opticsRequired = interactionOpticsRequired,
@@ -341,6 +345,7 @@ internal class RuntimeShaderGlassDelegate(
     if (layers.scaledSize != scaledSize) {
       layers.release(currentGraphicsContext)
       layers.scaledSize = scaledSize
+      clearRimLayerMetadata()
       clearInteractionLayerMetadata()
       clearRetainedMetadata()
     }
@@ -349,6 +354,9 @@ internal class RuntimeShaderGlassDelegate(
       interactionLighting = currentPreparedRender.interactionTopology.hasLighting,
       graphicsContext = currentGraphicsContext,
     )
+    if (currentRenderEffects.rim == null) {
+      clearRimLayerMetadata()
+    }
     clearRetainedMetadata()
     prepareInteractionRenderEffects(
       render = currentPreparedRender,
@@ -958,6 +966,11 @@ internal class RuntimeShaderGlassDelegate(
     interactionLightingEffectLayer = null
   }
 
+  private fun clearRimLayerMetadata() {
+    recordedRimLayer = null
+    recordedRimKey = null
+  }
+
   override fun detach() {
     releaseRetainedResources(releaseShaderHandles = false)
   }
@@ -1017,6 +1030,7 @@ internal class RuntimeShaderGlassDelegate(
     preparedInteractionPatch = null
     preparedSourceAvailable = false
     preparedStageAvailability = null
+    clearRimLayerMetadata()
     clearRetainedMetadata()
   }
 
@@ -1258,12 +1272,20 @@ internal class RuntimeShaderGlassDelegate(
   ): Unit? {
     val rimEffect = effects.rim ?: return Unit
     val layer = layers.rim?.takeUnless { it.isReleased } ?: return null
+    val key = params.rimEffectKey()
     layer.alpha = 1f
     layer.renderEffect = rimEffect.asComposeRenderEffect()
-    layer.record(params.coordinates.sampleSize.roundToIntSize()) {
-      drawRect(Color.Black)
+    if (
+      layer !== recordedRimLayer ||
+      key != recordedRimKey
+    ) {
+      layer.record(params.coordinates.sampleSize.roundToIntSize()) {
+        drawRect(Color.Black)
+      }
+      recordedRimLayer = layer
+      recordedRimKey = key
+      rimRecordCount++
     }
-    rimRecordCount++
     return Unit
   }
 

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -6,9 +6,11 @@ package dev.chrisbanes.haze.glass
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.RenderEffect
+import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.drawscope.scale
@@ -30,7 +32,9 @@ import dev.chrisbanes.haze.TrimMemoryLevel
 import dev.chrisbanes.haze.asComposeRenderEffect
 import dev.chrisbanes.haze.createBlendRenderEffect
 import dev.chrisbanes.haze.createMutableRuntimeShaderRenderEffect
+import dev.chrisbanes.haze.createOffsetRenderEffect
 import dev.chrisbanes.haze.createRuntimeEffect
+import dev.chrisbanes.haze.createShaderRenderEffect
 import dev.chrisbanes.haze.trace
 
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
@@ -135,6 +139,7 @@ internal class RuntimeShaderGlassDelegate(
   private var preparedSourceAvailable: Boolean = false
   private var preparedStageAvailability: GlassStageAvailability? = null
   private var retainedOutputAvailable: Boolean = false
+  private var backdropOutputAvailable: Boolean = false
   internal var lastSuccessfulSourceSnapshot: GlassRuntimeSourceSnapshot? = null
     private set
   internal var lastSuccessfulStageInputs: GlassStageInputs? = null
@@ -170,6 +175,7 @@ internal class RuntimeShaderGlassDelegate(
     )
 
   override fun DrawScope.prepareDraw(context: HazeEffectRuntimeDrawScope) {
+    backdropOutputAvailable = false
     val currentPreparedRender = effect.preparedRender
     if (
       effect.preparedRenderBudget !is GlassRenderBudgetDecision.Runtime ||
@@ -300,6 +306,76 @@ internal class RuntimeShaderGlassDelegate(
     preparedRenderEffects = currentRenderEffects
     preparedInteractionUniforms = interactionUniforms
     preparedInteractionPatch = interactionPatch
+  }
+
+  internal fun DrawScope.prepareBackdrop(
+    context: HazeEffectRuntimeDrawScope,
+  ): PlatformRenderEffect? {
+    val currentPreparedRender = effect.preparedRender
+    if (
+      !supportsFusedGlassRenderEffect ||
+      effect.preparedRenderBudget !is GlassRenderBudgetDecision.Runtime ||
+      currentPreparedRender == null
+    ) {
+      releaseRetainedResources()
+      return null
+    }
+    val params = currentPreparedRender.params
+    val interactionUniforms = currentPreparedRender.interactionUniforms
+    val currentRenderEffects = trace(GlassTraceSection.PrepareEffects) {
+      getFusedRenderEffects(currentPreparedRender, backdrop = true)
+    }
+    val interactionPatch = if (currentPreparedRender.interactionTopology.hasLighting) {
+      resolveGlassInteractionPatch(
+        params = params,
+        uniforms = interactionUniforms,
+        topology = currentPreparedRender.interactionTopology,
+      )
+    } else {
+      null
+    }
+
+    val currentGraphicsContext = context.requireGraphicsContext()
+    val scaledSize = params.coordinates.sampleSize.roundToIntSize()
+    graphicsContext = currentGraphicsContext
+    if (layers.scaledSize != scaledSize) {
+      layers.release(currentGraphicsContext)
+      layers.scaledSize = scaledSize
+      clearInteractionLayerMetadata()
+      clearRetainedMetadata()
+    }
+    layers.prepareBackdrop(
+      rim = currentRenderEffects.rim != null,
+      interactionLighting = currentPreparedRender.interactionTopology.hasLighting,
+      graphicsContext = currentGraphicsContext,
+    )
+    clearRetainedMetadata()
+    prepareInteractionRenderEffects(
+      render = currentPreparedRender,
+      effects = currentRenderEffects,
+      patch = interactionPatch,
+      params = params,
+    )
+    preparedRender = currentPreparedRender
+    preparedParams = params
+    preparedRenderEffects = currentRenderEffects
+    preparedInteractionUniforms = interactionUniforms
+    preparedInteractionPatch = interactionPatch
+
+    if (recordRimIfNeeded(params, currentRenderEffects) == null) return null
+    if (currentPreparedRender.interactionTopology.hasLighting) {
+      val patch = interactionPatch ?: return null
+      recordInteractionLighting(
+        key = GlassInteractionLightingKey(
+          coordinates = patch.coordinates,
+          edgeSoftnessPx = params.edgeSoftnessPx,
+          cornerRadii = params.cornerRadii,
+        ),
+        patch = patch,
+      ) ?: return null
+    }
+    backdropOutputAvailable = true
+    return currentRenderEffects.optical
   }
 
   private fun prepareInteractionRenderEffects(
@@ -767,7 +843,7 @@ internal class RuntimeShaderGlassDelegate(
       val render = preparedRender ?: return
       val params = preparedParams ?: return
       requireDrawableMaterialSize(params.coordinates.materialSize, ::clearRetainedOutput) ?: return
-      if (!retainedOutputAvailable) return
+      if (!retainedOutputAvailable && !backdropOutputAvailable) return
       // Rim and interaction lighting must draw above this node's content. With group alpha, their
       // independent alpha is an approximation of full-group composition and can slightly
       // double-lighten where they overlap the glass.
@@ -822,6 +898,7 @@ internal class RuntimeShaderGlassDelegate(
 
   private fun clearRetainedMetadata() {
     retainedOutputAvailable = false
+    backdropOutputAvailable = false
     lastSuccessfulSourceSnapshot = null
     lastSuccessfulStageInputs = null
   }
@@ -1655,14 +1732,21 @@ internal class RuntimeShaderGlassDelegate(
     )
   }
 
-  private fun getFusedRenderEffects(render: GlassPreparedRender): GlassRenderEffects {
+  private fun getFusedRenderEffects(
+    render: GlassPreparedRender,
+    backdrop: Boolean = false,
+  ): GlassRenderEffects {
     updateRimEffect(render.rimKey)
+    val backdropBackground = render.params.backgroundColor.takeIf {
+      backdrop && it.alpha > 0f
+    }
     val nextFusedEffectKey = GlassFusedEffectKey(
       blur = render.blurKey,
       depth = render.params.depth,
       optical = render.opticalKey,
       detail = render.refractionDetailKey,
       interaction = render.interactionUniforms.takeIf { render.interactionTopology.hasOptics },
+      backdropBackground = backdropBackground,
     )
     if (nextFusedEffectKey != fusedEffectKey || fusedEffect == null) {
       fusedEffect = nextFusedEffectKey.let { key ->
@@ -1671,6 +1755,7 @@ internal class RuntimeShaderGlassDelegate(
           depth = key.depth,
           interactionOptics = render.interactionTopology.hasOptics,
           sharpDetail = key.detail != null,
+          backdropBackground = key.backdropBackground,
         )
         val previousInputKey = fusedInputKey
         val inputChanged = previousInputKey != nextInputKey
@@ -1678,10 +1763,17 @@ internal class RuntimeShaderGlassDelegate(
           previousInputKey.interactionOptics != nextInputKey.interactionOptics ||
           previousInputKey.sharpDetail != nextInputKey.sharpDetail
         val nextInput = if (inputChanged) {
+          val backdropInput = key.backdropBackground?.let { color ->
+            createGlassBackdropInputRenderEffect(
+              backgroundColor = color,
+              sampleSize = key.optical.coordinates.sampleSize,
+            )
+          }
           updateFusedDepthInputRenderEffect(
             blur = key.blur,
             depth = key.depth,
             sampleSize = key.optical.coordinates.sampleSize,
+            input = backdropInput,
           )
         } else {
           null
@@ -1762,9 +1854,10 @@ internal class RuntimeShaderGlassDelegate(
     blur: GlassBlurEffectKey?,
     depth: Float,
     sampleSize: Size,
+    input: PlatformRenderEffect?,
   ): PlatformRenderEffect? {
-    if (depth <= 0.0001f) return null
-    val plan = blur?.plan?.takeUnless { it.isIdentity } ?: return null
+    if (depth <= 0.0001f) return input
+    val plan = blur?.plan?.takeUnless { it.isIdentity } ?: return input
     val offsetScale = 1f / plan.scaleFactor
     val horizontalKernel = plan.horizontalKernel.copy(
       taps = plan.horizontalKernel.taps.map { tap ->
@@ -1811,7 +1904,7 @@ internal class RuntimeShaderGlassDelegate(
     val prefilter = if (plan.requiresPrefilter) {
       // The retained path gets additional low-pass energy from rasterizing at half resolution
       // and scaling back up. Reproduce that response inside the one-layer graph.
-      var result: PlatformRenderEffect? = null
+      var result: PlatformRenderEffect? = input
       shaders.prefilters.forEachIndexed { index, shader ->
         result = shader.updateInputs(inputs = arrayOf(result)) {
           setFloatUniform("sampleSize", sampleSize.width, sampleSize.height)
@@ -1827,7 +1920,7 @@ internal class RuntimeShaderGlassDelegate(
       }
       result
     } else {
-      null
+      input
     }
     val progressiveMask = blur.progressive?.toShader(blur.maskSize)
     val horizontal = shaders.horizontal.updateInputs(inputs = arrayOf(prefilter)) {
@@ -1838,7 +1931,27 @@ internal class RuntimeShaderGlassDelegate(
       setGlassBlurUniforms(blur, verticalKernel, sampleSize.width, sampleSize.height)
       progressiveMask?.let { setChildShader("mask", it) }
     }
-    return createGlassDepthInputRenderEffect(vertical, depth)
+    return createGlassDepthInputRenderEffect(
+      sharp = input,
+      blur = vertical,
+      depth = depth,
+    )
+  }
+
+  private fun createGlassBackdropInputRenderEffect(
+    backgroundColor: Color,
+    sampleSize: Size,
+  ): PlatformRenderEffect {
+    val backgroundBrush = Brush.linearGradient(listOf(backgroundColor, backgroundColor))
+    val backgroundShader = (backgroundBrush as ShaderBrush).createShader(sampleSize)
+    val background = createShaderRenderEffect(
+      backgroundShader,
+    )
+    return createBlendRenderEffect(
+      blendMode = BlendMode.SrcOver,
+      background = background,
+      foreground = createOffsetRenderEffect(0f, 0f),
+    )
   }
 
   private fun updateBlurRenderEffects(key: GlassBlurEffectKey): GlassBlurRenderEffects? {
@@ -1968,6 +2081,7 @@ private class GlassFusedEffectKey(
   val optical: GlassOpticalEffectKey,
   val detail: GlassRefractionDetailEffectKey?,
   val interaction: GlassInteractionUniforms?,
+  val backdropBackground: Color?,
 )
 
 @Poko
@@ -1976,6 +2090,7 @@ private class GlassDepthInputKey(
   val depth: Float,
   val interactionOptics: Boolean = false,
   val sharpDetail: Boolean = false,
+  val backdropBackground: Color? = null,
 )
 
 private class FusedDepthInputShaders(
@@ -2007,6 +2122,7 @@ internal data class GlassBlurRenderEffects(
 )
 
 internal expect fun createGlassDepthInputRenderEffect(
+  sharp: PlatformRenderEffect?,
   blur: PlatformRenderEffect?,
   depth: Float,
 ): PlatformRenderEffect?

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropRenderEffectTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassBackdropRenderEffectTest.kt
@@ -1,0 +1,18 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.glass
+
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import dev.chrisbanes.haze.HazeEffectRendererBackdrop
+import kotlin.test.Test
+
+class GlassBackdropRenderEffectTest {
+
+  @Test
+  fun glassRenderer_exposesBuiltInBackdropCapability() {
+    assertThat(GlassHazeEffectFactory.createRenderer())
+      .isInstanceOf<HazeEffectRendererBackdrop<*>>()
+  }
+}

--- a/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudgetTest.kt
+++ b/haze-glass/src/commonTest/kotlin/dev/chrisbanes/haze/glass/GlassRenderBudgetTest.kt
@@ -18,6 +18,37 @@ import kotlin.test.Test
 class GlassRenderBudgetTest {
 
   @Test
+  fun backdropWithoutForegroundLayers_hasAValidZeroRetentionPlan() {
+    val plan = buildGlassBackdropLayerPlan(
+      sampleSize = IntSize(5000, 5000),
+      rimActive = false,
+      interactionPatchSize = IntSize.Zero,
+      interactionLightingActive = false,
+    )
+
+    assertThat(plan.layers).isEqualTo(emptyList())
+    assertThat(plan.fitsGlassRenderBudget()).isTrue()
+  }
+
+  @Test
+  fun backdropPlan_countsOnlyLocalForegroundLayers() {
+    val sampleSize = IntSize(1000, 600)
+    val patchSize = IntSize(240, 240)
+
+    val plan = buildGlassBackdropLayerPlan(
+      sampleSize = sampleSize,
+      rimActive = true,
+      interactionPatchSize = patchSize,
+      interactionLightingActive = true,
+    )
+
+    assertThat(plan.layers).containsExactly(
+      GlassRetainedLayer(GlassRetainedLayerKind.Rim, sampleSize),
+      GlassRetainedLayer(GlassRetainedLayerKind.InteractionLighting, patchSize),
+    )
+  }
+
+  @Test
   fun configuredInteractionBudget_usesLocalPatchSize() {
     val patchSize = IntSize(240, 240)
     val plan = buildGlassBudgetLayerPlan(

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateTrimMemoryTest.kt
@@ -631,6 +631,51 @@ class RuntimeShaderGlassDelegateTrimMemoryTest {
   }
 
   @Test
+  fun prepareBackdrop_releasesSourceAndOutputLayers() {
+    val layers = GlassLayers()
+    val graphicsContext = TestGraphicsContext()
+    layers.populate(graphicsContext)
+
+    layers.prepareBackdrop(
+      rim = true,
+      interactionLighting = true,
+      graphicsContext = graphicsContext,
+    )
+
+    assertThat(layers.hasSource).isFalse()
+    assertThat(layers.hasBlurPrefiltered).isFalse()
+    assertThat(layers.hasBlurHorizontal).isFalse()
+    assertThat(layers.hasBlurred).isFalse()
+    assertThat(layers.hasDepthMixed).isFalse()
+    assertThat(layers.hasOptical).isFalse()
+    assertThat(layers.hasRefractionDetail).isFalse()
+    assertThat(layers.hasRefractionDetailCoverage).isFalse()
+    assertThat(layers.hasRefractionComposite).isFalse()
+    assertThat(layers.hasInteractionOptical).isFalse()
+    assertThat(layers.hasInteractionRefractionDetail).isFalse()
+    assertThat(layers.hasInteractionRefractionDetailCoverage).isFalse()
+    assertThat(layers.hasInteractionRefractionComposite).isFalse()
+    assertThat(layers.groupAlpha.isAvailable).isFalse()
+    assertThat(layers.hasInteractionLighting).isTrue()
+    assertThat(layers.hasRim).isTrue()
+  }
+
+  @Test
+  fun prepareBackdrop_withoutForegroundEffects_releasesEveryLayer() {
+    val layers = GlassLayers()
+    val graphicsContext = TestGraphicsContext()
+    layers.populate(graphicsContext)
+
+    layers.prepareBackdrop(
+      rim = false,
+      interactionLighting = false,
+      graphicsContext = graphicsContext,
+    )
+
+    assertThat(layers.isEmpty).isTrue()
+  }
+
+  @Test
   fun prepareDraw_invalidSizeReleasesResourcesBeforeGeometryCalibration() {
     listOf(
       RecordingVisualEffectContext(size = Size(0f, 100f), layerSize = Size(100f, 100f)),

--- a/haze-glass/src/skikoMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectFactory.skiko.kt
+++ b/haze-glass/src/skikoMain/kotlin/dev/chrisbanes/haze/glass/GlassRenderEffectFactory.skiko.kt
@@ -9,6 +9,7 @@ import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.PlatformRenderEffect
 
 internal actual fun createGlassDepthInputRenderEffect(
+  sharp: PlatformRenderEffect?,
   blur: PlatformRenderEffect?,
   depth: Float,
 ): PlatformRenderEffect? = null

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -5,12 +5,13 @@ package dev.chrisbanes.haze {
   }
 
   @dev.chrisbanes.haze.InternalHazeApi public final class HazeEffectBackdrop {
-    ctor public HazeEffectBackdrop(PlatformRenderEffect effect, optional float alpha, optional dev.chrisbanes.haze.HazeEffectContentTransform materialTransform);
+    ctor public HazeEffectBackdrop(PlatformRenderEffect platformEffect, optional float alpha, optional dev.chrisbanes.haze.HazeEffectContentTransform materialTransform);
     method @InaccessibleFromKotlin public float getAlpha();
     method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeEffectContentTransform getMaterialTransform();
-    method public PlatformRenderEffect platformEffect();
+    method @InaccessibleFromKotlin public PlatformRenderEffect getPlatformEffect();
     property public float alpha;
     property public dev.chrisbanes.haze.HazeEffectContentTransform materialTransform;
+    property public PlatformRenderEffect platformEffect;
   }
 
   @dev.chrisbanes.haze.InternalHazeApi public final class HazeEffectContentTransform {

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -137,17 +137,12 @@ package dev.chrisbanes.haze {
   }
 
   @androidx.compose.runtime.Stable public static final class HazeInput.Backdrop implements dev.chrisbanes.haze.HazeInput {
-    ctor public HazeInput.Backdrop(dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeSourceSelection fallbackSelection, optional dev.chrisbanes.haze.HazeSourceRetention fallbackRetention);
-    method public dev.chrisbanes.haze.HazeState component1();
-    method public dev.chrisbanes.haze.HazeSourceSelection component2();
-    method public dev.chrisbanes.haze.HazeSourceRetention component3();
-    method public dev.chrisbanes.haze.HazeInput.Backdrop copy(optional dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeSourceSelection fallbackSelection, optional dev.chrisbanes.haze.HazeSourceRetention fallbackRetention);
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeSourceRetention getFallbackRetention();
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeSourceSelection getFallbackSelection();
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeState getState();
-    property public dev.chrisbanes.haze.HazeSourceRetention fallbackRetention;
-    property public dev.chrisbanes.haze.HazeSourceSelection fallbackSelection;
-    property public dev.chrisbanes.haze.HazeState state;
+    ctor public HazeInput.Backdrop(dev.chrisbanes.haze.HazeInput.Sources fallback);
+    ctor public HazeInput.Backdrop(dev.chrisbanes.haze.HazeState state);
+    method public dev.chrisbanes.haze.HazeInput.Sources component1();
+    method public dev.chrisbanes.haze.HazeInput.Backdrop copy(optional dev.chrisbanes.haze.HazeInput.Sources fallback);
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeInput.Sources getFallback();
+    property public dev.chrisbanes.haze.HazeInput.Sources fallback;
   }
 
   public static final class HazeInput.Content implements dev.chrisbanes.haze.HazeInput {

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -4,6 +4,15 @@ package dev.chrisbanes.haze {
   @kotlin.RequiresOptIn(message="Experimental Haze API", level=kotlin.RequiresOptIn.Level.WARNING) public @interface ExperimentalHazeApi {
   }
 
+  @dev.chrisbanes.haze.InternalHazeApi public final class HazeEffectBackdrop {
+    ctor public HazeEffectBackdrop(PlatformRenderEffect effect, optional float alpha, optional dev.chrisbanes.haze.HazeEffectContentTransform materialTransform);
+    method @InaccessibleFromKotlin public float getAlpha();
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeEffectContentTransform getMaterialTransform();
+    method public PlatformRenderEffect platformEffect();
+    property public float alpha;
+    property public dev.chrisbanes.haze.HazeEffectContentTransform materialTransform;
+  }
+
   @dev.chrisbanes.haze.InternalHazeApi public final class HazeEffectContentTransform {
     ctor @KotlinOnly public HazeEffectContentTransform(float scaleX, float scaleY, androidx.compose.ui.geometry.Offset pivot);
     method @InaccessibleFromKotlin public float getScaleX();
@@ -68,6 +77,10 @@ package dev.chrisbanes.haze {
     method public default void onTrimMemory(dev.chrisbanes.haze.TrimMemoryLevel level);
   }
 
+  @dev.chrisbanes.haze.InternalHazeApi public interface HazeEffectRendererBackdrop<Style> {
+    method public dev.chrisbanes.haze.HazeEffectBackdrop? backdropEffect(dev.chrisbanes.haze.HazeEffectRuntimeDrawScope, Style style);
+  }
+
   @dev.chrisbanes.haze.InternalHazeApi public interface HazeEffectRendererDrawHooks<Style> {
     method public default void drawForeground(dev.chrisbanes.haze.HazeEffectRuntimeDrawScope, Style style);
     method public default void prepareDraw(dev.chrisbanes.haze.HazeEffectRuntimeDrawScope, Style style);
@@ -115,6 +128,14 @@ package dev.chrisbanes.haze {
   }
 
   public sealed exhaustive interface HazeInput {
+  }
+
+  @androidx.compose.runtime.Stable @dev.chrisbanes.haze.ExperimentalHazeApi public static final class HazeInput.Backdrop implements dev.chrisbanes.haze.HazeInput {
+    ctor public HazeInput.Backdrop(dev.chrisbanes.haze.HazeInput.Sources fallback);
+    method public dev.chrisbanes.haze.HazeInput.Sources component1();
+    method public dev.chrisbanes.haze.HazeInput.Backdrop copy(optional dev.chrisbanes.haze.HazeInput.Sources fallback);
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeInput.Sources getFallback();
+    property public dev.chrisbanes.haze.HazeInput.Sources fallback;
   }
 
   public static final class HazeInput.Content implements dev.chrisbanes.haze.HazeInput {

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -5,13 +5,12 @@ package dev.chrisbanes.haze {
   }
 
   @dev.chrisbanes.haze.InternalHazeApi public final class HazeEffectBackdrop {
-    ctor public HazeEffectBackdrop(PlatformRenderEffect platformEffect, optional float alpha, optional dev.chrisbanes.haze.HazeEffectContentTransform materialTransform);
+    ctor public HazeEffectBackdrop(PlatformRenderEffect effect, optional float alpha, optional dev.chrisbanes.haze.HazeEffectContentTransform materialTransform);
     method @InaccessibleFromKotlin public float getAlpha();
     method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeEffectContentTransform getMaterialTransform();
-    method @InaccessibleFromKotlin public PlatformRenderEffect getPlatformEffect();
+    method public PlatformRenderEffect platformEffect();
     property public float alpha;
     property public dev.chrisbanes.haze.HazeEffectContentTransform materialTransform;
-    property public PlatformRenderEffect platformEffect;
   }
 
   @dev.chrisbanes.haze.InternalHazeApi public final class HazeEffectContentTransform {
@@ -128,15 +127,27 @@ package dev.chrisbanes.haze {
     property public abstract androidx.compose.ui.geometry.Size modifierSize;
   }
 
+  @dev.chrisbanes.haze.ExperimentalHazeApi public final class HazeFeatureFlags {
+    property public boolean isPlatformBackdropEnabled;
+    field public static final dev.chrisbanes.haze.HazeFeatureFlags INSTANCE;
+    field public static boolean isPlatformBackdropEnabled;
+  }
+
   public sealed exhaustive interface HazeInput {
   }
 
-  @androidx.compose.runtime.Stable @dev.chrisbanes.haze.ExperimentalHazeApi public static final class HazeInput.Backdrop implements dev.chrisbanes.haze.HazeInput {
-    ctor public HazeInput.Backdrop(dev.chrisbanes.haze.HazeInput.Sources fallback);
-    method public dev.chrisbanes.haze.HazeInput.Sources component1();
-    method public dev.chrisbanes.haze.HazeInput.Backdrop copy(optional dev.chrisbanes.haze.HazeInput.Sources fallback);
-    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeInput.Sources getFallback();
-    property public dev.chrisbanes.haze.HazeInput.Sources fallback;
+  @androidx.compose.runtime.Stable public static final class HazeInput.Backdrop implements dev.chrisbanes.haze.HazeInput {
+    ctor public HazeInput.Backdrop(dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeSourceSelection fallbackSelection, optional dev.chrisbanes.haze.HazeSourceRetention fallbackRetention);
+    method public dev.chrisbanes.haze.HazeState component1();
+    method public dev.chrisbanes.haze.HazeSourceSelection component2();
+    method public dev.chrisbanes.haze.HazeSourceRetention component3();
+    method public dev.chrisbanes.haze.HazeInput.Backdrop copy(optional dev.chrisbanes.haze.HazeState state, optional dev.chrisbanes.haze.HazeSourceSelection fallbackSelection, optional dev.chrisbanes.haze.HazeSourceRetention fallbackRetention);
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeSourceRetention getFallbackRetention();
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeSourceSelection getFallbackSelection();
+    method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeState getState();
+    property public dev.chrisbanes.haze.HazeSourceRetention fallbackRetention;
+    property public dev.chrisbanes.haze.HazeSourceSelection fallbackSelection;
+    property public dev.chrisbanes.haze.HazeState state;
   }
 
   public static final class HazeInput.Content implements dev.chrisbanes.haze.HazeInput {
@@ -325,3 +336,4 @@ package dev.chrisbanes.haze {
   }
 
 }
+

--- a/haze/api/api.txt
+++ b/haze/api/api.txt
@@ -5,10 +5,10 @@ package dev.chrisbanes.haze {
   }
 
   @dev.chrisbanes.haze.InternalHazeApi public final class HazeEffectBackdrop {
-    ctor public HazeEffectBackdrop(PlatformRenderEffect effect, optional float alpha, optional dev.chrisbanes.haze.HazeEffectContentTransform materialTransform);
+    ctor public HazeEffectBackdrop(PlatformRenderEffect platformEffect, optional float alpha, optional dev.chrisbanes.haze.HazeEffectContentTransform materialTransform);
     method @InaccessibleFromKotlin public float getAlpha();
     method @InaccessibleFromKotlin public dev.chrisbanes.haze.HazeEffectContentTransform getMaterialTransform();
-    method public PlatformRenderEffect platformEffect();
+    method public PlatformRenderEffect getPlatformEffect();
     property public float alpha;
     property public dev.chrisbanes.haze.HazeEffectContentTransform materialTransform;
   }
@@ -336,4 +336,3 @@ package dev.chrisbanes.haze {
   }
 
 }
-

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -89,6 +89,7 @@ kotlin {
         implementation(libs.androidx.compose.ui.test.manifest)
         implementation(libs.androidx.test.core)
         implementation(libs.androidx.test.runner)
+        implementation(libs.compose.foundation)
       }
     }
 

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -71,6 +71,16 @@ kotlin {
       }
     }
 
+    named("androidDeviceTest") {
+      dependencies {
+        implementation(libs.androidx.activity.compose)
+        implementation(libs.assertk)
+        implementation(libs.androidx.compose.ui.test.manifest)
+        implementation(libs.androidx.test.core)
+        implementation(libs.androidx.test.runner)
+      }
+    }
+
     jvmTest {
       dependencies {
         implementation(compose.desktop.currentOs)

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -14,6 +14,17 @@ plugins {
   id("dev.drewhamilton.poko")
 }
 
+// Metalava writes an extra blank line at EOF for this module's API signature. Keep the checked-in
+// signature stable so regeneration does not create a whitespace-only diff.
+tasks.named("metalavaGenerateSignature").configure {
+  val apiFile = File(project.projectDir, "api/api.txt")
+  doLast {
+    val contents = apiFile.readText()
+    val normalized = contents.trimEnd() + "\n"
+    if (contents != normalized) apiFile.writeText(normalized)
+  }
+}
+
 kotlin {
   android {
     namespace = "dev.chrisbanes.haze"

--- a/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
+++ b/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
@@ -55,16 +55,23 @@ class AndroidBackdropRendererInstrumentationTest {
 
   private lateinit var activityScenario: ActivityScenario<ComponentActivity>
   private lateinit var activity: ComponentActivity
+  private var previousPlatformBackdropEnabled = false
 
   @Before
   fun setUp() {
+    previousPlatformBackdropEnabled = HazeFeatureFlags.isPlatformBackdropEnabled
+    HazeFeatureFlags.isPlatformBackdropEnabled = true
     activityScenario = ActivityScenario.launch(ComponentActivity::class.java)
     activityScenario.onActivity { activity = it }
   }
 
   @After
   fun tearDown() {
-    activityScenario.close()
+    try {
+      activityScenario.close()
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previousPlatformBackdropEnabled
+    }
   }
 
   @Test
@@ -383,7 +390,7 @@ class AndroidBackdropRendererInstrumentationTest {
               .size(width = 200.dp, height = 100.dp)
               .hazeEffect(
                 factory = BackdropBlurEffectFactory(drawReady),
-                input = HazeInput.Backdrop(HazeInput.Sources(state)),
+                input = HazeInput.Backdrop(state),
                 style = 14.dp,
               ),
           )

--- a/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
+++ b/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
@@ -327,12 +327,9 @@ class AndroidBackdropRendererInstrumentationTest {
 
       root.addView(source, centered)
       root.addView(backdrop, FrameLayout.LayoutParams(centered))
-      View::class.java
-        .getMethod("setBackdropRenderEffect", RenderEffect::class.java)
-        .invoke(
-          backdrop,
-          RenderEffect.createBlurEffect(radius, radius, Shader.TileMode.CLAMP),
-        )
+      backdrop.setBackdropRenderEffect(
+        RenderEffect.createBlurEffect(radius, radius, Shader.TileMode.CLAMP),
+      )
       activity.setContentView(root)
       backdropView = backdrop
     }
@@ -436,9 +433,7 @@ class AndroidBackdropRendererInstrumentationTest {
 
     fun fullSdkInt(): Int {
       if (Build.VERSION.SDK_INT < 36) return Build.VERSION.SDK_INT * 100_000
-      return runCatching {
-        Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
-      }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
+      return Build.VERSION.SDK_INT_FULL
     }
   }
 }

--- a/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
+++ b/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
@@ -467,7 +467,7 @@ private class PrototypeBackdropNode(
   clip: PrototypeClip?,
   drawReady: CountDownLatch,
 ) : Modifier.Node(), DrawModifierNode {
-  private val renderer = createHazeBackdropRenderer()
+  private val renderer = checkNotNull(createHazeBackdropRenderer())
   var radius = radius
   var clip = clip
   var drawReady = drawReady

--- a/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
+++ b/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
@@ -5,12 +5,20 @@
 
 package dev.chrisbanes.haze
 
+import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Canvas as AndroidCanvas
 import android.graphics.Color as AndroidColor
+import android.graphics.Paint
+import android.graphics.RenderEffect
+import android.graphics.Shader
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.view.Gravity
 import android.view.PixelCopy
+import android.view.View
+import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
@@ -249,6 +257,103 @@ class AndroidBackdropRendererInstrumentationTest {
     assertThat(clippedLeak.red, "caller clipping prevents expanded leakage").isLessThan(0.05f)
   }
 
+  @Test
+  fun renderNodeBackdropEffect_blursEarlierSibling() {
+    assumeTrue(
+      "Backdrop RenderNode requires Android 37.2 or the matching preview",
+      isHazeBackdropSdkSupported(fullSdkInt(), Build.VERSION.PREVIEW_SDK_INT),
+    )
+
+    val drawReady = CountDownLatch(1)
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .background(Color.Black),
+          )
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = 50.dp)
+              .size(width = 100.dp, height = 100.dp)
+              .background(Color.White),
+          )
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .prototypeBackdrop(
+                radius = 14.dp,
+                clip = PrototypeClip.Content,
+                drawReady = drawReady,
+              ),
+          )
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Backdrop node presented its first draw").isTrue()
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    val bitmap = activity.copyWindow()
+    val density = Density(activity.resources.displayMetrics.density)
+    val centerX = bitmap.width / 2
+    val centerY = bitmap.height / 2
+    bitmap.assertVerticalEdgeSoftened(centerX, centerY, density, "direct RenderNode backdrop")
+  }
+
+  @Test
+  fun viewBackdropEffect_blursEarlierSibling() {
+    assumeTrue(
+      "View backdrop effect requires Android 37.2 or the matching preview",
+      isHazeBackdropSdkSupported(fullSdkInt(), Build.VERSION.PREVIEW_SDK_INT),
+    )
+
+    val drawReady = CountDownLatch(1)
+    lateinit var backdropView: View
+    activityScenario.onActivity { activity ->
+      val density = Density(activity.resources.displayMetrics.density)
+      val width = 200.dp.roundToPx(density)
+      val height = 100.dp.roundToPx(density)
+      val radius = 14.dp.roundToPx(density).toFloat()
+      val centered = FrameLayout.LayoutParams(width, height, Gravity.CENTER)
+      val root = FrameLayout(activity).apply {
+        setBackgroundColor(AndroidColor.WHITE)
+      }
+      val source = BackdropSourceView(activity)
+      val backdrop = BackdropProbeView(activity, drawReady)
+
+      root.addView(source, centered)
+      root.addView(backdrop, FrameLayout.LayoutParams(centered))
+      View::class.java
+        .getMethod("setBackdropRenderEffect", RenderEffect::class.java)
+        .invoke(
+          backdrop,
+          RenderEffect.createBlurEffect(radius, radius, Shader.TileMode.CLAMP),
+        )
+      activity.setContentView(root)
+      backdropView = backdrop
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Backdrop View presented its first draw").isTrue()
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    val location = IntArray(2)
+    var backdropWidth = 0
+    var backdropHeight = 0
+    activityScenario.onActivity {
+      backdropView.getLocationInWindow(location)
+      backdropWidth = backdropView.width
+      backdropHeight = backdropView.height
+    }
+    val bitmap = activity.copyWindow()
+    val density = Density(activity.resources.displayMetrics.density)
+    val centerX = location[0] + backdropWidth / 2
+    val centerY = location[1] + backdropHeight / 2
+    bitmap.assertVerticalEdgeSoftened(centerX, centerY, density, "public View backdrop")
+  }
+
   private fun ComponentActivity.copyWindow(): Bitmap {
     val targetWindow = this.window
     val bitmap = Bitmap.createBitmap(
@@ -265,16 +370,6 @@ class AndroidBackdropRendererInstrumentationTest {
     assertThat(latch.await(5, TimeUnit.SECONDS), "Window PixelCopy completed").isTrue()
     assertThat(result, "Window PixelCopy result").isEqualTo(PixelCopy.SUCCESS)
     return bitmap
-  }
-
-  private fun Bitmap.pixel(x: Int, y: Int): Color {
-    val pixel = getPixel(x.coerceIn(0, width - 1), y.coerceIn(0, height - 1))
-    return Color(
-      red = AndroidColor.red(pixel) / 255f,
-      green = AndroidColor.green(pixel) / 255f,
-      blue = AndroidColor.blue(pixel) / 255f,
-      alpha = AndroidColor.alpha(pixel) / 255f,
-    )
   }
 
   private companion object {
@@ -363,3 +458,56 @@ private class PrototypeBackdropNode(
 
 private fun androidx.compose.ui.unit.Dp.roundToPx(density: Density): Int =
   kotlin.math.round(value * density.density).toInt()
+
+private fun Bitmap.pixel(x: Int, y: Int): Color {
+  val pixel = getPixel(x.coerceIn(0, width - 1), y.coerceIn(0, height - 1))
+  return Color(
+    red = AndroidColor.red(pixel) / 255f,
+    green = AndroidColor.green(pixel) / 255f,
+    blue = AndroidColor.blue(pixel) / 255f,
+    alpha = AndroidColor.alpha(pixel) / 255f,
+  )
+}
+
+private fun Bitmap.assertVerticalEdgeSoftened(
+  centerX: Int,
+  centerY: Int,
+  density: Density,
+  rendererName: String,
+) {
+  val blackInterior = pixel(centerX - 60.dp.roundToPx(density), centerY)
+  val blackNearEdge = pixel(centerX - 3.dp.roundToPx(density), centerY)
+  val whiteNearEdge = pixel(centerX + 3.dp.roundToPx(density), centerY)
+  val whiteInterior = pixel(centerX + 60.dp.roundToPx(density), centerY)
+
+  assertThat(
+    blackNearEdge.red - blackInterior.red,
+    "$rendererName softens the black side of the earlier edge",
+  ).isGreaterThan(0.05f)
+  assertThat(
+    whiteInterior.red - whiteNearEdge.red,
+    "$rendererName softens the white side of the earlier edge",
+  ).isGreaterThan(0.05f)
+}
+
+private class BackdropSourceView(context: Context) : View(context) {
+  private val paint = Paint()
+
+  override fun onDraw(canvas: AndroidCanvas) {
+    val edge = width / 2f
+    paint.color = AndroidColor.BLACK
+    canvas.drawRect(0f, 0f, edge, height.toFloat(), paint)
+    paint.color = AndroidColor.WHITE
+    canvas.drawRect(edge, 0f, width.toFloat(), height.toFloat(), paint)
+  }
+}
+
+private class BackdropProbeView(
+  context: Context,
+  private val drawReady: CountDownLatch,
+) : View(context) {
+  override fun onDraw(canvas: AndroidCanvas) {
+    canvas.drawColor(AndroidColor.argb(0x99, 0xF0, 0xF0, 0xF0))
+    drawReady.countDown()
+  }
+}

--- a/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
+++ b/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
@@ -1,0 +1,362 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(InternalHazeApi::class)
+
+package dev.chrisbanes.haze
+
+import android.graphics.Bitmap
+import android.graphics.Color as AndroidColor
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.PixelCopy
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.node.DrawModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import assertk.assertions.isTrue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+
+class AndroidBackdropRendererInstrumentationTest {
+
+  private lateinit var activityScenario: ActivityScenario<ComponentActivity>
+  private lateinit var activity: ComponentActivity
+
+  @Before
+  fun setUp() {
+    activityScenario = ActivityScenario.launch(ComponentActivity::class.java)
+    activityScenario.onActivity { activity = it }
+  }
+
+  @After
+  fun tearDown() {
+    activityScenario.close()
+  }
+
+  @Test
+  fun backdropRenderer_samplesOrderingTransformsExpandedBoundsAndClip() {
+    assumeTrue("Backdrop RenderNode requires Android 37.2", fullSdkInt() >= HAZE_BACKDROP_MIN_FULL_SDK)
+
+    val drawReady = CountDownLatch(PROTOTYPE_NODE_COUNT)
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          // The ordering row has a black source with a white edge already in the window when the
+          // backdrop node is drawn.
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = (-90).dp, y = (-80).dp)
+              .size(80.dp)
+              .background(Color.Black),
+          )
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = (-110).dp, y = (-80).dp)
+              .size(20.dp)
+              .background(Color.White),
+          )
+
+          // The transform row uses a source edge which only falls inside the node after its
+          // translation, scale, and rotation are inherited by the RenderNode.
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = 80.dp, y = (-80).dp)
+              .size(100.dp)
+              .background(Color.Black),
+          )
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = 110.dp, y = (-80).dp)
+              .size(10.dp)
+              .background(Color.White),
+          )
+
+          // The expanded row places a contrasting source edge just outside the content bounds.
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = (-90).dp, y = 80.dp)
+              .size(90.dp)
+              .background(Color.Black),
+          )
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = (-60).dp, y = 80.dp)
+              .size(10.dp)
+              .background(Color.White),
+          )
+
+          // The clipping row uses the same edge as the expanded row. The sample just beyond the
+          // content must remain black when the renderer applies its local clip.
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = 90.dp, y = 80.dp)
+              .size(90.dp)
+              .background(Color.Black),
+          )
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = 120.dp, y = 80.dp)
+              .size(10.dp)
+              .background(Color.White),
+          )
+
+          // The ordering node's own content is drawn after the backdrop and must remain sharp.
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = (-90).dp, y = (-80).dp)
+              .size(80.dp)
+              .prototypeBackdrop(radius = 14.dp, clip = null, drawReady = drawReady)
+              .background(Color.Transparent),
+          )
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = (-70).dp, y = (-80).dp)
+              .size(20.dp)
+              .background(Color.Red),
+          )
+
+          // This node's backdrop RenderNode inherits the full Compose transform.
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = 20.dp, y = (-80).dp)
+              .size(80.dp)
+              .graphicsLayer {
+                translationX = 60.dp.toPx()
+                scaleX = 0.9f
+                scaleY = 1.1f
+                rotationZ = 4f
+              }
+              .prototypeBackdrop(radius = 14.dp, clip = null, drawReady = drawReady)
+              .background(Color.Transparent),
+          )
+
+          // A caller clip must still stop expanded bounds from leaking into the surrounding area.
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = 90.dp, y = 80.dp)
+              .size(60.dp)
+              .prototypeBackdrop(
+                radius = 14.dp,
+                clip = PrototypeClip.Content,
+                drawReady = drawReady,
+              )
+              .background(Color.Transparent),
+          )
+
+          // Expanded bounds are enabled for the same edge but without a local clip.
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .offset(x = (-90).dp, y = 80.dp)
+              .size(60.dp)
+              .prototypeBackdrop(radius = 14.dp, clip = null, drawReady = drawReady)
+              .background(Color.Transparent),
+          )
+        }
+      }
+    }
+    assertThat(
+      drawReady.await(5, TimeUnit.SECONDS),
+      "All backdrop nodes presented their first draw",
+    ).isTrue()
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    val bitmap = activity.copyWindow()
+    val density = Density(activity.resources.displayMetrics.density)
+    val centerX = bitmap.width / 2
+    val centerY = bitmap.height / 2
+    val radiusPx = 14.dp.roundToPx(density)
+
+    // The black/white boundary is softened by the earlier backdrop content in the ordering row.
+    val boundary = bitmap.pixel(
+      centerX - 95.dp.roundToPx(density),
+      centerY - 80.dp.roundToPx(density),
+    )
+    assertThat(boundary.red, "earlier pixels are blurred").isGreaterThan(0.05f)
+    assertThat(boundary.red, "earlier pixels are blurred").isLessThan(0.95f)
+
+    // The later red sibling is composited after the node and remains a solid red pixel.
+    val later = bitmap.pixel(
+      centerX - 70.dp.roundToPx(density),
+      centerY - 80.dp.roundToPx(density),
+    )
+    assertThat(later.red, "later content remains sharp").isGreaterThan(0.9f)
+    assertThat(later.green, "later content remains sharp").isLessThan(0.1f)
+
+    // This sample is outside the untransformed node, but inside its translated, scaled, and
+    // rotated bounds. A renderer which ignores the Compose canvas transform leaves the white
+    // stripe edge sharp and fails this assertion.
+    val transformed = bitmap.pixel(
+      centerX + 122.dp.roundToPx(density),
+      centerY - 80.dp.roundToPx(density),
+    )
+    assertThat(transformed.red, "Compose transforms reach the backdrop node").isGreaterThan(0.05f)
+
+    // Sampling just outside the expanded row's content edge demonstrates that its bounds include
+    // the blur kernel.
+    val expanded = bitmap.pixel(
+      centerX - 48.dp.roundToPx(density),
+      centerY + 80.dp.roundToPx(density),
+    )
+    assertThat(expanded.red, "expanded bounds contain the kernel").isGreaterThan(0.05f)
+    assertThat(radiusPx, "prototype uses non-zero expansion").isGreaterThan(0)
+
+    val clippedLeak = bitmap.pixel(
+      centerX + 132.dp.roundToPx(density),
+      centerY + 80.dp.roundToPx(density),
+    )
+    assertThat(clippedLeak.red, "caller clipping prevents expanded leakage").isLessThan(0.05f)
+  }
+
+  private fun ComponentActivity.copyWindow(): Bitmap {
+    val targetWindow = this.window
+    val bitmap = Bitmap.createBitmap(
+      targetWindow.decorView.width,
+      targetWindow.decorView.height,
+      Bitmap.Config.ARGB_8888,
+    )
+    val latch = CountDownLatch(1)
+    var result = PixelCopy.ERROR_UNKNOWN
+    PixelCopy.request(targetWindow, bitmap, { copyResult ->
+      result = copyResult
+      latch.countDown()
+    }, Handler(Looper.getMainLooper()))
+    assertThat(latch.await(5, TimeUnit.SECONDS), "Window PixelCopy completed").isTrue()
+    assertThat(result, "Window PixelCopy result").isEqualTo(PixelCopy.SUCCESS)
+    return bitmap
+  }
+
+  private fun Bitmap.pixel(x: Int, y: Int): Color {
+    val pixel = getPixel(x.coerceIn(0, width - 1), y.coerceIn(0, height - 1))
+    return Color(
+      red = AndroidColor.red(pixel) / 255f,
+      green = AndroidColor.green(pixel) / 255f,
+      blue = AndroidColor.blue(pixel) / 255f,
+      alpha = AndroidColor.alpha(pixel) / 255f,
+    )
+  }
+
+  private companion object {
+    const val PROTOTYPE_NODE_COUNT = 4
+
+    fun fullSdkInt(): Int {
+      if (Build.VERSION.SDK_INT < 36) return Build.VERSION.SDK_INT * 100_000
+      return runCatching {
+        Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
+      }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
+    }
+  }
+}
+
+private fun Modifier.prototypeBackdrop(
+  radius: androidx.compose.ui.unit.Dp,
+  clip: PrototypeClip?,
+  drawReady: CountDownLatch,
+): Modifier = this then PrototypeBackdropElement(radius, clip, drawReady)
+
+private enum class PrototypeClip {
+  Content,
+}
+
+private data class PrototypeBackdropElement(
+  val radius: androidx.compose.ui.unit.Dp,
+  val clip: PrototypeClip?,
+  val drawReady: CountDownLatch,
+) : ModifierNodeElement<PrototypeBackdropNode>() {
+  override fun create(): PrototypeBackdropNode = PrototypeBackdropNode(radius, clip, drawReady)
+
+  override fun update(node: PrototypeBackdropNode) {
+    node.radius = radius
+    node.clip = clip
+    node.drawReady = drawReady
+  }
+}
+
+private class PrototypeBackdropNode(
+  radius: androidx.compose.ui.unit.Dp,
+  clip: PrototypeClip?,
+  drawReady: CountDownLatch,
+) : Modifier.Node(), DrawModifierNode {
+  private val renderer = createHazeBackdropRenderer()
+  var radius = radius
+  var clip = clip
+  var drawReady = drawReady
+
+  override fun ContentDrawScope.draw() {
+    assertThat(
+      drawContext.canvas.nativeCanvas.isHardwareAccelerated,
+      "Backdrop renderer requires a hardware canvas",
+    ).isTrue()
+    assertThat(renderer.isSupported(drawContext.canvas), "Backdrop renderer is unavailable").isTrue()
+    val radiusPx = radius.toPx()
+    val effect = createBlurRenderEffect(
+      radiusX = radiusPx,
+      radiusY = radiusPx,
+      tileMode = TileMode.Clamp,
+    ) ?: return drawContent()
+    check(
+      renderer.configure(
+        bounds = androidx.compose.ui.geometry.Rect(
+          left = -radiusPx,
+          top = -radiusPx,
+          right = size.width + radiusPx,
+          bottom = size.height + radiusPx,
+        ),
+        clip = if (clip == PrototypeClip.Content) {
+          androidx.compose.ui.geometry.Rect(0f, 0f, size.width, size.height)
+        } else {
+          null
+        },
+        effect = effect,
+      ),
+    )
+    check(renderer.draw(drawContext.canvas))
+    drawContent()
+    drawReady.countDown()
+  }
+
+  override fun onDetach() {
+    renderer.release()
+  }
+}
+
+private fun androidx.compose.ui.unit.Dp.roundToPx(density: Density): Int =
+  kotlin.math.round(value * density.density).toInt()

--- a/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
+++ b/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
@@ -1,7 +1,7 @@
 // Copyright 2026, Christopher Banes and the Haze project contributors
 // SPDX-License-Identifier: Apache-2.0
 
-@file:OptIn(InternalHazeApi::class)
+@file:OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
 
 package dev.chrisbanes.haze
 
@@ -354,6 +354,65 @@ class AndroidBackdropRendererInstrumentationTest {
     bitmap.assertVerticalEdgeSoftened(centerX, centerY, density, "public View backdrop")
   }
 
+  @Test
+  fun hazeInputBackdrop_usesNativeWithoutCapturingFallbackSource() {
+    assumeTrue(
+      "HazeInput.Backdrop requires Android 37.2 or the matching preview",
+      isHazeBackdropSdkSupported(fullSdkInt(), Build.VERSION.PREVIEW_SDK_INT),
+    )
+
+    val state = HazeState()
+    val drawReady = CountDownLatch(1)
+    activityScenario.onActivity { activity ->
+      activity.setContent {
+        Box(Modifier.fillMaxSize().background(Color.White)) {
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .hazeSource(state)
+              .background(Color.Black),
+          ) {
+            Box(
+              Modifier
+                .align(Alignment.CenterEnd)
+                .size(width = 100.dp, height = 100.dp)
+                .background(Color.White),
+            )
+          }
+          Box(
+            Modifier
+              .align(Alignment.Center)
+              .size(width = 200.dp, height = 100.dp)
+              .hazeEffect(
+                factory = BackdropBlurEffectFactory(drawReady),
+                input = HazeInput.Backdrop(HazeInput.Sources(state)),
+                style = 14.dp,
+              ),
+          )
+        }
+      }
+    }
+    assertThat(drawReady.await(5, TimeUnit.SECONDS), "Native Haze backdrop presented a draw").isTrue()
+    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+    val bitmap = activity.copyWindow()
+    val density = Density(activity.resources.displayMetrics.density)
+    bitmap.assertVerticalEdgeSoftened(
+      centerX = bitmap.width / 2,
+      centerY = bitmap.height / 2,
+      density = density,
+      rendererName = "HazeInput.Backdrop",
+    )
+
+    activityScenario.onActivity {
+      val area = state.areas.single()
+      assertThat(area.captureConsumerCount, "native backdrop capture consumers").isEqualTo(0)
+      assertThat(area.contentVersion, "native backdrop source records").isEqualTo(0L)
+      assertThat(area.contentLayer, "native backdrop source layer").isEqualTo(null)
+    }
+  }
+
   private fun ComponentActivity.copyWindow(): Bitmap {
     val targetWindow = this.window
     val bitmap = Bitmap.createBitmap(
@@ -510,4 +569,45 @@ private class BackdropProbeView(
     canvas.drawColor(AndroidColor.argb(0x99, 0xF0, 0xF0, 0xF0))
     drawReady.countDown()
   }
+}
+
+private class BackdropBlurEffectFactory(
+  private val drawReady: CountDownLatch,
+) : HazeEffectFactory<androidx.compose.ui.unit.Dp> {
+  override fun createRenderer(): HazeEffectRenderer<androidx.compose.ui.unit.Dp> =
+    BackdropBlurEffectRenderer(drawReady)
+}
+
+private class BackdropBlurEffectRenderer(
+  private val drawReady: CountDownLatch,
+) :
+  HazeEffectRenderer<androidx.compose.ui.unit.Dp>,
+  HazeEffectRendererBackdrop<androidx.compose.ui.unit.Dp>,
+  HazeEffectRendererDrawHooks<androidx.compose.ui.unit.Dp> {
+
+  override fun HazeEffectDrawScope.draw(style: androidx.compose.ui.unit.Dp) {
+    drawInput()
+  }
+
+  override fun HazeEffectLayoutScope.calculateLayerBounds(
+    style: androidx.compose.ui.unit.Dp,
+  ): androidx.compose.ui.geometry.Rect = modifierBounds.inflate(style.toPx())
+
+  override fun HazeEffectRuntimeDrawScope.backdropEffect(
+    style: androidx.compose.ui.unit.Dp,
+  ): HazeEffectBackdrop? {
+    val radius = style.toPx()
+    val effect = createBlurRenderEffect(
+      radiusX = radius,
+      radiusY = radius,
+      tileMode = TileMode.Clamp,
+    ) ?: return null
+    return HazeEffectBackdrop(effect)
+  }
+
+  override fun HazeEffectRuntimeDrawScope.drawForeground(style: androidx.compose.ui.unit.Dp) {
+    drawReady.countDown()
+  }
+
+  override fun shouldClipToNodeBounds(): Boolean = true
 }

--- a/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
+++ b/haze/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/AndroidBackdropRendererInstrumentationTest.kt
@@ -61,7 +61,10 @@ class AndroidBackdropRendererInstrumentationTest {
 
   @Test
   fun backdropRenderer_samplesOrderingTransformsExpandedBoundsAndClip() {
-    assumeTrue("Backdrop RenderNode requires Android 37.2", fullSdkInt() >= HAZE_BACKDROP_MIN_FULL_SDK)
+    assumeTrue(
+      "Backdrop RenderNode requires Android 37.2 or the matching preview",
+      isHazeBackdropSdkSupported(fullSdkInt(), Build.VERSION.PREVIEW_SDK_INT),
+    )
 
     val drawReady = CountDownLatch(PROTOTYPE_NODE_COUNT)
     activityScenario.onActivity { activity ->

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
@@ -69,16 +69,15 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
     }
     setBackdropRenderEffect?.invoke(node, effect)
 
-    // A transparent display list makes the RenderNode drawable while leaving its backdrop
-    // untouched. The actual filtering is performed by the compositor's backdrop effect.
+    // A transparent SRC_OVER draw leaves the node visually empty but keeps its backdrop filter
+    // composited. Recording a CLEAR operation instead suppresses the backdrop on Android 37.2.
     val recordingCanvas = beginRecording?.invoke(node, width, height)
     if (recordingCanvas == null) return false
     val drawColor = recordingCanvas.javaClass.getMethod(
       "drawColor",
       Int::class.javaPrimitiveType,
-      android.graphics.PorterDuff.Mode::class.java,
     )
-    drawColor.invoke(recordingCanvas, android.graphics.Color.TRANSPARENT, android.graphics.PorterDuff.Mode.CLEAR)
+    drawColor.invoke(recordingCanvas, android.graphics.Color.TRANSPARENT)
     endRecording?.invoke(node)
     return true
   }

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
@@ -1,0 +1,150 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(InternalHazeApi::class)
+
+package dev.chrisbanes.haze
+
+import android.graphics.Rect as AndroidRect
+import android.os.Build
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.nativeCanvas
+import java.lang.reflect.Method
+import kotlin.math.ceil
+import kotlin.math.floor
+
+/**
+ * Android's backdrop RenderNode API is introduced in the second 37.x platform release. The
+ * library currently compiles against a 37.0 SDK, so resolving and invoking that method through
+ * reflection keeps older devices safe while retaining the exact public platform API at runtime.
+ */
+@InternalHazeApi
+internal actual fun createHazeBackdropRenderer(): HazeBackdropRenderer =
+  AndroidHazeBackdropRenderer()
+
+private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
+  private var renderNode: Any? = null
+  private var drawRenderNode: Method? = null
+  private var setPosition: Method? = null
+  private var setClipToBounds: Method? = null
+  private var setClipRect: Method? = null
+  private var setBackdropRenderEffect: Method? = null
+  private var beginRecording: Method? = null
+  private var endRecording: Method? = null
+  private var discardDisplayList: Method? = null
+
+  override fun isSupported(canvas: Canvas): Boolean {
+    if (!canvas.nativeCanvas.isHardwareAccelerated) return false
+    if (fullSdkInt() < HAZE_BACKDROP_MIN_FULL_SDK) return false
+    return resolveReflection()
+  }
+
+  override fun configure(
+    bounds: Rect,
+    clip: Rect?,
+    effect: PlatformRenderEffect,
+  ): Boolean {
+    val node = renderNode ?: return false
+    val left = floor(bounds.left).toInt()
+    val top = floor(bounds.top).toInt()
+    val right = ceil(bounds.right).toInt()
+    val bottom = ceil(bounds.bottom).toInt()
+    val width = right - left
+    val height = bottom - top
+    if (width <= 0 || height <= 0) return false
+
+    setPosition?.invoke(node, left, top, right, bottom)
+    setClipToBounds?.invoke(node, clip != null)
+    if (clip != null) {
+      setClipRect?.invoke(
+        node,
+        AndroidRect(
+          floor(clip.left - left).toInt(),
+          floor(clip.top - top).toInt(),
+          ceil(clip.right - left).toInt(),
+          ceil(clip.bottom - top).toInt(),
+        ),
+      )
+    }
+    setBackdropRenderEffect?.invoke(node, effect)
+
+    // A transparent display list makes the RenderNode drawable while leaving its backdrop
+    // untouched. The actual filtering is performed by the compositor's backdrop effect.
+    val recordingCanvas = beginRecording?.invoke(node, width, height)
+    if (recordingCanvas == null) return false
+    val drawColor = recordingCanvas.javaClass.getMethod(
+      "drawColor",
+      Int::class.javaPrimitiveType,
+      android.graphics.PorterDuff.Mode::class.java,
+    )
+    drawColor.invoke(recordingCanvas, android.graphics.Color.TRANSPARENT, android.graphics.PorterDuff.Mode.CLEAR)
+    endRecording?.invoke(node)
+    return true
+  }
+
+  override fun draw(canvas: Canvas): Boolean {
+    val node = renderNode ?: return false
+    val drawMethod = drawRenderNode ?: return false
+    if (!canvas.nativeCanvas.isHardwareAccelerated) return false
+    drawMethod.invoke(canvas.nativeCanvas, node)
+    return true
+  }
+
+  override fun release() {
+    renderNode?.let { discardDisplayList?.invoke(it) }
+    renderNode = null
+    drawRenderNode = null
+    setPosition = null
+    setClipToBounds = null
+    setClipRect = null
+    setBackdropRenderEffect = null
+    beginRecording = null
+    endRecording = null
+    discardDisplayList = null
+  }
+
+  private fun resolveReflection(): Boolean {
+    if (renderNode != null) return true
+
+    return try {
+      val nodeClass = Class.forName("android.graphics.RenderNode")
+      val node = nodeClass.getConstructor(String::class.java).newInstance("HazeBackdropPrototype")
+      val nativeCanvasClass = Class.forName("android.graphics.Canvas")
+      val renderEffectClass = Class.forName("android.graphics.RenderEffect")
+
+      renderNode = node
+      drawRenderNode = nativeCanvasClass.getMethod("drawRenderNode", nodeClass)
+      setPosition = nodeClass.getMethod(
+        "setPosition",
+        Int::class.javaPrimitiveType,
+        Int::class.javaPrimitiveType,
+        Int::class.javaPrimitiveType,
+        Int::class.javaPrimitiveType,
+      )
+      setClipToBounds = nodeClass.getMethod("setClipToBounds", Boolean::class.javaPrimitiveType)
+      setClipRect = nodeClass.getMethod("setClipRect", AndroidRect::class.java)
+      setBackdropRenderEffect = nodeClass.getMethod("setBackdropRenderEffect", renderEffectClass)
+      beginRecording = nodeClass.getMethod(
+        "beginRecording",
+        Int::class.javaPrimitiveType,
+        Int::class.javaPrimitiveType,
+      )
+      endRecording = nodeClass.getMethod("endRecording")
+      discardDisplayList = nodeClass.getMethod("discardDisplayList")
+      true
+    } catch (_: ReflectiveOperationException) {
+      release()
+      false
+    }
+  }
+
+  private companion object {
+    fun fullSdkInt(): Int {
+      if (Build.VERSION.SDK_INT < 36) return Build.VERSION.SDK_INT * 100_000
+      return runCatching {
+        Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
+      }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
+    }
+  }
+}

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
@@ -36,7 +36,7 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
 
   override fun isSupported(canvas: Canvas): Boolean {
     if (!canvas.nativeCanvas.isHardwareAccelerated) return false
-    if (fullSdkInt() < HAZE_BACKDROP_MIN_FULL_SDK) return false
+    if (!isHazeBackdropSdkSupported(fullSdkInt(), Build.VERSION.PREVIEW_SDK_INT)) return false
     return resolveReflection()
   }
 

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
@@ -50,16 +50,16 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
 
     node.setPosition(left, top, right, bottom)
     node.setClipToBounds(clip != null)
-    if (clip != null) {
-      node.setClipRect(
+    node.setClipRect(
+      clip?.let {
         AndroidRect(
-          floor(clip.left - left).toInt(),
-          floor(clip.top - top).toInt(),
-          ceil(clip.right - left).toInt(),
-          ceil(clip.bottom - top).toInt(),
-        ),
-      )
-    }
+          floor(it.left - left).toInt(),
+          floor(it.top - top).toInt(),
+          ceil(it.right - left).toInt(),
+          ceil(it.bottom - top).toInt(),
+        )
+      },
+    )
     node.setAlpha(alpha)
     node.setBackdropRenderEffect(effect)
 

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
@@ -29,6 +29,7 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
   private var setPosition: Method? = null
   private var setClipToBounds: Method? = null
   private var setClipRect: Method? = null
+  private var setAlpha: Method? = null
   private var setBackdropRenderEffect: Method? = null
   private var beginRecording: Method? = null
   private var endRecording: Method? = null
@@ -44,6 +45,7 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
     bounds: Rect,
     clip: Rect?,
     effect: PlatformRenderEffect,
+    alpha: Float,
   ): Boolean {
     val node = renderNode ?: return false
     val left = floor(bounds.left).toInt()
@@ -67,6 +69,7 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
         ),
       )
     }
+    setAlpha?.invoke(node, alpha)
     setBackdropRenderEffect?.invoke(node, effect)
 
     // A transparent SRC_OVER draw leaves the node visually empty but keeps its backdrop filter
@@ -97,6 +100,7 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
     setPosition = null
     setClipToBounds = null
     setClipRect = null
+    setAlpha = null
     setBackdropRenderEffect = null
     beginRecording = null
     endRecording = null
@@ -123,6 +127,7 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
       )
       setClipToBounds = nodeClass.getMethod("setClipToBounds", Boolean::class.javaPrimitiveType)
       setClipRect = nodeClass.getMethod("setClipRect", AndroidRect::class.java)
+      setAlpha = nodeClass.getMethod("setAlpha", Float::class.javaPrimitiveType)
       setBackdropRenderEffect = nodeClass.getMethod("setBackdropRenderEffect", renderEffectClass)
       beginRecording = nodeClass.getMethod(
         "beginRecording",

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
@@ -6,39 +6,31 @@
 package dev.chrisbanes.haze
 
 import android.graphics.Rect as AndroidRect
+import android.graphics.RenderNode
 import android.os.Build
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.nativeCanvas
-import java.lang.reflect.Method
 import kotlin.math.ceil
 import kotlin.math.floor
 
-/**
- * Android's backdrop RenderNode API is introduced in the second 37.x platform release. The
- * library currently compiles against a 37.0 SDK, so resolving and invoking that method through
- * reflection keeps older devices safe while retaining the exact public platform API at runtime.
- */
 @InternalHazeApi
 internal actual fun createHazeBackdropRenderer(): HazeBackdropRenderer =
-  AndroidHazeBackdropRenderer()
+  if (isAndroidBackdropSdkSupported()) {
+    AndroidHazeBackdropRenderer()
+  } else {
+    UnavailableHazeBackdropRenderer
+  }
 
 private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
-  private var renderNode: Any? = null
-  private var drawRenderNode: Method? = null
-  private var setPosition: Method? = null
-  private var setClipToBounds: Method? = null
-  private var setClipRect: Method? = null
-  private var setAlpha: Method? = null
-  private var setBackdropRenderEffect: Method? = null
-  private var beginRecording: Method? = null
-  private var endRecording: Method? = null
-  private var discardDisplayList: Method? = null
+  private var renderNode: RenderNode? = null
 
   override fun isSupported(canvas: Canvas): Boolean {
     if (!canvas.nativeCanvas.isHardwareAccelerated) return false
-    if (!isHazeBackdropSdkSupported(fullSdkInt(), Build.VERSION.PREVIEW_SDK_INT)) return false
-    return resolveReflection()
+    if (renderNode == null) {
+      renderNode = RenderNode("HazeBackdrop")
+    }
+    return true
   }
 
   override fun configure(
@@ -56,11 +48,10 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
     val height = bottom - top
     if (width <= 0 || height <= 0) return false
 
-    setPosition?.invoke(node, left, top, right, bottom)
-    setClipToBounds?.invoke(node, clip != null)
+    node.setPosition(left, top, right, bottom)
+    node.setClipToBounds(clip != null)
     if (clip != null) {
-      setClipRect?.invoke(
-        node,
+      node.setClipRect(
         AndroidRect(
           floor(clip.left - left).toInt(),
           floor(clip.top - top).toInt(),
@@ -69,86 +60,49 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
         ),
       )
     }
-    setAlpha?.invoke(node, alpha)
-    setBackdropRenderEffect?.invoke(node, effect)
+    node.setAlpha(alpha)
+    node.setBackdropRenderEffect(effect)
 
     // A transparent SRC_OVER draw leaves the node visually empty but keeps its backdrop filter
     // composited. Recording a CLEAR operation instead suppresses the backdrop on Android 37.2.
-    val recordingCanvas = beginRecording?.invoke(node, width, height)
-    if (recordingCanvas == null) return false
-    val drawColor = recordingCanvas.javaClass.getMethod(
-      "drawColor",
-      Int::class.javaPrimitiveType,
-    )
-    drawColor.invoke(recordingCanvas, android.graphics.Color.TRANSPARENT)
-    endRecording?.invoke(node)
+    val recordingCanvas = node.beginRecording(width, height)
+    recordingCanvas.drawColor(android.graphics.Color.TRANSPARENT)
+    node.endRecording()
     return true
   }
 
   override fun draw(canvas: Canvas): Boolean {
     val node = renderNode ?: return false
-    val drawMethod = drawRenderNode ?: return false
     if (!canvas.nativeCanvas.isHardwareAccelerated) return false
-    drawMethod.invoke(canvas.nativeCanvas, node)
+    canvas.nativeCanvas.drawRenderNode(node)
     return true
   }
 
   override fun release() {
-    renderNode?.let { discardDisplayList?.invoke(it) }
+    renderNode?.discardDisplayList()
     renderNode = null
-    drawRenderNode = null
-    setPosition = null
-    setClipToBounds = null
-    setClipRect = null
-    setAlpha = null
-    setBackdropRenderEffect = null
-    beginRecording = null
-    endRecording = null
-    discardDisplayList = null
   }
+}
 
-  private fun resolveReflection(): Boolean {
-    if (renderNode != null) return true
+private object UnavailableHazeBackdropRenderer : HazeBackdropRenderer {
+  override fun isSupported(canvas: Canvas): Boolean = false
 
-    return try {
-      val nodeClass = Class.forName("android.graphics.RenderNode")
-      val node = nodeClass.getConstructor(String::class.java).newInstance("HazeBackdropPrototype")
-      val nativeCanvasClass = Class.forName("android.graphics.Canvas")
-      val renderEffectClass = Class.forName("android.graphics.RenderEffect")
+  override fun configure(
+    bounds: Rect,
+    clip: Rect?,
+    effect: PlatformRenderEffect,
+    alpha: Float,
+  ): Boolean = false
 
-      renderNode = node
-      drawRenderNode = nativeCanvasClass.getMethod("drawRenderNode", nodeClass)
-      setPosition = nodeClass.getMethod(
-        "setPosition",
-        Int::class.javaPrimitiveType,
-        Int::class.javaPrimitiveType,
-        Int::class.javaPrimitiveType,
-        Int::class.javaPrimitiveType,
-      )
-      setClipToBounds = nodeClass.getMethod("setClipToBounds", Boolean::class.javaPrimitiveType)
-      setClipRect = nodeClass.getMethod("setClipRect", AndroidRect::class.java)
-      setAlpha = nodeClass.getMethod("setAlpha", Float::class.javaPrimitiveType)
-      setBackdropRenderEffect = nodeClass.getMethod("setBackdropRenderEffect", renderEffectClass)
-      beginRecording = nodeClass.getMethod(
-        "beginRecording",
-        Int::class.javaPrimitiveType,
-        Int::class.javaPrimitiveType,
-      )
-      endRecording = nodeClass.getMethod("endRecording")
-      discardDisplayList = nodeClass.getMethod("discardDisplayList")
-      true
-    } catch (_: ReflectiveOperationException) {
-      release()
-      false
-    }
-  }
+  override fun draw(canvas: Canvas): Boolean = false
 
-  private companion object {
-    fun fullSdkInt(): Int {
-      if (Build.VERSION.SDK_INT < 36) return Build.VERSION.SDK_INT * 100_000
-      return runCatching {
-        Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
-      }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
-    }
-  }
+  override fun release() = Unit
+}
+
+private fun isAndroidBackdropSdkSupported(): Boolean {
+  if (Build.VERSION.SDK_INT < 36) return false
+  return isHazeBackdropSdkSupported(
+    fullSdkInt = Build.VERSION.SDK_INT_FULL,
+    previewSdkInt = Build.VERSION.PREVIEW_SDK_INT,
+  )
 }

--- a/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
+++ b/haze/src/androidMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.android.kt
@@ -15,11 +15,11 @@ import kotlin.math.ceil
 import kotlin.math.floor
 
 @InternalHazeApi
-internal actual fun createHazeBackdropRenderer(): HazeBackdropRenderer =
+internal actual fun createHazeBackdropRenderer(): HazeBackdropRenderer? =
   if (isAndroidBackdropSdkSupported()) {
     AndroidHazeBackdropRenderer()
   } else {
-    UnavailableHazeBackdropRenderer
+    null
   }
 
 private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
@@ -82,21 +82,6 @@ private class AndroidHazeBackdropRenderer : HazeBackdropRenderer {
     renderNode?.discardDisplayList()
     renderNode = null
   }
-}
-
-private object UnavailableHazeBackdropRenderer : HazeBackdropRenderer {
-  override fun isSupported(canvas: Canvas): Boolean = false
-
-  override fun configure(
-    bounds: Rect,
-    clip: Rect?,
-    effect: PlatformRenderEffect,
-    alpha: Float,
-  ): Boolean = false
-
-  override fun draw(canvas: Canvas): Boolean = false
-
-  override fun release() = Unit
 }
 
 private fun isAndroidBackdropSdkSupported(): Boolean {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -148,6 +148,22 @@ internal class HazeArea {
 
   internal val preDrawListeners = mutableStateSetOf<OnPreDrawListener>()
 
+  private val captureConsumers = mutableStateSetOf<Any>()
+
+  internal val hasCaptureDemand: Boolean
+    get() = captureConsumers.isNotEmpty()
+
+  internal val captureConsumerCount: Int
+    get() = captureConsumers.size
+
+  internal fun addCaptureConsumer(consumer: Any) {
+    captureConsumers += consumer
+  }
+
+  internal fun removeCaptureConsumer(consumer: Any) {
+    captureConsumers -= consumer
+  }
+
   /**
    * Internal content [GraphicsLayer] used when capturing source content for effects.
    *

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropBackend.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropBackend.kt
@@ -14,14 +14,11 @@ internal class HazeBackdropBackendState {
   var selection: HazeBackdropBackendSelection = HazeBackdropBackendSelection.Undecided
     private set
 
-  val usesNative: Boolean
-    get() = selection == HazeBackdropBackendSelection.Native
-
   val usesFallback: Boolean
     get() = selection == HazeBackdropBackendSelection.FallbackUnavailable ||
       selection == HazeBackdropBackendSelection.FallbackFailed
 
-  fun resolve(nativeAvailable: Boolean): HazeBackdropBackendSelection {
+  fun resolve(nativeAvailable: Boolean) {
     if (!usesFallback) {
       selection = if (nativeAvailable) {
         HazeBackdropBackendSelection.Native
@@ -29,14 +26,12 @@ internal class HazeBackdropBackendState {
         HazeBackdropBackendSelection.FallbackUnavailable
       }
     }
-    return selection
   }
 
-  fun fail(): HazeBackdropBackendSelection {
+  fun fail() {
     if (!usesFallback) {
       selection = HazeBackdropBackendSelection.FallbackFailed
     }
-    return selection
   }
 
   fun reset() {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropBackend.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropBackend.kt
@@ -1,0 +1,45 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+internal enum class HazeBackdropBackendSelection {
+  Undecided,
+  Native,
+  FallbackUnavailable,
+  FallbackFailed,
+}
+
+internal class HazeBackdropBackendState {
+  var selection: HazeBackdropBackendSelection = HazeBackdropBackendSelection.Undecided
+    private set
+
+  val usesNative: Boolean
+    get() = selection == HazeBackdropBackendSelection.Native
+
+  val usesFallback: Boolean
+    get() = selection == HazeBackdropBackendSelection.FallbackUnavailable ||
+      selection == HazeBackdropBackendSelection.FallbackFailed
+
+  fun resolve(nativeAvailable: Boolean): HazeBackdropBackendSelection {
+    if (!usesFallback) {
+      selection = if (nativeAvailable) {
+        HazeBackdropBackendSelection.Native
+      } else {
+        HazeBackdropBackendSelection.FallbackUnavailable
+      }
+    }
+    return selection
+  }
+
+  fun fail(): HazeBackdropBackendSelection {
+    if (!usesFallback) {
+      selection = HazeBackdropBackendSelection.FallbackFailed
+    }
+    return selection
+  }
+
+  fun reset() {
+    selection = HazeBackdropBackendSelection.Undecided
+  }
+}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropBackend.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropBackend.kt
@@ -18,6 +18,14 @@ internal class HazeBackdropBackendState {
     get() = selection == HazeBackdropBackendSelection.FallbackUnavailable ||
       selection == HazeBackdropBackendSelection.FallbackFailed
 
+  fun attach(platformBackdropEnabled: Boolean) {
+    selection = if (platformBackdropEnabled) {
+      HazeBackdropBackendSelection.Undecided
+    } else {
+      HazeBackdropBackendSelection.FallbackUnavailable
+    }
+  }
+
   fun resolve(nativeAvailable: Boolean) {
     if (!usesFallback) {
       selection = if (nativeAvailable) {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
@@ -20,6 +20,7 @@ internal interface HazeBackdropRenderer {
     bounds: Rect,
     clip: Rect?,
     effect: PlatformRenderEffect,
+    alpha: Float = 1f,
   ): Boolean
 
   fun draw(canvas: Canvas): Boolean

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
@@ -29,7 +29,7 @@ internal interface HazeBackdropRenderer {
 }
 
 @InternalHazeApi
-internal expect fun createHazeBackdropRenderer(): HazeBackdropRenderer
+internal expect fun createHazeBackdropRenderer(): HazeBackdropRenderer?
 
 // Platform-neutral equivalent of Build.VERSION_CODES_FULL.CINNAMON_BUN_2 for common tests.
 @InternalHazeApi

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
@@ -31,8 +31,7 @@ internal interface HazeBackdropRenderer {
 @InternalHazeApi
 internal expect fun createHazeBackdropRenderer(): HazeBackdropRenderer
 
-// Build.VERSION_CODES_FULL.CINNAMON_BUN_2 is unavailable in the locally installed 37.0 SDK.
-// Android full SDK versions encode 37.2 as 3_700_002 (the micro release occupies the low digits).
+// Platform-neutral equivalent of Build.VERSION_CODES_FULL.CINNAMON_BUN_2 for common tests.
 @InternalHazeApi
 internal const val HAZE_BACKDROP_MIN_FULL_SDK = 3_700_002
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
@@ -1,0 +1,36 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Canvas
+
+/**
+ * Internal platform boundary for a renderer which samples the already-drawn window backdrop.
+ *
+ * This is intentionally not part of the public Haze input or renderer API. The Android
+ * implementation is experimental until the compositor behavior is proven on API 37.2.
+ */
+@InternalHazeApi
+internal interface HazeBackdropRenderer {
+  fun isSupported(canvas: Canvas): Boolean
+
+  fun configure(
+    bounds: Rect,
+    clip: Rect?,
+    effect: PlatformRenderEffect,
+  ): Boolean
+
+  fun draw(canvas: Canvas): Boolean
+
+  fun release()
+}
+
+@InternalHazeApi
+internal expect fun createHazeBackdropRenderer(): HazeBackdropRenderer
+
+// Build.VERSION_CODES_FULL.CINNAMON_BUN_2 is unavailable in the locally installed 37.0 SDK.
+// Android full SDK versions encode 37.2 as 3_700_002 (the micro release occupies the low digits).
+@InternalHazeApi
+internal const val HAZE_BACKDROP_MIN_FULL_SDK = 3_700_002

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.kt
@@ -34,3 +34,21 @@ internal expect fun createHazeBackdropRenderer(): HazeBackdropRenderer
 // Android full SDK versions encode 37.2 as 3_700_002 (the micro release occupies the low digits).
 @InternalHazeApi
 internal const val HAZE_BACKDROP_MIN_FULL_SDK = 3_700_002
+
+// The available 37.2 beta 3 image is based on 37.1 and identifies its exact preview revision
+// separately. Android requires prerelease API checks to match PREVIEW_SDK_INT exactly.
+@InternalHazeApi
+internal const val HAZE_BACKDROP_PREVIEW_BASE_FULL_SDK = 3_700_001
+
+@InternalHazeApi
+internal const val HAZE_BACKDROP_37_2_BETA_3_PREVIEW_SDK = 3_723
+
+@InternalHazeApi
+internal fun isHazeBackdropSdkSupported(
+  fullSdkInt: Int,
+  previewSdkInt: Int,
+): Boolean = fullSdkInt >= HAZE_BACKDROP_MIN_FULL_SDK ||
+  (
+    fullSdkInt == HAZE_BACKDROP_PREVIEW_BASE_FULL_SDK &&
+      previewSdkInt == HAZE_BACKDROP_37_2_BETA_3_PREVIEW_SDK
+    )

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffect.kt
@@ -107,9 +107,7 @@ private class TypedHazeEffectNodeElement<Style>(
   val lifecycle: Lifecycle,
 ) : ModifierNodeElement<HazeEffectNode>() {
 
-  override fun create(): HazeEffectNode = HazeEffectNode(
-    state = (input as? HazeInput.Sources)?.state,
-  ).also { node ->
+  override fun create(): HazeEffectNode = HazeEffectNode().also { node ->
     node.explicitInput = input
     node.explicitExpandLayerBounds = expandLayerBounds
     node.updateTypedEffect(factory, style, sampling)
@@ -119,7 +117,6 @@ private class TypedHazeEffectNodeElement<Style>(
   override fun update(node: HazeEffectNode) {
     node.explicitInput = input
     node.explicitExpandLayerBounds = expandLayerBounds
-    node.state = (input as? HazeInput.Sources)?.state
     node.updateTypedEffect(factory, style, sampling)
     node.updateLifecycle(lifecycle)
     node.update()

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -179,8 +179,7 @@ public interface HazeEffectRendererBackdrop<Style> {
 /** Prepared built-in effect for the current-window backdrop path. */
 @InternalHazeApi
 public class HazeEffectBackdrop(
-  /** Platform root effect consumed by the internal backdrop backend. */
-  public val platformEffect: PlatformRenderEffect,
+  private val effect: PlatformRenderEffect,
   /** Alpha applied while drawing the filtered backdrop. */
   public val alpha: Float = 1f,
   /** Transform from effect-local coordinates into the authored material coordinate space. */
@@ -191,6 +190,9 @@ public class HazeEffectBackdrop(
       "alpha must be finite and in the range 0f..1f"
     }
   }
+
+  /** Returns the platform root effect consumed by the internal backdrop backend. */
+  public fun platformEffect(): PlatformRenderEffect = effect
 }
 
 /** Built-in-only retained-output capability. */

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -179,7 +179,7 @@ public interface HazeEffectRendererBackdrop<Style> {
 /** Prepared built-in effect for the current-window backdrop path. */
 @InternalHazeApi
 public class HazeEffectBackdrop(
-  private val effect: PlatformRenderEffect,
+  private val platformEffect: PlatformRenderEffect,
   /** Alpha applied while drawing the filtered backdrop. */
   public val alpha: Float = 1f,
   /** Transform from effect-local coordinates into the authored material coordinate space. */
@@ -191,8 +191,13 @@ public class HazeEffectBackdrop(
     }
   }
 
-  /** Returns the platform root effect consumed by the internal backdrop backend. */
-  public fun platformEffect(): PlatformRenderEffect = effect
+  /**
+   * Returns the platform root effect consumed by the internal backdrop backend.
+   *
+   * This remains a getter-shaped function so Metalava records the stable JVM getter signature
+   * without exposing [PlatformRenderEffect] as a public Kotlin property.
+   */
+  public fun getPlatformEffect(): PlatformRenderEffect = platformEffect
 }
 
 /** Built-in-only retained-output capability. */

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -179,7 +179,8 @@ public interface HazeEffectRendererBackdrop<Style> {
 /** Prepared built-in effect for the current-window backdrop path. */
 @InternalHazeApi
 public class HazeEffectBackdrop(
-  private val effect: PlatformRenderEffect,
+  /** Platform root effect consumed by the internal backdrop backend. */
+  public val platformEffect: PlatformRenderEffect,
   /** Alpha applied while drawing the filtered backdrop. */
   public val alpha: Float = 1f,
   /** Transform from effect-local coordinates into the authored material coordinate space. */
@@ -190,9 +191,6 @@ public class HazeEffectBackdrop(
       "alpha must be finite and in the range 0f..1f"
     }
   }
-
-  /** Returns the platform root effect consumed by the internal backdrop backend. */
-  public fun platformEffect(): PlatformRenderEffect = effect
 }
 
 /** Built-in-only retained-output capability. */

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -180,7 +180,9 @@ public interface HazeEffectRendererBackdrop<Style> {
 @InternalHazeApi
 public class HazeEffectBackdrop(
   private val effect: PlatformRenderEffect,
+  /** Alpha applied while drawing the filtered backdrop. */
   public val alpha: Float = 1f,
+  /** Transform from effect-local coordinates into the authored material coordinate space. */
   public val materialTransform: HazeEffectContentTransform = HazeEffectContentTransform.Identity,
 ) {
   init {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectFactory.kt
@@ -169,6 +169,30 @@ public interface HazeEffectRendererDrawHooks<Style> {
   public fun shouldPreferClipToInputBounds(): Boolean = false
 }
 
+/** Built-in-only capability for rendering from the current-window backdrop. */
+@InternalHazeApi
+public interface HazeEffectRendererBackdrop<Style> {
+  /** Returns the prepared platform effect used to filter the current-window backdrop. */
+  public fun HazeEffectRuntimeDrawScope.backdropEffect(style: Style): HazeEffectBackdrop?
+}
+
+/** Prepared built-in effect for the current-window backdrop path. */
+@InternalHazeApi
+public class HazeEffectBackdrop(
+  private val effect: PlatformRenderEffect,
+  public val alpha: Float = 1f,
+  public val materialTransform: HazeEffectContentTransform = HazeEffectContentTransform.Identity,
+) {
+  init {
+    require(alpha.isFinite() && alpha in 0f..1f) {
+      "alpha must be finite and in the range 0f..1f"
+    }
+  }
+
+  /** Returns the platform root effect consumed by the internal backdrop backend. */
+  public fun platformEffect(): PlatformRenderEffect = effect
+}
+
 /** Built-in-only retained-output capability. */
 @InternalHazeApi
 public interface HazeEffectRendererRetainedOutput {
@@ -324,7 +348,7 @@ internal class HazeEffectDrawScopeImpl(
     get() = node.layerOffset
 
   override val hasDrawableInput: Boolean
-    get() = node.hasDrawableSourceLayers()
+    get() = node.hasDrawableInput()
 
   override val inputSnapshot: HazeEffectInputSnapshot?
     get() = node.inputSnapshot()

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -699,12 +699,14 @@ internal class HazeEffectNode :
             size = layerSize,
           )
           val clip = Rect(Offset.Zero, size).takeIf { shouldClipEffectToNodeBounds() }
-          backdropDrawn = renderer.configure(
-            bounds = bounds,
-            clip = clip,
-            effect = backdrop.platformEffect(),
-            alpha = backdrop.alpha,
-          ) && renderer.draw(drawContext.canvas)
+          backdropDrawn = trace("HazeBackdrop.draw") {
+            renderer.configure(
+              bounds = bounds,
+              clip = clip,
+              effect = backdrop.platformEffect(),
+              alpha = backdrop.alpha,
+            ) && renderer.draw(drawContext.canvas)
+          }
         }
       } catch (exception: Exception) {
         HazeLogger.d(TAG, exception) { "Backdrop renderer draw failed" }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -48,7 +48,9 @@ import kotlinx.coroutines.DisposableHandle
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 
-internal class HazeEffectNode :
+internal class HazeEffectNode(
+  private val createBackdropRenderer: () -> HazeBackdropRenderer? = ::createHazeBackdropRenderer,
+) :
   DelegatingNode(),
   CompositionLocalConsumerModifierNode,
   ModifierLocalModifierNode,
@@ -669,11 +671,19 @@ internal class HazeEffectNode :
       return
     }
 
-    val renderer = backdropRenderer ?: createHazeBackdropRenderer()?.also {
-      backdropRenderer = it
+    val renderer = backdropRenderer ?: try {
+      createBackdropRenderer()?.also {
+        backdropRenderer = it
+      }
+    } catch (exception: Exception) {
+      HazeLogger.d(TAG, exception) { "Backdrop renderer creation failed" }
+      activateBackdropFallback(failed = true)
+      null
     }
     if (renderer == null) {
-      activateBackdropFallback(failed = false)
+      if (!backdropBackendState.usesFallback) {
+        activateBackdropFallback(failed = false)
+      }
       withVisualEffectTransform { drawContentSafely() }
       return
     }
@@ -693,7 +703,14 @@ internal class HazeEffectNode :
     }
 
     val scope = HazeEffectDrawScopeImpl(this, this@HazeEffectNode, typedEffectSampling)
-    val backdrop = with(capability) { scope.backdropEffect(typedEffectStyle) }
+    val backdrop = try {
+      with(capability) { scope.backdropEffect(typedEffectStyle) }
+    } catch (exception: Exception) {
+      HazeLogger.d(TAG, exception) { "Backdrop effect preparation failed" }
+      activateBackdropFallback(failed = true)
+      withVisualEffectTransform { drawContentSafely() }
+      return
+    }
     if (backdrop == null) {
       activateBackdropFallback(failed = false)
       withVisualEffectTransform { drawContentSafely() }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -664,8 +664,13 @@ internal class HazeEffectNode :
       return
     }
 
-    val renderer = backdropRenderer ?: createHazeBackdropRenderer().also {
+    val renderer = backdropRenderer ?: createHazeBackdropRenderer()?.also {
       backdropRenderer = it
+    }
+    if (renderer == null) {
+      activateBackdropFallback(failed = false)
+      withVisualEffectTransform { drawContentSafely() }
+      return
     }
     val supported = try {
       renderer.isSupported(drawContext.canvas)
@@ -682,7 +687,8 @@ internal class HazeEffectNode :
       return
     }
 
-    val backdrop = preparedBackdropEffect(capability)
+    val scope = HazeEffectDrawScopeImpl(this, this@HazeEffectNode, typedEffectSampling)
+    val backdrop = with(capability) { scope.backdropEffect(typedEffectStyle) }
     if (backdrop == null) {
       activateBackdropFallback(failed = false)
       withVisualEffectTransform { drawContentSafely() }
@@ -693,7 +699,7 @@ internal class HazeEffectNode :
     var backdropDrawn = false
     withVisualEffectTransform {
       try {
-        withBackdropMaterialTransform(backdrop.materialTransform) {
+        withVisualEffectTransform(transform = backdrop.materialTransform) {
           val bounds = Rect(
             offset = Offset.Zero - layerOffset,
             size = layerSize,
@@ -703,7 +709,7 @@ internal class HazeEffectNode :
             renderer.configure(
               bounds = bounds,
               clip = clip,
-              effect = backdrop.platformEffect(),
+              effect = backdrop.platformEffect,
               alpha = backdrop.alpha,
             ) && renderer.draw(drawContext.canvas)
           }
@@ -719,14 +725,6 @@ internal class HazeEffectNode :
         drawEffectForeground()
       }
     }
-  }
-
-  @OptIn(InternalHazeApi::class)
-  private fun ContentDrawScope.preparedBackdropEffect(
-    capability: HazeEffectRendererBackdrop<Any?>,
-  ): HazeEffectBackdrop? {
-    val scope = HazeEffectDrawScopeImpl(this, this@HazeEffectNode, typedEffectSampling)
-    return with(capability) { scope.backdropEffect(typedEffectStyle) }
   }
 
   private fun activateBackdropFallback(failed: Boolean) {
@@ -1267,11 +1265,12 @@ internal class HazeEffectNode :
   }
 
   private inline fun ContentDrawScope.withVisualEffectTransform(
+    transform: HazeEffectContentTransform =
+      (typedEffectRenderer as? HazeEffectRendererInteraction)
+        ?.currentContentTransform()
+        ?: HazeEffectContentTransform.Identity,
     block: ContentDrawScope.() -> Unit,
   ) {
-    val transform = (typedEffectRenderer as? HazeEffectRendererInteraction)
-      ?.currentContentTransform()
-      ?: HazeEffectContentTransform.Identity
     if (transform == HazeEffectContentTransform.Identity) {
       block()
     } else {
@@ -1280,22 +1279,6 @@ internal class HazeEffectNode :
         scaleY = transform.scaleY,
         pivot = transform.pivot,
         block = { block(this@withVisualEffectTransform) },
-      )
-    }
-  }
-
-  private inline fun ContentDrawScope.withBackdropMaterialTransform(
-    transform: HazeEffectContentTransform,
-    block: ContentDrawScope.() -> Unit,
-  ) {
-    if (transform == HazeEffectContentTransform.Identity) {
-      block()
-    } else {
-      scale(
-        scaleX = transform.scaleX,
-        scaleY = transform.scaleY,
-        pivot = transform.pivot,
-        block = { block(this@withBackdropMaterialTransform) },
       )
     }
   }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -714,7 +714,7 @@ internal class HazeEffectNode :
             renderer.configure(
               bounds = bounds,
               clip = clip,
-              effect = backdrop.platformEffect(),
+              effect = backdrop.getPlatformEffect(),
               alpha = backdrop.alpha,
             ) && renderer.draw(drawContext.canvas)
           }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -657,9 +657,8 @@ internal class HazeEffectNode :
       return
     }
 
-    prepareEffectDraw()
-    val backdrop = preparedBackdropEffect()
-    if (backdrop == null) {
+    val capability = typedEffectRenderer as? HazeEffectRendererBackdrop<Any?>
+    if (capability == null) {
       activateBackdropFallback(failed = false)
       withVisualEffectTransform { drawContentSafely() }
       return
@@ -679,6 +678,13 @@ internal class HazeEffectNode :
       if (!backdropBackendState.usesFallback) {
         activateBackdropFallback(failed = false)
       }
+      withVisualEffectTransform { drawContentSafely() }
+      return
+    }
+
+    val backdrop = preparedBackdropEffect(capability)
+    if (backdrop == null) {
+      activateBackdropFallback(failed = false)
       withVisualEffectTransform { drawContentSafely() }
       return
     }
@@ -714,9 +720,9 @@ internal class HazeEffectNode :
   }
 
   @OptIn(InternalHazeApi::class)
-  private fun ContentDrawScope.preparedBackdropEffect(): HazeEffectBackdrop? {
-    val renderer = typedEffectRenderer ?: return null
-    val capability = renderer as? HazeEffectRendererBackdrop<Any?> ?: return null
+  private fun ContentDrawScope.preparedBackdropEffect(
+    capability: HazeEffectRendererBackdrop<Any?>,
+  ): HazeEffectBackdrop? {
     val scope = HazeEffectDrawScopeImpl(this, this@HazeEffectNode, typedEffectSampling)
     return with(capability) { scope.backdropEffect(typedEffectStyle) }
   }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -48,9 +48,8 @@ import kotlinx.coroutines.DisposableHandle
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 
-internal class HazeEffectNode(
-  state: HazeState? = null,
-) : DelegatingNode(),
+internal class HazeEffectNode :
+  DelegatingNode(),
   CompositionLocalConsumerModifierNode,
   ModifierLocalModifierNode,
   GlobalPositionAwareModifierNode,
@@ -66,7 +65,7 @@ internal class HazeEffectNode(
 
   internal var dirtyTracker = Bitmask(DirtyFields.Areas)
 
-  internal var state: HazeState? = state
+  internal var state: HazeState? = null
     set(value) {
       if (value != field) {
         HazeLogger.d(TAG) { "state changed. Current: $field. New: $value" }
@@ -81,28 +80,43 @@ internal class HazeEffectNode(
     set(value) {
       if (value != field) {
         HazeLogger.d(TAG) { "explicitInput changed. Current: $field. New: $value" }
-        val previous = field
-        val changesRetainedContent = previous !is HazeInput.Sources ||
-          value !is HazeInput.Sources ||
-          previous.state !== value.state
-        if (changesRetainedContent) {
-          clearRetainedOutput()
-        }
-        sourceSelectionSnapshotObserver?.clear(sourceSelectionObservationScope)
-        if ((value as? HazeInput.Sources)?.selection?.hasRefinements() != true) {
-          stopSourceSelectionSnapshotObserver()
-        }
-        dirtyTracker += DirtyFields.Areas
+        val previousInput = field
+        val previousSources = resolvedSourcesInput()
         field = value
-        reconcileSourceDemand()
-        when {
-          value is HazeInput.Sources -> {
-            retainOutputWhenSourceUnavailable = value.retention.keepsLastFrame()
-          }
-          previous is HazeInput.Sources -> retainOutputWhenSourceUnavailable = true
+        if (previousInput is HazeInput.Backdrop && value !is HazeInput.Backdrop) {
+          releaseBackdropRenderer()
         }
+        refreshResolvedSourcesInput(previousSources)
       }
     }
+
+  private val backdropBackendState = HazeBackdropBackendState()
+  private var backdropRenderer: HazeBackdropRenderer? = null
+  private val captureConsumer = Any()
+  private var captureDemandAreas: List<HazeArea> = emptyList()
+
+  private fun resolvedSourcesInput(): HazeInput.Sources? = when (val input = explicitInput) {
+    is HazeInput.Sources -> input
+    is HazeInput.Backdrop -> input.fallback.takeIf { backdropBackendState.usesFallback }
+    HazeInput.Content,
+    null,
+    -> null
+  }
+
+  private fun refreshResolvedSourcesInput(previous: HazeInput.Sources?) {
+    val current = resolvedSourcesInput()
+    if (previous == null || current == null || previous.state !== current.state) {
+      clearRetainedOutput()
+    }
+    sourceSelectionSnapshotObserver?.clear(sourceSelectionObservationScope)
+    if (current?.selection?.hasRefinements() != true) {
+      stopSourceSelectionSnapshotObserver()
+    }
+    retainOutputWhenSourceUnavailable = current?.retention?.keepsLastFrame() ?: true
+    state = current?.state
+    dirtyTracker += DirtyFields.Areas
+    syncCaptureDemand()
+  }
 
   private var needsPreDrawInvalidation = false
   private var needsDirtyFieldsInvalidation = false
@@ -244,10 +258,22 @@ internal class HazeEffectNode(
           area.preDrawListeners += areaPreDrawListener
         }
         field = value
+        syncCaptureDemand()
       }
     }
 
   internal val areas: List<HazeArea> get() = _areas
+
+  private fun syncCaptureDemand() {
+    val desiredAreas = if (resolvedSourcesInput() != null) _areas else emptyList()
+    for (area in captureDemandAreas) {
+      if (area !in desiredAreas) area.removeCaptureConsumer(captureConsumer)
+    }
+    for (area in desiredAreas) {
+      if (area !in captureDemandAreas) area.addCaptureConsumer(captureConsumer)
+    }
+    captureDemandAreas = desiredAreas
+  }
 
   private val contentDrawArea by lazy { HazeArea() }
 
@@ -428,14 +454,20 @@ internal class HazeEffectNode(
     coordinateTransformValues = null
     screenToEffectTransform = null
     lastInputSnapshot = null
+    releaseBackdropRenderer()
+    if (explicitInput is HazeInput.Backdrop) {
+      val previousSources = resolvedSourcesInput()
+      backdropBackendState.reset()
+      refreshResolvedSourcesInput(previousSources)
+    } else {
+      backdropBackendState.reset()
+    }
     disposeTypedRenderer()
     typedEffectRenderer = null
   }
 
   private fun reconcileSourceDemand() {
-    val demandState = state
-      ?.takeIf { explicitInput is HazeInput.Sources }
-      ?.takeIf { (explicitInput as HazeInput.Sources).state === it }
+    val demandState = resolvedSourcesInput()?.state
     if (!isAttached) return
     if (sourceDemandState !== demandState) {
       sourceDemandState?.removeSourceDemand(sourceDemandKey)
@@ -546,64 +578,11 @@ internal class HazeEffectNode(
 
       if (this@HazeEffectNode.size.isSpecified && this@HazeEffectNode.layerSize.isSpecified) {
         val shouldPrepareDraw = shouldPrepareEffectDraw()
-        if (state != null) {
-          val hasDrawableSourceLayers = hasDrawableSourceLayers()
-          if (!retainOutputWhenSourceUnavailable && !hasDrawableSourceLayers) {
-            clearRetainedOutput()
-          }
-
-          val shouldDrawEffect = shouldPrepareDraw && if (retainOutputWhenSourceUnavailable) {
-            areas.isNotEmpty() || shouldDrawRetainedOutput()
-          } else {
-            hasDrawableSourceLayers
-          }
-          if (shouldDrawEffect) {
-            prepareEffectDraw()
-          }
-          withVisualEffectTransform {
-            if (shouldDrawEffect) {
-              drawEffect()
-              if (typedEffectRenderer != null && hasDrawableSourceLayers) {
-                hasRenderedTypedSourceOutput = true
-              }
-            }
-            drawContentSafely()
-            if (shouldDrawEffect) {
-              drawEffectForeground()
-            }
-          }
-        } else if (shouldPrepareDraw) {
-          // Else we're doing content (foreground) blurring, so we need to use our
-          // contentDrawArea
-          val contentLayer = contentDrawArea.contentLayer
-            ?.takeUnless { it.isReleased }
-            ?: requireGraphicsContext().createGraphicsLayer().also {
-              contentDrawArea.contentLayer = it
-              HazeLogger.d(TAG) { "Updated contentLayer in content HazeArea" }
-            }
-          // Record the this node's content into the layer
-          contentLayer.record(size.toIntSize()) {
-            this@draw.drawContentSafely()
-          }
-          val effectOnlyDraw = needsVisualEffectInvalidation &&
-            !needsPreDrawInvalidation &&
-            !needsDirtyFieldsInvalidation &&
-            !needsContentInvalidation
-          if (!effectOnlyDraw) {
-            contentDrawArea.contentVersion++
-          }
-          prepareEffectDraw()
-          withVisualEffectTransform {
-            if (shouldDrawContentBehindEffect()) {
-              drawLayer(contentLayer)
-            }
-            drawEffect()
-            drawEffectForeground()
-          }
-        } else {
-          withVisualEffectTransform {
-            drawContentSafely()
-          }
+        when {
+          state != null -> drawSourceBackedEffect(shouldPrepareDraw)
+          explicitInput is HazeInput.Backdrop -> drawBackdropEffect(shouldPrepareDraw)
+          explicitInput === HazeInput.Content && shouldPrepareDraw -> drawContentEffect()
+          else -> withVisualEffectTransform { drawContentSafely() }
         }
       } else {
         HazeLogger.d(TAG) { "-> State not valid, so no need to draw effect." }
@@ -614,6 +593,160 @@ internal class HazeEffectNode(
       onPostDraw()
       HazeLogger.d(TAG) { "-> end draw()" }
     }
+  }
+
+  private fun ContentDrawScope.drawSourceBackedEffect(shouldPrepareDraw: Boolean) {
+    val hasDrawableSourceLayers = hasDrawableSourceLayers()
+    if (!retainOutputWhenSourceUnavailable && !hasDrawableSourceLayers) {
+      clearRetainedOutput()
+    }
+
+    val shouldDrawEffect = shouldPrepareDraw && if (retainOutputWhenSourceUnavailable) {
+      areas.isNotEmpty() || shouldDrawRetainedOutput()
+    } else {
+      hasDrawableSourceLayers
+    }
+    if (shouldDrawEffect) {
+      prepareEffectDraw()
+    }
+    withVisualEffectTransform {
+      if (shouldDrawEffect) {
+        drawEffect()
+        if (typedEffectRenderer != null && hasDrawableSourceLayers) {
+          hasRenderedTypedSourceOutput = true
+        }
+      }
+      drawContentSafely()
+      if (shouldDrawEffect) {
+        drawEffectForeground()
+      }
+    }
+  }
+
+  private fun ContentDrawScope.drawContentEffect() {
+    val contentLayer = contentDrawArea.contentLayer
+      ?.takeUnless { it.isReleased }
+      ?: requireGraphicsContext().createGraphicsLayer().also {
+        contentDrawArea.contentLayer = it
+        HazeLogger.d(TAG) { "Updated contentLayer in content HazeArea" }
+      }
+    contentLayer.record(size.toIntSize()) {
+      this@drawContentEffect.drawContentSafely()
+    }
+    val effectOnlyDraw = needsVisualEffectInvalidation &&
+      !needsPreDrawInvalidation &&
+      !needsDirtyFieldsInvalidation &&
+      !needsContentInvalidation
+    if (!effectOnlyDraw) {
+      contentDrawArea.contentVersion++
+    }
+    prepareEffectDraw()
+    withVisualEffectTransform {
+      if (shouldDrawContentBehindEffect()) {
+        drawLayer(contentLayer)
+      }
+      drawEffect()
+      drawEffectForeground()
+    }
+  }
+
+  @OptIn(InternalHazeApi::class)
+  private fun ContentDrawScope.drawBackdropEffect(shouldPrepareDraw: Boolean) {
+    if (!shouldPrepareDraw) {
+      withVisualEffectTransform { drawContentSafely() }
+      return
+    }
+
+    prepareEffectDraw()
+    val backdrop = preparedBackdropEffect()
+    if (backdrop == null) {
+      activateBackdropFallback(failed = false)
+      withVisualEffectTransform { drawContentSafely() }
+      return
+    }
+
+    val renderer = backdropRenderer ?: createHazeBackdropRenderer().also {
+      backdropRenderer = it
+    }
+    val supported = try {
+      renderer.isSupported(drawContext.canvas)
+    } catch (exception: Exception) {
+      HazeLogger.d(TAG, exception) { "Backdrop renderer support check failed" }
+      activateBackdropFallback(failed = true)
+      false
+    }
+    if (!supported) {
+      if (!backdropBackendState.usesFallback) {
+        activateBackdropFallback(failed = false)
+      }
+      withVisualEffectTransform { drawContentSafely() }
+      return
+    }
+
+    backdropBackendState.resolve(nativeAvailable = true)
+    var backdropDrawn = false
+    withVisualEffectTransform {
+      try {
+        withBackdropMaterialTransform(backdrop.materialTransform) {
+          val bounds = Rect(
+            offset = Offset.Zero - layerOffset,
+            size = layerSize,
+          )
+          val clip = Rect(Offset.Zero, size).takeIf { shouldClipEffectToNodeBounds() }
+          backdropDrawn = renderer.configure(
+            bounds = bounds,
+            clip = clip,
+            effect = backdrop.platformEffect(),
+            alpha = backdrop.alpha,
+          ) && renderer.draw(drawContext.canvas)
+        }
+      } catch (exception: Exception) {
+        HazeLogger.d(TAG, exception) { "Backdrop renderer draw failed" }
+      }
+      if (!backdropDrawn) {
+        activateBackdropFallback(failed = true)
+      }
+      drawContentSafely()
+      if (backdropDrawn) {
+        drawEffectForeground()
+      }
+    }
+  }
+
+  @OptIn(InternalHazeApi::class)
+  private fun ContentDrawScope.preparedBackdropEffect(): HazeEffectBackdrop? {
+    val renderer = typedEffectRenderer ?: return null
+    val capability = renderer as? HazeEffectRendererBackdrop<Any?> ?: return null
+    val scope = HazeEffectDrawScopeImpl(this, this@HazeEffectNode, typedEffectSampling)
+    return with(capability) { scope.backdropEffect(typedEffectStyle) }
+  }
+
+  private fun activateBackdropFallback(failed: Boolean) {
+    val previousSources = resolvedSourcesInput()
+    if (failed) {
+      backdropBackendState.fail()
+    } else {
+      backdropBackendState.resolve(nativeAvailable = false)
+    }
+    HazeLogger.d(TAG) {
+      "Backdrop selected ${backdropBackendState.selection}; using source fallback"
+    }
+    releaseBackdropRenderer()
+    refreshResolvedSourcesInput(previousSources)
+    coroutineScope.launch {
+      yield()
+      if (isAttached && backdropBackendState.usesFallback) {
+        dirtyTracker += DirtyFields.Areas
+        dirtyTracker += DirtyFields.VisualEffectLayerBounds
+        update()
+      }
+    }
+  }
+
+  private fun releaseBackdropRenderer() {
+    runCatching { backdropRenderer?.release() }
+      .onFailure { HazeLogger.d(TAG, it) { "Failed to release backdrop renderer" } }
+    backdropRenderer = null
   }
 
   @OptIn(InternalHazeApi::class)
@@ -687,7 +820,7 @@ internal class HazeEffectNode(
         }
 
         val unfilteredAreas = stateAreas.orEmpty()
-        val selection = checkNotNull(explicitInput as? HazeInput.Sources).selection
+        val selection = checkNotNull(resolvedSourcesInput()).selection
         val ancestorSourceNode = if (selection.baseSelection() == HazeSourceSelection.Behind) {
           var result: HazeSourceNode? = null
           traverseAncestors(HazeTraversableNodeKeys.Source) { node ->
@@ -746,7 +879,7 @@ internal class HazeEffectNode(
         updateAreaZIndexes(currentStateAreas)
         updateAreaKeys(currentStateAreas)
       }
-    } else {
+    } else if (explicitInput === HazeInput.Content) {
       areaZIndexes.clear()
       areaKeys.clear()
       // Foreground (content) blur: always update contentDrawArea since its size,
@@ -756,6 +889,10 @@ internal class HazeEffectNode(
       contentDrawArea.coordinates.screenPosition = position
       contentDrawArea.windowId = windowId
       _areas = listOf(contentDrawArea)
+    } else {
+      areaZIndexes.clear()
+      areaKeys.clear()
+      _areas = emptyList()
     }
 
     // Auto-promote position strategy when cross-window is detected
@@ -830,7 +967,21 @@ internal class HazeEffectNode(
         // Keep the previous layer bounds for source transition gaps. Recomputing
         // bounds with no areas collapses to the node size and clears the retained layer.
       } else if (
-        state == null &&
+        explicitInput is HazeInput.Backdrop &&
+        size.isSpecified
+      ) {
+        val rect = size.toRect()
+        val expanded = rect.letIf(shouldExpandLayer()) {
+          calculateEffectLayerBounds(it, requireDensity())
+        }
+        val clippedLayerBounds = expanded.intersect(rootBoundsInEffect())
+        _layerSize = Size(
+          width = clippedLayerBounds.width.coerceAtLeast(0f),
+          height = clippedLayerBounds.height.coerceAtLeast(0f),
+        )
+        _layerOffset = rect.topLeft - clippedLayerBounds.topLeft
+      } else if (
+        explicitInput === HazeInput.Content &&
         size.isSpecified &&
         !shouldClipEffectToNodeBounds() &&
         shouldExpandLayer()
@@ -1125,6 +1276,22 @@ internal class HazeEffectNode(
     }
   }
 
+  private inline fun ContentDrawScope.withBackdropMaterialTransform(
+    transform: HazeEffectContentTransform,
+    block: ContentDrawScope.() -> Unit,
+  ) {
+    if (transform == HazeEffectContentTransform.Identity) {
+      block()
+    } else {
+      scale(
+        scaleX = transform.scaleX,
+        scaleY = transform.scaleY,
+        pivot = transform.pivot,
+        block = { block(this@withBackdropMaterialTransform) },
+      )
+    }
+  }
+
   private fun shouldDrawRetainedOutput(): Boolean {
     return retainOutputWhenSourceUnavailable &&
       hasRenderedTypedSourceOutput &&
@@ -1141,6 +1308,10 @@ internal class HazeEffectNode(
         area.contentLayer?.isReleased == false
     }
   }
+
+  internal fun hasDrawableInput(): Boolean =
+    (explicitInput is HazeInput.Backdrop && !backdropBackendState.usesFallback) ||
+      hasDrawableSourceLayers()
 
   internal fun inputSnapshot(): HazeEffectInputSnapshot? {
     lastInputSnapshot

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -100,11 +100,7 @@ internal class HazeEffectNode(
   private fun resolvedSourcesInput(): HazeInput.Sources? = when (val input = explicitInput) {
     is HazeInput.Sources -> input
     is HazeInput.Backdrop -> if (backdropBackendState.usesFallback) {
-      HazeInput.Sources(
-        state = input.state,
-        selection = input.fallbackSelection,
-        retention = input.fallbackRetention,
-      )
+      input.fallback
     } else {
       null
     }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -97,7 +97,15 @@ internal class HazeEffectNode :
 
   private fun resolvedSourcesInput(): HazeInput.Sources? = when (val input = explicitInput) {
     is HazeInput.Sources -> input
-    is HazeInput.Backdrop -> input.fallback.takeIf { backdropBackendState.usesFallback }
+    is HazeInput.Backdrop -> if (backdropBackendState.usesFallback) {
+      HazeInput.Sources(
+        state = input.state,
+        selection = input.fallbackSelection,
+        retention = input.fallbackRetention,
+      )
+    } else {
+      null
+    }
     HazeInput.Content,
     null,
     -> null
@@ -419,6 +427,9 @@ internal class HazeEffectNode :
   private var trimMemoryCallbackDisposable: DisposableHandle? = null
 
   override fun onAttach() {
+    val previousSources = resolvedSourcesInput()
+    backdropBackendState.attach(HazeFeatureFlags.isPlatformBackdropEnabled)
+    refreshResolvedSourcesInput(previousSources)
     val typedRenderer = typedEffectRenderer ?: createTypedRenderer?.invoke()?.also {
       typedEffectRenderer = it
     }
@@ -455,13 +466,7 @@ internal class HazeEffectNode :
     screenToEffectTransform = null
     lastInputSnapshot = null
     releaseBackdropRenderer()
-    if (explicitInput is HazeInput.Backdrop) {
-      val previousSources = resolvedSourcesInput()
-      backdropBackendState.reset()
-      refreshResolvedSourcesInput(previousSources)
-    } else {
-      backdropBackendState.reset()
-    }
+    backdropBackendState.reset()
     disposeTypedRenderer()
     typedEffectRenderer = null
   }
@@ -709,7 +714,7 @@ internal class HazeEffectNode :
             renderer.configure(
               bounds = bounds,
               clip = clip,
-              effect = backdrop.platformEffect,
+              effect = backdrop.platformEffect(),
               alpha = backdrop.alpha,
             ) && renderer.draw(drawContext.canvas)
           }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeFeatureFlags.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeFeatureFlags.kt
@@ -1,0 +1,23 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import kotlin.jvm.JvmField
+
+/** Experimental process-wide runtime feature switches. */
+@ExperimentalHazeApi
+public object HazeFeatureFlags {
+
+  /**
+   * Whether built-in effects may use a platform window-backdrop renderer.
+   *
+   * This value is read when a Haze effect modifier node is attached. Changing it does not alter
+   * nodes that are already attached; reattach a node for it to observe the new value. Enabling the
+   * flag only makes native rendering eligible. Platform, window, canvas, effect, setup, and draw
+   * checks can still select the configured source fallback, which remains the portable behavior.
+   * The default is `false` while the platform implementation is experimental.
+   */
+  @JvmField
+  public var isPlatformBackdropEnabled: Boolean = false
+}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeFeatureFlags.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeFeatureFlags.kt
@@ -17,6 +17,9 @@ public object HazeFeatureFlags {
    * flag only makes native rendering eligible. Platform, window, canvas, effect, setup, and draw
    * checks can still select the configured source fallback, which remains the portable behavior.
    * The default is `false` while the platform implementation is experimental.
+   *
+   * Once physical Android 37.2 acceptance is complete, a later release may flip the default while
+   * retaining a temporary `false` escape hatch for regressions, then remove this experimental flag.
    */
   @JvmField
   public var isPlatformBackdropEnabled: Boolean = false

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
@@ -25,18 +25,26 @@ public sealed interface HazeInput {
   ) : HazeInput
 
   /**
-   * Pixels already drawn behind the effect in the current hardware-accelerated window.
+   * Pixels already drawn behind the effect in the current window.
    *
-   * The native backdrop path is currently available only on supported Android releases and for
-   * built-in effects that expose a compatible platform effect. [fallback] is used everywhere else
-   * and after any native setup or draw failure.
+   * The native backdrop path is available only when enabled by
+   * [HazeFeatureFlags.isPlatformBackdropEnabled], on supported Android releases, and for
+   * built-in effects that expose a compatible platform effect. The fallback options are used
+   * everywhere else and after any native setup or draw failure. Native backdrop rendering samples
+   * earlier pixels in the same window; it does not select individual [HazeSource] instances or
+   * sample content from another window.
    *
-   * @property fallback Source-backed input used when the native backdrop is unavailable or fails.
+   * @property state Shared state used by the source fallback.
+   * @property fallbackSelection Selection used only when the native backdrop is unavailable or
+   * fails.
+   * @property fallbackRetention Retention policy used only when the native backdrop is unavailable
+   * or fails.
    */
-  @ExperimentalHazeApi
   @Stable
   public data class Backdrop(
-    public val fallback: Sources,
+    public val state: HazeState,
+    public val fallbackSelection: HazeSourceSelection = HazeSourceSelection.Behind,
+    public val fallbackRetention: HazeSourceRetention = HazeSourceRetention.KeepLastFrame,
   ) : HazeInput
 
   /**

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
@@ -39,18 +39,16 @@ public sealed interface HazeInput {
    * Changing it affects later attachments only. A native-to-source fallback transition can take
    * one frame and remains selected until detachment after a known native failure.
    *
-   * @property state Shared state used by the source fallback.
-   * @property fallbackSelection Selection used only when the native backdrop is unavailable or
-   * fails; it does not filter native window pixels.
-   * @property fallbackRetention Retention policy used only when the native backdrop is unavailable
-   * or fails.
+   * @property fallback Source input used only when the native backdrop is unavailable or fails; it
+   * does not filter native window pixels.
    */
   @Stable
   public data class Backdrop(
-    public val state: HazeState,
-    public val fallbackSelection: HazeSourceSelection = HazeSourceSelection.Behind,
-    public val fallbackRetention: HazeSourceRetention = HazeSourceRetention.KeepLastFrame,
-  ) : HazeInput
+    public val fallback: HazeInput.Sources,
+  ) : HazeInput {
+    /** Creates a backdrop input with the default source fallback for [state]. */
+    public constructor(state: HazeState) : this(Sources(state))
+  }
 
   /**
    * The content of the composable carrying the effect modifier.

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
@@ -25,18 +25,23 @@ public sealed interface HazeInput {
   ) : HazeInput
 
   /**
-   * Pixels already drawn behind the effect in the current window.
+   * The intent to consume pixels already drawn behind the effect in the current window.
    *
-   * The native backdrop path is available only when enabled by
-   * [HazeFeatureFlags.isPlatformBackdropEnabled], on supported Android releases, and for
-   * built-in effects that expose a compatible platform effect. The fallback options are used
-   * everywhere else and after any native setup or draw failure. Native backdrop rendering samples
-   * earlier pixels in the same window; it does not select individual [HazeSource] instances or
-   * sample content from another window.
+   * This is the normal portable input for built-in effects. When
+   * [HazeFeatureFlags.isPlatformBackdropEnabled] is enabled before attachment, the native path is
+   * eligible on supported Android releases and for built-in effects that expose a compatible
+   * platform effect. Eligibility is not a guarantee: the fallback options are used everywhere
+   * else and after any native setup or draw failure. Native backdrop rendering samples earlier
+   * pixels in the same window; it does not select individual source instances, include later
+   * drawing, or sample content from another window.
+   *
+   * The experimental flag defaults to `false` and is read when the modifier node attaches.
+   * Changing it affects later attachments only. A native-to-source fallback transition can take
+   * one frame and remains selected until detachment after a known native failure.
    *
    * @property state Shared state used by the source fallback.
    * @property fallbackSelection Selection used only when the native backdrop is unavailable or
-   * fails.
+   * fails; it does not filter native window pixels.
    * @property fallbackRetention Retention policy used only when the native backdrop is unavailable
    * or fails.
    */

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeInput.kt
@@ -25,6 +25,21 @@ public sealed interface HazeInput {
   ) : HazeInput
 
   /**
+   * Pixels already drawn behind the effect in the current hardware-accelerated window.
+   *
+   * The native backdrop path is currently available only on supported Android releases and for
+   * built-in effects that expose a compatible platform effect. [fallback] is used everywhere else
+   * and after any native setup or draw failure.
+   *
+   * @property fallback Source-backed input used when the native backdrop is unavailable or fails.
+   */
+  @ExperimentalHazeApi
+  @Stable
+  public data class Backdrop(
+    public val fallback: Sources,
+  ) : HazeInput
+
+  /**
    * The content of the composable carrying the effect modifier.
    */
   public data object Content : HazeInput

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -265,7 +265,7 @@ internal class HazeSourceNode(
         return
       }
 
-      if (!hasCaptureDemand) {
+      if (!hasCaptureDemand || !area.hasCaptureDemand) {
         area.releaseLayer()
         drawContentSafely()
         return
@@ -285,9 +285,11 @@ internal class HazeSourceNode(
           }
 
         // First we draw the composable content into a graphics layer
-        contentLayer.record {
-          this@draw.drawContentSafely()
-          HazeLogger.d(TAG) { "Drawn content into layer: $contentLayer" }
+        trace("HazeSource.record") {
+          contentLayer.record {
+            this@draw.drawContentSafely()
+            HazeLogger.d(TAG) { "Drawn content into layer: $contentLayer" }
+          }
         }
         area.contentVersion++
 
@@ -295,9 +297,9 @@ internal class HazeSourceNode(
         drawLayer(contentLayer)
         HazeLogger.d(TAG) { "Drawn layer to canvas: $contentLayer" }
       } else {
-        HazeLogger.d(TAG) { "Not using graphics layer, so drawing content direct to canvas" }
-        // A previously recorded layer must not remain available to effects after this source
-        // becomes too small to capture. Effects may retain their own output separately.
+        HazeLogger.d(TAG) { "No capture demand, so drawing content direct to canvas" }
+        // A previously recorded layer must not remain available after capture demand disappears or
+        // this source becomes too small. Effects may retain their own output separately.
         area.releaseLayer()
         // If we're not using graphics layers, just call drawContent and return early
         drawContentSafely()

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Log.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Log.kt
@@ -5,11 +5,13 @@ package dev.chrisbanes.haze
 
 import androidx.compose.runtime.snapshots.Snapshot
 
-/** Debug logging controls for diagnosing Haze rendering behavior. */
+/** Debug logging controls for diagnosing Haze rendering behavior, including Backdrop selection. */
 public object HazeLogger {
   /**
    * Whether to print debug log statements to the relevant system logger. Do not build release
-   * artifacts with this enabled. It's purely for debugging purposes.
+   * artifacts with this enabled. When enabled, Backdrop selection and source-fallback messages are
+   * included. Native backdrop work is marked separately by the `HazeBackdrop.draw` trace section.
+   * This is purely for debugging purposes.
    */
   public var enabled: Boolean = false
 

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeAreaCaptureDemandTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeAreaCaptureDemandTest.kt
@@ -1,0 +1,34 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class HazeAreaCaptureDemandTest {
+
+  @Test
+  fun captureDemand_tracksConsumersByIdentity() {
+    val area = HazeArea()
+    val firstConsumer = Any()
+    val secondConsumer = Any()
+
+    assertThat(area.hasCaptureDemand).isFalse()
+    area.addCaptureConsumer(firstConsumer)
+    area.addCaptureConsumer(firstConsumer)
+    assertThat(area.captureConsumerCount).isEqualTo(1)
+
+    area.addCaptureConsumer(secondConsumer)
+    assertThat(area.captureConsumerCount).isEqualTo(2)
+    assertThat(area.hasCaptureDemand).isTrue()
+
+    area.removeCaptureConsumer(firstConsumer)
+    assertThat(area.hasCaptureDemand).isTrue()
+    area.removeCaptureConsumer(secondConsumer)
+    assertThat(area.hasCaptureDemand).isFalse()
+  }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeBackdropBackendStateTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeBackdropBackendStateTest.kt
@@ -15,11 +15,10 @@ class HazeBackdropBackendStateTest {
   fun nativeSelection_remainsNativeWhileAvailable() {
     val state = HazeBackdropBackendState()
 
-    assertThat(state.resolve(nativeAvailable = true))
-      .isEqualTo(HazeBackdropBackendSelection.Native)
-    assertThat(state.resolve(nativeAvailable = true))
-      .isEqualTo(HazeBackdropBackendSelection.Native)
-    assertThat(state.usesNative).isTrue()
+    state.resolve(nativeAvailable = true)
+    state.resolve(nativeAvailable = true)
+
+    assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.Native)
     assertThat(state.usesFallback).isFalse()
   }
 
@@ -28,8 +27,9 @@ class HazeBackdropBackendStateTest {
     val state = HazeBackdropBackendState()
     state.resolve(nativeAvailable = true)
 
-    assertThat(state.resolve(nativeAvailable = false))
-      .isEqualTo(HazeBackdropBackendSelection.FallbackUnavailable)
+    state.resolve(nativeAvailable = false)
+
+    assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.FallbackUnavailable)
     assertThat(state.usesFallback).isTrue()
   }
 
@@ -37,10 +37,10 @@ class HazeBackdropBackendStateTest {
   fun unavailableSelection_remainsStickyWhenNativeBecomesAvailable() {
     val state = HazeBackdropBackendState()
 
-    assertThat(state.resolve(nativeAvailable = false))
-      .isEqualTo(HazeBackdropBackendSelection.FallbackUnavailable)
-    assertThat(state.resolve(nativeAvailable = true))
-      .isEqualTo(HazeBackdropBackendSelection.FallbackUnavailable)
+    state.resolve(nativeAvailable = false)
+    state.resolve(nativeAvailable = true)
+
+    assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.FallbackUnavailable)
     assertThat(state.usesFallback).isTrue()
   }
 
@@ -49,9 +49,10 @@ class HazeBackdropBackendStateTest {
     val state = HazeBackdropBackendState()
     state.resolve(nativeAvailable = true)
 
-    assertThat(state.fail()).isEqualTo(HazeBackdropBackendSelection.FallbackFailed)
-    assertThat(state.resolve(nativeAvailable = true))
-      .isEqualTo(HazeBackdropBackendSelection.FallbackFailed)
+    state.fail()
+    state.resolve(nativeAvailable = true)
+
+    assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.FallbackFailed)
     assertThat(state.usesFallback).isTrue()
   }
 
@@ -63,7 +64,6 @@ class HazeBackdropBackendStateTest {
     state.reset()
 
     assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.Undecided)
-    assertThat(state.usesNative).isFalse()
     assertThat(state.usesFallback).isFalse()
   }
 }

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeBackdropBackendStateTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeBackdropBackendStateTest.kt
@@ -1,0 +1,69 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class HazeBackdropBackendStateTest {
+
+  @Test
+  fun nativeSelection_remainsNativeWhileAvailable() {
+    val state = HazeBackdropBackendState()
+
+    assertThat(state.resolve(nativeAvailable = true))
+      .isEqualTo(HazeBackdropBackendSelection.Native)
+    assertThat(state.resolve(nativeAvailable = true))
+      .isEqualTo(HazeBackdropBackendSelection.Native)
+    assertThat(state.usesNative).isTrue()
+    assertThat(state.usesFallback).isFalse()
+  }
+
+  @Test
+  fun nativeSelection_downgradesWhenPlatformBecomesUnavailable() {
+    val state = HazeBackdropBackendState()
+    state.resolve(nativeAvailable = true)
+
+    assertThat(state.resolve(nativeAvailable = false))
+      .isEqualTo(HazeBackdropBackendSelection.FallbackUnavailable)
+    assertThat(state.usesFallback).isTrue()
+  }
+
+  @Test
+  fun unavailableSelection_remainsStickyWhenNativeBecomesAvailable() {
+    val state = HazeBackdropBackendState()
+
+    assertThat(state.resolve(nativeAvailable = false))
+      .isEqualTo(HazeBackdropBackendSelection.FallbackUnavailable)
+    assertThat(state.resolve(nativeAvailable = true))
+      .isEqualTo(HazeBackdropBackendSelection.FallbackUnavailable)
+    assertThat(state.usesFallback).isTrue()
+  }
+
+  @Test
+  fun nativeFailure_remainsStickyAcrossLaterResolution() {
+    val state = HazeBackdropBackendState()
+    state.resolve(nativeAvailable = true)
+
+    assertThat(state.fail()).isEqualTo(HazeBackdropBackendSelection.FallbackFailed)
+    assertThat(state.resolve(nativeAvailable = true))
+      .isEqualTo(HazeBackdropBackendSelection.FallbackFailed)
+    assertThat(state.usesFallback).isTrue()
+  }
+
+  @Test
+  fun reset_returnsToUndecidedForNewAttachment() {
+    val state = HazeBackdropBackendState()
+    state.resolve(nativeAvailable = false)
+
+    state.reset()
+
+    assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.Undecided)
+    assertThat(state.usesNative).isFalse()
+    assertThat(state.usesFallback).isFalse()
+  }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeBackdropBackendStateTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeBackdropBackendStateTest.kt
@@ -12,6 +12,26 @@ import kotlin.test.Test
 class HazeBackdropBackendStateTest {
 
   @Test
+  fun disabledAttachment_selectsFallbackImmediately() {
+    val state = HazeBackdropBackendState()
+
+    state.attach(platformBackdropEnabled = false)
+
+    assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.FallbackUnavailable)
+    assertThat(state.usesFallback).isTrue()
+  }
+
+  @Test
+  fun enabledAttachment_remainsUndecidedUntilCapabilityResolution() {
+    val state = HazeBackdropBackendState()
+
+    state.attach(platformBackdropEnabled = true)
+
+    assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.Undecided)
+    assertThat(state.usesFallback).isFalse()
+  }
+
+  @Test
   fun nativeSelection_remainsNativeWhileAvailable() {
     val state = HazeBackdropBackendState()
 
@@ -65,5 +85,16 @@ class HazeBackdropBackendStateTest {
 
     assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.Undecided)
     assertThat(state.usesFallback).isFalse()
+  }
+
+  @Test
+  fun reset_allowsNewAttachmentDecision() {
+    val state = HazeBackdropBackendState()
+    state.attach(platformBackdropEnabled = false)
+
+    state.reset()
+    state.attach(platformBackdropEnabled = true)
+
+    assertThat(state.selection).isEqualTo(HazeBackdropBackendSelection.Undecided)
   }
 }

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeBackdropSdkSupportTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeBackdropSdkSupportTest.kt
@@ -1,0 +1,54 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(InternalHazeApi::class)
+
+package dev.chrisbanes.haze
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class HazeBackdropSdkSupportTest {
+
+  @Test
+  fun isHazeBackdropSdkSupported_returnsTrue_forFinal37_2() {
+    assertThat(
+      isHazeBackdropSdkSupported(
+        fullSdkInt = 3_700_002,
+        previewSdkInt = 0,
+      ),
+    ).isTrue()
+  }
+
+  @Test
+  fun isHazeBackdropSdkSupported_returnsTrue_for37_2Beta3() {
+    assertThat(
+      isHazeBackdropSdkSupported(
+        fullSdkInt = 3_700_001,
+        previewSdkInt = 3_723,
+      ),
+    ).isTrue()
+  }
+
+  @Test
+  fun isHazeBackdropSdkSupported_returnsFalse_forDifferentPreviewRevision() {
+    assertThat(
+      isHazeBackdropSdkSupported(
+        fullSdkInt = 3_700_001,
+        previewSdkInt = 3_722,
+      ),
+    ).isFalse()
+  }
+
+  @Test
+  fun isHazeBackdropSdkSupported_returnsFalse_forFinal37_1() {
+    assertThat(
+      isHazeBackdropSdkSupported(
+        fullSdkInt = 3_700_001,
+        previewSdkInt = 0,
+      ),
+    ).isFalse()
+  }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeFeatureFlagsTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeFeatureFlagsTest.kt
@@ -1,0 +1,25 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+
+class HazeFeatureFlagsTest {
+
+  @Test
+  fun platformBackdrop_isDisabledByDefaultAndMutable() {
+    assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isFalse()
+
+    val previous = HazeFeatureFlags.isPlatformBackdropEnabled
+    try {
+      HazeFeatureFlags.isPlatformBackdropEnabled = true
+      assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isTrue()
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previous
+    }
+  }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeInputTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeInputTest.kt
@@ -6,6 +6,8 @@ package dev.chrisbanes.haze
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
+import assertk.assertions.isNotEqualTo
+import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import kotlin.test.Test
 
@@ -36,21 +38,25 @@ class HazeInputTest {
     val state = HazeState()
     val input = HazeInput.Backdrop(state)
 
-    assertThat(input.state).isEqualTo(state)
-    assertThat(input.fallbackSelection).isEqualTo(HazeSourceSelection.Behind)
-    assertThat(input.fallbackRetention).isEqualTo(HazeSourceRetention.KeepLastFrame)
+    assertThat(input).isEqualTo(HazeInput.Backdrop(HazeInput.Sources(state)))
+    assertThat(input.fallback.state).isEqualTo(state)
+    assertThat(input.fallback.selection).isEqualTo(HazeSourceSelection.Behind)
+    assertThat(input.fallback.retention).isEqualTo(HazeSourceRetention.KeepLastFrame)
   }
 
   @Test
-  fun backdrop_acceptsAllAndClearWhenUnavailableFallback() {
-    val input = HazeInput.Backdrop(
-      state = HazeState(),
-      fallbackSelection = HazeSourceSelection.All,
-      fallbackRetention = HazeSourceRetention.ClearWhenUnavailable,
+  fun backdrop_preservesCustomFallbackSourcesIdentityAndValueSemantics() {
+    val state = HazeState()
+    val fallback = HazeInput.Sources(
+      state = state,
+      selection = HazeSourceSelection.All,
+      retention = HazeSourceRetention.ClearWhenUnavailable,
     )
+    val input = HazeInput.Backdrop(fallback)
 
-    assertThat(input.fallbackSelection).isEqualTo(HazeSourceSelection.All)
-    assertThat(input.fallbackRetention).isEqualTo(HazeSourceRetention.ClearWhenUnavailable)
+    assertThat(input.fallback).isSameInstanceAs(fallback)
+    assertThat(input.copy()).isEqualTo(input)
+    assertThat(input.copy(fallback = HazeInput.Sources(state))).isNotEqualTo(input)
   }
 
   @Test

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeInputTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeInputTest.kt
@@ -31,16 +31,26 @@ class HazeInputTest {
     assertThat(input.retention).isEqualTo(HazeSourceRetention.ClearWhenUnavailable)
   }
 
-  @OptIn(ExperimentalHazeApi::class)
   @Test
-  fun backdrop_requiresExplicitSourcesFallback() {
-    val fallback = HazeInput.Sources(
+  fun backdrop_defaultsToBehindAndKeepLastFrame() {
+    val state = HazeState()
+    val input = HazeInput.Backdrop(state)
+
+    assertThat(input.state).isEqualTo(state)
+    assertThat(input.fallbackSelection).isEqualTo(HazeSourceSelection.Behind)
+    assertThat(input.fallbackRetention).isEqualTo(HazeSourceRetention.KeepLastFrame)
+  }
+
+  @Test
+  fun backdrop_acceptsAllAndClearWhenUnavailableFallback() {
+    val input = HazeInput.Backdrop(
       state = HazeState(),
-      selection = HazeSourceSelection.All,
-      retention = HazeSourceRetention.ClearWhenUnavailable,
+      fallbackSelection = HazeSourceSelection.All,
+      fallbackRetention = HazeSourceRetention.ClearWhenUnavailable,
     )
 
-    assertThat(HazeInput.Backdrop(fallback).fallback).isEqualTo(fallback)
+    assertThat(input.fallbackSelection).isEqualTo(HazeSourceSelection.All)
+    assertThat(input.fallbackRetention).isEqualTo(HazeSourceRetention.ClearWhenUnavailable)
   }
 
   @Test

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeInputTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeInputTest.kt
@@ -31,6 +31,18 @@ class HazeInputTest {
     assertThat(input.retention).isEqualTo(HazeSourceRetention.ClearWhenUnavailable)
   }
 
+  @OptIn(ExperimentalHazeApi::class)
+  @Test
+  fun backdrop_requiresExplicitSourcesFallback() {
+    val fallback = HazeInput.Sources(
+      state = HazeState(),
+      selection = HazeSourceSelection.All,
+      retention = HazeSourceRetention.ClearWhenUnavailable,
+    )
+
+    assertThat(HazeInput.Backdrop(fallback).fallback).isEqualTo(fallback)
+  }
+
   @Test
   fun sourceMetadata_exposesOnlyStableValues() {
     val metadata = HazeSourceMetadata(key = "source", zIndex = 2f)

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeBackdropFallbackTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeBackdropFallbackTest.kt
@@ -1,0 +1,265 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isNull
+import kotlin.test.Test
+import org.jetbrains.skia.FilterTileMode
+import org.jetbrains.skia.ImageFilter
+
+@OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class, InternalHazeApi::class)
+class HazeBackdropFallbackTest {
+  @Test
+  fun healthyNativeBackdrop_doesNotDemandFallbackCapture() = runComposeUiTest {
+    val state = HazeState()
+    val nativeRenderer = TestBackdropRenderer()
+    val previousFlag = HazeFeatureFlags.isPlatformBackdropEnabled
+    HazeFeatureFlags.isPlatformBackdropEnabled = true
+    try {
+      setContent {
+        val lifecycle = LocalLifecycleOwner.current.lifecycle
+        Box(Modifier.size(100.dp)) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .hazeSource(state)
+              .background(Color.Red),
+          )
+          Box(
+            Modifier
+              .fillMaxSize()
+              .then(
+                FaultInjectedEffectElement(
+                  input = HazeInput.Backdrop(state),
+                  lifecycle = lifecycle,
+                  createRenderer = { nativeRenderer },
+                  renderer = HealthyBackdropRenderer(),
+                ),
+              ),
+          )
+        }
+      }
+      waitForIdle()
+
+      val area = state.areas.single()
+      assertThat(area.captureConsumerCount).isEqualTo(0)
+      assertThat(area.contentVersion).isEqualTo(0L)
+      assertThat(area.contentLayer).isNull()
+      assertThat(nativeRenderer.drawCalls).isGreaterThan(0)
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previousFlag
+    }
+  }
+
+  @Test
+  fun rendererCreationFailure_activatesFallbackWithoutEscapingDraw() = runComposeUiTest {
+    val state = HazeState()
+    var creationAttempts = 0
+    val previousFlag = HazeFeatureFlags.isPlatformBackdropEnabled
+    HazeFeatureFlags.isPlatformBackdropEnabled = true
+    try {
+      setContent {
+        val lifecycle = LocalLifecycleOwner.current.lifecycle
+        Box(Modifier.size(100.dp)) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .hazeSource(state)
+              .background(Color.Red),
+          )
+          Box(
+            Modifier
+              .fillMaxSize()
+              .testTag("creation-effect")
+              .then(
+                FaultInjectedEffectElement(
+                  input = HazeInput.Backdrop(state),
+                  lifecycle = lifecycle,
+                  createRenderer = {
+                    creationAttempts++
+                    error("test renderer creation failure")
+                  },
+                  renderer = ThrowingBackdropRenderer(),
+                ),
+              ),
+          )
+        }
+      }
+      waitForIdle()
+
+      assertThat(onNodeWithTag("creation-effect").captureToImage().toPixelMap()[50, 50])
+        .isEqualTo(Color.Red)
+      assertThat(state.areas.single().captureConsumerCount).isEqualTo(1)
+      assertThat(creationAttempts).isEqualTo(1)
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previousFlag
+    }
+  }
+
+  @Test
+  fun preparationFailure_activatesStickyFallbackAndDemandsCapture() = runComposeUiTest {
+    val state = HazeState()
+    var creationAttempts = 0
+    val attached = mutableStateOf(true)
+    val invalidation = mutableStateOf(0)
+    val renderers = mutableListOf<TestBackdropRenderer>()
+    val input = HazeInput.Backdrop(state)
+    val previousFlag = HazeFeatureFlags.isPlatformBackdropEnabled
+    HazeFeatureFlags.isPlatformBackdropEnabled = true
+    try {
+      setContent {
+        val lifecycle = LocalLifecycleOwner.current.lifecycle
+        Box(Modifier.size(100.dp)) {
+          Box(
+            Modifier
+              .fillMaxSize()
+              .hazeSource(state)
+              .background(Color.Red),
+          )
+          if (attached.value) {
+            Box(
+              Modifier
+                .fillMaxSize()
+                .testTag("effect")
+                .drawWithContent {
+                  invalidation.value
+                  drawContent()
+                }
+                .then(
+                  FaultInjectedEffectElement(
+                    input = input,
+                    lifecycle = lifecycle,
+                    createRenderer = {
+                      creationAttempts++
+                      TestBackdropRenderer().also(renderers::add)
+                    },
+                    renderer = ThrowingBackdropRenderer(),
+                  ),
+                ),
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      assertThat(onNodeWithTag("effect").captureToImage().toPixelMap()[50, 50])
+        .isEqualTo(Color.Red)
+      assertThat(state.areas.single().captureConsumerCount).isEqualTo(1)
+      assertThat(creationAttempts).isEqualTo(1)
+      assertThat(renderers.size).isEqualTo(1)
+      assertThat(renderers.single().releaseCalls).isEqualTo(1)
+
+      repeat(3) {
+        invalidation.value++
+        waitForIdle()
+      }
+      assertThat(creationAttempts).isEqualTo(1)
+      assertThat(renderers.single().releaseCalls).isEqualTo(1)
+
+      attached.value = false
+      waitForIdle()
+      attached.value = true
+      waitForIdle()
+      assertThat(creationAttempts).isEqualTo(2)
+      assertThat(renderers.size).isEqualTo(2)
+      assertThat(renderers.first().releaseCalls).isEqualTo(1)
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previousFlag
+    }
+  }
+}
+
+private class FaultInjectedEffectElement(
+  private val input: HazeInput,
+  private val lifecycle: Lifecycle,
+  private val createRenderer: () -> HazeBackdropRenderer?,
+  private val renderer: HazeEffectRenderer<Unit>,
+) : ModifierNodeElement<HazeEffectNode>() {
+  override fun create(): HazeEffectNode = HazeEffectNode(createRenderer).also {
+    it.explicitInput = input
+    it.updateTypedEffect(StaticRendererFactory(renderer), Unit, HazeSampling.Default)
+    it.updateLifecycle(lifecycle)
+  }
+
+  override fun update(node: HazeEffectNode) {
+    node.explicitInput = input
+    node.updateLifecycle(lifecycle)
+    node.update()
+  }
+
+  override fun hashCode(): Int = input.hashCode()
+
+  override fun equals(other: Any?): Boolean =
+    other is FaultInjectedEffectElement && other.input == input
+}
+
+private class StaticRendererFactory(
+  private val renderer: HazeEffectRenderer<Unit>,
+) : HazeEffectFactory<Unit> {
+  override fun createRenderer(): HazeEffectRenderer<Unit> = renderer
+}
+
+private class ThrowingBackdropRenderer :
+  HazeEffectRenderer<Unit>,
+  HazeEffectRendererBackdrop<Unit> {
+  override fun HazeEffectDrawScope.draw(style: Unit) = drawInput()
+
+  override fun HazeEffectRuntimeDrawScope.backdropEffect(style: Unit): HazeEffectBackdrop {
+    throw IllegalStateException("test backdrop preparation failure")
+  }
+}
+
+private class HealthyBackdropRenderer :
+  HazeEffectRenderer<Unit>,
+  HazeEffectRendererBackdrop<Unit> {
+  override fun HazeEffectDrawScope.draw(style: Unit) = drawInput()
+
+  override fun HazeEffectRuntimeDrawScope.backdropEffect(style: Unit): HazeEffectBackdrop =
+    HazeEffectBackdrop(ImageFilter.makeBlur(0f, 0f, FilterTileMode.CLAMP))
+}
+
+private class TestBackdropRenderer : HazeBackdropRenderer {
+  var drawCalls = 0
+  var releaseCalls = 0
+
+  override fun isSupported(canvas: Canvas): Boolean = true
+
+  override fun configure(
+    bounds: androidx.compose.ui.geometry.Rect,
+    clip: androidx.compose.ui.geometry.Rect?,
+    effect: PlatformRenderEffect,
+    alpha: Float,
+  ): Boolean = true
+
+  override fun draw(canvas: Canvas): Boolean {
+    drawCalls++
+    return true
+  }
+
+  override fun release() {
+    releaseCalls++
+  }
+}

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
@@ -68,7 +68,7 @@ class HazeEffectInputTest {
   }
 
   @Test
-  fun unavailableBackdrop_demandsFallbackSourceCapture() = runComposeUiTest {
+  fun disabledBackdrop_demandsFallbackSourceCaptureImmediately() = runComposeUiTest {
     val state = HazeState()
 
     setContent {
@@ -79,7 +79,7 @@ class HazeEffectInputTest {
             .fillMaxSize()
             .hazeEffect(
               factory = PassthroughFactory,
-              input = HazeInput.Backdrop(HazeInput.Sources(state)),
+              input = HazeInput.Backdrop(state),
               style = Unit,
             ),
         )
@@ -97,7 +97,7 @@ class HazeEffectInputTest {
   fun unavailableBackdrop_releasesFallbackCaptureAfterInputChanges() = runComposeUiTest {
     val state = HazeState()
     val input = mutableStateOf<HazeInput>(
-      HazeInput.Backdrop(HazeInput.Sources(state)),
+      HazeInput.Backdrop(state),
     )
 
     setContent {
@@ -125,6 +125,42 @@ class HazeEffectInputTest {
 
     assertThat(area.captureConsumerCount).isEqualTo(0)
     assertThat(area.contentLayer).isNull()
+  }
+
+  @Test
+  fun disabledBackdrop_appliesFallbackRetentionPolicy() = runComposeUiTest {
+    val state = HazeState()
+    val showSource = mutableStateOf(true)
+    val factory = RecordingRendererFactory(::RetainedOutputRenderer)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        if (showSource.value) {
+          source(state, "source", 0f, Color.Red)
+        }
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(
+              factory = factory,
+              input = HazeInput.Backdrop(
+                state = state,
+                fallbackSelection = HazeSourceSelection.All,
+                fallbackRetention = HazeSourceRetention.ClearWhenUnavailable,
+              ),
+              style = Unit,
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val renderer = factory.renderers.single()
+    val clearsBeforeRemoval = renderer.clearCalls
+    showSource.value = false
+    waitForIdle()
+
+    assertThat(renderer.clearCalls).isGreaterThan(clearsBeforeRemoval)
   }
 
   @Test

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
@@ -25,11 +25,161 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isGreaterThan
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import kotlin.test.Test
 
-@OptIn(ExperimentalTestApi::class, InternalHazeApi::class)
+@OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class, InternalHazeApi::class)
 class HazeEffectInputTest {
+
+  @Test
+  fun sourceWithoutConsumers_drawsDirectWithoutRecording() = runComposeUiTest {
+    val state = HazeState()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(state, "source", 0f, Color.Red)
+      }
+    }
+    waitForIdle()
+
+    val area = state.areas.single()
+    assertThat(area.contentVersion).isEqualTo(0L)
+    assertThat(area.contentLayer).isNull()
+  }
+
+  @Test
+  fun sourcesInput_demandsSourceCapture() = runComposeUiTest {
+    val state = HazeState()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(state, "source", 0f, Color.Red)
+        effect(state, HazeSourceSelection.All)
+      }
+    }
+    waitForIdle()
+
+    val area = state.areas.single()
+    assertThat(area.captureConsumerCount).isEqualTo(1)
+    assertThat(area.contentVersion).isGreaterThan(0L)
+    assertThat(area.contentLayer).isNotNull()
+  }
+
+  @Test
+  fun unavailableBackdrop_demandsFallbackSourceCapture() = runComposeUiTest {
+    val state = HazeState()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(state, "source", 0f, Color.Red)
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(
+              factory = PassthroughFactory,
+              input = HazeInput.Backdrop(HazeInput.Sources(state)),
+              style = Unit,
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val area = state.areas.single()
+    assertThat(area.captureConsumerCount).isEqualTo(1)
+    assertThat(area.contentVersion).isGreaterThan(0L)
+    assertThat(area.contentLayer).isNotNull()
+  }
+
+  @Test
+  fun unavailableBackdrop_releasesFallbackCaptureAfterInputChanges() = runComposeUiTest {
+    val state = HazeState()
+    val input = mutableStateOf<HazeInput>(
+      HazeInput.Backdrop(HazeInput.Sources(state)),
+    )
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(state, "source", 0f, Color.Red)
+        Box(
+          Modifier
+            .fillMaxSize()
+            .hazeEffect(
+              factory = PassthroughFactory,
+              input = input.value,
+              style = Unit,
+            ),
+        )
+      }
+    }
+    waitForIdle()
+
+    val area = state.areas.single()
+    assertThat(area.captureConsumerCount).isEqualTo(1)
+    assertThat(area.contentLayer).isNotNull()
+
+    input.value = HazeInput.Content
+    waitForIdle()
+
+    assertThat(area.captureConsumerCount).isEqualTo(0)
+    assertThat(area.contentLayer).isNull()
+  }
+
+  @Test
+  fun sourcesSelection_releasesCaptureForDeselectedArea() = runComposeUiTest {
+    val state = HazeState()
+    val selection = mutableStateOf<HazeSourceSelection>(HazeSourceSelection.All)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(state, "source", 0f, Color.Red)
+        effect(state, selection.value)
+      }
+    }
+    waitForIdle()
+
+    val area = state.areas.single()
+    assertThat(area.captureConsumerCount).isEqualTo(1)
+    assertThat(area.contentLayer).isNotNull()
+
+    selection.value = HazeSourceSelection.All.where { false }
+    waitForIdle()
+
+    assertThat(area.captureConsumerCount).isEqualTo(0)
+    assertThat(area.contentLayer).isNull()
+  }
+
+  @Test
+  fun sourceCapture_remainsUntilLastConsumerLeaves() = runComposeUiTest {
+    val state = HazeState()
+    val showFirst = mutableStateOf(true)
+    val showSecond = mutableStateOf(true)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(state, "source", 0f, Color.Red)
+        if (showFirst.value) effect(state, HazeSourceSelection.All)
+        if (showSecond.value) effect(state, HazeSourceSelection.All)
+      }
+    }
+    waitForIdle()
+
+    val area = state.areas.single()
+    assertThat(area.captureConsumerCount).isEqualTo(2)
+    assertThat(area.contentLayer).isNotNull()
+
+    showFirst.value = false
+    waitForIdle()
+    assertThat(area.captureConsumerCount).isEqualTo(1)
+    assertThat(area.contentLayer).isNotNull()
+
+    showSecond.value = false
+    waitForIdle()
+    assertThat(area.captureConsumerCount).isEqualTo(0)
+    assertThat(area.contentLayer).isNull()
+  }
 
   @Test
   fun content_capturesTheModifierOwnContent() = runComposeUiTest {

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
@@ -144,9 +144,11 @@ class HazeEffectInputTest {
             .hazeEffect(
               factory = factory,
               input = HazeInput.Backdrop(
-                state = state,
-                fallbackSelection = HazeSourceSelection.All,
-                fallbackRetention = HazeSourceRetention.ClearWhenUnavailable,
+                HazeInput.Sources(
+                  state = state,
+                  selection = HazeSourceSelection.All,
+                  retention = HazeSourceRetention.ClearWhenUnavailable,
+                ),
               ),
               style = Unit,
             ),

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.skiko.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.skiko.kt
@@ -1,0 +1,25 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Canvas
+
+@InternalHazeApi
+internal actual fun createHazeBackdropRenderer(): HazeBackdropRenderer =
+  UnavailableHazeBackdropRenderer
+
+private object UnavailableHazeBackdropRenderer : HazeBackdropRenderer {
+  override fun isSupported(canvas: Canvas): Boolean = false
+
+  override fun configure(
+    bounds: Rect,
+    clip: Rect?,
+    effect: PlatformRenderEffect,
+  ): Boolean = false
+
+  override fun draw(canvas: Canvas): Boolean = false
+
+  override fun release() = Unit
+}

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.skiko.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.skiko.kt
@@ -3,24 +3,5 @@
 
 package dev.chrisbanes.haze
 
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Canvas
-
 @InternalHazeApi
-internal actual fun createHazeBackdropRenderer(): HazeBackdropRenderer =
-  UnavailableHazeBackdropRenderer
-
-private object UnavailableHazeBackdropRenderer : HazeBackdropRenderer {
-  override fun isSupported(canvas: Canvas): Boolean = false
-
-  override fun configure(
-    bounds: Rect,
-    clip: Rect?,
-    effect: PlatformRenderEffect,
-    alpha: Float,
-  ): Boolean = false
-
-  override fun draw(canvas: Canvas): Boolean = false
-
-  override fun release() = Unit
-}
+internal actual fun createHazeBackdropRenderer(): HazeBackdropRenderer? = null

--- a/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.skiko.kt
+++ b/haze/src/skikoMain/kotlin/dev/chrisbanes/haze/HazeBackdropRenderer.skiko.kt
@@ -17,6 +17,7 @@ private object UnavailableHazeBackdropRenderer : HazeBackdropRenderer {
     bounds: Rect,
     clip: Rect?,
     effect: PlatformRenderEffect,
+    alpha: Float,
   ): Boolean = false
 
   override fun draw(canvas: Canvas): Boolean = false

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -131,6 +131,26 @@ adb shell cmd power set-fixed-performance-mode-enabled false
 Always run the final cleanup command, including after a failed or interrupted benchmark. Verify
 fixed-performance mode is off before returning the device to normal use.
 
+## Emulator correctness evidence (2026-09-05)
+
+The committed native-backdrop fixes were exercised on the supported preview emulator before any
+performance claim. The run used the `Medium_Phone` AVD with the
+`android-37.2-beta3/google_apis_playstore_ps16k/arm64-v8a` revision 3 image, SDK 37, full SDK
+37.1, preview 3723, fingerprint
+`google/sdk_gphone16k_arm64/emu64a16k:DEV/CP41.260731.005.B1/16056512:user/dev-keys`, emulator
+37.1.11.0 build 15917651, and the Apple M1 Max `skiagl` host renderer. The tested commit was
+`56c866937a872cc9b73e063b34b12d3c4d74ade5`.
+
+The core suite passed 4 tests, Blur passed 6, and Glass passed 5; all had zero failures, errors,
+or skips. The suites covered native fallback state, progressive Blur, clip transitions, paired
+offscreen pixel scenes, and Glass window/offscreen pixel scenes. The saved XML reports are
+`haze/build/outputs/androidTest-results/connected/androidMain/TEST-Medium_Phone(AVD) - 17.xml`,
+with equivalent paths under `haze-blur/` and `haze-glass/`.
+
+This emulator result establishes preview correctness only. It does not provide physical-device
+37.2 compositor evidence, per-offscreen capture-counter evidence, or the order-reversed
+fixed-performance measurements required by the physical performance gate above.
+
 ## Calibration matrix
 
 The controlled Blur and Glass calibration suites measure every built-in

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -88,6 +88,49 @@ startup, frame time, or any other performance improvement.
 
 Record the device model, API level, and selected refresh rate with saved results.
 
+## Android 37.2 source/backdrop comparisons
+
+Backdrop comparisons require a physical, hardware-accelerated Android 37.2 device. Record the full
+SDK level (including the minor release), build SHA and variant, display refresh rate, fixed-
+performance state, starting battery level, and thermal status with every JSON/Perfetto result.
+
+The paired Quality workloads are:
+
+| Effect | Source | Backdrop |
+| --- | --- | --- |
+| Blur stable | `blurStableQuality` | `blurBackdropStableQuality` |
+| Blur updating | `blurSourceUpdateQuality` | `blurBackdropSourceUpdateQuality` |
+| Glass stable | `stableQuality` | `backdropStableQuality` |
+| Glass updating | `sourceUpdateQuality` | `backdropSourceUpdateQuality` |
+| Nine Glass nodes updating | `sourceUpdate9` | `backdropSourceUpdate9` |
+
+Each row records `FrameTimingMetric`, max `MemoryUsageMetric`, `HazeBackdrop.draw` count, and
+`HazeSource.record` count. A healthy backdrop result has native backdrop draws and zero source
+records; its source control has source records and no required backdrop draw.
+
+Run a dry run first on the same physical 37.2 device:
+
+```shell
+./gradlew --no-scan :sample:shared:testAndroidHostTest \
+  :internal:benchmark:connectedBenchmarkReleaseAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.dryRunMode.enable=true \
+  -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.BenchmarkTest#blurStableQuality,dev.chrisbanes.haze.BenchmarkTest#blurBackdropStableQuality,dev.chrisbanes.haze.BenchmarkTest#blurSourceUpdateQuality,dev.chrisbanes.haze.BenchmarkTest#blurBackdropSourceUpdateQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#stableQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#backdropStableQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#sourceUpdateQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#backdropSourceUpdateQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#sourceUpdate9,dev.chrisbanes.haze.GlassProfilingBenchmark#backdropSourceUpdate9
+```
+
+Measure three source/backdrop pairs, then repeat three pairs in backdrop/source order. Return the
+device to the same thermal envelope before each pair. Keep all JSON and Perfetto outputs; compare
+CPU P90, actual-frame P90, frame overrun, and peak memory against the order-reversed control
+envelope rather than one run.
+
+```shell
+adb shell cmd power set-fixed-performance-mode-enabled true
+# Run one source/backdrop pair with the focused class argument above, then reverse its order.
+adb shell cmd power set-fixed-performance-mode-enabled false
+```
+
+Always run the final cleanup command, including after a failed or interrupted benchmark. Verify
+fixed-performance mode is off before returning the device to normal use.
+
 ## Calibration matrix
 
 The controlled Blur and Glass calibration suites measure every built-in

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/BenchmarkTest.kt
@@ -33,7 +33,20 @@ class BenchmarkTest {
   fun blurStableAdaptive() = measureBlurProfilingScenario("stable_adaptive")
 
   @Test
-  fun blurStableQuality() = measureBlurProfilingScenario("stable_quality")
+  fun blurStableQuality() = measureBlurProfilingScenario(
+    scenarioId = "stable_quality",
+    includeBackdropComparisonMetrics = true,
+  )
+
+  @Test
+  fun blurBackdropStableQuality() {
+    requireBackdropBenchmarkDevice()
+    measureBlurProfilingScenario(
+      scenarioId = "backdrop_stable_quality",
+      includeBackdropComparisonMetrics = true,
+      requireBackdropDraw = true,
+    )
+  }
 
   @Test
   fun blurStableBalanced() = measureBlurProfilingScenario("stable_balanced")
@@ -69,7 +82,20 @@ class BenchmarkTest {
   }
 
   @Test
-  fun blurSourceUpdateQuality() = measureBlurProfilingScenario("source_update_quality")
+  fun blurSourceUpdateQuality() = measureBlurProfilingScenario(
+    scenarioId = "source_update_quality",
+    includeBackdropComparisonMetrics = true,
+  )
+
+  @Test
+  fun blurBackdropSourceUpdateQuality() {
+    requireBackdropBenchmarkDevice()
+    measureBlurProfilingScenario(
+      scenarioId = "backdrop_source_update_quality",
+      includeBackdropComparisonMetrics = true,
+      requireBackdropDraw = true,
+    )
+  }
 
   @Test
   fun blurSourceUpdateBalanced() = measureBlurProfilingScenario("source_update_balanced")
@@ -85,10 +111,18 @@ class BenchmarkTest {
     )
   }
 
-  private fun measureBlurProfilingScenario(scenarioId: String) {
+  private fun measureBlurProfilingScenario(
+    scenarioId: String,
+    includeBackdropComparisonMetrics: Boolean = false,
+    requireBackdropDraw: Boolean = false,
+  ) {
     benchmarkRule.measureRepeated(
       packageName = APP_PACKAGE,
-      metrics = listOf(FrameTimingMetric()),
+      metrics = if (includeBackdropComparisonMetrics) {
+        backdropComparisonMetrics(requireBackdropDraw)
+      } else {
+        listOf(FrameTimingMetric())
+      },
       startupMode = StartupMode.WARM,
       iterations = DEFAULT_ITERATIONS,
       setupBlock = {

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassBenchmarkSupport.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassBenchmarkSupport.kt
@@ -47,12 +47,13 @@ private fun isBackdropSdkSupported(): Boolean {
   val fullSdkInt = if (Build.VERSION.SDK_INT < 36) {
     Build.VERSION.SDK_INT * 100_000
   } else {
-    runCatching {
-      Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
-    }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
+    Build.VERSION.SDK_INT_FULL
   }
-  return fullSdkInt >= 3_700_002 ||
-    (fullSdkInt == 3_700_001 && Build.VERSION.PREVIEW_SDK_INT == 3_723)
+  return fullSdkInt >= Build.VERSION_CODES_FULL.CINNAMON_BUN_2 ||
+    (
+      fullSdkInt == Build.VERSION_CODES_FULL.CINNAMON_BUN_1 &&
+        Build.VERSION.PREVIEW_SDK_INT == 3_723
+      )
 }
 
 @OptIn(ExperimentalMetricApi::class)

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassBenchmarkSupport.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassBenchmarkSupport.kt
@@ -9,6 +9,7 @@ import androidx.benchmark.macro.FrameTimingMetric
 import androidx.benchmark.macro.MemoryUsageMetric
 import androidx.benchmark.macro.Metric
 import androidx.benchmark.macro.TraceSectionMetric
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
 
@@ -18,23 +19,67 @@ internal const val GLASS_RUNTIME_DRAW_SECTION = "HazeGlass.runtimeDraw"
 internal const val GLASS_CREATE_RENDER_EFFECT_SECTION = "HazeGlass.createRenderEffect"
 internal const val GLASS_PREPARE_EFFECTS_SECTION = "HazeGlass.prepareEffects"
 internal const val GLASS_PREPARE_LAYERS_SECTION = "HazeGlass.prepareLayers"
+internal const val HAZE_BACKDROP_DRAW_SECTION = "HazeBackdrop.draw"
+internal const val HAZE_SOURCE_RECORD_SECTION = "HazeSource.record"
 
 internal fun requireGlassBenchmarkDevice() {
   assumeTrue(
     "Glass profiling requires API 33 or newer",
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU,
   )
-  assumeFalse(
-    "Glass profiling requires a physical device",
-    isProbablyEmulator(),
+  if (!isBenchmarkDryRun()) {
+    assumeFalse(
+      "Glass profiling requires a physical device",
+      isProbablyEmulator(),
+    )
+  }
+}
+
+internal fun requireBackdropBenchmarkDevice() {
+  requireGlassBenchmarkDevice()
+  assumeTrue(
+    "Backdrop profiling requires Android 37.2",
+    isBackdropSdkSupported(),
   )
 }
+
+private fun isBackdropSdkSupported(): Boolean {
+  val fullSdkInt = if (Build.VERSION.SDK_INT < 36) {
+    Build.VERSION.SDK_INT * 100_000
+  } else {
+    runCatching {
+      Build.VERSION::class.java.getField("SDK_INT_FULL").getInt(null)
+    }.getOrElse { Build.VERSION.SDK_INT * 100_000 }
+  }
+  return fullSdkInt >= 3_700_002 ||
+    (fullSdkInt == 3_700_001 && Build.VERSION.PREVIEW_SDK_INT == 3_723)
+}
+
+@OptIn(ExperimentalMetricApi::class)
+internal fun backdropComparisonMetrics(
+  requireBackdropDraw: Boolean,
+): List<Metric> = listOf(
+  FrameTimingMetric(),
+  MemoryUsageMetric(MemoryUsageMetric.Mode.Max),
+  TraceSectionMetric(
+    sectionName = HAZE_BACKDROP_DRAW_SECTION,
+    mode = TraceSectionMetric.Mode.Count,
+    label = if (requireBackdropDraw) "requiredHazeBackdropDraw" else "hazeBackdropDraw",
+  ),
+  TraceSectionMetric(
+    sectionName = HAZE_SOURCE_RECORD_SECTION,
+    mode = TraceSectionMetric.Mode.Count,
+    label = "hazeSourceRecord",
+  ),
+)
 
 @OptIn(ExperimentalMetricApi::class)
 internal fun glassMetrics(
   includeMemory: Boolean,
   requireRuntimeMarker: Boolean = true,
   includePreparationMetrics: Boolean = false,
+  includeBackdropComparisonMetrics: Boolean = false,
+  requireBackdropDraw: Boolean = false,
 ): List<Metric> = buildList {
   add(FrameTimingMetric())
   if (requireRuntimeMarker) {
@@ -48,6 +93,22 @@ internal fun glassMetrics(
   }
   if (includeMemory) {
     add(MemoryUsageMetric(MemoryUsageMetric.Mode.Max))
+  }
+  if (includeBackdropComparisonMetrics) {
+    add(
+      TraceSectionMetric(
+        sectionName = HAZE_BACKDROP_DRAW_SECTION,
+        mode = TraceSectionMetric.Mode.Count,
+        label = if (requireBackdropDraw) "requiredHazeBackdropDraw" else "hazeBackdropDraw",
+      ),
+    )
+    add(
+      TraceSectionMetric(
+        sectionName = HAZE_SOURCE_RECORD_SECTION,
+        mode = TraceSectionMetric.Mode.Count,
+        label = "hazeSourceRecord",
+      ),
+    )
   }
   if (includePreparationMetrics) {
     add(
@@ -83,3 +144,8 @@ private fun isProbablyEmulator(): Boolean =
     Build.HARDWARE.contains("goldfish", ignoreCase = true) ||
     Build.HARDWARE.contains("ranchu", ignoreCase = true) ||
     Build.PRODUCT.contains("sdk", ignoreCase = true)
+
+private fun isBenchmarkDryRun(): Boolean =
+  InstrumentationRegistry.getArguments()
+    .getString("androidx.benchmark.dryRunMode.enable")
+    .toBoolean()

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassBenchmarkSupport.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassBenchmarkSupport.kt
@@ -59,9 +59,15 @@ private fun isBackdropSdkSupported(): Boolean {
 @OptIn(ExperimentalMetricApi::class)
 internal fun backdropComparisonMetrics(
   requireBackdropDraw: Boolean,
-): List<Metric> = listOf(
+): List<Metric> = listOf<Metric>(
   FrameTimingMetric(),
   MemoryUsageMetric(MemoryUsageMetric.Mode.Max),
+) + backdropTraceMetrics(requireBackdropDraw)
+
+@OptIn(ExperimentalMetricApi::class)
+private fun backdropTraceMetrics(
+  requireBackdropDraw: Boolean,
+): List<Metric> = listOf(
   TraceSectionMetric(
     sectionName = HAZE_BACKDROP_DRAW_SECTION,
     mode = TraceSectionMetric.Mode.Count,
@@ -96,20 +102,7 @@ internal fun glassMetrics(
     add(MemoryUsageMetric(MemoryUsageMetric.Mode.Max))
   }
   if (includeBackdropComparisonMetrics) {
-    add(
-      TraceSectionMetric(
-        sectionName = HAZE_BACKDROP_DRAW_SECTION,
-        mode = TraceSectionMetric.Mode.Count,
-        label = if (requireBackdropDraw) "requiredHazeBackdropDraw" else "hazeBackdropDraw",
-      ),
-    )
-    add(
-      TraceSectionMetric(
-        sectionName = HAZE_SOURCE_RECORD_SECTION,
-        mode = TraceSectionMetric.Mode.Count,
-        label = "hazeSourceRecord",
-      ),
-    )
+    addAll(backdropTraceMetrics(requireBackdropDraw))
   }
   if (includePreparationMetrics) {
     add(

--- a/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassProfilingBenchmark.kt
+++ b/internal/benchmark/src/main/kotlin/dev/chrisbanes/haze/GlassProfilingBenchmark.kt
@@ -38,7 +38,13 @@ class GlassProfilingBenchmark {
   fun stableAdaptive() = measureCalibrationScenario("stable_adaptive")
 
   @Test
-  fun stableQuality() = measureCalibrationScenario("stable_quality")
+  fun stableQuality() = measureBackdropComparisonScenario("stable_quality")
+
+  @Test
+  fun backdropStableQuality() {
+    requireBackdropBenchmarkDevice()
+    measureBackdropComparisonScenario("backdrop_stable_quality", requireBackdropDraw = true)
+  }
 
   @Test
   fun stableBalanced() = measureCalibrationScenario("stable_balanced")
@@ -50,7 +56,16 @@ class GlassProfilingBenchmark {
   fun sourceUpdateAdaptive() = measureCalibrationScenario("source_update_adaptive")
 
   @Test
-  fun sourceUpdateQuality() = measureCalibrationScenario("source_update_quality")
+  fun sourceUpdateQuality() = measureBackdropComparisonScenario("source_update_quality")
+
+  @Test
+  fun backdropSourceUpdateQuality() {
+    requireBackdropBenchmarkDevice()
+    measureBackdropComparisonScenario(
+      "backdrop_source_update_quality",
+      requireBackdropDraw = true,
+    )
+  }
 
   @Test
   fun sourceUpdateBalanced() = measureCalibrationScenario("source_update_balanced")
@@ -128,7 +143,13 @@ class GlassProfilingBenchmark {
   fun blurUpdate() = measureScenario("blur_update")
 
   @Test
-  fun sourceUpdate9() = measureScenario("source_update_9", includeMemory = true)
+  fun sourceUpdate9() = measureBackdropComparisonScenario("source_update_9")
+
+  @Test
+  fun backdropSourceUpdate9() {
+    requireBackdropBenchmarkDevice()
+    measureBackdropComparisonScenario("backdrop_source_update_9", requireBackdropDraw = true)
+  }
 
   @Test
   fun sourceUpdateNoGlass() = measureScenario(
@@ -148,11 +169,25 @@ class GlassProfilingBenchmark {
     measureScenario(scenarioId = scenarioId, includeMemory = true)
   }
 
+  private fun measureBackdropComparisonScenario(
+    scenarioId: String,
+    requireBackdropDraw: Boolean = false,
+  ) {
+    measureScenario(
+      scenarioId = scenarioId,
+      includeMemory = true,
+      includeBackdropComparisonMetrics = true,
+      requireBackdropDraw = requireBackdropDraw,
+    )
+  }
+
   private fun measureScenario(
     scenarioId: String,
     includeMemory: Boolean = false,
     requireRuntimeMarker: Boolean = true,
     includePreparationMetrics: Boolean = false,
+    includeBackdropComparisonMetrics: Boolean = false,
+    requireBackdropDraw: Boolean = false,
   ) {
     benchmarkRule.measureRepeated(
       packageName = GLASS_TARGET_PACKAGE,
@@ -160,6 +195,8 @@ class GlassProfilingBenchmark {
         includeMemory = includeMemory,
         requireRuntimeMarker = requireRuntimeMarker,
         includePreparationMetrics = includePreparationMetrics,
+        includeBackdropComparisonMetrics = includeBackdropComparisonMetrics,
+        requireBackdropDraw = requireBackdropDraw,
       ),
       compilationMode = CompilationMode.Full(),
       startupMode = StartupMode.WARM,

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSampleTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSampleTest.kt
@@ -11,11 +11,17 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.navigation.compose.rememberNavController
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeFeatureFlags
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 import org.robolectric.annotation.Config
 
-@OptIn(ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class)
 @Config(qualifiers = "w393dp-h698dp-440dpi")
 class BlurProfilingSampleTest : ContextTest() {
   @Test
@@ -73,5 +79,51 @@ class BlurProfilingSampleTest : ContextTest() {
     onNodeWithTag("blur_profiling_phase_ready").assertIsDisplayed()
     onNodeWithTag("blur_profiling_start").performClick()
     onNodeWithTag("blur_profiling_phase_complete").assertIsDisplayed()
+  }
+
+  @Test
+  fun sourceProfilingScenario_disablesPlatformBackdropEligibility() {
+    val previous = HazeFeatureFlags.isPlatformBackdropEnabled
+    try {
+      runComposeUiTest {
+        val sourceState = BlurProfilingState().apply {
+          select(BlurProfilingScenario.SourceUpdateQuality)
+        }
+        setContent {
+          BlurProfilingSampleContent(
+            state = sourceState,
+            navController = rememberNavController(),
+            onBack = {},
+          )
+        }
+        assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isFalse()
+      }
+      assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isEqualTo(previous)
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previous
+    }
+  }
+
+  @Test
+  fun backdropProfilingScenario_enablesPlatformBackdropEligibility() {
+    val previous = HazeFeatureFlags.isPlatformBackdropEnabled
+    try {
+      runComposeUiTest {
+        val state = BlurProfilingState().apply {
+          select(BlurProfilingScenario.BackdropSourceUpdateQuality)
+        }
+        setContent {
+          BlurProfilingSampleContent(
+            state = state,
+            navController = rememberNavController(),
+            onBack = {},
+          )
+        }
+        assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isTrue()
+      }
+      assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isEqualTo(previous)
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previous
+    }
   }
 }

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSampleTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSampleTest.kt
@@ -55,4 +55,23 @@ class BlurProfilingSampleTest : ContextTest() {
     onNodeWithTag("blur_profiling_start").performClick()
     onNodeWithTag("blur_profiling_phase_complete").assertIsDisplayed()
   }
+
+  @Test
+  fun backdropSourceUpdateScenario_exposesTheSettledStartProtocol() = runComposeUiTest {
+    setContent {
+      BlurProfilingSampleContent(
+        state = remember { BlurProfilingState() },
+        navController = rememberNavController(),
+        onBack = {},
+      )
+    }
+
+    onNodeWithTag("blur_profiling_select_backdrop_source_update_quality")
+      .performScrollTo()
+      .performClick()
+    onNodeWithTag("blur_profiling_selected_backdrop_source_update_quality").assertIsDisplayed()
+    onNodeWithTag("blur_profiling_phase_ready").assertIsDisplayed()
+    onNodeWithTag("blur_profiling_start").performClick()
+    onNodeWithTag("blur_profiling_phase_complete").assertIsDisplayed()
+  }
 }

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/BlurProfilingScenarioTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/BlurProfilingScenarioTest.kt
@@ -19,12 +19,14 @@ class BlurProfilingScenarioTest {
       listOf(
         "stable_adaptive",
         "stable_quality",
+        "backdrop_stable_quality",
         "stable_balanced",
         "stable_performance",
         "progressive_quality",
         "progressive_balanced",
         "source_update_adaptive",
         "source_update_quality",
+        "backdrop_source_update_quality",
         "source_update_balanced",
         "source_update_performance",
       ),
@@ -38,6 +40,7 @@ class BlurProfilingScenarioTest {
         false to listOf(
           HazePerformanceMode.Adaptive,
           HazePerformanceMode.Quality,
+          HazePerformanceMode.Quality,
           HazePerformanceMode.Balanced,
           HazePerformanceMode.Performance,
           HazePerformanceMode.Quality,
@@ -46,11 +49,24 @@ class BlurProfilingScenarioTest {
         true to listOf(
           HazePerformanceMode.Adaptive,
           HazePerformanceMode.Quality,
+          HazePerformanceMode.Quality,
           HazePerformanceMode.Balanced,
           HazePerformanceMode.Performance,
         ),
       ),
     )
+  }
+
+  @Test
+  fun qualityPairs_changeOnlyTheirInputBackend() {
+    assertThat(BlurProfilingScenario.StableQuality.usesBackdrop).isEqualTo(false)
+    assertThat(BlurProfilingScenario.BackdropStableQuality.usesBackdrop).isEqualTo(true)
+    assertThat(BlurProfilingScenario.StableQuality.updatesSource)
+      .isEqualTo(BlurProfilingScenario.BackdropStableQuality.updatesSource)
+    assertThat(BlurProfilingScenario.SourceUpdateQuality.usesBackdrop).isEqualTo(false)
+    assertThat(BlurProfilingScenario.BackdropSourceUpdateQuality.usesBackdrop).isEqualTo(true)
+    assertThat(BlurProfilingScenario.SourceUpdateQuality.updatesSource)
+      .isEqualTo(BlurProfilingScenario.BackdropSourceUpdateQuality.updatesSource)
   }
 
   @Test

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSampleTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSampleTest.kt
@@ -12,11 +12,16 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.v2.runComposeUiTest
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeFeatureFlags
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
 import org.robolectric.annotation.Config
 
-@OptIn(ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class, ExperimentalHazeApi::class)
 @Config(qualifiers = "w393dp-h698dp-440dpi")
 class GlassProfilingSampleTest : ContextTest() {
   @Test
@@ -111,6 +116,50 @@ class GlassProfilingSampleTest : ContextTest() {
     onNodeWithTag("glass_profiling_surface").assertIsDisplayed()
     repeat(9) { index ->
       onNodeWithTag("glass_profiling_surface_$index").assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun sourceProfilingScenario_disablesPlatformBackdropEligibility() {
+    val previous = HazeFeatureFlags.isPlatformBackdropEnabled
+    try {
+      runComposeUiTest {
+        val sourceState = GlassProfilingState().apply {
+          select(GlassProfilingScenario.SourceUpdateQuality)
+        }
+        setContent {
+          GlassProfilingSampleContent(
+            state = sourceState,
+            onBack = {},
+          )
+        }
+        assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isFalse()
+      }
+      assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isEqualTo(previous)
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previous
+    }
+  }
+
+  @Test
+  fun backdropProfilingScenario_enablesPlatformBackdropEligibility() {
+    val previous = HazeFeatureFlags.isPlatformBackdropEnabled
+    try {
+      runComposeUiTest {
+        val state = GlassProfilingState().apply {
+          select(GlassProfilingScenario.BackdropSourceUpdateQuality)
+        }
+        setContent {
+          GlassProfilingSampleContent(
+            state = state,
+            onBack = {},
+          )
+        }
+        assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isTrue()
+      }
+      assertThat(HazeFeatureFlags.isPlatformBackdropEnabled).isEqualTo(previous)
+    } finally {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previous
     }
   }
 }

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSampleTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSampleTest.kt
@@ -43,6 +43,25 @@ class GlassProfilingSampleTest : ContextTest() {
   }
 
   @Test
+  fun backdropSourceUpdate9_exposesNineIndependentGlassEffects() = runComposeUiTest {
+    setContent {
+      GlassProfilingSampleContent(
+        state = remember { GlassProfilingState() },
+        onBack = {},
+      )
+    }
+
+    onNodeWithTag("glass_profiling_select_backdrop_source_update_9")
+      .performScrollTo()
+      .performClick()
+    onNodeWithTag("glass_profiling_selected_backdrop_source_update_9").assertIsDisplayed()
+    onNodeWithTag("glass_profiling_phase_ready").assertIsDisplayed()
+    repeat(9) { index ->
+      onNodeWithTag("glass_profiling_surface_$index").assertIsDisplayed()
+    }
+  }
+
+  @Test
   fun effectAttach_settlesWithoutGlassBeforeExposingStart() = runComposeUiTest {
     mainClock.autoAdvance = false
     setContent {

--- a/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenarioTest.kt
+++ b/sample/shared/src/androidHostTest/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenarioTest.kt
@@ -74,6 +74,7 @@ class GlassProfilingScenarioTest {
         "effect_reattach",
         "stable_adaptive",
         "stable_quality",
+        "backdrop_stable_quality",
         "stable_balanced",
         "stable_performance",
         "steady_full_3",
@@ -99,15 +100,46 @@ class GlassProfilingScenarioTest {
         "blur_update",
         "source_update_adaptive",
         "source_update_quality",
+        "backdrop_source_update_quality",
         "source_update_balanced",
         "source_update_performance",
         "source_update_9",
+        "backdrop_source_update_9",
         "source_update_no_glass",
       ),
     )
     assertThat(
       GlassProfilingScenario.entries.map(GlassProfilingScenario::id).toSet().size,
     ).isEqualTo(GlassProfilingScenario.entries.size)
+  }
+
+  @Test
+  fun backdropPairs_matchSourceWorkloadsExceptForInputBackend() {
+    listOf(
+      GlassProfilingScenario.StableQuality to
+        GlassProfilingScenario.BackdropStableQuality,
+      GlassProfilingScenario.SourceUpdateQuality to
+        GlassProfilingScenario.BackdropSourceUpdateQuality,
+      GlassProfilingScenario.SourceUpdate9 to
+        GlassProfilingScenario.BackdropSourceUpdate9,
+    ).forEach { (source, backdrop) ->
+      assertThat(source.usesBackdrop, name = source.id).isFalse()
+      assertThat(backdrop.usesBackdrop, name = backdrop.id).isTrue()
+      assertThat(backdrop.performanceMode, name = backdrop.id).isEqualTo(source.performanceMode)
+      assertThat(backdrop.effectCount, name = backdrop.id).isEqualTo(source.effectCount)
+      assertThat(
+        changedFields(
+          glassProfilingFrame(source, 0.25f),
+          glassProfilingFrame(source, 0.75f),
+        ),
+        name = source.id,
+      ).isEqualTo(
+        changedFields(
+          glassProfilingFrame(backdrop, 0.25f),
+          glassProfilingFrame(backdrop, 0.75f),
+        ),
+      )
+    }
   }
 
   @Test
@@ -133,9 +165,11 @@ class GlassProfilingScenarioTest {
         GlassProfilingScenario.BlurUpdate -> setOf("blurRadius")
         GlassProfilingScenario.SourceUpdateAdaptive,
         GlassProfilingScenario.SourceUpdateQuality,
+        GlassProfilingScenario.BackdropSourceUpdateQuality,
         GlassProfilingScenario.SourceUpdateBalanced,
         GlassProfilingScenario.SourceUpdatePerformance,
         GlassProfilingScenario.SourceUpdate9,
+        GlassProfilingScenario.BackdropSourceUpdate9,
         GlassProfilingScenario.SourceUpdateNoGlass,
         -> setOf("sourceOffset")
         else -> emptySet()
@@ -212,9 +246,11 @@ class GlassProfilingScenarioTest {
       }
       val updatesSource = scenario == GlassProfilingScenario.SourceUpdateAdaptive ||
         scenario == GlassProfilingScenario.SourceUpdateQuality ||
+        scenario == GlassProfilingScenario.BackdropSourceUpdateQuality ||
         scenario == GlassProfilingScenario.SourceUpdateBalanced ||
         scenario == GlassProfilingScenario.SourceUpdatePerformance ||
         scenario == GlassProfilingScenario.SourceUpdate9 ||
+        scenario == GlassProfilingScenario.BackdropSourceUpdate9 ||
         scenario == GlassProfilingScenario.SourceUpdateNoGlass
 
       assertThat(readCount, name = scenario.id).isEqualTo(if (updatesSource) 1 else 0)

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSample.kt
@@ -1,6 +1,8 @@
 // Copyright 2026, Christopher Banes and the Haze project contributors
 // SPDX-License-Identifier: Apache-2.0
 
+@file:OptIn(ExperimentalHazeApi::class)
+
 package dev.chrisbanes.haze.sample
 
 import androidx.compose.animation.core.Animatable
@@ -17,13 +19,17 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeFeatureFlags
 
 @Composable
 internal fun BlurProfilingSampleContent(
@@ -82,6 +88,16 @@ private fun BlurProfilingScene(
   navController: NavHostController,
   modifier: Modifier = Modifier,
 ) {
+  val previousPlatformBackdropEnabled = remember {
+    HazeFeatureFlags.isPlatformBackdropEnabled
+  }
+  HazeFeatureFlags.isPlatformBackdropEnabled = scenario.usesBackdrop
+  DisposableEffect(Unit) {
+    onDispose {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previousPlatformBackdropEnabled
+    }
+  }
+
   LaunchedEffect(state.phase, scenario) {
     if (state.phase == BlurProfilingPhase.Settling) {
       repeat(BLUR_PROFILING_SETTLING_FRAMES) {

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/BlurProfilingSample.kt
@@ -108,7 +108,7 @@ private fun BlurProfilingScene(
   } else {
     null
   }
-  val profilingDrawProgress = if (scenario.updatesSource) {
+  val profilingDrawProgress = if (scenario.updatesSource && !scenario.usesBackdrop) {
     null
   } else {
     { state.progress }
@@ -121,7 +121,9 @@ private fun BlurProfilingScene(
       mode = scenario.mode,
       performanceMode = scenario.performanceMode,
       sourceOffset = sourceOffset,
+      sourceDrawProgress = if (scenario.updatesSource) ({ state.progress }) else null,
       profilingDrawProgress = profilingDrawProgress,
+      useBackdrop = scenario.usesBackdrop,
     )
     Column(
       modifier = Modifier

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/BlurProfilingScenario.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/BlurProfilingScenario.kt
@@ -22,9 +22,16 @@ internal enum class BlurProfilingScenario(
   val performanceMode: HazePerformanceMode,
   val updatesSource: Boolean,
   val mode: ScaffoldSampleMode = ScaffoldSampleMode.Default,
+  val usesBackdrop: Boolean = false,
 ) {
   StableAdaptive("stable_adaptive", HazePerformanceMode.Adaptive, updatesSource = false),
   StableQuality("stable_quality", HazePerformanceMode.Quality, updatesSource = false),
+  BackdropStableQuality(
+    "backdrop_stable_quality",
+    HazePerformanceMode.Quality,
+    updatesSource = false,
+    usesBackdrop = true,
+  ),
   StableBalanced("stable_balanced", HazePerformanceMode.Balanced, updatesSource = false),
   StablePerformance("stable_performance", HazePerformanceMode.Performance, updatesSource = false),
   ProgressiveQuality(
@@ -41,6 +48,12 @@ internal enum class BlurProfilingScenario(
   ),
   SourceUpdateAdaptive("source_update_adaptive", HazePerformanceMode.Adaptive, updatesSource = true),
   SourceUpdateQuality("source_update_quality", HazePerformanceMode.Quality, updatesSource = true),
+  BackdropSourceUpdateQuality(
+    "backdrop_source_update_quality",
+    HazePerformanceMode.Quality,
+    updatesSource = true,
+    usesBackdrop = true,
+  ),
   SourceUpdateBalanced("source_update_balanced", HazePerformanceMode.Balanced, updatesSource = true),
   SourceUpdatePerformance("source_update_performance", HazePerformanceMode.Performance, updatesSource = true),
 }

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
@@ -219,6 +219,7 @@ private fun GlassProfilingScene(
     if (scenario.glassEnabled && attachGlass) {
       GlassProfilingEffectGrid(
         hazeState = hazeState,
+        usesBackdrop = scenario.usesBackdrop,
         styles = styles,
         performanceMode = scenario.performanceMode,
         interactionSource = interactionSource,
@@ -285,6 +286,7 @@ private fun GlassProfilingScene(
 @Composable
 private fun GlassProfilingEffectGrid(
   hazeState: dev.chrisbanes.haze.HazeState,
+  usesBackdrop: Boolean,
   styles: List<GlassStyle>,
   performanceMode: HazePerformanceMode,
   interactionSource: MutableInteractionSource,
@@ -307,7 +309,11 @@ private fun GlassProfilingEffectGrid(
                 drawContent()
               }
               .hazeGlass(
-                input = HazeInput.Sources(hazeState),
+                input = if (usesBackdrop) {
+                  HazeInput.Backdrop(HazeInput.Sources(hazeState))
+                } else {
+                  HazeInput.Sources(hazeState)
+                },
                 style = styles[effectIndex],
                 performanceMode = performanceMode,
                 interactionSource = interactionSource,
@@ -358,6 +364,7 @@ internal fun profilingGlassStyle(
     GlassProfilingScenario.EffectReattach,
     GlassProfilingScenario.StableAdaptive,
     GlassProfilingScenario.StableQuality,
+    GlassProfilingScenario.BackdropStableQuality,
     GlassProfilingScenario.StableBalanced,
     GlassProfilingScenario.StablePerformance,
     GlassProfilingScenario.SteadyFull3,
@@ -380,9 +387,11 @@ internal fun profilingGlassStyle(
     GlassProfilingScenario.InteractionUpdate9,
     GlassProfilingScenario.SourceUpdateAdaptive,
     GlassProfilingScenario.SourceUpdateQuality,
+    GlassProfilingScenario.BackdropSourceUpdateQuality,
     GlassProfilingScenario.SourceUpdateBalanced,
     GlassProfilingScenario.SourceUpdatePerformance,
     GlassProfilingScenario.SourceUpdate9,
+    GlassProfilingScenario.BackdropSourceUpdate9,
     GlassProfilingScenario.SourceUpdateNoGlass,
     -> Unit
   }

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingSample.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,6 +45,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.haze.ExperimentalHazeApi
+import dev.chrisbanes.haze.HazeFeatureFlags
 import dev.chrisbanes.haze.HazeInput
 import dev.chrisbanes.haze.HazePerformanceMode
 import dev.chrisbanes.haze.glass.ChromaticAberrationMode
@@ -114,6 +116,16 @@ private fun GlassProfilingScene(
   onBack: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  val previousPlatformBackdropEnabled = remember {
+    HazeFeatureFlags.isPlatformBackdropEnabled
+  }
+  HazeFeatureFlags.isPlatformBackdropEnabled = scenario.usesBackdrop
+  DisposableEffect(Unit) {
+    onDispose {
+      HazeFeatureFlags.isPlatformBackdropEnabled = previousPlatformBackdropEnabled
+    }
+  }
+
   val hazeState = rememberHazeState()
   val interactionSource = remember { MutableInteractionSource() }
   val density = LocalDensity.current
@@ -310,7 +322,7 @@ private fun GlassProfilingEffectGrid(
               }
               .hazeGlass(
                 input = if (usesBackdrop) {
-                  HazeInput.Backdrop(HazeInput.Sources(hazeState))
+                  HazeInput.Backdrop(hazeState)
                 } else {
                   HazeInput.Sources(hazeState)
                 },

--- a/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenario.kt
+++ b/sample/shared/src/androidMain/kotlin/dev/chrisbanes/haze/sample/GlassProfilingScenario.kt
@@ -44,6 +44,7 @@ internal enum class GlassProfilingScenario(
   val performanceMode: HazePerformanceMode = HazePerformanceMode.Default,
   val opticsOverride: GlassOptics? = null,
   val fullChroma: Boolean = false,
+  val usesBackdrop: Boolean = false,
 ) {
   EffectAttach(
     id = "effect_attach",
@@ -73,6 +74,12 @@ internal enum class GlassProfilingScenario(
     id = "stable_quality",
     steadyDraw = true,
     performanceMode = HazePerformanceMode.Quality,
+  ),
+  BackdropStableQuality(
+    id = "backdrop_stable_quality",
+    steadyDraw = true,
+    performanceMode = HazePerformanceMode.Quality,
+    usesBackdrop = true,
   ),
   StableBalanced(
     id = "stable_balanced",
@@ -179,6 +186,11 @@ internal enum class GlassProfilingScenario(
     id = "source_update_quality",
     performanceMode = HazePerformanceMode.Quality,
   ),
+  BackdropSourceUpdateQuality(
+    id = "backdrop_source_update_quality",
+    performanceMode = HazePerformanceMode.Quality,
+    usesBackdrop = true,
+  ),
   SourceUpdateBalanced(
     id = "source_update_balanced",
     performanceMode = HazePerformanceMode.Balanced,
@@ -188,6 +200,11 @@ internal enum class GlassProfilingScenario(
     performanceMode = HazePerformanceMode.Performance,
   ),
   SourceUpdate9("source_update_9", effectCount = 9),
+  BackdropSourceUpdate9(
+    id = "backdrop_source_update_9",
+    effectCount = 9,
+    usesBackdrop = true,
+  ),
   SourceUpdateNoGlass("source_update_no_glass", glassEnabled = false),
 }
 
@@ -221,6 +238,7 @@ internal fun glassProfilingFrame(
     GlassProfilingScenario.EffectReattach,
     GlassProfilingScenario.StableAdaptive,
     GlassProfilingScenario.StableQuality,
+    GlassProfilingScenario.BackdropStableQuality,
     GlassProfilingScenario.StableBalanced,
     GlassProfilingScenario.StablePerformance,
     GlassProfilingScenario.SteadyFull3,
@@ -255,9 +273,11 @@ internal fun glassProfilingFrame(
     )
     GlassProfilingScenario.SourceUpdateAdaptive,
     GlassProfilingScenario.SourceUpdateQuality,
+    GlassProfilingScenario.BackdropSourceUpdateQuality,
     GlassProfilingScenario.SourceUpdateBalanced,
     GlassProfilingScenario.SourceUpdatePerformance,
     GlassProfilingScenario.SourceUpdate9,
+    GlassProfilingScenario.BackdropSourceUpdate9,
     GlassProfilingScenario.SourceUpdateNoGlass,
     -> base.copy(sourceOffset = lerp(-0.08f, 0.08f, progress))
   }
@@ -269,9 +289,11 @@ internal inline fun glassProfilingSourceProgress(
 ): Float = when (scenario) {
   GlassProfilingScenario.SourceUpdateAdaptive,
   GlassProfilingScenario.SourceUpdateQuality,
+  GlassProfilingScenario.BackdropSourceUpdateQuality,
   GlassProfilingScenario.SourceUpdateBalanced,
   GlassProfilingScenario.SourceUpdatePerformance,
   GlassProfilingScenario.SourceUpdate9,
+  GlassProfilingScenario.BackdropSourceUpdate9,
   GlassProfilingScenario.SourceUpdateNoGlass,
   -> progress()
   else -> 0f

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
@@ -108,12 +108,12 @@ fun BottomSheet(navController: NavHostController, effect: SampleEffect) {
             .then(
               when (effect) {
                 SampleEffect.Blur -> Modifier.hazeBlur(
-                  input = HazeInput.Sources(hazeState),
+                  input = HazeInput.Backdrop(hazeState),
                   style = HazeMaterials.thin(),
                 )
 
                 SampleEffect.Glass -> Modifier.hazeGlass(
-                  input = HazeInput.Sources(hazeState),
+                  input = HazeInput.Backdrop(hazeState),
                   style = GlassStyle.regular.then {
                     backgroundColor(glassBackgroundColor)
                     tint(glassTint)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CardSample.kt
@@ -37,7 +37,7 @@ fun CreditCardSample(
               Modifier
                 .clip(shape)
                 .hazeBlur(
-                  input = HazeInput.Sources(hazeState),
+                  input = HazeInput.Backdrop(hazeState),
                   style = HazeBlurStyle {
                     backgroundColor(Color.Black)
                     colorEffects(listOf(HazeColorEffect.tint(Color.Yellow.copy(alpha = 0.4f))))
@@ -48,7 +48,7 @@ fun CreditCardSample(
             SampleEffect.Glass ->
               Modifier
                 .hazeGlass(
-                  input = HazeInput.Sources(hazeState),
+                  input = HazeInput.Backdrop(hazeState),
                   style = GlassStyle.regular.then {
                     backgroundColor(glassBackgroundColor)
                     tint(Color.Yellow.copy(alpha = 0.18f))

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
@@ -159,7 +159,7 @@ internal fun GlassSurface(
       // Let Glass own the material silhouette. An outer Compose clip creates a second,
       // independently-rasterized rounded boundary and exposes isolated carrier pixels on Skiko.
       .hazeGlass(
-        input = HazeInput.Sources(hazeState),
+        input = HazeInput.Backdrop(hazeState),
         style = style.material3().then {
           this.shape(shape)
         }.then(interactionStyle),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassPlaygroundSample.kt
@@ -452,7 +452,7 @@ private fun PlaygroundSurface(
       .hazeSource(hazeState, zIndex = zIndex)
       .zIndex(zIndex)
       .hazeGlass(
-        input = HazeInput.Sources(hazeState),
+        input = HazeInput.Backdrop(hazeState),
         style = style,
         interactionSource = interactionSource,
         interactionTransformTarget = GlassTransformTarget.MaterialAndContent,

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
@@ -97,14 +97,14 @@ fun ImagesList(navController: NavHostController, effect: SampleEffect) {
                         Modifier
                           .clip(shape)
                           .hazeBlur(
-                            input = HazeInput.Sources(hazeState),
+                            input = HazeInput.Backdrop(hazeState),
                             style = HazeMaterials.thin(),
                           )
 
                       SampleEffect.Glass ->
                         Modifier
                           .hazeGlass(
-                            input = HazeInput.Sources(hazeState),
+                            input = HazeInput.Backdrop(hazeState),
                             style = GlassStyle.regular.then {
                               backgroundColor(glassBackgroundColor)
                               tint(glassTint)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
@@ -105,12 +105,12 @@ fun ListOverImage(navController: NavHostController, effect: SampleEffect) {
                   .then(
                     when (effect) {
                       SampleEffect.Blur -> Modifier.hazeBlur(
-                        input = HazeInput.Sources(hazeState),
+                        input = HazeInput.Backdrop(hazeState),
                         style = HazeMaterials.thin(),
                       )
 
                       SampleEffect.Glass -> Modifier.hazeGlass(
-                        input = HazeInput.Sources(hazeState),
+                        input = HazeInput.Backdrop(hazeState),
                         style = GlassStyle.regular.then {
                           backgroundColor(glassBackgroundColor)
                           tint(glassTint)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
@@ -83,13 +83,13 @@ fun ListWithStickyHeaders(navController: NavHostController, effect: SampleEffect
               .then(
                 when (effect) {
                   SampleEffect.Blur -> Modifier.hazeBlur(
-                    input = HazeInput.Sources(hazeState),
+                    input = HazeInput.Backdrop(hazeState),
                     style = blurStyle,
                     performanceMode = HazePerformanceMode.Adaptive,
                   )
 
                   SampleEffect.Glass -> Modifier.hazeGlass(
-                    input = HazeInput.Sources(hazeState),
+                    input = HazeInput.Backdrop(hazeState),
                     style = GlassStyle.regular.then {
                       backgroundColor(glassBackgroundColor)
                       tint(glassTint)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -266,7 +266,7 @@ private fun GlassMaterialsCard(
       Modifier
         .fillMaxSize()
         .hazeGlass(
-          input = HazeInput.Sources(hazeState),
+          input = HazeInput.Backdrop(hazeState),
           style = GlassStyle.regular.then {
             backgroundColor(glassBackgroundColor)
             this.tint(tint)
@@ -443,7 +443,7 @@ private fun MaterialsCard(
       Modifier
         .fillMaxSize()
         .hazeBlur(
-          input = HazeInput.Sources(state),
+          input = HazeInput.Backdrop(state),
           style = style,
         )
         .padding(16.dp),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -103,7 +103,7 @@ fun ScaffoldSample(
 ) {
   val hazeState = rememberHazeState()
   val hazeInput = if (useBackdrop) {
-    HazeInput.Backdrop(HazeInput.Sources(hazeState))
+    HazeInput.Backdrop(hazeState)
   } else {
     HazeInput.Sources(hazeState)
   }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -97,9 +97,16 @@ fun ScaffoldSample(
   mode: ScaffoldSampleMode = ScaffoldSampleMode.Default,
   performanceMode: HazePerformanceMode = HazePerformanceMode.Default,
   sourceOffset: (() -> Float)? = null,
+  sourceDrawProgress: (() -> Float)? = null,
   profilingDrawProgress: (() -> Float)? = null,
+  useBackdrop: Boolean = false,
 ) {
   val hazeState = rememberHazeState()
+  val hazeInput = if (useBackdrop) {
+    HazeInput.Backdrop(HazeInput.Sources(hazeState))
+  } else {
+    HazeInput.Sources(hazeState)
+  }
   val gridState = rememberLazyGridState()
   val showNavigationBar by remember(gridState) {
     derivedStateOf { gridState.firstVisibleItemIndex == 0 }
@@ -164,7 +171,7 @@ fun ScaffoldSample(
               drawContent()
             }
             .hazeBlur(
-              input = HazeInput.Sources(hazeState),
+              input = hazeInput,
               performanceMode = performanceMode,
               style = currentBlurStyle.then {
                 when (mode) {
@@ -218,7 +225,7 @@ fun ScaffoldSample(
                 drawContent()
               }
               .hazeBlur(
-                input = HazeInput.Sources(hazeState),
+                input = hazeInput,
                 performanceMode = performanceMode,
                 style = currentBlurStyle.then {
                   if (mode == ScaffoldSampleMode.StyleChurn) {
@@ -258,6 +265,10 @@ fun ScaffoldSample(
         .fillMaxSize()
         .testTag("lazy_grid")
         .hazeSource(state = hazeState)
+        .drawWithContent {
+          sourceDrawProgress?.invoke()
+          drawContent()
+        }
         .graphicsLayer { translationY = sourceOffset?.invoke() ?: 0f },
     ) {
       items(50) { index ->


### PR DESCRIPTION
## Summary

- add opt-in native window-backdrop input with source fallback
- implement the Android 37.2 RenderNode backend for Blur and Glass without reflection
- add documentation, device acceptance coverage, benchmark support, and Perfetto markers

## Validation

- :haze:jvmTest :haze:assemble :internal:benchmark:assemble
- git diff --check

## Outstanding acceptance

- Paired order-reversed performance profiling on a physical Android 37.2 device is still pending; this PR makes no performance claim.