### PR TITLE
Select Glass rim rendering from the destination canvas

### DIFF
--- a/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
+++ b/haze-glass/src/androidHostTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateAndroidHostTest.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
@@ -83,6 +85,48 @@ import org.robolectric.annotation.GraphicsMode
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [35])
 class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
+  @Test
+  fun destinationCanvasChanges_refreshRetainedRimWithoutChangingStyle() =
+    runAndroidComposeUiTest<ComponentActivity> {
+      val effect = animatedStageEffect()
+      val factory = TestGlassRuntimeFactory(effect)
+      setContent {
+        Box(
+          Modifier.size(120.dp).testTag("canvas-transition").hazeEffect(
+            factory = factory,
+            input = HazeInput.Content,
+            style = GlassNodeConfiguration(
+              style = effect.style,
+              performanceMode = HazePerformanceMode.Quality,
+              interactionSource = effect.interactionSource,
+            ),
+            expandLayerBounds = true,
+          ),
+        ) {
+          Box(Modifier.fillMaxSize().background(Color.Red))
+        }
+      }
+      waitForIdle()
+      onNodeWithTag("canvas-transition").captureToImage()
+      val delegate = effect.delegate as RuntimeShaderGlassDelegate
+      val rim = checkNotNull(delegate.layers.rim)
+      assertThat(rim.renderEffect).isNull()
+
+      factory.renderer.foregroundCanvas = androidx.compose.ui.graphics.Canvas(ImageBitmap(400, 400))
+      factory.renderer.invalidateDraw()
+      waitForIdle()
+      onNodeWithTag("canvas-transition").captureToImage()
+      assertThat(delegate.layers.rim).isSameInstanceAs(rim)
+      assertThat(rim.renderEffect).isNotNull()
+
+      factory.renderer.foregroundCanvas = null
+      factory.renderer.invalidateDraw()
+      waitForIdle()
+      onNodeWithTag("canvas-transition").captureToImage()
+      assertThat(delegate.layers.rim).isSameInstanceAs(rim)
+      assertThat(rim.renderEffect).isNull()
+    }
+
   @Test
   fun directRuntimePath_ownsRenderedResources() =
     runAndroidComposeUiTest<ComponentActivity> {
@@ -553,7 +597,8 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       val rimEffect = delegate.rimEffect
       val rimBrushProvider = checkNotNull(delegate.rimBrushProvider)
       val rimRecordCount = delegate.rimRecordCount
-      assertThat(delegate.layers.rim?.renderEffect).isNull()
+      // drawFrame uses a software bitmap canvas, so the rim retains its RenderEffect fallback.
+      assertThat(delegate.layers.rim?.renderEffect).isNotNull()
       style.value = style.value.then { lightPosition(exactLightAlignment(Offset(10f, 20f))) }
       waitForIdle()
       drawFrame()
@@ -562,7 +607,7 @@ class RuntimeShaderGlassDelegateAndroidHostTest : ContextTest() {
       assertThat(delegate.rimEffect).isNotSameInstanceAs(rimEffect)
       assertThat(delegate.rimBrushProvider).isSameInstanceAs(rimBrushProvider)
       assertThat(delegate.rimRecordCount).isGreaterThan(rimRecordCount)
-      assertThat(delegate.layers.rim?.renderEffect).isNull()
+      assertThat(delegate.layers.rim?.renderEffect).isNotNull()
     }
 
   @Test
@@ -1282,6 +1327,7 @@ private class TestGlassRuntimeRenderer(
   HazeEffectRendererLifecycle<GlassNodeConfiguration>,
   HazeEffectRendererDrawHooks<GlassNodeConfiguration> {
   private var lifecycleScope: HazeEffectLifecycleScope? = null
+  var foregroundCanvas: androidx.compose.ui.graphics.Canvas? = null
 
   override fun attach(scope: HazeEffectLifecycleScope) {
     lifecycleScope = scope
@@ -1314,7 +1360,15 @@ private class TestGlassRuntimeRenderer(
   }
 
   override fun HazeEffectRuntimeDrawScope.drawForeground(style: GlassNodeConfiguration) {
-    with(effect) { drawForeground(style) }
+    val canvas = foregroundCanvas
+    if (canvas == null) {
+      with(effect) { drawForeground(style) }
+    } else {
+      val context = this
+      CanvasDrawScope().draw(this, layoutDirection, canvas, size) {
+        with(effect.delegate) { drawForeground(context) }
+      }
+    }
   }
 
   override fun shouldDrawContentBehind(): Boolean = effect.shouldDrawContentBehind()

--- a/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
+++ b/haze-glass/src/commonMain/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegate.kt
@@ -128,6 +128,7 @@ internal class RuntimeShaderGlassDelegate(
   private var recordedInteractionLightingSize: IntSize? = null
   private var recordedRimLayer: GraphicsLayer? = null
   private var recordedRimKey: GlassRimEffectKey? = null
+  private var recordedRimSupportsDirectDrawing = false
   internal val layers = GlassLayers()
   private var graphicsContext: GraphicsContext? = null
   private var preparedRender: GlassPreparedRender? = null
@@ -866,6 +867,10 @@ internal class RuntimeShaderGlassDelegate(
         }
       }
       layers.rim?.takeUnless { it.isReleased }?.let { rim ->
+        if (supportsGlassRimBrush() != recordedRimSupportsDirectDrawing) {
+          val effects = preparedRenderEffects ?: return
+          recordRimIfNeeded(params, effects) ?: return
+        }
         drawCompletedLayer(rim, context, params, alpha = render.alpha)
       }
     }
@@ -966,6 +971,7 @@ internal class RuntimeShaderGlassDelegate(
   private fun clearRimLayerMetadata() {
     recordedRimLayer = null
     recordedRimKey = null
+    recordedRimSupportsDirectDrawing = false
   }
 
   override fun detach() {
@@ -1271,10 +1277,13 @@ internal class RuntimeShaderGlassDelegate(
     val rimEffect = effects.rim ?: return Unit
     val layer = layers.rim?.takeUnless { it.isReleased } ?: return null
     val key = params.rimEffectKey()
+    // Recording canvases may support shaders even when the destination canvas does not.
+    val supportsDirectDrawing = supportsGlassRimBrush()
     layer.alpha = 1f
     if (
       layer !== recordedRimLayer ||
-      key != recordedRimKey
+      key != recordedRimKey ||
+      supportsDirectDrawing != recordedRimSupportsDirectDrawing
     ) {
       if (!rimBrushProviderInitialized) {
         rimBrushProvider = createGlassRimBrushProvider()
@@ -1283,7 +1292,7 @@ internal class RuntimeShaderGlassDelegate(
       val brush = rimBrushProvider?.invoke(key)
       var drawnDirectly = false
       layer.record(params.coordinates.sampleSize.roundToIntSize()) {
-        drawnDirectly = brush != null && drawGlassRimWithBrush(brush)
+        drawnDirectly = supportsDirectDrawing && brush != null && drawGlassRimWithBrush(brush)
         if (!drawnDirectly) drawRect(Color.Black)
       }
       // The rim is procedural: supported canvases can draw it without an offscreen effect.
@@ -1291,6 +1300,7 @@ internal class RuntimeShaderGlassDelegate(
       layer.renderEffect = rimEffect.takeUnless { drawnDirectly }?.asComposeRenderEffect()
       recordedRimLayer = layer
       recordedRimKey = key
+      recordedRimSupportsDirectDrawing = supportsDirectDrawing
       rimRecordCount++
     }
     return Unit


### PR DESCRIPTION
Android layer recording exposes a hardware canvas even when the destination is a software bitmap. The direct-rim optimization could therefore retain a shader recording without its RenderEffect fallback after the destination changed.

Check destination support before recording and include that capability in rim retention. Foreground drawing refreshes an existing rim when the destination switches between hardware and software, while unchanged destinations reuse their recording. This addresses the destination-canvas review comment on #1297. No public APIs, screenshot goldens or comparison thresholds change.

Validation: the new hardware → software → hardware regression failed before the fix and passes afterwards. Fresh runs pass all 309 Android host tests, 360 Skiko/JVM tests and eight Desktop Gallery screenshots. Spotless and a fresh read-only audit pass. Existing bitmap-capture assertions now expect the software fallback.
