### PR TITLE
Isolate retained Haze source captures in a single node

### DIFF
--- a/docs/glass/performance.md
+++ b/docs/glass/performance.md
@@ -43,6 +43,11 @@ Exercise the states that represent the real screen:
 - resizing, orientation changes, and other layout transitions;
 - the lowest-performance devices and highest display resolutions you support.
 
+Measure effect attachment separately from steady-state drawing. Glass retains runtime shaders
+between draws, but renderer and submission work can remain after source capture and effect
+creation have settled. A slow frame alone does not identify shader compilation as the cause;
+inspect main-thread and RenderThread work before changing the material's optics.
+
 ## Reference measurements
 
 The following Haze reference run is a reproducible comparison point, not a performance target or
@@ -65,7 +70,9 @@ delegate/shader creation rather than representative interaction performance. The
 by the internal [Glass benchmark runbook][benchmark-runbook]. Compare the interactions, content,
 and device classes that your application supports.
 
-### Current performance-mode calibration
+<a id="current-performance-mode-calibration"></a>
+
+### Performance-mode calibration (2026-08-09)
 
 On 2026-08-09, the controlled Glass matrix ran in the `benchmarkRelease` variant on a Pixel 6
 (Android 17/API 37, 1080×2400), locked to 60 Hz with Android fixed-performance mode enabled. Each

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,6 +39,16 @@ adapt differently, so compare their results independently. Custom effects instea
 - **Effect complexity:** Progressive effects, masks, and advanced optics can add cost.
 - **Device and display:** Resolution, refresh rate, and GPU capability affect the result.
 
+### Stable and changing sources
+
+With `HazeInput.Sources`, Haze retains a source capture so unrelated sibling redraws can reuse it.
+Changes to the source's drawing still refresh that capture. Keep content that changes every frame
+outside the `hazeSource` subtree when the effect does not need to sample it.
+
+Reusing a capture avoids recording the source again; drawing the effect can still require renderer
+and GPU work. Measure both a stable background and scrolling or animated input. These capture
+details apply to source-backed effects; native `HazeInput.Backdrop` uses a different rendering path.
+
 ## Effect-specific guidance
 
 For Blur, see [Performance mode and layer expansion](blur/usage.md#performance-mode-and-layer-expansion). For Glass,
@@ -50,6 +60,11 @@ choices specific to that effect.
 Use a release-like build on physical hardware and reproduce the interactions users will perform.
 Keep device conditions and refresh rate consistent between runs. Measurements from another device
 or layout are useful context, not a guarantee for your application.
+
+Repeat comparisons in both build orders. Android's
+[fixed-performance mode](https://developer.android.com/games/optimize/adpf/fixed-performance-mode)
+still allows CPU core selection to change, which can move tail frame timings even when the code
+is unchanged. Use traces to check CPU placement when repeated results disagree.
 
 For Android, [Macrobenchmark](https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview)
 is a good starting point for repeatable frame measurements.

--- a/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurSourceReattachInstrumentationTest.kt
+++ b/haze-blur/src/androidDeviceTest/kotlin/dev/chrisbanes/haze/blur/BlurSourceReattachInstrumentationTest.kt
@@ -1,0 +1,94 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.blur
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import androidx.test.filters.SdkSuppress
+import assertk.assertThat
+import assertk.assertions.isCloseTo
+import dev.chrisbanes.haze.HazeInput
+import dev.chrisbanes.haze.HazePerformanceMode
+import dev.chrisbanes.haze.HazeState
+import dev.chrisbanes.haze.hazeSource
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class BlurSourceReattachInstrumentationTest {
+  @get:Rule
+  val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+  @Test
+  @SdkSuppress(minSdkVersion = 31)
+  fun conditionalBlur_reattachesWithCurrentSourcePixels() {
+    val state = HazeState()
+    val enabled = mutableStateOf(true)
+    val sourceColor = mutableStateOf(Color.Red)
+    val style = HazeBlurStyle {
+      blurRadius(8.dp)
+      noiseFactor(0f)
+      backgroundColor(Color.Transparent)
+      colorEffects(emptyList())
+    }
+
+    composeTestRule.setContent {
+      Box(Modifier.size(200.dp).testTag("root")) {
+        Box(Modifier.fillMaxSize().hazeSource(state).drawBehind { drawRect(sourceColor.value) })
+        // Hide the source so absent blur cannot look like a successful refresh.
+        Box(Modifier.fillMaxSize().background(Color.Black))
+        Box(
+          Modifier.fillMaxSize()
+            .hazeSource(state, zIndex = 1f)
+            .clip(RoundedCornerShape(16.dp))
+            .then(
+              if (enabled.value) {
+                Modifier.hazeBlur(
+                  input = HazeInput.Sources(state),
+                  style = style,
+                  performanceMode = HazePerformanceMode.Quality,
+                )
+              } else {
+                Modifier
+              },
+            ),
+        )
+      }
+    }
+
+    fun assertPixel(expected: Color) {
+      composeTestRule.waitForIdle()
+      val pixels = composeTestRule.onNodeWithTag("root").captureToImage().toPixelMap()
+      val actual = pixels[pixels.width / 2, pixels.height / 2]
+      assertThat(actual.red).isCloseTo(expected.red, 0.05f)
+      assertThat(actual.green).isCloseTo(expected.green, 0.05f)
+      assertThat(actual.blue).isCloseTo(expected.blue, 0.05f)
+    }
+
+    assertPixel(Color.Red)
+    for (color in listOf(Color.Blue, Color.Red)) {
+      composeTestRule.runOnIdle { enabled.value = false }
+      assertPixel(Color.Black)
+      composeTestRule.runOnIdle { sourceColor.value = color }
+      composeTestRule.runOnIdle { enabled.value = true }
+      assertPixel(color)
+    }
+  }
+}

--- a/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
+++ b/haze-glass/src/jvmTest/kotlin/dev/chrisbanes/haze/glass/RuntimeShaderGlassDelegateIntegrationTest.kt
@@ -107,8 +107,8 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
         Box(
           Modifier
             .fillMaxSize()
-            .background(sourceColor.value)
-            .hazeSource(hazeState),
+            .hazeSource(hazeState)
+            .background(sourceColor.value),
         )
         Box(
           Modifier
@@ -593,7 +593,7 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
   }
 
   @Test
-  fun heldInteraction_sourceContentChangeRecordsSource() = runComposeUiTest {
+  fun heldInteraction_sourceContentChangeUpdatesPixels() = runComposeUiTest {
     val hazeState = HazeState()
     val sourceColor = mutableStateOf(Color.Red)
     val effect = runtimeInteractiveEffect()
@@ -602,9 +602,10 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
         Box(
           Modifier
             .fillMaxSize()
-            .background(sourceColor.value)
-            .hazeSource(hazeState),
+            .hazeSource(hazeState)
+            .background(sourceColor.value),
         )
+        Box(Modifier.fillMaxSize().background(Color.Black))
         Box(
           Modifier
             .fillMaxSize()
@@ -621,25 +622,28 @@ class RuntimeShaderGlassDelegateIntegrationTest : ContextTest() {
     mainClock.advanceTimeBy(500)
     waitForIdle()
     val delegate = runtime(effect).delegate as RuntimeShaderGlassDelegate
-    val sourceRecordsBeforeMutation = delegate.sourceRecordCount
-    val interactionOpticalRecordsBeforeMutation = delegate.interactionOpticalRecordCount
-    val interactionDetailRecordsBeforeMutation = delegate.interactionDetailRecordCount
-    val interactionCompositeRecordsBeforeMutation = delegate.interactionCompositeRecordCount
-    val acceptedSnapshotBeforeMutation = checkNotNull(delegate.lastSuccessfulSourceSnapshot)
+    assertThat(delegate.interactionOpticalRecordCount).isGreaterThan(0)
+    assertThat(delegate.interactionDetailRecordCount).isGreaterThan(0)
+    assertThat(delegate.interactionCompositeRecordCount).isGreaterThan(0)
+
+    fun centerPixel(): Color = onNodeWithTag("glass").captureToImage().toPixelMap().let {
+      it[it.width / 2, it.height / 2]
+    }
+    val initial = centerPixel()
+    assertThat(initial.red).isGreaterThan(initial.blue + 0.5f)
 
     sourceColor.value = Color.Blue
     waitForIdle()
 
     assertThat(runtime(effect).currentInteractionSignals.pressed).isTrue()
-    assertThat(delegate.sourceRecordCount).isGreaterThan(sourceRecordsBeforeMutation)
-    assertThat(delegate.interactionOpticalRecordCount)
-      .isGreaterThan(interactionOpticalRecordsBeforeMutation)
-    assertThat(delegate.interactionDetailRecordCount)
-      .isGreaterThan(interactionDetailRecordsBeforeMutation)
-    assertThat(delegate.interactionCompositeRecordCount)
-      .isGreaterThan(interactionCompositeRecordsBeforeMutation)
-    assertThat(checkNotNull(delegate.lastSuccessfulSourceSnapshot))
-      .isNotEqualTo(acceptedSnapshotBeforeMutation)
+    // Retained layers may propagate new source pixels without recording every stage again.
+    val updated = centerPixel()
+    assertThat(updated.blue).isGreaterThan(updated.red + 0.5f)
+
+    sourceColor.value = Color.Red
+    waitForIdle()
+    val restored = centerPixel()
+    assertThat(restored.red).isGreaterThan(restored.blue + 0.5f)
   }
 
   @Test

--- a/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceSelectionAndroidTest.kt
+++ b/haze-screenshot-tests/src/androidHostTest/kotlin/dev/chrisbanes/haze/SourceSelectionAndroidTest.kt
@@ -1,0 +1,94 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(ExperimentalHazeApi::class)
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isCloseTo
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.hazeBlur
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
+import dev.chrisbanes.haze.test.ScreenshotTest
+import dev.chrisbanes.haze.test.ScreenshotTheme
+import dev.chrisbanes.haze.test.runScreenshotTest
+import kotlin.test.Test
+import org.robolectric.annotation.Config
+
+@Config(sdk = [35])
+class SourceSelectionAndroidTest : ScreenshotTest() {
+  @Test
+  @Config(sdk = [32, 35])
+  fun blur_selectionChange_capturesPreviouslyUnselectedSource() = assertSelectionChange(glass = false)
+
+  @Test
+  fun glass_selectionChange_capturesPreviouslyUnselectedSource() = assertSelectionChange(glass = true)
+
+  private fun assertSelectionChange(glass: Boolean) = runScreenshotTest {
+    val state = HazeState()
+    val selectedKey = mutableStateOf("first")
+    val selection = HazeSourceSelection.All.where { it.key == selectedKey.value }
+    val input = HazeInput.Sources(state, selection = selection)
+
+    setContent {
+      ScreenshotTheme {
+        Box(Modifier.fillMaxSize()) {
+          Box(Modifier.fillMaxSize().hazeSource(state, key = "first").background(Color.Red))
+          Box(Modifier.fillMaxSize().hazeSource(state, key = "second").background(Color.Blue))
+          Box(Modifier.fillMaxSize().background(Color.Black))
+          val modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(16.dp))
+          Box(
+            if (glass) {
+              modifier.hazeGlass(
+                input = input,
+                performanceMode = HazePerformanceMode.Quality,
+                style = GlassStyle {
+                  backgroundColor(Color.Transparent)
+                  tint(Color.Transparent)
+                  specularIntensity(0f)
+                  optics(blurRadius = 8.dp, depth = 0.5f)
+                },
+              )
+            } else {
+              modifier.hazeBlur(
+                input = input,
+                performanceMode = HazePerformanceMode.Quality,
+                style = HazeBlurStyle {
+                  blurRadius(8.dp)
+                  noiseFactor(0f)
+                  colorEffects(emptyList())
+                },
+              )
+            },
+          )
+        }
+      }
+    }
+
+    fun assertOutput(expected: Color) {
+      waitForIdle()
+      val pixels = captureRootPixels()
+      val actual = pixels[pixels.width / 2, pixels.height / 2]
+      assertThat(actual.red).isCloseTo(expected.red, 0.1f)
+      assertThat(actual.green).isCloseTo(expected.green, 0.1f)
+      assertThat(actual.blue).isCloseTo(expected.blue, 0.1f)
+    }
+
+    assertOutput(Color.Red)
+    selectedKey.value = "second"
+    assertOutput(Color.Blue)
+    selectedKey.value = "first"
+    assertOutput(Color.Red)
+  }
+}

--- a/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeSourceDrawUpdateTest.kt
+++ b/haze-screenshot-tests/src/commonTest/kotlin/dev/chrisbanes/haze/HazeSourceDrawUpdateTest.kt
@@ -1,0 +1,95 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isCloseTo
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.hazeBlur
+import dev.chrisbanes.haze.glass.GlassStyle
+import dev.chrisbanes.haze.glass.hazeGlass
+import dev.chrisbanes.haze.test.ScreenshotTest
+import dev.chrisbanes.haze.test.ScreenshotTheme
+import dev.chrisbanes.haze.test.runScreenshotTest
+import kotlin.test.Test
+
+@OptIn(InternalHazeApi::class)
+class HazeSourceDrawUpdateTest : ScreenshotTest() {
+
+  @Test
+  fun blur_sourceDrawChange_preservesExpectedOutput() = verifySourceDrawChanges(glass = false)
+
+  @Test
+  fun glass_sourceDrawChange_preservesExpectedOutput() = verifySourceDrawChanges(glass = true)
+
+  private fun verifySourceDrawChanges(glass: Boolean) = runScreenshotTest(size = Size(200f, 200f)) {
+    val sourceColor = mutableStateOf(Color.Red)
+
+    setContent {
+      ScreenshotTheme {
+        val state = rememberHazeState()
+        Box(Modifier.fillMaxSize()) {
+          Canvas(Modifier.fillMaxSize().hazeSource(state)) {
+            // Only the source's draw phase observes this value. The effect's style and
+            // composition remain unchanged while its retained layer receives new input.
+            drawRect(sourceColor.value)
+          }
+          // Hide the source itself so a transparent or missing effect cannot pass.
+          Box(Modifier.fillMaxSize().background(Color.Black))
+          val effect = if (glass) {
+            Modifier.hazeGlass(
+              input = HazeInput.Sources(state),
+              performanceMode = HazePerformanceMode.Quality,
+              style = GlassStyle {
+                backgroundColor(Color.Transparent)
+                tint(Color.Transparent)
+                specularIntensity(0f)
+                optics(blurRadius = 8.dp, depth = 0.5f)
+              },
+            )
+          } else {
+            Modifier.hazeBlur(
+              input = HazeInput.Sources(state),
+              performanceMode = HazePerformanceMode.Quality,
+              style = HazeBlurStyle {
+                blurRadius(8.dp)
+                noiseFactor(0f)
+                colorEffects(emptyList())
+              },
+            )
+          }
+          Box(Modifier.fillMaxSize().then(effect))
+        }
+      }
+    }
+    val samplesSource = if (glass) isRuntimeShaderRenderEffectSupported() else supportsRuntimeBlur
+    fun assertOutput(source: Color) {
+      // Transparent fallback styles leave the black occluder visible on older Android APIs.
+      val expected = if (samplesSource) source else Color.Black
+      val actual = captureRootPixels().let { it[it.width / 2, it.height / 2] }
+      assertThat(actual.red).isCloseTo(expected.red, 0.1f)
+      assertThat(actual.green).isCloseTo(expected.green, 0.1f)
+      assertThat(actual.blue).isCloseTo(expected.blue, 0.1f)
+    }
+    waitForIdle()
+    assertOutput(Color.Red)
+
+    sourceColor.value = Color.Blue
+    waitForIdle()
+    assertOutput(Color.Blue)
+
+    sourceColor.value = Color.Red
+    waitForIdle()
+    assertOutput(Color.Red)
+  }
+}

--- a/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
+++ b/haze/src/commonMain/kotlin/dev/chrisbanes/haze/HazeSourceNode.kt
@@ -13,17 +13,24 @@ import androidx.compose.ui.geometry.isUnspecified
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.GlobalPositionAwareModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
+import androidx.compose.ui.node.LayoutModifierNode
 import androidx.compose.ui.node.ObserverModifierNode
 import androidx.compose.ui.node.TraversableNode
 import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.node.invalidateDraw
+import androidx.compose.ui.node.invalidatePlacement
 import androidx.compose.ui.node.observeReads
+import androidx.compose.ui.node.updateLayerBlock
 import androidx.compose.ui.platform.LocalGraphicsContext
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.toSize
 import kotlin.math.roundToInt
 import kotlinx.coroutines.Job
@@ -46,6 +53,7 @@ internal class HazeSourceNode(
   CompositionLocalConsumerModifierNode,
   GlobalPositionAwareModifierNode,
   LayoutAwareModifierNode,
+  LayoutModifierNode,
   DrawModifierNode,
   TraversableNode,
   ObserverModifierNode {
@@ -81,6 +89,7 @@ internal class HazeSourceNode(
       if (isAttached) {
         onObservedReadsChanged()
         invalidateDraw()
+        invalidatePlacement()
       }
     }
 
@@ -132,6 +141,20 @@ internal class HazeSourceNode(
         invalidateDraw()
       } else {
         area.releaseLayer()
+      }
+    }
+  }
+
+  override fun MeasureScope.measure(measurable: Measurable, constraints: Constraints): MeasureResult {
+    val placeable = measurable.measure(constraints)
+    return layout(placeable.width, placeable.height) {
+      // Isolate captures from sibling redraws. Observing demand in placement also recreates
+      // the layer when capture resumes, invalidating its parent so this source draws before
+      // a reattached sibling effect tries to consume it.
+      if (state.hasSourceDemand && area.hasCaptureDemand) {
+        placeable.placeWithLayer(0, 0)
+      } else {
+        placeable.place(0, 0)
       }
     }
   }
@@ -327,6 +350,9 @@ internal class HazeSourceNode(
   }
 
   override fun onReset() {
+    // The placement layer must not retain a reference to the capture released below.
+    updateLayerBlock(null)
+    invalidatePlacement()
     HazeLogger.d(TAG) { "onReset. Resetting HazeArea: $area" }
     disablePreDrawListener()
     area.releaseLayer()

--- a/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceCaptureDemandTest.kt
+++ b/haze/src/jvmTest/kotlin/dev/chrisbanes/haze/HazeSourceCaptureDemandTest.kt
@@ -8,8 +8,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReusableContent
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
@@ -20,12 +24,126 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isGreaterThan
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isTrue
 import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class, InternalHazeApi::class)
 class HazeSourceCaptureDemandTest {
+
+  @Test
+  fun reusedSource_rebuildsReleasedCapture() = runComposeUiTest {
+    val state = HazeState()
+    val reuseKey = mutableIntStateOf(0)
+    val factory = DemandRecordingFactory()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        ReusableContent(reuseKey.intValue) {
+          Source(state)
+        }
+        Effect(state, factory)
+      }
+    }
+    waitForIdle()
+    val area = state.areas.single()
+    val originalLayer = requireNotNull(area.contentLayer)
+
+    reuseKey.intValue++
+    waitForIdle()
+
+    assertThat(state.areas.single()).isSameInstanceAs(area)
+    assertThat(originalLayer.isReleased).isTrue()
+    assertThat(area.contentLayer).isNotNull()
+    assertThat(requireNotNull(area.contentLayer).isReleased).isFalse()
+    assertThat(factory.renderer.snapshots.last()).isNotNull()
+  }
+
+  @Test
+  fun capturedSource_preservesDrawingOutsideLayoutBounds() = runComposeUiTest {
+    val state = HazeState()
+    val factory = DemandRecordingFactory()
+
+    setContent {
+      Box(Modifier.size(100.dp).background(Color.Black).testTag("root")) {
+        Box(
+          Modifier.size(40.dp).hazeSource(state).drawBehind {
+            drawRect(Color.Red, size = Size(size.width * 2f, size.height))
+          },
+        )
+        Effect(state, factory)
+      }
+    }
+    waitForIdle()
+    assertThat(state.areas.single().contentLayer).isNotNull()
+    val pixels = onNodeWithTag("root").captureToImage().toPixelMap()
+    assertThat(pixels[pixels.width * 3 / 5, pixels.height / 5])
+      .isEqualTo(Color.Red)
+  }
+
+  @Test
+  fun siblingRedraw_keepsUnchangedSourceCapture() = runComposeUiTest {
+    val state = HazeState()
+    val siblingFrame = mutableIntStateOf(0)
+    val factory = DemandRecordingFactory()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Source(state)
+        Effect(state, factory)
+        Box(
+          Modifier.size(1.dp).drawBehind {
+            drawRect(if (siblingFrame.intValue % 2 == 0) Color.White else Color.Black)
+          },
+        )
+      }
+    }
+    waitForIdle()
+    val area = state.areas.single()
+    val initialVersion = area.contentVersion
+    assertThat(initialVersion).isGreaterThan(0L)
+
+    repeat(5) {
+      siblingFrame.intValue++
+      waitForIdle()
+    }
+
+    assertThat(area.contentVersion).isEqualTo(initialVersion)
+  }
+
+  @Test
+  fun sourceDrawChange_refreshesCaptureAndEffect() = runComposeUiTest {
+    val state = HazeState()
+    val sourceColor = mutableStateOf(Color.Red)
+    val factory = DemandRecordingFactory()
+
+    setContent {
+      Box(Modifier.size(100.dp)) {
+        Box(
+          Modifier.fillMaxSize().hazeSource(state).drawBehind {
+            drawRect(sourceColor.value)
+          },
+        )
+        Effect(state, factory)
+      }
+    }
+    waitForIdle()
+    val area = state.areas.single()
+    val initialVersion = area.contentVersion
+    assertThat(onNodeWithTag(EFFECT_TAG).captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Red)
+
+    sourceColor.value = Color.Blue
+    waitForIdle()
+
+    assertThat(area.contentVersion).isGreaterThan(initialVersion)
+    assertThat(onNodeWithTag(EFFECT_TAG).captureToImage().toPixelMap()[50, 50])
+      .isEqualTo(Color.Blue)
+  }
 
   @Test
   fun sourceWithoutAttachedEffect_drawsDirectlyWithoutCapture() = runComposeUiTest {

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -98,6 +98,19 @@ startup, frame time, or any other performance improvement.
 
 Record the device model, API level, and selected refresh rate with saved results.
 
+### Check CPU placement before attributing a regression
+
+Android [fixed-performance mode](https://developer.android.com/games/optimize/adpf/fixed-performance-mode)
+constrains clocks but does not pin threads to CPU cores. Retain every iteration and report the
+aggregate frame metrics, then use Perfetto scheduler data within `measureBlock` to report main-thread
+and RenderThread CPU placement per iteration. Supplement the aggregate with comparable-placement
+groups; document their definitions and sample counts rather than dropping slower iterations.
+
+Repeat comparisons in both build orders with the same APKs and benchmark configuration. A small
+change in the proportion of slow-core iterations can move pooled P90 substantially. If placement
+coverage differs, repeat before attributing the aggregate difference to the code. Record thermal
+state and retain the original benchmark JSON, traces, build identities, and run order.
+
 ## Android 37.2 source/backdrop comparisons
 
 Backdrop comparisons require a physical, hardware-accelerated Android 37.2 device. Record the full
@@ -290,6 +303,21 @@ delegate. The no-Glass control intentionally omits that metric.
 Open representative traces in Android Studio or Perfetto. Application markers describe CPU-side
 preparation, recording, and submission; they do not directly measure GPU shader duration. Inspect
 system frame-timeline and GPU data when attributing GPU cost.
+
+For stable source-backed scenarios, check `HazeSource.record` separately from effect drawing:
+an unchanged source can remain captured while the effect continues to draw. For draw-only source
+updates, also verify output pixels; retained layers can propagate changes without re-recording
+every effect stage.
+
+Separate elapsed slice duration from running CPU time using scheduler states. `DrawFrames`,
+`Vulkan finish frame`, and `QueueSubmit` are nested scopes, so their durations cannot be added.
+Label stage averages separately from frame P90. Time inside `QueueSubmit` can include both CPU
+execution and waiting; the slice name alone does not identify the driver work or wait reason.
+
+Attribute compilation markers to their owning process and thread. `HazeGlass.createRenderEffect`
+measures Haze's effect construction, not every possible backend compilation step. Shader-related
+markers in SurfaceFlinger do not establish app shader compilation, and absent markers cannot
+rule out untraced driver work. Use native call stacks when finer CPU attribution is needed.
 
 Expected Glass markers include:
 


### PR DESCRIPTION
Unrelated sibling redraws could re-record an unchanged Haze source. Add demand-sensitive layer placement directly to `HazeSourceNode` so the source capture is isolated while `hazeSource` still contributes one modifier node. Rebuild placement when state changes and clear it before releasing captures on node reuse.

Add regression coverage for sibling redraws, draw-only source changes, out-of-bounds drawing, source selection, reuse, and Android Blur reattachment. Update the held-interaction Glass test to check rendered pixels rather than requiring every retained stage to record again. Document retained captures and how to distinguish CPU-placement variation from rendering regressions.

## Validation

- `spotlessApply --no-scan` and `git diff --check` passed.
- Full `check --no-scan` was interrupted after approximately 11 minutes: a Gradle Test Executor sustained high CPU and did not respond to a JVM attach request. The active test class was not identified, and no test-failure result was recorded. Full-suite validation remains outstanding; this PR is a draft.

- Existing targeted verification: 27 core, JVM screenshot, and Android host tests passed.
- Read-only reuse, quality, efficiency, clarity, and complexity reviews found no actionable issues.
- Pixel 6 comparisons against the previous three-node candidate: Blur stable/changing and Glass changing remained within 0.6% CPU frame-duration P90. Stable Glass initially appeared 8–12% slower with unequal CPU-placement coverage; two follow-up pairs were 0.4% and 1.3% faster. Across all 64 stable-Glass iterations, pooled P90 was +2.3% overall, -0.9% on mid/big cores, and +4.1% on little cores. The residual little-core difference remains inconclusive; this is not a claim of exact performance equivalence or a new performance-mode calibration.
- Physical reattachment correctness was exercised on the earlier three-node candidate; it has not been rerun on this single-node build. No screenshot baselines changed.
