### PR TITLE
Accept subpixel blur radii in the RenderScript backend

### DIFF
--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/RenderScriptBlurVisualEffectInstrumentationTest.kt
@@ -1,0 +1,126 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import android.os.Build
+import androidx.activity.ComponentActivity
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazePerformanceMode
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class RenderScriptBlurVisualEffectInstrumentationTest {
+
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  fun scaledSubpixelBlurRadius_animatesToZero() {
+    assumeTrue("RenderScript backend test requires API 30", Build.VERSION.SDK_INT == 30)
+    val hazeState = HazeState()
+    val targetRadius = mutableStateOf(0.5.dp)
+    val sourceColor = mutableStateOf(Color.Blue)
+
+    composeTestRule.setContent {
+      val blurRadius by animateDpAsState(
+        targetValue = targetRadius.value,
+        animationSpec = tween(durationMillis = 100),
+        label = "blurRadius",
+      )
+
+      Box(
+        Modifier
+          .size(100.dp)
+          .hazeSource(hazeState)
+          .background(sourceColor.value),
+      )
+      Box(
+        Modifier
+          .testTag(BLUR_EFFECT_TAG)
+          .size(100.dp)
+          .background(Color.Black)
+          .hazeBlur(
+            input = HazeInput.Sources(hazeState),
+            style = HazeBlurStyle {
+              blurEnabled(true)
+              blurRadius(blurRadius)
+              backgroundColor(Color.Transparent)
+              colorEffects(emptyList())
+              fallbackColorEffect(null)
+            },
+            performanceMode = HazePerformanceMode.Performance,
+          ),
+      )
+    }
+    composeTestRule.waitForIdle()
+    assertThat(Build.VERSION.SDK_INT).isEqualTo(30)
+    val initial = composeTestRule.captureCenterPixel()
+    assertThat(initial.blue, "initial RenderScript output").isGreaterThan(initial.red)
+
+    composeTestRule.mainClock.autoAdvance = false
+    composeTestRule.runOnIdle { sourceColor.value = Color.Red }
+    val updated = composeTestRule.awaitCenterPixel { it.red > it.blue }
+    assertThat(updated.red, "positive subpixel RenderScript output").isGreaterThan(updated.blue)
+
+    composeTestRule.runOnIdle { targetRadius.value = 0.dp }
+    repeat(8) {
+      composeTestRule.mainClock.advanceTimeByFrame()
+      composeTestRule.waitForIdle()
+    }
+    composeTestRule.runOnIdle { sourceColor.value = Color.Green }
+    val zeroRadius = composeTestRule.awaitCenterPixel {
+      it.green > it.red && it.green > it.blue
+    }
+    assertThat(zeroRadius.green, "zero-radius copy output").isGreaterThan(zeroRadius.red)
+    assertThat(zeroRadius.green, "zero-radius copy output").isGreaterThan(zeroRadius.blue)
+    composeTestRule.onNodeWithTag(BLUR_EFFECT_TAG).assertIsDisplayed()
+  }
+
+  private fun androidx.compose.ui.test.junit4.AndroidComposeTestRule<*, *>.captureCenterPixel(): Color {
+    val pixels = onNodeWithTag(BLUR_EFFECT_TAG).captureToImage().toPixelMap()
+    return pixels[pixels.width / 2, pixels.height / 2]
+  }
+
+  private fun androidx.compose.ui.test.junit4.AndroidComposeTestRule<*, *>.awaitCenterPixel(
+    predicate: (Color) -> Boolean,
+  ): Color {
+    var pixel = captureCenterPixel()
+    repeat(MAX_PIXEL_WAIT_FRAMES) {
+      if (predicate(pixel)) return pixel
+      mainClock.advanceTimeByFrame()
+      waitForIdle()
+      pixel = captureCenterPixel()
+    }
+    return pixel
+  }
+
+  private companion object {
+    const val BLUR_EFFECT_TAG = "render_script_blur_effect"
+    const val MAX_PIXEL_WAIT_FRAMES = 30
+  }
+}

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/RenderScriptContextInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/RenderScriptContextInstrumentationTest.kt
@@ -1,0 +1,67 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:Suppress("DEPRECATION")
+
+package dev.chrisbanes.haze.blur
+
+import android.graphics.Color
+import android.renderscript.RenderScript
+import androidx.compose.ui.unit.IntSize
+import androidx.test.platform.app.InstrumentationRegistry
+import assertk.assertFailure
+import assertk.assertions.isInstanceOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Test
+
+class RenderScriptContextInstrumentationTest {
+
+  @Test
+  fun applyBlur_acceptsFinitePositiveRadiusThroughRenderScriptMaximum() {
+    withContext { context ->
+      writeInput(context)
+      listOf(0.25f, 1f, 25f).forEach(context::applyBlur)
+    }
+  }
+
+  @Test
+  fun applyBlur_rejectsInvalidRadiusValues() {
+    withContext { context ->
+      listOf(
+        0f,
+        -1f,
+        Float.NaN,
+        Float.NEGATIVE_INFINITY,
+        Float.POSITIVE_INFINITY,
+        25.1f,
+      ).forEach { radius ->
+        assertFailure { context.applyBlur(radius) }
+          .isInstanceOf<IllegalArgumentException>()
+      }
+    }
+  }
+
+  private fun withContext(block: (RenderScriptContext) -> Unit) {
+    val renderScript = RenderScript.create(
+      InstrumentationRegistry.getInstrumentation().targetContext,
+    )
+    val context = RenderScriptContext(renderScript, IntSize(4, 4))
+    try {
+      block(context)
+    } finally {
+      context.release()
+      renderScript.destroy()
+    }
+  }
+
+  private fun writeInput(context: RenderScriptContext) {
+    val canvas = context.inputSurface.lockCanvas(null)
+    try {
+      canvas.drawColor(Color.BLUE)
+    } finally {
+      context.inputSurface.unlockCanvasAndPost(canvas)
+    }
+    runBlocking { withTimeout(3_000L) { context.awaitSurfaceWritten() } }
+  }
+}

--- a/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptContext.kt
+++ b/haze-blur/src/androidMain/kotlin/dev/chrisbanes/haze/blur/RenderScriptContext.kt
@@ -65,8 +65,8 @@ internal class RenderScriptContext(
 
   fun applyBlur(blurRadius: Float) {
     lock.withLock {
-      require(blurRadius in 1f..25f) {
-        "blurRadius needs to be >= 1 and <= 25"
+      require(blurRadius.isFinite() && blurRadius > 0f && blurRadius <= 25f) {
+        "blurRadius needs to be finite, > 0, and <= 25"
       }
       if (isDestroyed) return@withLock
 


### PR DESCRIPTION
RenderScript accepts blur radii greater than zero, but Haze rejected values below one pixel. This allows finite radii in `(0, 25]`, preserving the existing zero-radius copy path and maximum-radius scaling.

Adds boundary tests and an API 30 Compose regression that observes effect output at a scaled subpixel radius, then animates to zero. An opaque background beneath the effect prevents its pixel assertions from reading the source directly.

Validation: the original guard reproduced the asynchronous exception; the corrected guard passed. Independent API 30 AOSP ARM runs passed both boundary tests and the visual test, with no skips. Spotless and the remaining repository checks passed.

The full local check reproduced the two inherited desktop product screenshot failures already verified on clean main. No snapshots changed; the remaining check excluded only `:sample:screenshot-tests:jvmTest`. Full configured PR CI remains required.

Fixes #1286