### PR TITLE
Fix Behind selection across nested independent Haze states

### DIFF
--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeEffectNode.kt
@@ -33,10 +33,10 @@ import androidx.compose.ui.node.LayoutAwareModifierNode
 import androidx.compose.ui.node.ObserverModifierNode
 import androidx.compose.ui.node.PointerInputModifierNode
 import androidx.compose.ui.node.TraversableNode
-import androidx.compose.ui.node.findNearestAncestor
 import androidx.compose.ui.node.observeReads
 import androidx.compose.ui.node.requireDensity
 import androidx.compose.ui.node.requireGraphicsContext
+import androidx.compose.ui.node.traverseAncestors
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.toIntSize
 import androidx.compose.ui.unit.toSize
@@ -686,12 +686,24 @@ internal class HazeEffectNode(
           area.preDrawListeners -= areaPreDrawListener
         }
 
-        val ancestorSourceNode =
-          (findNearestAncestor(HazeTraversableNodeKeys.Source) as? HazeSourceNode)
-            ?.takeIf { it.state == this.state }
-
         val unfilteredAreas = stateAreas.orEmpty()
         val selection = checkNotNull(explicitInput as? HazeInput.Sources).selection
+        val ancestorSourceNode = if (selection.baseSelection() == HazeSourceSelection.Behind) {
+          var result: HazeSourceNode? = null
+          traverseAncestors(HazeTraversableNodeKeys.Source) { node ->
+            val sourceNode = node as? HazeSourceNode
+            if (sourceNode?.state === state) {
+              result = sourceNode
+              false
+            } else {
+              true
+            }
+          }
+          result
+        } else {
+          null
+        }
+
         HazeLogger.d(TAG) { "Background Areas observing: $unfilteredAreas" }
         val relatedSources = unfilteredAreas.mapNotNull { area ->
           val metadata = HazeSourceMetadata(key = area.key, zIndex = area.zIndex)

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeEffectInputTest.kt
@@ -70,6 +70,46 @@ class HazeEffectInputTest {
   }
 
   @Test
+  fun sourcesWhere_behindUsesNearestMatchingAncestorAcrossNestedStates() = runComposeUiTest {
+    val unrelatedState = HazeState()
+    val innerState = HazeState()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(innerState, "inner", 1f, Color.Green) {
+          source(innerState, "lower", 0f, Color.Yellow)
+          source(unrelatedState, "unrelated", 2f, Color.Blue) {
+            effect(innerState, HazeSourceSelection.Behind)
+          }
+        }
+      }
+    }
+
+    assertThat(effectCenterColor()).isEqualTo(Color.Yellow)
+  }
+
+  @Test
+  fun sourcesWhere_behindUsesNearestOfMultipleMatchingAncestors() = runComposeUiTest {
+    val state = HazeState()
+    val unrelatedState = HazeState()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        source(state, "outer", 3f, Color.Red) {
+          source(state, "inner", 1f, Color.Green) {
+            source(state, "lower", 0f, Color.Yellow)
+            source(unrelatedState, "unrelated", 2f, Color.Blue) {
+              effect(state, HazeSourceSelection.Behind)
+            }
+          }
+        }
+      }
+    }
+
+    assertThat(effectCenterColor()).isEqualTo(Color.Yellow)
+  }
+
+  @Test
   fun sourcesWhere_reactsToPredicateStateChanges() = runComposeUiTest {
     val state = HazeState()
     val selectedKey = mutableStateOf("first")
@@ -326,12 +366,14 @@ private fun androidx.compose.foundation.layout.BoxScope.source(
   key: String,
   zIndex: Float,
   color: Color,
+  content: @Composable androidx.compose.foundation.layout.BoxScope.() -> Unit = {},
 ) {
   Box(
     Modifier
       .fillMaxSize()
       .hazeSource(state, zIndex = zIndex, key = key)
       .background(color),
+    content = content,
   )
 }
 


### PR DESCRIPTION
When a Behind effect is nested inside a source from another HazeState, ancestor lookup now continues to the nearest source owned by the effect’s state. This preserves the matching source’s z-index cutoff; All selection keeps its existing behavior.

Adds JVM regressions for an intervening independent state and multiple matching ancestors, alongside the existing All self-inclusion guard.

Validation: RED/GREEN regression checks, `:haze:jvmTest`, `:haze:check`, and Spotless passed. Independent verification of the committed change passed `:haze:jvmTest --rerun check -x :sample:screenshot-tests:jvmTest -Pandroidx.baselineprofile.skipgeneration`.

The full local check was attempted. Two existing desktop product screenshots fail identically on clean main and this branch, with byte-identical actual and comparison images. Those snapshots are unchanged; PR CI runs the complete configured checks.

Fixes #1285