### PR TITLE
Correct published Compose dependency scopes

### DIFF
--- a/haze-blur/build.gradle.kts
+++ b/haze-blur/build.gradle.kts
@@ -47,7 +47,7 @@ kotlin {
       dependencies {
         api(projects.haze)
         api(libs.compose.ui)
-        implementation(libs.compose.foundation)
+        implementation(libs.compose.animation.core)
         implementation(libs.androidx.collection)
         implementation(projects.hazeUtils)
       }
@@ -55,13 +55,14 @@ kotlin {
 
     androidMain {
       dependencies {
-        implementation(libs.androidx.activity)
+        implementation(libs.androidx.core)
       }
     }
 
     named("androidDeviceTest") {
       dependencies {
         implementation(libs.assertk)
+        implementation(libs.androidx.activity)
         implementation(libs.androidx.compose.ui.test.junit4)
         implementation(libs.androidx.compose.ui.test.manifest)
         implementation(projects.internal.contextTest) {
@@ -72,6 +73,7 @@ kotlin {
 
     named("androidHostTest") {
       dependencies {
+        implementation(libs.androidx.activity)
         implementation(libs.androidx.compose.ui.test.junit4)
         implementation(libs.compose.material3)
       }
@@ -82,6 +84,7 @@ kotlin {
         implementation(libs.assertk)
         implementation(kotlin("test"))
 
+        implementation(libs.compose.foundation)
         implementation(libs.compose.ui.test)
 
         implementation(projects.internal.contextTest)

--- a/haze-blur/build.gradle.kts
+++ b/haze-blur/build.gradle.kts
@@ -65,6 +65,7 @@ kotlin {
         implementation(libs.androidx.activity)
         implementation(libs.androidx.compose.ui.test.junit4)
         implementation(libs.androidx.compose.ui.test.manifest)
+        implementation(libs.compose.foundation)
         implementation(projects.internal.contextTest) {
           exclude(group = "org.robolectric", module = "robolectric")
         }
@@ -75,6 +76,7 @@ kotlin {
       dependencies {
         implementation(libs.androidx.activity)
         implementation(libs.androidx.compose.ui.test.junit4)
+        implementation(libs.compose.foundation)
         implementation(libs.compose.material3)
       }
     }

--- a/haze-glass/build.gradle.kts
+++ b/haze-glass/build.gradle.kts
@@ -31,9 +31,9 @@ kotlin {
       dependencies {
         api(projects.haze)
         api(libs.compose.animation.core)
+        api(libs.compose.foundation)
         implementation(projects.hazeUtils)
         implementation(libs.compose.ui)
-        implementation(libs.compose.foundation)
       }
     }
 

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -66,6 +66,7 @@ kotlin {
 
     named("androidHostTest") {
       dependencies {
+        implementation(libs.compose.foundation)
         implementation(projects.internal.screenshotTest)
       }
     }

--- a/haze/build.gradle.kts
+++ b/haze/build.gradle.kts
@@ -38,9 +38,9 @@ kotlin {
   sourceSets {
     commonMain {
       dependencies {
+        api(libs.compose.animation.core)
         api(libs.compose.ui)
         implementation(projects.hazeUtils)
-        implementation(libs.compose.foundation)
         implementation(libs.androidx.collection)
         implementation(libs.androidx.lifecycle.runtime.compose)
       }
@@ -57,6 +57,7 @@ kotlin {
         implementation(kotlin("test"))
         implementation(libs.assertk)
 
+        implementation(libs.compose.foundation)
         implementation(libs.compose.ui.test)
 
         implementation(projects.internal.contextTest)


### PR DESCRIPTION
## Summary

- expose Compose Foundation from `haze-glass` API variants
- move test-only Foundation and Activity dependencies to their consuming test source sets
- declare the direct Animation Core and AndroidX Core production dependencies that were previously supplied transitively

## Testing

- `./gradlew --no-scan :haze:check :haze-blur:check :haze-glass:check`
- generated and inspected Kotlin Multiplatform, JVM, and Android POMs and Gradle module metadata
- published the adjusted modules to an isolated local Maven repository
- compiled an external JVM consumer using `haze-glass` Foundation API types without a direct Foundation dependency

Fixes #1280
