### PR TITLE
Document Haze 2 benchmark improvements

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -80,8 +80,9 @@ improved by 37% while scrolling the Images List and by 15% while dragging the Cr
 | Credit Card dragging | 11.5 ms | 9.8 ms | 15% faster |
 
 These results come from Android Macrobenchmarks on a Pixel 6 running Android 17 at 60 Hz, with 32
-iterations per workload. P90 highlights the slower frames during each interaction. Treat these as
-a useful reference rather than a guarantee for a different screen or device.
+iterations per workload. The comparison used Haze 1 at `7a2557f1` and Haze 2 at `fc46813e`. P90
+highlights the slower frames during each interaction. Treat these as a useful reference rather
+than a guarantee for a different screen or device.
 
 ### A reference point, not a target
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -69,6 +69,20 @@ is unchanged. Use traces to check CPU placement when repeated results disagree.
 For Android, [Macrobenchmark](https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview)
 is a good starting point for repeatable frame measurements.
 
+### Haze 2 compared with Haze 1
+
+Haze 2 was faster in both of the sample interactions shared with Haze 1. P90 CPU frame duration
+improved by 37% while scrolling the Images List and by 15% while dragging the Credit Card.
+
+| Workload | Haze 1 | Haze 2 | Improvement |
+| --- | ---: | ---: | ---: |
+| Images List scrolling | 14.9 ms | 9.3 ms | 37% faster |
+| Credit Card dragging | 11.5 ms | 9.8 ms | 15% faster |
+
+These results come from Android Macrobenchmarks on a Pixel 6 running Android 17 at 60 Hz, with 32
+iterations per workload. P90 highlights the slower frames during each interaction. Treat these as
+a useful reference rather than a guarantee for a different screen or device.
+
 ### A reference point, not a target
 
 In Haze's 2026-08-04 Glass reference run on a Pixel 6 (Android 17/API 37, 1080×2400 at


### PR DESCRIPTION
## Summary

- publish fresh Haze 1 versus Haze 2 Android Macrobenchmark results
- highlight the measured 37% improvement for Images List scrolling and 15% improvement for Credit Card dragging
- keep the comparison focused on what the results mean for users

## Validation

- ran both workloads in both branch orders on a Pixel 6 at 60 Hz with fixed-performance mode enabled
- pooled 32 iterations per workload and checked all 128 Perfetto traces for CPU-placement anomalies
- `properdocs build`
- `git diff --check`