### PR TITLE
Skip haze source capture without active effects

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -39,17 +39,17 @@ public class HazeState {
   private val _areas = mutableStateListOf<HazeArea>()
   internal val areas: List<HazeArea> get() = _areas
 
-  private val sourceDemand = mutableStateSetOf<HazeEffectNode>()
+  private val sourceDemand = mutableStateSetOf<Any>()
 
   internal val hasSourceDemand: Boolean
     get() = sourceDemand.isNotEmpty()
 
-  internal fun addSourceDemand(effect: HazeEffectNode) {
-    sourceDemand += effect
+  internal fun addSourceDemand(key: Any) {
+    sourceDemand += key
   }
 
-  internal fun removeSourceDemand(effect: HazeEffectNode) {
-    sourceDemand -= effect
+  internal fun removeSourceDemand(key: Any) {
+    sourceDemand -= key
   }
 
   internal fun addArea(area: HazeArea) {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/Haze.kt
@@ -39,6 +39,19 @@ public class HazeState {
   private val _areas = mutableStateListOf<HazeArea>()
   internal val areas: List<HazeArea> get() = _areas
 
+  private val sourceDemand = mutableStateSetOf<HazeEffectNode>()
+
+  internal val hasSourceDemand: Boolean
+    get() = sourceDemand.isNotEmpty()
+
+  internal fun addSourceDemand(effect: HazeEffectNode) {
+    sourceDemand += effect
+  }
+
+  internal fun removeSourceDemand(effect: HazeEffectNode) {
+    sourceDemand -= effect
+  }
+
   internal fun addArea(area: HazeArea) {
     _areas += area
   }

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -109,6 +109,7 @@ internal class HazeEffectNode(
   private var needsVisualEffectInvalidation = false
   private var needsNextFrameVisualEffectInvalidation = false
   private var needsContentInvalidation = false
+  private val sourceDemandKey = Any()
   private var sourceDemandState: HazeState? = null
   private var hasRenderedTypedSourceOutput = false
   private var lastInputSnapshot: HazeEffectInputSnapshotImpl? = null
@@ -437,14 +438,14 @@ internal class HazeEffectNode(
       ?.takeIf { (explicitInput as HazeInput.Sources).state === it }
     if (!isAttached) return
     if (sourceDemandState !== demandState) {
-      sourceDemandState?.removeSourceDemand(this)
-      demandState?.addSourceDemand(this)
+      sourceDemandState?.removeSourceDemand(sourceDemandKey)
+      demandState?.addSourceDemand(sourceDemandKey)
       sourceDemandState = demandState
     }
   }
 
   private fun unregisterSourceDemand() {
-    sourceDemandState?.removeSourceDemand(this)
+    sourceDemandState?.removeSourceDemand(sourceDemandKey)
     sourceDemandState = null
   }
 

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -73,6 +73,7 @@ internal class HazeEffectNode(
         clearRetainedOutput()
         dirtyTracker += DirtyFields.Areas
         field = value
+        reconcileSourceDemand()
       }
     }
 
@@ -93,6 +94,7 @@ internal class HazeEffectNode(
         }
         dirtyTracker += DirtyFields.Areas
         field = value
+        reconcileSourceDemand()
         when {
           value is HazeInput.Sources -> {
             retainOutputWhenSourceUnavailable = value.retention.keepsLastFrame()
@@ -107,6 +109,7 @@ internal class HazeEffectNode(
   private var needsVisualEffectInvalidation = false
   private var needsNextFrameVisualEffectInvalidation = false
   private var needsContentInvalidation = false
+  private var sourceDemandState: HazeState? = null
   private var hasRenderedTypedSourceOutput = false
   private var lastInputSnapshot: HazeEffectInputSnapshotImpl? = null
   private var inputCaptureGeneration = 0L
@@ -398,9 +401,11 @@ internal class HazeEffectNode(
     updateTypedRenderer()
     rebindTrimMemoryCallback()
     update()
+    reconcileSourceDemand()
   }
 
   override fun onDetach() {
+    unregisterSourceDemand()
     stopSourceSelectionSnapshotObserver()
     trimMemoryCallbackDisposable?.dispose()
     trimMemoryCallbackDisposable = null
@@ -424,6 +429,23 @@ internal class HazeEffectNode(
     lastInputSnapshot = null
     disposeTypedRenderer()
     typedEffectRenderer = null
+  }
+
+  private fun reconcileSourceDemand() {
+    val demandState = state
+      ?.takeIf { explicitInput is HazeInput.Sources }
+      ?.takeIf { (explicitInput as HazeInput.Sources).state === it }
+    if (!isAttached) return
+    if (sourceDemandState !== demandState) {
+      sourceDemandState?.removeSourceDemand(this)
+      demandState?.addSourceDemand(this)
+      sourceDemandState = demandState
+    }
+  }
+
+  private fun unregisterSourceDemand() {
+    sourceDemandState?.removeSourceDemand(this)
+    sourceDemandState = null
   }
 
   private fun HazeArea.releaseLayer() {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.node.LayoutAwareModifierNode
 import androidx.compose.ui.node.ObserverModifierNode
 import androidx.compose.ui.node.TraversableNode
 import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.invalidateDraw
 import androidx.compose.ui.node.observeReads
 import androidx.compose.ui.platform.LocalGraphicsContext
 import androidx.compose.ui.unit.toSize
@@ -77,6 +78,10 @@ internal class HazeSourceNode(
         // Finally re-attach ourselves to the new state
         value.addArea(area)
       }
+      if (isAttached) {
+        onObservedReadsChanged()
+        invalidateDraw()
+      }
     }
 
   internal var key: Any?
@@ -90,6 +95,7 @@ internal class HazeSourceNode(
   }
 
   private var lastCoordinates: LayoutCoordinates? = null
+  private var hasCaptureDemand = false
 
   private var preDrawJob: Job? = null
   private var regularPreDrawPending = false
@@ -110,13 +116,22 @@ internal class HazeSourceNode(
   }
 
   override fun onObservedReadsChanged() {
+    var observedCaptureDemand = false
     observeReads {
+      observedCaptureDemand = state.hasSourceDemand
       // Observe pre-draw listeners only. Position is now updated directly in onPositioned.
       if (area.preDrawListeners.isEmpty()) {
         disablePreDrawListener()
       } else {
         enablePreDrawListener()
       }
+    }
+    if (hasCaptureDemand != observedCaptureDemand) {
+      hasCaptureDemand = observedCaptureDemand
+      if (!hasCaptureDemand) {
+        area.releaseLayer()
+      }
+      invalidateDraw()
     }
   }
 
@@ -239,15 +254,24 @@ internal class HazeSourceNode(
   }
 
   override fun ContentDrawScope.draw() {
+    var isContentDrawing = false
     try {
       HazeLogger.d(TAG) { "start draw()" }
-      area.contentDrawing = true
 
       if (!isAttached) {
         // This shouldn't happen, but it does...
         // https://github.com/chrisbanes/haze/issues/665
         return
       }
+
+      if (!hasCaptureDemand) {
+        area.releaseLayer()
+        drawContentSafely()
+        return
+      }
+
+      isContentDrawing = true
+      area.contentDrawing = true
 
       if (size.minDimension.roundToInt() >= 1) {
         val graphicsContext = currentValueOf(LocalGraphicsContext)
@@ -278,7 +302,9 @@ internal class HazeSourceNode(
         drawContentSafely()
       }
     } finally {
-      area.contentDrawing = false
+      if (isContentDrawing) {
+        area.contentDrawing = false
+      }
       HazeLogger.d(TAG) { "end draw()" }
 
       Snapshot.withoutReadObservation {

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -128,10 +128,11 @@ internal class HazeSourceNode(
     }
     if (hasCaptureDemand != observedCaptureDemand) {
       hasCaptureDemand = observedCaptureDemand
-      if (!hasCaptureDemand) {
+      if (hasCaptureDemand) {
+        invalidateDraw()
+      } else {
         area.releaseLayer()
       }
-      invalidateDraw()
     }
   }
 

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceCaptureDemandTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceCaptureDemandTest.kt
@@ -32,7 +32,7 @@ class HazeSourceCaptureDemandTest {
     val state = HazeState()
 
     setContent {
-      source(state)
+      Source(state)
     }
     waitForIdle()
 
@@ -50,8 +50,8 @@ class HazeSourceCaptureDemandTest {
 
     setContent {
       Box(Modifier.size(100.dp)) {
-        source(state)
-        effect(state, factory)
+        Source(state)
+        Effect(state, factory)
       }
     }
     waitForIdle()
@@ -70,9 +70,9 @@ class HazeSourceCaptureDemandTest {
 
     setContent {
       Box(Modifier.size(100.dp)) {
-        source(state)
-        if (showFirst.value) effect(state, DemandRecordingFactory())
-        if (showSecond.value) effect(state, DemandRecordingFactory())
+        Source(state)
+        if (showFirst.value) Effect(state, DemandRecordingFactory())
+        if (showSecond.value) Effect(state, DemandRecordingFactory())
       }
     }
     waitForIdle()
@@ -98,9 +98,9 @@ class HazeSourceCaptureDemandTest {
 
     setContent {
       Box(Modifier.size(100.dp)) {
-        source(firstState)
-        source(secondState)
-        effect(effectState.value, DemandRecordingFactory())
+        Source(firstState)
+        Source(secondState)
+        Effect(effectState.value, DemandRecordingFactory())
       }
     }
     waitForIdle()
@@ -124,8 +124,8 @@ class HazeSourceCaptureDemandTest {
 
     setContent {
       Box(Modifier.size(100.dp)) {
-        source(sourceState.value)
-        effect(activeState, DemandRecordingFactory())
+        Source(sourceState.value)
+        Effect(activeState, DemandRecordingFactory())
       }
     }
     waitForIdle()
@@ -144,7 +144,7 @@ class HazeSourceCaptureDemandTest {
   }
 
   @Composable
-  private fun source(state: HazeState) {
+  private fun Source(state: HazeState) {
     Box(
       Modifier
         .fillMaxSize()
@@ -155,7 +155,7 @@ class HazeSourceCaptureDemandTest {
   }
 
   @Composable
-  private fun effect(state: HazeState, factory: DemandRecordingFactory) {
+  private fun Effect(state: HazeState, factory: DemandRecordingFactory) {
     Box(
       Modifier
         .fillMaxSize()

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceCaptureDemandTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceCaptureDemandTest.kt
@@ -1,0 +1,192 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class, InternalHazeApi::class)
+class HazeSourceCaptureDemandTest {
+
+  @Test
+  fun sourceWithoutAttachedEffect_drawsDirectlyWithoutCapture() = runComposeUiTest {
+    val state = HazeState()
+
+    setContent {
+      source(state)
+    }
+    waitForIdle()
+
+    val area = state.areas.single()
+    assertThat(area.contentLayer).isNull()
+    assertThat(area.contentVersion).isEqualTo(0L)
+    assertThat(onNodeWithTag(SOURCE_TAG).captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Red)
+  }
+
+  @Test
+  fun firstAttachedEffect_hasDrawableInputOnFirstDraw() = runComposeUiTest {
+    val state = HazeState()
+    val factory = DemandRecordingFactory()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(state)
+        effect(state, factory)
+      }
+    }
+    waitForIdle()
+
+    val renderer = factory.renderer
+    assertThat(renderer.snapshots.first()).isNotNull()
+    assertThat(onNodeWithTag(EFFECT_TAG).captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Red)
+  }
+
+  @Test
+  fun lastEffectDetaches_releasesCapture() = runComposeUiTest {
+    val state = HazeState()
+    val showFirst = mutableStateOf(true)
+    val showSecond = mutableStateOf(true)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(state)
+        if (showFirst.value) effect(state, DemandRecordingFactory())
+        if (showSecond.value) effect(state, DemandRecordingFactory())
+      }
+    }
+    waitForIdle()
+    val area = state.areas.single()
+    assertThat(area.contentLayer).isNotNull()
+
+    showFirst.value = false
+    waitForIdle()
+    assertThat(area.contentLayer).isNotNull()
+
+    showSecond.value = false
+    waitForIdle()
+    assertThat(area.contentLayer).isNull()
+  }
+
+  @Test
+  fun effectStateChange_transfersCaptureDemand() = runComposeUiTest {
+    val firstState = HazeState()
+    val secondState = HazeState()
+    val effectState = mutableStateOf(firstState)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(firstState)
+        source(secondState)
+        effect(effectState.value, DemandRecordingFactory())
+      }
+    }
+    waitForIdle()
+    val firstArea = firstState.areas.first()
+    val secondArea = secondState.areas.first()
+    assertThat(firstArea.contentLayer).isNotNull()
+    assertThat(secondArea.contentLayer).isNull()
+
+    effectState.value = secondState
+    waitForIdle()
+
+    assertThat(firstArea.contentLayer).isNull()
+    assertThat(secondArea.contentLayer).isNotNull()
+  }
+
+  @Test
+  fun sourceStateChange_rebindsCaptureDemand() = runComposeUiTest {
+    val activeState = HazeState()
+    val dormantState = HazeState()
+    val sourceState = mutableStateOf(activeState)
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(sourceState.value)
+        effect(activeState, DemandRecordingFactory())
+      }
+    }
+    waitForIdle()
+    val activeArea = activeState.areas.single()
+    assertThat(activeArea.contentLayer).isNotNull()
+
+    sourceState.value = dormantState
+    waitForIdle()
+    val dormantArea = dormantState.areas.single()
+    assertThat(activeArea.contentLayer).isNull()
+    assertThat(dormantArea.contentLayer).isNull()
+
+    sourceState.value = activeState
+    waitForIdle()
+    assertThat(activeArea.contentLayer).isNotNull()
+  }
+
+  @Composable
+  private fun source(state: HazeState) {
+    Box(
+      Modifier
+        .fillMaxSize()
+        .testTag(SOURCE_TAG)
+        .hazeSource(state)
+        .background(Color.Red),
+    )
+  }
+
+  @Composable
+  private fun effect(state: HazeState, factory: DemandRecordingFactory) {
+    Box(
+      Modifier
+        .fillMaxSize()
+        .testTag(EFFECT_TAG)
+        .hazeEffect(
+          factory = factory,
+          input = HazeInput.Sources(state),
+          style = Unit,
+        ),
+    )
+  }
+
+  private companion object {
+    const val SOURCE_TAG = "demand-source"
+    const val EFFECT_TAG = "demand-effect"
+  }
+}
+
+private class DemandRecordingFactory : HazeEffectFactory<Unit> {
+  lateinit var renderer: DemandRecordingRenderer
+    private set
+
+  override fun createRenderer(): HazeEffectRenderer<Unit> = DemandRecordingRenderer().also {
+    renderer = it
+  }
+}
+
+@OptIn(InternalHazeApi::class)
+private class DemandRecordingRenderer : HazeEffectRenderer<Unit> {
+  val snapshots = mutableListOf<HazeEffectInputSnapshot?>()
+
+  override fun HazeEffectDrawScope.draw(style: Unit) {
+    snapshots += (this as HazeEffectRuntimeDrawScope).inputSnapshot
+    drawInput()
+  }
+}

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceCaptureDemandTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceCaptureDemandTest.kt
@@ -86,6 +86,8 @@ class HazeSourceCaptureDemandTest {
     showSecond.value = false
     waitForIdle()
     assertThat(area.contentLayer).isNull()
+    assertThat(onNodeWithTag(SOURCE_TAG).captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Red)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Track attached `HazeInput.Sources` consumers per `HazeState` with opaque demand keys.
- Draw `hazeSource` content directly and release its capture layer while no consumer is attached.
- Restore capture on first demand and transfer it across effect or source state changes.

## Testing

- `./gradlew :haze:allTests spotlessCheck --no-scan`