### PR TITLE
Consolidate performance documentation

### DIFF
--- a/docs/benchmark-results.md
+++ b/docs/benchmark-results.md
@@ -1,0 +1,82 @@
+# Benchmark results
+
+These Android measurements record specific builds, workloads, and devices. They are historical
+reference points, not performance budgets for other applications or measurements of the current
+checkout. Use the [performance guide](performance.md) to tune your screen and the
+[Android benchmark runbook][benchmark-runbook] to run Haze's workloads.
+
+CPU frame duration describes UI-thread and RenderThread cost; it does not directly measure GPU
+shader duration. Frame overrun describes deadline misses. The tables below retain the metrics and
+conditions recorded for each run.
+
+## Haze 2 compared with Haze 1
+
+Haze 2 had lower P90 CPU frame duration in both sample interactions shared with Haze 1:
+37% lower while scrolling the Images List and 15% lower while dragging the Credit Card.
+
+| Workload | Haze 1 | Haze 2 | Reduction in P90 CPU frame duration |
+| --- | ---: | ---: | ---: |
+| Images List scrolling | 14.9 ms | 9.3 ms | 37% lower |
+| Credit Card dragging | 11.5 ms | 9.8 ms | 15% lower |
+
+These results come from Android Macrobenchmarks on a Pixel 6 running Android 17 at 60 Hz, with 32
+iterations per workload. The comparison used Haze 1 at `7a2557f1` and Haze 2 at `fc46813e`. P90
+highlights the slower frames during each interaction. The original summary did not record the run
+date, build variant, or run order.
+
+## Glass journeys and steady state (2026-08-04)
+
+This run used the `benchmarkRelease` build at commit `334557df` on 2026-08-04: Pixel 6,
+Android 17/API 37, 1080×2400, locked 60 Hz render rate, locked CPU frequency, and eight
+Macrobenchmark iterations per scenario. The metric is P90 CPU frame duration in milliseconds.
+
+| Scenario | Workload | P90 CPU frame duration |
+| --- | --- | ---: |
+| `productPager` | Gallery paging journey | 7.5 ms |
+| `playgroundTimeline` | Gallery animated timeline journey | 11.2 ms |
+| `steadyFull` | Controlled steady state, 1 Glass effect | 5.6 ms |
+| `steadyFull3` | Controlled steady state, 3 Glass effects | 5.2 ms |
+| `steadyFull9` | Controlled steady state, 9 Glass effects | 8.1 ms |
+
+The Gallery journeys are closest to the sample's visible user work. The `steadyFull*` controls
+characterize the baseline at different effect counts. Cold-initialization `effectAttach*` results
+are deliberately omitted: they attach new effects at the measurement boundary and diagnose
+delegate/shader creation rather than representative interaction performance. They remain covered
+by the internal [Glass benchmark runbook][benchmark-runbook]. Compare the interactions, content,
+and device classes that your application supports.
+
+## Performance-mode calibration (2026-08-09)
+
+The controlled Blur and Glass samples ran in `benchmarkRelease` on a Pixel 6 (Android 17/API 37,
+1080×2400), locked to 60 Hz with Android fixed-performance mode enabled. Each row contains 16
+fixed-duration iterations. The original summaries did not record the build SHA or run order;
+these tables cannot establish the calibration of the current implementation.
+
+Values are **P90 CPU frame duration / P90 frame overrun**, in milliseconds. A negative overrun
+is margin below the 60 Hz frame budget. Each sample holds its other style choices fixed; the Glass
+run keeps the other `GlassDefaults` values unchanged.
+
+### Blur
+
+| Workload | Adaptive | Quality | Balanced | Performance |
+| --- | ---: | ---: | ---: | ---: |
+| Stable source | 10.0 / -3.2 | 10.2 / -3.0 | 10.1 / -3.1 | 10.0 / -2.7 |
+| Continuously changing source | 10.0 / -2.9 | 10.2 / -2.7 | 10.1 / -1.8 | 10.1 / -3.0 |
+
+### Glass
+
+| Workload | Adaptive | Quality | Balanced | Performance |
+| --- | ---: | ---: | ---: | ---: |
+| Stable source | 6.6 / -7.1 | 8.2 / -1.7 | 8.9 / -4.0 | 7.2 / -6.5 |
+| Continuously changing source | 6.5 / -7.3 | 8.2 / -1.6 | 8.3 / -4.5 | 6.9 / -6.9 |
+
+These CPU timings do not rank visual quality or establish that the named profiles have a monotonic
+frame-time cost. Use a visual comparison alongside measurements before choosing an override.
+
+The adaptive-policy decisions and their original evidence remain in [ADR-0004][blur-adr] and
+[ADR-0005][glass-adr]. [ADR-0006][performance-mode-adr] records the current public terminology.
+
+[benchmark-runbook]: https://github.com/chrisbanes/haze/blob/main/internal/benchmark/README.md
+[blur-adr]: adr/0004-use-quality-gated-adaptive-input-scaling-for-blur.md
+[glass-adr]: adr/0005-use-cadence-weighted-adaptive-input-scaling-for-glass.md
+[performance-mode-adr]: adr/0006-reconcile-built-in-performance-mode-terminology.md

--- a/docs/blur/usage.md
+++ b/docs/blur/usage.md
@@ -190,9 +190,9 @@ val maskedStyle = HazeBlurStyle {
 }
 ```
 
-## Performance mode
+<a id="performance-mode"></a>
 
-### Performance mode and layer expansion
+## Performance mode and layer expansion
 
 Performance mode and layer expansion are structural modifier policies, not Style properties:
 
@@ -205,31 +205,10 @@ Modifier.hazeBlur(
 )
 ```
 
-- `HazePerformanceMode.Default` and `Adaptive` let Blur balance quality and cost automatically.
-- `HazePerformanceMode.Quality`, `Balanced`, and `Performance` select named fixed fidelity
-  profiles.
-- `HazePerformanceMode.Fixed(qualityFraction)` selects a deterministic fidelity profile for a
-  normalized quality fraction from `0f` through `1f`.
-
-Start with the default. Override it only after comparing visual quality and performance on the
-devices you support. `Default` is `Adaptive`, and `Quality` replaces the previous built-in
-full-resolution choice. Remeasure any previous built-in fixed input-pixel fraction before choosing
-an explicit `Fixed(qualityFraction)` value.
+See the [performance guide](../performance.md#performance-mode) for mode selection and
+[Blur guidance](../performance.md#blur) for the cost and edge behaviour of layer expansion.
 
 ### Controlled calibration reference
 
-The following Android Macrobenchmark reference is a comparison point, not a performance target or
-promise. It was captured on 2026-08-09 with the `benchmarkRelease` variant on a Pixel 6 (Android
-17/API 37, 1080×2400), with the display locked to 60 Hz and Android fixed-performance mode enabled.
-Each row contains 16 fixed-duration iterations of the controlled Blur sample. Values are **P90 CPU
-frame duration / P90 frame overrun**, in milliseconds; a negative overrun is margin below the
-60 Hz frame budget.
-
-| Workload | Adaptive | Quality | Balanced | Performance |
-| --- | ---: | ---: | ---: | ---: |
-| Stable source | 10.0 / -3.2 | 10.2 / -3.0 | 10.1 / -3.1 | 10.0 / -2.7 |
-| Continuously changing source | 10.0 / -2.9 | 10.2 / -2.7 | 10.1 / -1.8 | 10.1 / -3.0 |
-
-The controlled sample holds all other style choices fixed. It is useful for comparing the named
-profiles, but measure the layout, content, and interaction patterns of your application before
-choosing an override.
+The historical Blur table has moved to
+[performance-mode calibration (2026-08-09)](../benchmark-results.md#performance-mode-calibration-2026-08-09).

--- a/docs/effects/glass.md
+++ b/docs/effects/glass.md
@@ -362,7 +362,7 @@ details may be omitted by a fallback.
 ## Performance
 
 Start with `HazePerformanceMode.Default` (the adaptive performance mode) and tune only after
-measuring a representative screen. The [Glass performance guide](../glass/performance.md) explains
+measuring a representative screen. The [performance guide](../performance.md#glass) explains
 which Glass-specific workloads and interactions to test.
 
 ## Interaction

--- a/docs/glass/performance.md
+++ b/docs/glass/performance.md
@@ -1,97 +1,30 @@
 # Glass performance
 
-Read the [general performance guide](../performance.md) first for the shared workflow,
-performance-mode choices, and measurement advice. This page focuses on the decisions that are
-specific to Glass.
-
-For styling and API guidance, see the [Glass overview](../effects/glass.md).
+Glass tuning advice is now part of the [performance guide](../performance.md#glass).
+For styling and API examples, see the [Glass overview](../effects/glass.md).
 
 ## Start here
 
-- Use `HazePerformanceMode.Default` with `GlassStyle.regular`.
-- Build the complete screen before tuning; isolated effects do not represent a real workload.
-- Profile the slowest devices you support with realistic content and interactions.
-- Override one setting at a time and keep it only when the benefit is visible or measurable.
+See the [recommended workflow](../performance.md#recommended-workflow).
 
 ## Glass-specific cost drivers
 
-- **Surface size:** Large Glass surfaces process more content and optical detail.
-- **Number of surfaces:** Several independent Glass elements add work even when they share a Style.
-- **Changing content:** Scrolling or animation behind Glass costs more than a stable background.
-- **Optical complexity:** Progressive blur and Full chromatic aberration can add work relative to
-  the default material. Measure them with the surfaces and content your application uses.
-- **Interaction:** Animated lighting, refraction, and transforms add a changing workload while the
-  user hovers, focuses, or presses the element.
+See [Glass guidance](../performance.md#glass) and [common cost drivers](../performance.md#common-cost-drivers).
 
 ## When to change performance mode
 
-Keep the adaptive mode unless a target-device comparison gives you a reason to override it:
-
-- Choose `Quality` when fine source detail is visibly important.
-- Choose `Balanced` or `Performance` for a named, deterministic trade-off.
-- Choose `Fixed(qualityFraction)` when you need a normalized, deterministic profile for a known
-  layout.
-- Return to `Default` when an override does not produce a meaningful improvement.
+See [performance mode](../performance.md#performance-mode).
 
 ## What to test
 
-Exercise the states that represent the real screen:
-
-- the largest number of Glass surfaces visible at once;
-- scrolling or animation behind those surfaces;
-- hover, focus, and press responses;
-- resizing, orientation changes, and other layout transitions;
-- the lowest-performance devices and highest display resolutions you support.
-
-Measure effect attachment separately from steady-state drawing. Glass retains runtime shaders
-between draws, but renderer and submission work can remain after source capture and effect
-creation have settled. A slow frame alone does not identify shader compilation as the cause;
-inspect main-thread and RenderThread work before changing the material's optics.
+See [Glass guidance](../performance.md#glass) and [measurement advice](../performance.md#measure-on-target-devices).
 
 ## Reference measurements
 
-The following Haze reference run is a reproducible comparison point, not a performance target or
-promise. It used the `benchmarkRelease` build at commit `334557df` on 2026-08-04: Pixel 6,
-Android 17/API 37, 1080×2400, locked 60 Hz render rate, locked CPU frequency, and eight
-Macrobenchmark iterations per scenario. The metric is P90 CPU frame duration in milliseconds.
-
-| Scenario | Workload | P90 CPU frame duration |
-| --- | --- | ---: |
-| `productPager` | Gallery paging journey | 7.5 ms |
-| `playgroundTimeline` | Gallery animated timeline journey | 11.2 ms |
-| `steadyFull` | Controlled steady state, 1 Glass effect | 5.6 ms |
-| `steadyFull3` | Controlled steady state, 3 Glass effects | 5.2 ms |
-| `steadyFull9` | Controlled steady state, 9 Glass effects | 8.1 ms |
-
-The Gallery journeys are closest to the sample's visible user work. The `steadyFull*` controls
-characterize the baseline at different effect counts. Cold-initialization `effectAttach*` results
-are deliberately omitted: they attach new effects at the measurement boundary and diagnose
-delegate/shader creation rather than representative interaction performance. They remain covered
-by the internal [Glass benchmark runbook][benchmark-runbook]. Compare the interactions, content,
-and device classes that your application supports.
+See [Glass journeys and steady state (2026-08-04)](../benchmark-results.md#glass-journeys-and-steady-state-2026-08-04).
 
 <a id="current-performance-mode-calibration"></a>
 
 ### Performance-mode calibration (2026-08-09)
 
-On 2026-08-09, the controlled Glass matrix ran in the `benchmarkRelease` variant on a Pixel 6
-(Android 17/API 37, 1080×2400), locked to 60 Hz with Android fixed-performance mode enabled. Each
-row contains 16 fixed-duration iterations. Values are **P90 CPU frame duration / P90 frame
-overrun**, in milliseconds; a negative overrun is margin below the 60 Hz frame budget.
-
-| Workload | Adaptive | Quality | Balanced | Performance |
-| --- | ---: | ---: | ---: | ---: |
-| Stable source | 6.6 / -7.1 | 8.2 / -1.7 | 8.9 / -4.0 | 7.2 / -6.5 |
-| Continuously changing source | 6.5 / -7.3 | 8.2 / -1.6 | 8.3 / -4.5 | 6.9 / -6.9 |
-
-The calibration keeps the other `GlassDefaults` values unchanged. It compares the named built-in
-profiles under controlled input; it is not a guarantee for another layout, device, or visual
-configuration.
-
-The adaptive performance rationale and supporting measurements are recorded in
-[ADR-0005][sampling-adr] and reconciled with the current public terminology by
-[ADR-0006][performance-mode-adr].
-
-[benchmark-runbook]: https://github.com/chrisbanes/haze/blob/main/internal/benchmark/README.md
-[sampling-adr]: ../adr/0005-use-cadence-weighted-adaptive-input-scaling-for-glass.md
-[performance-mode-adr]: ../adr/0006-reconcile-built-in-performance-mode-terminology.md
+See the [Blur and Glass calibration results](../benchmark-results.md#performance-mode-calibration-2026-08-09).

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -22,14 +22,13 @@ their input changes.
 - **`Default` or `Adaptive`**: Recommended for most applications. Built-in effects adjust the
   quality and cost trade-off automatically.
 - **`Quality`**, **`Balanced`**, or **`Performance`**: Select a named, deterministic profile.
-- **`Fixed(qualityFraction)`**: Select a normalized, deterministic profile when the named
-  profiles are not the right fit.
+- **`Fixed(qualityFraction)`**: Select a normalized, deterministic profile from `0f` through `1f`
+  when the named profiles are not the right fit.
 
-`Default` is `Adaptive`, and `Quality` replaces the previous built-in full-resolution choice.
-There is no formula for translating a previous built-in fixed input-pixel fraction: remeasure an
-explicit `Fixed(qualityFraction)` choice on the effect and layout you actually use. Blur and Glass
-adapt differently, so compare their results independently. Custom effects instead use
-`HazeSampling` to control how much input they process.
+`Default` is `Adaptive`. Blur and Glass resolve these profiles differently, so a quality fraction
+is not an input-pixel scale or a cross-effect resolution guarantee. Custom effects use
+`HazeSampling` to control how much input they process. For older built-in sampling settings, see
+the [migration guide](migrating-2.0.md).
 
 ## Common cost drivers
 
@@ -49,46 +48,52 @@ Reusing a capture avoids recording the source again; drawing the effect can stil
 and GPU work. Measure both a stable background and scrolling or animated input. These capture
 details apply to source-backed effects; native `HazeInput.Backdrop` uses a different rendering path.
 
-## Effect-specific guidance
+<a id="effect-specific-guidance"></a>
 
-For Blur, see [Performance mode and layer expansion](blur/usage.md#performance-mode-and-layer-expansion). For Glass,
-see the [Glass performance guide](glass/performance.md), which covers optical and interaction
-choices specific to that effect.
+## Blur
+
+Progressive Blur varies blur intensity across the surface. If you only need to fade opacity, use a
+mask; see [Progressive Blur and masks](blur/usage.md#progressive-blur-and-masks).
+
+For source-backed Blur, `expandLayerBounds` allows the capture layer to expand by the resolved blur
+radius. This gives the blur surrounding input to sample, at the cost of a larger capture area.
+Disabling it limits that area and can change the result near the edges. Keep the default unless
+visual and performance comparisons justify changing it. See the
+[modifier example](blur/usage.md#performance-mode-and-layer-expansion).
+
+## Glass
+
+Start with `GlassStyle.regular`. Progressive blur and Full chromatic aberration can add work;
+measure them at the surface sizes and effect counts your screen uses. Animated lighting,
+refraction, and transforms also add work during hover, focus, and press responses. Include those
+states, background scrolling, and layout transitions in your comparison.
+
+Measure effect attachment separately from steady-state drawing. Glass retains runtime shaders
+between draws, but renderer and submission work can remain after source capture and effect
+creation have settled. A slow frame alone does not identify shader compilation as the cause;
+inspect main-thread and RenderThread work before changing the material's optics.
+
+For styling and API examples, see the [Glass overview](effects/glass.md).
 
 ## Measure on target devices
 
 Use a release-like build on physical hardware and reproduce the interactions users will perform.
-Keep device conditions and refresh rate consistent between runs. Measurements from another device
-or layout are useful context, not a guarantee for your application.
-
-Repeat comparisons in both build orders. Android's
-[fixed-performance mode](https://developer.android.com/games/optimize/adpf/fixed-performance-mode)
-still allows CPU core selection to change, which can move tail frame timings even when the code
-is unchanged. Use traces to check CPU placement when repeated results disagree.
+Keep device conditions and refresh rate consistent between runs. Compare frame timing and visual
+quality, including on the slowest devices you support.
 
 For Android, [Macrobenchmark](https://developer.android.com/topic/performance/benchmarking/macrobenchmark-overview)
-is a good starting point for repeatable frame measurements.
+provides repeatable frame measurements. Use frame overrun to identify deadline misses and CPU frame
+duration to assess UI-thread and RenderThread cost. Neither directly measures GPU shader duration.
 
-### Haze 2 compared with Haze 1
+Repeat comparisons in both build orders. If repeated results disagree, inspect traces before
+attributing the difference to the code. Haze's [Android benchmark runbook][benchmark-runbook] covers
+device preparation, CPU-placement checks, workload selection, and trace interpretation.
 
-Haze 2 was faster in both of the sample interactions shared with Haze 1. P90 CPU frame duration
-improved by 37% while scrolling the Images List and by 15% while dragging the Credit Card.
+<a id="haze-2-compared-with-haze-1"></a>
+<a id="a-reference-point-not-a-target"></a>
 
-| Workload | Haze 1 | Haze 2 | Improvement |
-| --- | ---: | ---: | ---: |
-| Images List scrolling | 14.9 ms | 9.3 ms | 37% faster |
-| Credit Card dragging | 11.5 ms | 9.8 ms | 15% faster |
+See the [Haze 1 versus Haze 2 comparison](benchmark-results.md#haze-2-compared-with-haze-1) and
+[Blur and Glass reference measurements](benchmark-results.md), with the recorded setup and
+limitations for each run.
 
-These results come from Android Macrobenchmarks on a Pixel 6 running Android 17 at 60 Hz, with 32
-iterations per workload. The comparison used Haze 1 at `7a2557f1` and Haze 2 at `fc46813e`. P90
-highlights the slower frames during each interaction. Treat these as a useful reference rather
-than a guarantee for a different screen or device.
-
-### A reference point, not a target
-
-In Haze's 2026-08-04 Glass reference run on a Pixel 6 (Android 17/API 37, 1080×2400 at
-60 Hz), the Gallery's `productPager` journey measured 7.5 ms P90 CPU frame duration and its
-`playgroundTimeline` journey measured 11.2 ms. These are one workload on one device, not a
-performance budget or promise for other devices and layouts. See the
-[Glass reference measurements](glass/performance.md#reference-measurements) for the setup and
-controlled scenarios.
+[benchmark-runbook]: https://github.com/chrisbanes/haze/blob/main/internal/benchmark/README.md

--- a/internal/benchmark/BACKDROP_VALIDATION.md
+++ b/internal/benchmark/BACKDROP_VALIDATION.md
@@ -1,0 +1,22 @@
+# Backdrop validation evidence
+
+## Emulator correctness evidence (2026-09-05)
+
+The committed native-backdrop fixes were exercised on the supported preview emulator before any
+performance claim. The run used the `Medium_Phone` AVD with the
+`android-37.2-beta3/google_apis_playstore_ps16k/arm64-v8a` revision 3 image, SDK 37, full SDK
+37.1, preview 3723, fingerprint
+`google/sdk_gphone16k_arm64/emu64a16k:DEV/CP41.260731.005.B1/16056512:user/dev-keys`, emulator
+37.1.11.0 build 15917651, and the Apple M1 Max `skiagl` host renderer. The tested commit was
+`56c866937a872cc9b73e063b34b12d3c4d74ade5`.
+
+The core suite passed 4 tests, Blur passed 6, and Glass passed 5; all had zero failures, errors,
+or skips. The suites covered native fallback state, progressive Blur, clip transitions, paired
+offscreen pixel scenes, and Glass window/offscreen pixel scenes. The saved XML reports are
+`haze/build/outputs/androidTest-results/connected/androidMain/TEST-Medium_Phone(AVD) - 17.xml`,
+with equivalent paths under `haze-blur/` and `haze-glass/`.
+
+This emulator result establishes preview correctness only. It does not provide physical-device
+37.2 compositor evidence, per-offscreen capture-counter evidence, or the order-reversed
+fixed-performance measurements required by the
+[physical performance gate](README.md#android-372-sourcebackdrop-comparisons).

--- a/internal/benchmark/BASELINE_PROFILES.md
+++ b/internal/benchmark/BASELINE_PROFILES.md
@@ -1,0 +1,89 @@
+# Android baseline profiles
+
+The library baseline profile generator exercises the current core, Blur, and Glass paths through
+the sample's Images List, Scaffold, Credit Card, Glass Product, and Glass Playground journeys. It
+runs on both AOSP managed devices: `pixel5Api30` (API 30) and `pixel5Api34` (API 34). The profile
+filter is limited to Haze-owned packages under `dev.chrisbanes.haze.**`.
+
+Generation requires JDK 21 and an Android SDK selected by `ANDROID_HOME` or `ANDROID_SDK_ROOT`.
+Verify the environment with `java -version`, `echo "$ANDROID_HOME"` (or
+`echo "$ANDROID_SDK_ROOT"`), and `command -v sdkmanager`; the latter checks that SDK package
+management tooling is available, while Gradle uses the configured SDK environment. The managed-
+device definitions and AOSP images are declared in `internal/benchmark/build.gradle.kts`.
+
+`RenderScriptScrollRegressionTest` exercises allocation teardown while scrolling Images on API 30.
+It runs five launches with twelve alternating scrolls each, without profile compilation or timing
+metrics. Run it independently from profile collection:
+
+```shell
+./gradlew --no-scan :internal:benchmark:pixel5Api30NonMinifiedReleaseAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.RenderScriptScrollRegressionTest
+```
+
+Run generation from the repository root:
+
+```shell
+./gradlew --no-scan :haze:generateBaselineProfile \
+  -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.BaselineProfileGenerator
+```
+
+The checked-in output is
+`haze/src/androidMain/generated/baselineProfiles/baseline-prof.txt`. Generation and packaging
+coverage verify which classes and methods are exercised and shipped; they do not measure startup,
+frame time, or any other performance improvement.
+
+After generating, package the six existing Haze Kotlin Multiplatform `androidMain` AARs and the
+non-minified sample consumer. The package task is `bundleAndroidMainAar`; skip profile generation
+when validating packaging because the checked-in profile is the input to this check:
+
+```shell
+./gradlew --no-scan \
+  :haze-utils:bundleAndroidMainAar \
+  :haze:bundleAndroidMainAar \
+  :haze-blur:bundleAndroidMainAar \
+  :haze-glass:bundleAndroidMainAar \
+  :haze-materials:bundleAndroidMainAar \
+  :haze-glass-material3:bundleAndroidMainAar \
+  :sample:android:assembleNonMinifiedRelease \
+  -Pandroidx.baselineprofile.skipgeneration
+```
+
+The six AARs are written to `build/outputs/aar/<module>.aar` in their respective module
+directories. The consumer APK is
+`sample/android/build/outputs/apk/nonMinifiedRelease/android-nonMinifiedRelease.apk`. Verify the
+profile against exact defined class and method members in every AAR and every consumer
+`classes*.dex` file:
+
+```shell
+python3 internal/benchmark/verify_baseline_profile.py \
+  --profile haze/src/androidMain/generated/baselineProfiles/baseline-prof.txt \
+  --aar haze/build/outputs/aar/haze.aar \
+  --aar haze-blur/build/outputs/aar/haze-blur.aar \
+  --aar haze-glass/build/outputs/aar/haze-glass.aar \
+  --aar haze-utils/build/outputs/aar/haze-utils.aar \
+  --aar haze-materials/build/outputs/aar/haze-materials.aar \
+  --aar haze-glass-material3/build/outputs/aar/haze-glass-material3.aar \
+  --apk sample/android/build/outputs/apk/nonMinifiedRelease/android-nonMinifiedRelease.apk
+```
+
+For the retained final profile, the verifier reports 2,285 rules (215 class and 2,070 method), zero
+missing ordinary AAR members, and zero missing consumer-Dex members. Its ordinary counts are `469`
+(`haze`), `341` (`haze-blur`), `1,101` (`haze-glass`), `36` (`haze-utils`), `7`
+(`haze-materials`), and `3` (`haze-glass-material3`). The expected generated counts are 295
+external-synthetic entries, 16 lambda bridges, 16 `$-CC` interface companions, and one
+namespaced `R$drawable` class. Generated entries still require exact consumer-Dex definitions;
+`$-CC` entries also require an interface owner with the interface access flag in an AAR, and
+`R$drawable` requires the matching AAR manifest namespace.
+
+Only the root `haze` AAR may contain `baseline-prof.txt`, and its bytes must match the checked-in
+file exactly. The other five AARs must contain no profile asset. The verifier preserves HSP flags,
+nested `$` names, synthetic names, and complete method descriptors. It rejects malformed,
+foreign/sample, missing, or unexplained rules instead of deleting or renaming them. Keep the
+generated profile as collection output; do not hand-author rules or retain obsolete Haze 1 rules.
+The API 30 and API 34 device collections need no rerun for verifier or README changes while the
+collection-relevant generator, sample/runtime, and toolchain inputs remain unchanged. Generation,
+packaging, and descriptor verification establish artifact coverage only; they do not measure
+startup, frame time, or any other performance improvement.
+
+
+Return to the [Android benchmark runbook](README.md).

--- a/internal/benchmark/README.md
+++ b/internal/benchmark/README.md
@@ -1,93 +1,32 @@
 # Android benchmarks
 
-## Android baseline profiles
+Use this runbook for local physical-device measurements and trace analysis. For application tuning,
+see the [performance guide](../../docs/performance.md); published historical measurements live in
+[benchmark results](../../docs/benchmark-results.md).
 
-The library baseline profile generator exercises the current core, Blur, and Glass paths through
-the sample's Images List, Scaffold, Credit Card, Glass Product, and Glass Playground journeys. It
-runs on both AOSP managed devices: `pixel5Api30` (API 30) and `pixel5Api34` (API 34). The profile
-filter is limited to Haze-owned packages under `dev.chrisbanes.haze.**`.
+## Choose a workload
 
-Generation requires JDK 21 and an Android SDK selected by `ANDROID_HOME` or `ANDROID_SDK_ROOT`.
-Verify the environment with `java -version`, `echo "$ANDROID_HOME"` (or
-`echo "$ANDROID_SDK_ROOT"`), and `command -v sdkmanager`; the latter checks that SDK package
-management tooling is available, while Gradle uses the configured SDK environment. The managed-
-device definitions and AOSP images are declared in `internal/benchmark/build.gradle.kts`.
+| Task | Start here |
+| --- | --- |
+| Compare Blur and Glass performance modes | [Calibration matrix](#calibration-matrix) |
+| Diagnose one controlled scenario or run Gallery journeys | [Run a profile](#run-a-profile) |
+| Compare source and native backdrop paths | [Android 37.2 comparisons](#android-372-sourcebackdrop-comparisons) |
+| Find artifacts and interpret metrics or traces | [Results](#results) |
+| Generate and verify library baseline profiles | [Baseline-profile maintenance](BASELINE_PROFILES.md) |
 
-`RenderScriptScrollRegressionTest` exercises allocation teardown while scrolling Images on API 30.
-It runs five launches with twelve alternating scrolls each, without profile compilation or timing
-metrics. Run it independently from profile collection:
+<a id="emulator-correctness-evidence-2026-09-05"></a>
 
-```shell
-./gradlew --no-scan :internal:benchmark:pixel5Api30NonMinifiedReleaseAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.RenderScriptScrollRegressionTest
-```
+Saved preview-emulator correctness evidence is recorded separately in
+[Backdrop validation](BACKDROP_VALIDATION.md). It does not establish physical-device performance.
 
-Run generation from the repository root:
+<a id="android-baseline-profiles"></a>
 
-```shell
-./gradlew --no-scan :haze:generateBaselineProfile \
-  -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.BaselineProfileGenerator
-```
+For managed-device profile collection and artifact checks, use
+[baseline-profile maintenance](BASELINE_PROFILES.md).
 
-The checked-in output is
-`haze/src/androidMain/generated/baselineProfiles/baseline-prof.txt`. Generation and packaging
-coverage verify which classes and methods are exercised and shipped; they do not measure startup,
-frame time, or any other performance improvement.
+<a id="performance-mode-benchmark-requirements"></a>
 
-After generating, package the six existing Haze Kotlin Multiplatform `androidMain` AARs and the
-non-minified sample consumer. The package task is `bundleAndroidMainAar`; skip profile generation
-when validating packaging because the checked-in profile is the input to this check:
-
-```shell
-./gradlew --no-scan \
-  :haze-utils:bundleAndroidMainAar \
-  :haze:bundleAndroidMainAar \
-  :haze-blur:bundleAndroidMainAar \
-  :haze-glass:bundleAndroidMainAar \
-  :haze-materials:bundleAndroidMainAar \
-  :haze-glass-material3:bundleAndroidMainAar \
-  :sample:android:assembleNonMinifiedRelease \
-  -Pandroidx.baselineprofile.skipgeneration
-```
-
-The six AARs are written to `build/outputs/aar/<module>.aar` in their respective module
-directories. The consumer APK is
-`sample/android/build/outputs/apk/nonMinifiedRelease/android-nonMinifiedRelease.apk`. Verify the
-profile against exact defined class and method members in every AAR and every consumer
-`classes*.dex` file:
-
-```shell
-python3 internal/benchmark/verify_baseline_profile.py \
-  --profile haze/src/androidMain/generated/baselineProfiles/baseline-prof.txt \
-  --aar haze/build/outputs/aar/haze.aar \
-  --aar haze-blur/build/outputs/aar/haze-blur.aar \
-  --aar haze-glass/build/outputs/aar/haze-glass.aar \
-  --aar haze-utils/build/outputs/aar/haze-utils.aar \
-  --aar haze-materials/build/outputs/aar/haze-materials.aar \
-  --aar haze-glass-material3/build/outputs/aar/haze-glass-material3.aar \
-  --apk sample/android/build/outputs/apk/nonMinifiedRelease/android-nonMinifiedRelease.apk
-```
-
-For the retained final profile, the verifier reports 2,285 rules (215 class and 2,070 method), zero
-missing ordinary AAR members, and zero missing consumer-Dex members. Its ordinary counts are `469`
-(`haze`), `341` (`haze-blur`), `1,101` (`haze-glass`), `36` (`haze-utils`), `7`
-(`haze-materials`), and `3` (`haze-glass-material3`). The expected generated counts are 295
-external-synthetic entries, 16 lambda bridges, 16 `$-CC` interface companions, and one
-namespaced `R$drawable` class. Generated entries still require exact consumer-Dex definitions;
-`$-CC` entries also require an interface owner with the interface access flag in an AAR, and
-`R$drawable` requires the matching AAR manifest namespace.
-
-Only the root `haze` AAR may contain `baseline-prof.txt`, and its bytes must match the checked-in
-file exactly. The other five AARs must contain no profile asset. The verifier preserves HSP flags,
-nested `$` names, synthetic names, and complete method descriptors. It rejects malformed,
-foreign/sample, missing, or unexplained rules instead of deleting or renaming them. Keep the
-generated profile as collection output; do not hand-author rules or retain obsolete Haze 1 rules.
-The API 30 and API 34 device collections need no rerun for verifier or README changes while the
-collection-relevant generator, sample/runtime, and toolchain inputs remain unchanged. Generation,
-packaging, and descriptor verification establish artifact coverage only; they do not measure
-startup, frame time, or any other performance improvement.
-
-## Performance-mode benchmark requirements
+## Prepare the device
 
 - Physical Android device on API 33 or newer.
 - Release-like, non-debuggable target build.
@@ -110,69 +49,6 @@ Repeat comparisons in both build orders with the same APKs and benchmark configu
 change in the proportion of slow-core iterations can move pooled P90 substantially. If placement
 coverage differs, repeat before attributing the aggregate difference to the code. Record thermal
 state and retain the original benchmark JSON, traces, build identities, and run order.
-
-## Android 37.2 source/backdrop comparisons
-
-Backdrop comparisons require a physical, hardware-accelerated Android 37.2 device. Record the full
-SDK level (including the minor release), build SHA and variant, display refresh rate, fixed-
-performance state, starting battery level, and thermal status with every JSON/Perfetto result.
-
-The paired Quality workloads are:
-
-| Effect | Source | Backdrop |
-| --- | --- | --- |
-| Blur stable | `blurStableQuality` | `blurBackdropStableQuality` |
-| Blur updating | `blurSourceUpdateQuality` | `blurBackdropSourceUpdateQuality` |
-| Glass stable | `stableQuality` | `backdropStableQuality` |
-| Glass updating | `sourceUpdateQuality` | `backdropSourceUpdateQuality` |
-| Nine Glass nodes updating | `sourceUpdate9` | `backdropSourceUpdate9` |
-
-Each row records `FrameTimingMetric`, max `MemoryUsageMetric`, `HazeBackdrop.draw` count, and
-`HazeSource.record` count. A healthy backdrop result has native backdrop draws and zero source
-records; its source control has source records and no required backdrop draw.
-
-Run a dry run first on the same physical 37.2 device:
-
-```shell
-./gradlew --no-scan :sample:shared:testAndroidHostTest \
-  :internal:benchmark:connectedBenchmarkReleaseAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.dryRunMode.enable=true \
-  -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.BenchmarkTest#blurStableQuality,dev.chrisbanes.haze.BenchmarkTest#blurBackdropStableQuality,dev.chrisbanes.haze.BenchmarkTest#blurSourceUpdateQuality,dev.chrisbanes.haze.BenchmarkTest#blurBackdropSourceUpdateQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#stableQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#backdropStableQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#sourceUpdateQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#backdropSourceUpdateQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#sourceUpdate9,dev.chrisbanes.haze.GlassProfilingBenchmark#backdropSourceUpdate9
-```
-
-Measure three source/backdrop pairs, then repeat three pairs in backdrop/source order. Return the
-device to the same thermal envelope before each pair. Keep all JSON and Perfetto outputs; compare
-CPU P90, actual-frame P90, frame overrun, and peak memory against the order-reversed control
-envelope rather than one run.
-
-```shell
-adb shell cmd power set-fixed-performance-mode-enabled true
-# Run one source/backdrop pair with the focused class argument above, then reverse its order.
-adb shell cmd power set-fixed-performance-mode-enabled false
-```
-
-Always run the final cleanup command, including after a failed or interrupted benchmark. Verify
-fixed-performance mode is off before returning the device to normal use.
-
-## Emulator correctness evidence (2026-09-05)
-
-The committed native-backdrop fixes were exercised on the supported preview emulator before any
-performance claim. The run used the `Medium_Phone` AVD with the
-`android-37.2-beta3/google_apis_playstore_ps16k/arm64-v8a` revision 3 image, SDK 37, full SDK
-37.1, preview 3723, fingerprint
-`google/sdk_gphone16k_arm64/emu64a16k:DEV/CP41.260731.005.B1/16056512:user/dev-keys`, emulator
-37.1.11.0 build 15917651, and the Apple M1 Max `skiagl` host renderer. The tested commit was
-`56c866937a872cc9b73e063b34b12d3c4d74ade5`.
-
-The core suite passed 4 tests, Blur passed 6, and Glass passed 5; all had zero failures, errors,
-or skips. The suites covered native fallback state, progressive Blur, clip transitions, paired
-offscreen pixel scenes, and Glass window/offscreen pixel scenes. The saved XML reports are
-`haze/build/outputs/androidTest-results/connected/androidMain/TEST-Medium_Phone(AVD) - 17.xml`,
-with equivalent paths under `haze-blur/` and `haze-glass/`.
-
-This emulator result establishes preview correctness only. It does not provide physical-device
-37.2 compositor evidence, per-offscreen capture-counter evidence, or the order-reversed
-fixed-performance measurements required by the physical performance gate above.
 
 ## Calibration matrix
 
@@ -340,3 +216,46 @@ Expected Glass markers include:
 - `HazeGlass.interactionLighting`
 - `HazeGlass.groupAlpha`
 - `HazeGlass.compose`
+
+## Android 37.2 source/backdrop comparisons
+
+Backdrop comparisons require a physical, hardware-accelerated Android 37.2 device. Record the full
+SDK level (including the minor release), build SHA and variant, display refresh rate, fixed-
+performance state, starting battery level, and thermal status with every JSON/Perfetto result.
+
+The paired Quality workloads are:
+
+| Effect | Source | Backdrop |
+| --- | --- | --- |
+| Blur stable | `blurStableQuality` | `blurBackdropStableQuality` |
+| Blur updating | `blurSourceUpdateQuality` | `blurBackdropSourceUpdateQuality` |
+| Glass stable | `stableQuality` | `backdropStableQuality` |
+| Glass updating | `sourceUpdateQuality` | `backdropSourceUpdateQuality` |
+| Nine Glass nodes updating | `sourceUpdate9` | `backdropSourceUpdate9` |
+
+Each row records `FrameTimingMetric`, max `MemoryUsageMetric`, `HazeBackdrop.draw` count, and
+`HazeSource.record` count. A healthy backdrop result has native backdrop draws and zero source
+records; its source control has source records and no required backdrop draw.
+
+Run a dry run first on the same physical 37.2 device:
+
+```shell
+./gradlew --no-scan :sample:shared:testAndroidHostTest \
+  :internal:benchmark:connectedBenchmarkReleaseAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.dryRunMode.enable=true \
+  -Pandroid.testInstrumentationRunnerArguments.class=dev.chrisbanes.haze.BenchmarkTest#blurStableQuality,dev.chrisbanes.haze.BenchmarkTest#blurBackdropStableQuality,dev.chrisbanes.haze.BenchmarkTest#blurSourceUpdateQuality,dev.chrisbanes.haze.BenchmarkTest#blurBackdropSourceUpdateQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#stableQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#backdropStableQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#sourceUpdateQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#backdropSourceUpdateQuality,dev.chrisbanes.haze.GlassProfilingBenchmark#sourceUpdate9,dev.chrisbanes.haze.GlassProfilingBenchmark#backdropSourceUpdate9
+```
+
+Measure three source/backdrop pairs, then repeat three pairs in backdrop/source order. Return the
+device to the same thermal envelope before each pair. Keep all JSON and Perfetto outputs; compare
+CPU P90, actual-frame P90, frame overrun, and peak memory against the order-reversed control
+envelope rather than one run.
+
+```shell
+adb shell cmd power set-fixed-performance-mode-enabled true
+# Run one source/backdrop pair with the focused class argument above, then reverse its order.
+adb shell cmd power set-fixed-performance-mode-enabled false
+```
+
+Always run the final cleanup command, including after a failed or interrupted benchmark. Verify
+fixed-performance mode is off before returning the device to normal use.

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -32,8 +32,8 @@ nav:
     - "Overview": effects/glass.md
   - "Custom Effects": custom-effects.md
   - "Performance":
-    - "Overview": performance.md
-    - "Glass": glass/performance.md
+    - "Guide": performance.md
+    - "Benchmark results": benchmark-results.md
   - "Scenarios":
     - "Camera": scenarios/camera.md
   - "Recipes": recipes.md


### PR DESCRIPTION
Performance guidance was spread across the general guide, Glass guide, Blur usage page, and a benchmark README that mixed measurement instructions with maintenance and historical evidence.

Consolidate application guidance into one performance guide and collect the existing measurements on a benchmark-results page. Split baseline-profile maintenance and emulator validation evidence out of the Android benchmark runbook, update navigation, and preserve existing page and section links. Explain Blur layer expansion and describe the Haze 1/2 comparison as lower P90 CPU frame duration. Benchmark values and runbook commands are unchanged.

Validation:
- Documentation link and retained-anchor checks passed across all eight changed Markdown files.
- All 11 measurement rows and every benchmark command block were preserved; `git diff --check` passed.
- Offline Properdocs rendering passed with social cards disabled. The normal strict build was blocked by a Google Fonts download and missing generated API, sample, and changelog artifacts.
- `spotlessApply check` was run through the managed Gradle wrapper, then interrupted after 10 minutes during screenshot-test execution to keep validation proportional to this documentation-only change. The bounded summary reported no failed tasks, but the full check is incomplete.
