### PR TITLE
Validate HazeProgressive gradient inputs

### DIFF
--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
@@ -217,9 +217,6 @@ internal fun DrawScope.drawProgressiveWithMultipleLayers(
   stepHeight: Dp = 64.dp,
   block: (mask: Brush, intensity: Float) -> Unit,
 ) {
-  require(progressive.startIntensity in 0f..1f)
-  require(progressive.endIntensity in 0f..1f)
-
   // Here we're going to calculate an appropriate amount of steps for the length.
   // We use a calculation of 60dp per step, which is a good balance between
   // quality vs performance

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeProgressive.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeProgressive.kt
@@ -42,7 +42,12 @@ public sealed interface HazeProgressive {
     public val startIntensity: Float = 0f,
     public val end: Offset = Offset.Infinite,
     public val endIntensity: Float = 1f,
-  ) : HazeProgressive
+  ) : HazeProgressive {
+    init {
+      requireIntensity("startIntensity", startIntensity)
+      requireIntensity("endIntensity", endIntensity)
+    }
+  }
 
   /**
    * A radial gradient effect.
@@ -71,6 +76,11 @@ public sealed interface HazeProgressive {
     public val radius: Float = Float.POSITIVE_INFINITY,
     public val radiusIntensity: Float = 0f,
   ) : HazeProgressive {
+    init {
+      requireIntensity("centerIntensity", centerIntensity)
+      requireIntensity("radiusIntensity", radiusIntensity)
+    }
+
     /** Compares this gradient's parameters for value equality. */
     override fun equals(other: Any?): Boolean {
       if (this === other) return true
@@ -187,8 +197,9 @@ public fun HazeProgressive.asBrush(numStops: Int = 20): Brush = when (this) {
   is HazeProgressive.Brush -> brush
 }
 
-private fun HazeProgressive.LinearGradient.asBrush(numStops: Int = 20): Brush =
-  Brush.linearGradient(
+private fun HazeProgressive.LinearGradient.asBrush(numStops: Int = 20): Brush {
+  requireValidNumStops(numStops)
+  return Brush.linearGradient(
     colors = List(numStops) { i ->
       val x = i * 1f / (numStops - 1)
       Color.Magenta.copy(alpha = lerp(startIntensity, endIntensity, easing.transform(x)))
@@ -196,9 +207,11 @@ private fun HazeProgressive.LinearGradient.asBrush(numStops: Int = 20): Brush =
     start = start,
     end = end,
   )
+}
 
-private fun HazeProgressive.RadialGradient.asBrush(numStops: Int = 20): Brush =
-  Brush.radialGradient(
+private fun HazeProgressive.RadialGradient.asBrush(numStops: Int = 20): Brush {
+  requireValidNumStops(numStops)
+  return Brush.radialGradient(
     colors = List(numStops) { i ->
       val x = i * 1f / (numStops - 1)
       Color.Magenta.copy(alpha = lerp(centerIntensity, radiusIntensity, easing.transform(x)))
@@ -206,3 +219,14 @@ private fun HazeProgressive.RadialGradient.asBrush(numStops: Int = 20): Brush =
     center = center,
     radius = radius,
   )
+}
+
+private fun requireIntensity(property: String, value: Float) {
+  require(value.isFinite() && value in 0f..1f) {
+    "$property must be finite and in 0f..1f"
+  }
+}
+
+private fun requireValidNumStops(numStops: Int) {
+  require(numStops >= 2) { "numStops must be at least 2" }
+}

--- a/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeProgressiveTest.kt
+++ b/haze/src/commonTest/kotlin/dev/chrisbanes/haze/HazeProgressiveTest.kt
@@ -5,11 +5,18 @@ package dev.chrisbanes.haze
 
 import androidx.compose.animation.core.EaseIn
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotEqualTo
+import assertk.assertions.isSameInstanceAs
 import kotlin.test.Test
 
+@OptIn(InternalHazeApi::class)
 class HazeProgressiveTest {
 
   @Test
@@ -37,10 +44,77 @@ class HazeProgressiveTest {
   }
 
   @Test
-  fun radialGradient_usesDataClassFloatEquality() {
-    assertThat(HazeProgressive.RadialGradient(centerIntensity = Float.NaN))
-      .isEqualTo(HazeProgressive.RadialGradient(centerIntensity = Float.NaN))
+  fun radialGradient_usesDataClassFloatEqualityForSignedZero() {
     assertThat(HazeProgressive.RadialGradient(centerIntensity = -0f))
       .isNotEqualTo(HazeProgressive.RadialGradient(centerIntensity = 0f))
+  }
+
+  @Test
+  fun generatedGradients_retainValidIntensities() {
+    listOf(0f, 0.5f, 1f).forEach { intensity ->
+      assertThat(HazeProgressive.LinearGradient(startIntensity = intensity).startIntensity)
+        .isEqualTo(intensity)
+      assertThat(HazeProgressive.LinearGradient(endIntensity = intensity).endIntensity)
+        .isEqualTo(intensity)
+      assertThat(HazeProgressive.RadialGradient(centerIntensity = intensity).centerIntensity)
+        .isEqualTo(intensity)
+      assertThat(HazeProgressive.RadialGradient(radiusIntensity = intensity).radiusIntensity)
+        .isEqualTo(intensity)
+    }
+  }
+
+  @Test
+  fun linearGradient_rejectsInvalidIntensities() {
+    assertInvalidIntensity("startIntensity") {
+      HazeProgressive.LinearGradient(startIntensity = it)
+    }
+    assertInvalidIntensity("endIntensity") {
+      HazeProgressive.LinearGradient(endIntensity = it)
+    }
+  }
+
+  @Test
+  fun radialGradient_rejectsInvalidIntensities() {
+    assertInvalidIntensity("centerIntensity") {
+      HazeProgressive.RadialGradient(centerIntensity = it)
+    }
+    assertInvalidIntensity("radiusIntensity") {
+      HazeProgressive.RadialGradient(radiusIntensity = it)
+    }
+  }
+
+  @Test
+  fun generatedGradients_rejectStopCountsBelowTwo() {
+    listOf(
+      HazeProgressive.LinearGradient(),
+      HazeProgressive.RadialGradient(),
+    ).forEach { progressive ->
+      listOf(-1, 0, 1).forEach { numStops ->
+        val failure = assertFailure { progressive.asBrush(numStops) }
+        failure.isInstanceOf<IllegalArgumentException>()
+        failure.hasMessage("numStops must be at least 2")
+      }
+    }
+  }
+
+  @Test
+  fun brush_ignoresGeneratedGradientStopValidation() {
+    val brush = SolidColor(Color.Black)
+
+    assertThat(HazeProgressive.Brush(brush).asBrush(numStops = 0)).isSameInstanceAs(brush)
+  }
+}
+
+private fun assertInvalidIntensity(property: String, create: (Float) -> Unit) {
+  listOf(
+    -0.1f,
+    Float.NaN,
+    Float.NEGATIVE_INFINITY,
+    Float.POSITIVE_INFINITY,
+    1.1f,
+  ).forEach { intensity ->
+    val failure = assertFailure { create(intensity) }
+    failure.isInstanceOf<IllegalArgumentException>()
+    failure.hasMessage("$property must be finite and in 0f..1f")
   }
 }


### PR DESCRIPTION
## Summary

- validate generated linear and radial gradient intensities at construction
- require at least two stops when converting generated gradients to brushes, while leaving caller-provided brushes unchanged
- remove the redundant legacy renderer-time intensity checks

## Testing

- ./gradlew :haze:jvmTest :haze-blur:jvmTest :haze-screenshot-tests:test --no-scan
- ./gradlew :haze:spotlessCheck :haze-blur:spotlessCheck --no-scan

Screenshot verification passed without baseline updates.

Fixes #1281