### PR TITLE
Preserve progressive blur coverage for custom intensity ranges

### DIFF
--- a/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
+++ b/haze-blur/src/commonMain/kotlin/dev/chrisbanes/haze/blur/BlurRenderEffectVisualEffect.kt
@@ -25,8 +25,6 @@ import dev.chrisbanes.haze.InternalHazeApi
 import dev.chrisbanes.haze.Poko
 import dev.chrisbanes.haze.TrimMemoryLevel
 import kotlin.math.ceil
-import kotlin.math.max
-import kotlin.math.min
 
 @OptIn(ExperimentalHazeApi::class, InternalHazeApi::class)
 internal class RenderEffectBlurVisualEffectDelegate(
@@ -238,14 +236,11 @@ internal fun DrawScope.drawProgressiveWithMultipleLayers(
       progressive.easing.transform(fraction),
     )
 
-    val min = min(progressive.startIntensity, progressive.endIntensity)
-    val max = max(progressive.startIntensity, progressive.endIntensity)
-
     val mask = Brush.linearGradient(
-      lerp(min, max, (i - 2f) / steps) to Color.Transparent,
-      lerp(min, max, (i - 1f) / steps) to Color.Black,
-      lerp(min, max, (i + 0f) / steps) to Color.Black,
-      lerp(min, max, (i + 1f) / steps) to Color.Transparent,
+      (i - 2f) / steps to Color.Transparent,
+      (i - 1f) / steps to Color.Black,
+      (i + 0f) / steps to Color.Black,
+      (i + 1f) / steps to Color.Transparent,
       start = progressive.start,
       end = progressive.end,
     )

--- a/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/ProgressiveBlurMaskTest.kt
+++ b/haze-blur/src/jvmTest/kotlin/dev/chrisbanes/haze/blur/ProgressiveBlurMaskTest.kt
@@ -1,0 +1,134 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isGreaterThan
+import dev.chrisbanes.haze.HazeProgressive
+import kotlin.test.Test
+
+class ProgressiveBlurMaskTest {
+
+  @Test
+  fun layeredMasks_coverTheFullAxisIndependentOfIntensityRange() {
+    val probes = listOf(
+      Probe(
+        name = "vertical equal",
+        progressive = HazeProgressive.LinearGradient(
+          easing = LinearEasing,
+          start = Offset(0f, 0f),
+          startIntensity = 0.5f,
+          end = Offset(0f, 128f),
+          endIntensity = 0.5f,
+        ),
+        expectedIntensities = listOf(0.5f, 0.5f, 0.5f),
+        samples = listOf(64 to 8, 64 to 64, 64 to 120),
+      ),
+      Probe(
+        name = "horizontal restricted increasing",
+        progressive = HazeProgressive.LinearGradient(
+          easing = LinearEasing,
+          start = Offset(0f, 0f),
+          startIntensity = 0.25f,
+          end = Offset(128f, 0f),
+          endIntensity = 0.75f,
+        ),
+        expectedIntensities = listOf(0.25f, 0.5f, 0.75f),
+        samples = listOf(8 to 64, 64 to 64, 120 to 64),
+      ),
+      Probe(
+        name = "vertical restricted decreasing",
+        progressive = HazeProgressive.LinearGradient(
+          easing = LinearEasing,
+          start = Offset(0f, 0f),
+          startIntensity = 0.75f,
+          end = Offset(0f, 128f),
+          endIntensity = 0.25f,
+        ),
+        expectedIntensities = listOf(0.25f, 0.5f, 0.75f),
+        samples = listOf(64 to 8, 64 to 64, 64 to 120),
+      ),
+      Probe(
+        name = "horizontal default linear",
+        progressive = HazeProgressive.LinearGradient(
+          easing = LinearEasing,
+          start = Offset(0f, 0f),
+          startIntensity = 0f,
+          end = Offset(128f, 0f),
+          endIntensity = 1f,
+        ),
+        expectedIntensities = listOf(0f, 0.5f, 1f),
+        samples = listOf(8 to 64, 64 to 64, 120 to 64),
+      ),
+      Probe(
+        name = "horizontal nonlinear easing",
+        progressive = HazeProgressive.LinearGradient(
+          easing = Easing { fraction -> fraction * fraction },
+          start = Offset(0f, 0f),
+          startIntensity = 0f,
+          end = Offset(128f, 0f),
+          endIntensity = 1f,
+        ),
+        expectedIntensities = listOf(0f, 0.25f, 1f),
+        samples = listOf(8 to 64, 64 to 64, 120 to 64),
+      ),
+    )
+
+    probes.forEach { probe ->
+      val result = rasterize(probe.progressive)
+
+      assertThat(result.intensities, probe.name).containsExactly(
+        *probe.expectedIntensities.toTypedArray(),
+      )
+      probe.samples.forEach { (x, y) ->
+        assertThat(result.pixels[x, y].alpha, "${probe.name} coverage at ($x, $y)")
+          .isGreaterThan(0.95f)
+      }
+    }
+  }
+
+  private fun rasterize(progressive: HazeProgressive.LinearGradient): RasterResult {
+    val width = 128
+    val height = 128
+    val bitmap = ImageBitmap(width, height)
+    val intensities = mutableListOf<Float>()
+
+    CanvasDrawScope().draw(
+      density = Density(1f),
+      layoutDirection = LayoutDirection.Ltr,
+      canvas = Canvas(bitmap),
+      size = Size(width.toFloat(), height.toFloat()),
+    ) {
+      drawProgressiveWithMultipleLayers(progressive) { mask, intensity ->
+        intensities += intensity
+        drawRect(brush = mask)
+      }
+    }
+
+    return RasterResult(intensities, bitmap.toPixelMap())
+  }
+
+  private class Probe(
+    val name: String,
+    val progressive: HazeProgressive.LinearGradient,
+    val expectedIntensities: List<Float>,
+    val samples: List<Pair<Int, Int>>,
+  )
+
+  private class RasterResult(
+    val intensities: List<Float>,
+    val pixels: androidx.compose.ui.graphics.PixelMap,
+  )
+}

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/ProgressiveBlurAndroidScreenshotTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/ProgressiveBlurAndroidScreenshotTest.kt
@@ -1,0 +1,91 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(ExperimentalHazeApi::class)
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isLessThan
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.hazeBlur
+import dev.chrisbanes.haze.test.ScreenshotTest
+import dev.chrisbanes.haze.test.ScreenshotTheme
+import dev.chrisbanes.haze.test.runScreenshotTest
+import kotlin.test.Test
+import org.robolectric.annotation.Config
+
+@Config(sdk = [31, 32])
+class ProgressiveBlurAndroidScreenshotTest : ScreenshotTest() {
+
+  @Test
+  fun progressiveBlur_contentInputKeepsCoverageAtBothEndsOfTheAxis() = runScreenshotTest {
+    val style = HazeBlurStyle {
+      blurRadius(48.dp)
+      noiseFactor(0f)
+      progressive(
+        HazeProgressive.horizontalGradient(
+          startIntensity = 0.5f,
+          endIntensity = 0.5f,
+        ),
+      )
+    }
+
+    setContent {
+      ScreenshotTheme {
+        Box(
+          Modifier
+            .fillMaxSize()
+            .background(Color.Black),
+        ) {
+          Column(
+            Modifier
+              .fillMaxSize()
+              .hazeBlur(
+                input = HazeInput.Content,
+                style = style,
+                performanceMode = HazePerformanceMode.Quality,
+              ),
+          ) {
+            Box(
+              Modifier
+                .weight(1f)
+                .fillMaxSize()
+                .background(Color.Black),
+            )
+            Box(
+              Modifier
+                .weight(1f)
+                .fillMaxSize()
+                .background(Color.White),
+            )
+          }
+        }
+      }
+    }
+
+    val pixels = captureRootPixels()
+    listOf(pixels.width / 4, pixels.width * 3 / 4).forEach { x ->
+      val farUpper = pixels[x, pixels.height / 4].luminance()
+      val farLower = pixels[x, pixels.height * 3 / 4].luminance()
+      assertThat(farUpper, "upper source at x=$x").isLessThan(0.2f)
+      assertThat(farLower, "lower source at x=$x").isGreaterThan(0.8f)
+
+      listOf(pixels.height / 2 - 4, pixels.height / 2 + 4).forEach { y ->
+        val luminance = pixels[x, y].luminance()
+        val label = "progressive transition at ($x, $y) on ${pixels.width}x${pixels.height}"
+        assertThat(luminance, label).isGreaterThan(0.02f)
+        assertThat(luminance, label).isLessThan(0.98f)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Progressive blur currently places layer masks using the authored intensity range, leaving gaps when that range is constant or restricted. Use normalized spatial mask stops while preserving the existing eased intensities, geometry, and draw order.

Add JVM raster coverage for constant, increasing, decreasing, default, and nonlinear ranges, plus an Android API 31/32 own-content regression. The Android test fails on the unchanged baseline and passes with this fix on both versions.

Validation: focused JVM tests passed; an independent final run of all Android host tests and remaining `check` tasks passed. Full local `check` still fails the inherited Glass Gallery `productPortrait` and `productLandscape` desktop snapshots; their actual and comparison images are byte-identical to failures on the clean baseline. No snapshots were changed. Baseline-profile generation was skipped for local checks.

Fixes #1287