### PR TITLE
Embed individual web samples in blog posts

### DIFF
--- a/docs/embedding-samples.md
+++ b/docs/embedding-samples.md
@@ -1,0 +1,73 @@
+# Embed a sample
+
+You can embed one Haze Wasm sample in an article with an iframe. Choose a released documentation
+version that includes sample embedding, then replace `<VERSION-WITH-EMBED-SUPPORT>` below with that
+version. Do not use a moving alias, snapshot, or `latest` for a published article.
+
+```html
+<iframe
+  src="https://chrisbanes.github.io/haze/<VERSION-WITH-EMBED-SUPPORT>/sample/wasm/index.html?embed=true&amp;sample=scaffold&amp;effect=glass&amp;theme=light"
+  title="Haze Glass Scaffold sample"
+  loading="lazy"
+  style="width: 100%; height: 560px; border: 0;"
+></iframe>
+```
+
+The iframe width follows its container. Change the `height` value to suit the sample and surrounding
+copy; the sample scrolls inside that fixed frame. Browser lazy loading is a proximity hint, so it does
+not guarantee an exact visibility boundary or pause the sample when it is off screen.
+
+Use the same URL as a normal link when readers need to open the demo directly:
+
+```text
+https://chrisbanes.github.io/haze/<VERSION-WITH-EMBED-SUPPORT>/sample/wasm/index.html?embed=true&sample=scaffold&effect=glass&theme=light
+```
+
+## URL parameters
+
+`embed=true` enables the standalone sample view. It requires both `sample` and `effect`. The browser
+decodes the query string and uses the first value if a key appears more than once. Unknown keys are
+ignored. Any missing or invalid explicit embed value, sample, effect, unsupported sample/effect pair,
+or theme shows a compact error instead of selecting another demo.
+
+| Parameter | Values | Default |
+| --- | --- | --- |
+| `sample` | A route from the catalog below | Required |
+| `effect` | `blur` or `glass`, when the chosen sample supports it | Required |
+| `theme` | `system`, `light`, or `dark` | `system` |
+
+The theme changes the sample app theme only. It does not synchronize with the parent page or recolor
+artwork that deliberately uses its own dark scene design. Each embed starts with the ordinary defaults
+for that sample. Its own controls remain available, including artwork paging, dialogs, drag gestures,
+playback, reset, and recording controls; navigation back to the sample browser is hidden.
+
+## Sample catalog
+
+| Sample | `sample` | Effects |
+| --- | --- | --- |
+| Scaffold | `scaffold` | `blur`, `glass` |
+| Scaffold (adaptive) | `scaffold-adaptive` | `blur`, `glass` |
+| Scaffold (quality) | `scaffold-quality` | `blur`, `glass` |
+| Scaffold (balanced) | `scaffold-balanced` | `blur`, `glass` |
+| Scaffold (performance) | `scaffold-performance` | `blur`, `glass` |
+| Scaffold (progressive blur) | `scaffold-progressive` | `blur`, `glass` |
+| Scaffold (progressive blur, quality) | `scaffold-progressive-quality` | `blur`, `glass` |
+| Scaffold (masked) | `scaffold-masked` | `blur`, `glass` |
+| Scaffold (masked, quality) | `scaffold-masked-quality` | `blur`, `glass` |
+| Credit Card | `credit-card` | `blur`, `glass` |
+| Images List | `images-list` | `blur`, `glass` |
+| List over Image | `list-over-image` | `blur`, `glass` |
+| Dialog | `dialog` | `blur`, `glass` |
+| Popup | `popup` | `blur`, `glass` |
+| Materials | `materials` | `blur`, `glass` |
+| List with Sticky Headers | `list-with-sticky-headers` | `blur`, `glass` |
+| Bottom Sheet | `bottom-sheet` | `blur`, `glass` |
+| Content Blurring | `content-blurring` | `blur`, `glass` |
+| Custom VisualEffect | `custom-visual-effect` | `blur` |
+| Layer Transformations | `layer-transformations` | `blur`, `glass` |
+| Glass — Product | `glass-product` | `glass` |
+| Glass — Playground | `glass-playground` | `glass` |
+| Glass — Lab | `glass-lab` | `glass` |
+
+Find the first release that supports embedding in its release notes or documentation navigation, and
+pin that exact version in the article. A query string cannot add this feature to an older release.

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -42,6 +42,7 @@ nav:
   - "API reference": api/index.html
   - "Sample code": https://github.com/chrisbanes/haze/tree/main/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample
   - "🕸️ Sample app (Wasm)": sample/wasm/index.html
+  - "Embed a sample": embedding-samples.md
 
 # Configuration
 theme:

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -42,7 +42,6 @@ nav:
   - "API reference": api/index.html
   - "Sample code": https://github.com/chrisbanes/haze/tree/main/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample
   - "🕸️ Sample app (Wasm)": sample/wasm/index.html
-  - "Embed a sample": embedding-samples.md
 
 # Configuration
 theme:

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/BottomSheet.kt
@@ -48,6 +48,7 @@ import dev.chrisbanes.haze.rememberHazeState
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
 fun BottomSheet(navController: NavHostController, effect: SampleEffect) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   var imageIndex by remember { mutableIntStateOf(0) }
 
   Scaffold(
@@ -55,8 +56,10 @@ fun BottomSheet(navController: NavHostController, effect: SampleEffect) {
       TopAppBar(
         title = { Text(text = "Bottom Sheet") },
         navigationIcon = {
-          IconButton(onClick = navController::navigateUp) {
-            Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
+          if (navigationEnabled) {
+            IconButton(onClick = navController::navigateUp) {
+              Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+            }
           }
         },
         actions = {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ContentBlurring.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ContentBlurring.kt
@@ -57,6 +57,7 @@ fun ContentBlurring(
   navController: NavHostController,
   effect: SampleEffect,
 ) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   var imageIndex by remember { mutableIntStateOf(0) }
   val glassBackgroundColor = MaterialTheme.colorScheme.surface
 
@@ -65,11 +66,13 @@ fun ContentBlurring(
       TopAppBar(
         title = { Text("Content Blurring") },
         navigationIcon = {
-          IconButton(
-            onClick = navController::navigateUp,
-            modifier = Modifier.testTag("back"),
-          ) {
-            Icon(Icons.AutoMirrored.Default.ArrowBack, null)
+          if (navigationEnabled) {
+            IconButton(
+              onClick = navController::navigateUp,
+              modifier = Modifier.testTag("back"),
+            ) {
+              Icon(Icons.AutoMirrored.Default.ArrowBack, "Back")
+            }
           }
         },
         actions = {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CreditCardScene.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CreditCardScene.kt
@@ -53,6 +53,7 @@ internal fun CreditCardScene(
     zIndex: Float,
   ) -> Unit,
 ) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   val hazeState = rememberHazeState()
 
   Box(modifier = modifier) {
@@ -95,16 +96,19 @@ internal fun CreditCardScene(
       )
     }
 
-    FloatingActionButton(
-      onClick = onNavigateUp,
-      modifier = Modifier
-        .windowInsetsPadding(WindowInsets.statusBars)
-        .padding(24.dp),
-    ) {
-      Icon(
-        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-        contentDescription = null,
-      )
+    if (navigationEnabled) {
+      FloatingActionButton(
+        onClick = onNavigateUp,
+        modifier = Modifier
+          .testTag("credit_card_back")
+          .windowInsetsPadding(WindowInsets.statusBars)
+          .padding(24.dp),
+      ) {
+        Icon(
+          imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+          contentDescription = "Back",
+        )
+      }
     }
   }
 }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CustomVisualEffectSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/CustomVisualEffectSample.kt
@@ -84,6 +84,7 @@ private val LocalSparklePhase = compositionLocalOf { 0f }
 fun CustomVisualEffectSample(
   navController: NavHostController,
 ) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   val hazeState = rememberHazeState()
   var selectedSparkIndex by remember { mutableIntStateOf(0) }
   var sparkAlpha by remember { mutableFloatStateOf(0.30f) }
@@ -109,11 +110,13 @@ fun CustomVisualEffectSample(
       TopAppBar(
         title = { Text("Custom VisualEffect") },
         navigationIcon = {
-          IconButton(
-            onClick = navController::navigateUp,
-            modifier = Modifier.testTag("back"),
-          ) {
-            Icon(Icons.AutoMirrored.Default.ArrowBack, null)
+          if (navigationEnabled) {
+            IconButton(
+              onClick = navController::navigateUp,
+              modifier = Modifier.testTag("back"),
+            ) {
+              Icon(Icons.AutoMirrored.Default.ArrowBack, "Back")
+            }
           }
         },
         modifier = Modifier.fillMaxWidth(),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/DialogSample.kt
@@ -51,15 +51,18 @@ import kotlin.time.Duration.Companion.seconds
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
 fun DialogSample(navController: NavHostController, effect: SampleEffect) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   Scaffold(
     modifier = Modifier.fillMaxSize(),
     topBar = {
       TopAppBar(
         title = { Text(text = "Haze Dialog sample") },
         navigationIcon = {
-          IconButton(onClick = navController::navigateUp) {
-            @Suppress("DEPRECATION")
-            Icon(Icons.Default.ArrowBack, null)
+          if (navigationEnabled) {
+            IconButton(onClick = navController::navigateUp) {
+              @Suppress("DEPRECATION")
+              Icon(Icons.Default.ArrowBack, "Back")
+            }
           }
         },
         modifier = Modifier.fillMaxWidth(),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisuals.kt
@@ -184,6 +184,7 @@ internal fun DemoChrome(
   isPlaying: Boolean? = null,
   onPlayPause: (() -> Unit)? = null,
 ) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   val shape = RoundedCornerShape(24.dp)
   GlassSurface(
     hazeState = hazeState,
@@ -214,8 +215,10 @@ internal fun DemoChrome(
       modifier = Modifier.padding(4.dp),
       verticalAlignment = Alignment.CenterVertically,
     ) {
-      IconButton(onClick = onBack) {
-        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+      if (navigationEnabled) {
+        IconButton(onClick = onBack) {
+          Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+        }
       }
       if (isPlaying != null && onPlayPause != null) {
         IconButton(onClick = onPlayPause) {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassProductSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/GlassProductSample.kt
@@ -204,6 +204,7 @@ private fun ProductTopBar(
   onRecordingModeChanged: (Boolean) -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   GlassSurface(
     hazeState = hazeState,
     style = style,
@@ -231,8 +232,10 @@ private fun ProductTopBar(
       modifier = Modifier.padding(4.dp),
       verticalAlignment = Alignment.CenterVertically,
     ) {
-      IconButton(onClick = onBack) {
-        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+      if (navigationEnabled) {
+        IconButton(onClick = onBack) {
+          Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+        }
       }
       Column(modifier = Modifier.padding(horizontal = 8.dp)) {
         Text("Glass Gallery", color = Color.White, style = MaterialTheme.typography.labelLarge)

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ImagesList.kt
@@ -41,17 +41,20 @@ import dev.chrisbanes.haze.rememberHazeState
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
 fun ImagesList(navController: NavHostController, effect: SampleEffect) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   MaterialTheme {
     Scaffold(
       topBar = {
         LargeTopAppBar(
           title = { Text(text = "Images") },
           navigationIcon = {
-            IconButton(
-              onClick = navController::navigateUp,
-              modifier = Modifier.testTag("back"),
-            ) {
-              Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
+            if (navigationEnabled) {
+              IconButton(
+                onClick = navController::navigateUp,
+                modifier = Modifier.testTag("back"),
+              ) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+              }
             }
           },
           modifier = Modifier.fillMaxWidth(),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/LayerTransformations.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/LayerTransformations.kt
@@ -60,6 +60,7 @@ fun LayerTransformations(
   topOffset: DpOffset = DpOffset.Zero,
   modifier: Modifier = Modifier,
 ) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   val hazeState = rememberHazeState()
   val glassBackgroundColor = MaterialTheme.colorScheme.surface
 
@@ -138,23 +139,25 @@ fun LayerTransformations(
         .padding(16.dp),
     )
 
-    Surface(
-      modifier = Modifier
-        .align(Alignment.TopStart)
-        .windowInsetsPadding(WindowInsets.statusBars)
-        .padding(16.dp),
-      shape = CircleShape,
-      color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
-      shadowElevation = 6.dp,
-    ) {
-      IconButton(
-        onClick = onBack,
-        modifier = Modifier.size(48.dp).testTag("back"),
+    if (navigationEnabled) {
+      Surface(
+        modifier = Modifier
+          .align(Alignment.TopStart)
+          .windowInsetsPadding(WindowInsets.statusBars)
+          .padding(16.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+        shadowElevation = 6.dp,
       ) {
-        Icon(
-          imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-          contentDescription = "Back",
-        )
+        IconButton(
+          onClick = onBack,
+          modifier = Modifier.size(48.dp).testTag("back"),
+        ) {
+          Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = "Back",
+          )
+        }
       }
     }
   }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListOverImage.kt
@@ -45,6 +45,7 @@ import dev.chrisbanes.haze.rememberHazeState
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
 fun ListOverImage(navController: NavHostController, effect: SampleEffect) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   var imageIndex by remember { mutableIntStateOf(0) }
 
   MaterialTheme {
@@ -53,8 +54,10 @@ fun ListOverImage(navController: NavHostController, effect: SampleEffect) {
         TopAppBar(
           title = { Text(text = "List over Image") },
           navigationIcon = {
-            IconButton(onClick = navController::navigateUp) {
-              Icon(Icons.AutoMirrored.Filled.ArrowBack, null)
+            if (navigationEnabled) {
+              IconButton(onClick = navController::navigateUp) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
+              }
             }
           },
           actions = {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ListWithStickyHeaders.kt
@@ -45,6 +45,7 @@ import dev.chrisbanes.haze.rememberHazeState
 )
 @Composable
 fun ListWithStickyHeaders(navController: NavHostController, effect: SampleEffect) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   val hazeState = rememberHazeState()
   val listState = rememberLazyListState()
 
@@ -58,8 +59,10 @@ fun ListWithStickyHeaders(navController: NavHostController, effect: SampleEffect
       TopAppBar(
         title = { },
         navigationIcon = {
-          IconButton(onClick = navController::navigateUp, modifier = Modifier.testTag("back")) {
-            Icon(Icons.AutoMirrored.Default.ArrowBack, null)
+          if (navigationEnabled) {
+            IconButton(onClick = navController::navigateUp, modifier = Modifier.testTag("back")) {
+              Icon(Icons.AutoMirrored.Default.ArrowBack, "Back")
+            }
           }
         },
         modifier = Modifier.fillMaxWidth(),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Materials.kt
@@ -57,6 +57,7 @@ import dev.chrisbanes.haze.rememberHazeState
 @OptIn(ExperimentalHazeApi::class)
 @Composable
 fun MaterialsSample(navController: NavHostController, effect: SampleEffect) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   val hazeState = rememberHazeState()
 
   Box(modifier = Modifier.fillMaxSize()) {
@@ -175,23 +176,25 @@ fun MaterialsSample(navController: NavHostController, effect: SampleEffect) {
       GlassMaterialsContent(hazeState = hazeState)
     }
 
-    Surface(
-      modifier = Modifier
-        .align(Alignment.TopStart)
-        .windowInsetsPadding(WindowInsets.statusBars)
-        .padding(16.dp),
-      shape = CircleShape,
-      color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
-      shadowElevation = 6.dp,
-    ) {
-      IconButton(
-        onClick = navController::navigateUp,
-        modifier = Modifier.size(48.dp).testTag("back"),
+    if (navigationEnabled) {
+      Surface(
+        modifier = Modifier
+          .align(Alignment.TopStart)
+          .windowInsetsPadding(WindowInsets.statusBars)
+          .padding(16.dp),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
+        shadowElevation = 6.dp,
       ) {
-        Icon(
-          imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-          contentDescription = "Back",
-        )
+        IconButton(
+          onClick = navController::navigateUp,
+          modifier = Modifier.size(48.dp).testTag("back"),
+        ) {
+          Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = "Back",
+          )
+        }
       }
     }
   }

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/PopupSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/PopupSample.kt
@@ -51,15 +51,18 @@ import kotlin.time.Duration.Companion.seconds
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalHazeApi::class)
 @Composable
 fun PopupSample(navController: NavHostController, effect: SampleEffect) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   Scaffold(
     modifier = Modifier.fillMaxSize(),
     topBar = {
       TopAppBar(
         title = { Text(text = "Haze Popup sample") },
         navigationIcon = {
-          IconButton(onClick = navController::navigateUp) {
-            @Suppress("DEPRECATION")
-            Icon(Icons.Default.ArrowBack, null)
+          if (navigationEnabled) {
+            IconButton(onClick = navController::navigateUp) {
+              @Suppress("DEPRECATION")
+              Icon(Icons.Default.ArrowBack, "Back")
+            }
           }
         },
         modifier = Modifier.fillMaxWidth(),

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/SampleEmbed.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/SampleEmbed.kt
@@ -1,0 +1,101 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+@file:OptIn(dev.chrisbanes.haze.InternalHazeApi::class)
+
+package dev.chrisbanes.haze.sample
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.navigation.compose.rememberNavController
+import dev.chrisbanes.haze.Poko
+import dev.chrisbanes.haze.blur.HazeBlurStyle
+import dev.chrisbanes.haze.blur.LocalHazeBlurStyle
+
+public enum class SampleEmbedTheme {
+  System,
+  Light,
+  Dark,
+}
+
+public sealed interface SampleEmbedRequest {
+  public data object Normal : SampleEmbedRequest
+
+  @Poko
+  public class Embedded(
+    val sample: Sample,
+    val effect: SampleEffect,
+    val theme: SampleEmbedTheme,
+  ) : SampleEmbedRequest
+
+  @Poko
+  public class Invalid(val message: String) : SampleEmbedRequest
+}
+
+public fun resolveSampleEmbed(
+  query: Map<String, String>,
+  samples: List<Sample>,
+): SampleEmbedRequest {
+  if ("embed" !in query) return SampleEmbedRequest.Normal
+  if (query["embed"] != "true") return SampleEmbedRequest.Invalid("embed must be true")
+
+  val route = query["sample"] ?: return SampleEmbedRequest.Invalid("sample is required")
+  val effect = when (query["effect"]) {
+    "blur" -> SampleEffect.Blur
+    "glass" -> SampleEffect.Glass
+    null -> return SampleEmbedRequest.Invalid("effect is required")
+    else -> return SampleEmbedRequest.Invalid("effect is invalid")
+  }
+  val theme = when (query["theme"]) {
+    null, "system" -> SampleEmbedTheme.System
+    "light" -> SampleEmbedTheme.Light
+    "dark" -> SampleEmbedTheme.Dark
+    else -> return SampleEmbedRequest.Invalid("theme is invalid")
+  }
+  val sample = samples.firstOrNull { it.route == route }
+    ?: return SampleEmbedRequest.Invalid("sample is invalid")
+  if (effect !in sample.effects) return SampleEmbedRequest.Invalid("effect is unsupported for sample")
+
+  return SampleEmbedRequest.Embedded(sample, effect, theme)
+}
+
+internal val LocalSampleNavigationEnabled = staticCompositionLocalOf { true }
+
+@Composable
+public fun EmbeddedSample(
+  request: SampleEmbedRequest.Embedded,
+  modifier: Modifier = Modifier,
+) {
+  val useDarkColors = when (request.theme) {
+    SampleEmbedTheme.System -> isSystemInDarkTheme()
+    SampleEmbedTheme.Light -> false
+    SampleEmbedTheme.Dark -> true
+  }
+  val navController = rememberNavController()
+  val localBlurStyle = remember { HazeBlurStyle }
+
+  SamplesTheme(useDarkColors = useDarkColors) {
+    CompositionLocalProvider(
+      LocalHazeBlurStyle provides localBlurStyle,
+      LocalSampleNavigationEnabled provides false,
+    ) {
+      Box(
+        modifier = modifier
+          .fillMaxSize()
+          .testTag("embedded_sample"),
+      ) {
+        key(request.sample.route, request.effect) {
+          request.sample.content(navController, request.effect)
+        }
+      }
+    }
+  }
+}

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/ScaffoldSample.kt
@@ -101,6 +101,7 @@ fun ScaffoldSample(
   profilingDrawProgress: (() -> Float)? = null,
   useBackdrop: Boolean = false,
 ) {
+  val navigationEnabled = LocalSampleNavigationEnabled.current
   val hazeState = rememberHazeState()
   val hazeInput = if (useBackdrop) {
     HazeInput.Backdrop(hazeState)
@@ -154,11 +155,13 @@ fun ScaffoldSample(
         SampleEffect.Blur -> LargeTopAppBar(
           title = {},
           navigationIcon = {
-            IconButton(
-              onClick = navController::navigateUp,
-              modifier = Modifier.testTag("back"),
-            ) {
-              Icon(Icons.AutoMirrored.Default.ArrowBack, null)
+            if (navigationEnabled) {
+              IconButton(
+                onClick = navController::navigateUp,
+                modifier = Modifier.testTag("back"),
+              ) {
+                Icon(Icons.AutoMirrored.Default.ArrowBack, "Back")
+              }
             }
           },
           colors = TopAppBarDefaults.topAppBarColors(
@@ -197,7 +200,7 @@ fun ScaffoldSample(
             else -> GlassDefaults.optics
           },
           title = "Glass shaped boundary".takeIf { mode == ScaffoldSampleMode.Mask },
-          onBack = navController::navigateUp,
+          onBack = if (navigationEnabled) ({ navController.navigateUp() }) else null,
           modifier = Modifier
             .drawWithContent {
               profilingDrawProgress?.invoke()
@@ -293,7 +296,7 @@ private fun GlassScaffoldTopBar(
   performanceMode: HazePerformanceMode,
   optics: GlassOptics,
   title: String?,
-  onBack: () -> Unit,
+  onBack: (() -> Unit)?,
   modifier: Modifier = Modifier,
 ) {
   Row(
@@ -303,20 +306,22 @@ private fun GlassScaffoldTopBar(
     horizontalArrangement = Arrangement.spacedBy(8.dp),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    GlassScaffoldSurface(
-      hazeState = hazeState,
-      backgroundColor = backgroundColor,
-      tint = tint,
-      performanceMode = performanceMode,
-      optics = optics,
-      shape = RoundedCornerShape(50),
-      modifier = Modifier.size(56.dp).testTag("glass_scaffold_back"),
-    ) {
-      IconButton(onClick = onBack) {
-        Icon(
-          imageVector = Icons.AutoMirrored.Default.ArrowBack,
-          contentDescription = "Back",
-        )
+    if (onBack != null) {
+      GlassScaffoldSurface(
+        hazeState = hazeState,
+        backgroundColor = backgroundColor,
+        tint = tint,
+        performanceMode = performanceMode,
+        optics = optics,
+        shape = RoundedCornerShape(50),
+        modifier = Modifier.size(56.dp).testTag("glass_scaffold_back"),
+      ) {
+        IconButton(onClick = onBack) {
+          Icon(
+            imageVector = Icons.AutoMirrored.Default.ArrowBack,
+            contentDescription = "Back",
+          )
+        }
       }
     }
 

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/EmbeddedSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/EmbeddedSampleTest.kt
@@ -102,7 +102,8 @@ class EmbeddedSampleTest : ContextTest() {
   fun embeddedMode_hidesContentBlurringExitControl() = assertEmbeddedSampleHidesBack(Sample.ContentBlurring)
 
   @Test
-  fun embeddedMode_hidesCustomVisualEffectExitControl() = assertEmbeddedSampleHidesBack(Sample.CustomVisualEffect)
+  fun embeddedMode_hidesCustomVisualEffectExitControl() =
+    assertEmbeddedSampleHidesBack(Sample.CustomVisualEffect, SampleEffect.Blur)
 
   @Test
   fun embeddedMode_hidesMaterialsExitControl() = assertEmbeddedSampleHidesBack(Sample.Materials)

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/EmbeddedSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/EmbeddedSampleTest.kt
@@ -1,0 +1,123 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import dev.chrisbanes.haze.test.ContextTest
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class EmbeddedSampleTest : ContextTest() {
+  @Test
+  fun embeddedSample_rendersOnlyTheSelectedContentWithTheRequestedEffectAndTheme() = runComposeUiTest {
+    var selectedEffect: SampleEffect? = null
+    var background: Color? = null
+    val probe = Sample(
+      route = "probe",
+      title = "Probe",
+      effects = listOf(SampleEffect.Glass),
+    ) { _, effect ->
+      selectedEffect = effect
+      background = MaterialTheme.colorScheme.background
+      androidx.compose.material3.Text("Probe", modifier = Modifier.testTag("probe"))
+    }
+
+    setContent {
+      EmbeddedSample(SampleEmbedRequest.Embedded(probe, SampleEffect.Glass, SampleEmbedTheme.Dark))
+    }
+
+    onNodeWithTag("embedded_sample").assertIsDisplayed()
+    onNodeWithTag("probe").assertIsDisplayed()
+    onAllNodesWithTag("sample_effect_list").assertCountEquals(0)
+    onAllNodesWithTag("sample_list").assertCountEquals(0)
+    runOnIdle {
+      assertThat(selectedEffect).isEqualTo(SampleEffect.Glass)
+      assertThat(background).isEqualTo(darkColorScheme().background)
+    }
+  }
+
+  @Test
+  fun embeddedMode_hidesDedicatedExitControlsAtNarrowAndWideSizes() = runComposeUiTest {
+    var width by mutableStateOf(320.dp)
+    setContent {
+      androidx.compose.foundation.layout.Box(Modifier.size(width = width, height = 560.dp)) {
+        EmbeddedSample(
+          SampleEmbedRequest.Embedded(Sample.Scaffold, SampleEffect.Glass, SampleEmbedTheme.Light),
+        )
+      }
+    }
+
+    onAllNodesWithTag("back").assertCountEquals(0)
+    onAllNodesWithTag("glass_scaffold_back").assertCountEquals(0)
+    runOnIdle { width = 960.dp }
+    waitForIdle()
+    onAllNodesWithTag("back").assertCountEquals(0)
+    onAllNodesWithTag("glass_scaffold_back").assertCountEquals(0)
+  }
+
+  @Test
+  fun embeddedMode_hidesCreditCardExitButton() = runComposeUiTest {
+    setContent {
+      EmbeddedSample(
+        SampleEmbedRequest.Embedded(Sample.CreditCard, SampleEffect.Glass, SampleEmbedTheme.System),
+      )
+    }
+
+    onAllNodesWithTag("credit_card_back").assertCountEquals(0)
+    onNodeWithTag("credit_card_2").assertIsDisplayed()
+  }
+
+  @Test
+  fun embeddedMode_hidesImagesListExitControl() = assertEmbeddedSampleHidesBack(Sample.ImageList)
+
+  @Test
+  fun embeddedMode_hidesListOverImageExitControl() = assertEmbeddedSampleHidesBack(Sample.ListOverImage)
+
+  @Test
+  fun embeddedMode_hidesStickyHeadersExitControl() = assertEmbeddedSampleHidesBack(Sample.ListWithStickyHeaders)
+
+  @Test
+  fun embeddedMode_hidesBottomSheetExitControl() = assertEmbeddedSampleHidesBack(Sample.BottomSheet)
+
+  @Test
+  fun embeddedMode_hidesContentBlurringExitControl() = assertEmbeddedSampleHidesBack(Sample.ContentBlurring)
+
+  @Test
+  fun embeddedMode_hidesCustomVisualEffectExitControl() = assertEmbeddedSampleHidesBack(Sample.CustomVisualEffect)
+
+  @Test
+  fun embeddedMode_hidesMaterialsExitControl() = assertEmbeddedSampleHidesBack(Sample.Materials)
+
+  @Test
+  fun embeddedMode_hidesLayerTransformationsExitControl() = assertEmbeddedSampleHidesBack(Sample.LayerTransformations)
+
+  private fun assertEmbeddedSampleHidesBack(
+    sample: Sample,
+    effect: SampleEffect = SampleEffect.Glass,
+  ) = runComposeUiTest {
+    setContent {
+      EmbeddedSample(SampleEmbedRequest.Embedded(sample, effect, SampleEmbedTheme.System))
+    }
+
+    onAllNodesWithContentDescription("Back").assertCountEquals(0)
+  }
+}

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisualsTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassGalleryVisualsTest.kt
@@ -5,10 +5,13 @@ package dev.chrisbanes.haze.sample
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.v2.runComposeUiTest
@@ -21,6 +24,26 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class GlassGalleryVisualsTest : ContextTest() {
+  @Test
+  fun embeddedMode_hidesDemoChromeExitControlButKeepsReset() = runComposeUiTest {
+    var resetCount = 0
+    setContent {
+      val hazeState = rememberHazeState()
+      CompositionLocalProvider(LocalSampleNavigationEnabled provides false) {
+        DemoChrome(
+          hazeState = hazeState,
+          onBack = {},
+          onEnterRecordingMode = {},
+          onReset = { resetCount++ },
+        )
+      }
+    }
+
+    onAllNodesWithContentDescription("Back").assertCountEquals(0)
+    onNodeWithContentDescription("Reset demo").performSemanticsAction(SemanticsActions.OnClick) { action -> action() }
+    assertThat(resetCount).isEqualTo(1)
+  }
+
   @Test
   fun demoChrome_showsAndForwardsConfiguredActions() = runComposeUiTest {
     var playPauseCount = 0

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassProductSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/GlassProductSampleTest.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.sample
 
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -24,6 +25,28 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalHazeApi::class, ExperimentalTestApi::class)
 class GlassProductSampleTest : ContextTest() {
+  @Test
+  fun embeddedMode_hidesExitControlButKeepsArtworkNavigation() = runComposeUiTest {
+    var selectedIndex by mutableIntStateOf(0)
+    setContent {
+      CompositionLocalProvider(LocalSampleNavigationEnabled provides false) {
+        GlassProductSampleContent(
+          selectedArtworkIndex = selectedIndex,
+          favorite = false,
+          recordingMode = false,
+          onArtworkSelected = { selectedIndex = it },
+          onFavoriteChanged = {},
+          onRecordingModeChanged = {},
+          onBack = {},
+        )
+      }
+    }
+
+    onAllNodesWithContentDescription("Back").assertCountEquals(0)
+    onNodeWithContentDescription("Next artwork").performClick()
+    onNodeWithText("Signal Garden").assertIsDisplayed()
+  }
+
   @Test
   fun normalMode_showsProductSceneTopBar() = runComposeUiTest {
     setContent {

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SampleEmbedTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SampleEmbedTest.kt
@@ -46,6 +46,7 @@ class SampleEmbedTest : ContextTest() {
     val blurOnly = Sample(route = "blur", title = "Blur") { _, _ -> }
     listOf(
       mapOf("embed" to "true"),
+      mapOf("embed" to "true", "sample" to "blur"),
       mapOf("embed" to "true", "sample" to "missing", "effect" to "blur"),
       mapOf("embed" to "true", "sample" to "blur", "effect" to "missing"),
       mapOf("embed" to "true", "sample" to "blur", "effect" to "glass"),

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SampleEmbedTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SampleEmbedTest.kt
@@ -1,0 +1,73 @@
+// Copyright 2026, Christopher Banes and the Haze project contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.chrisbanes.haze.sample
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import dev.chrisbanes.haze.test.ContextTest
+import kotlin.test.Test
+
+class SampleEmbedTest : ContextTest() {
+  @Test
+  fun resolver_withoutEmbedFlag_startsTheNormalApp() {
+    assertThat(resolveSampleEmbed(emptyMap(), CommonSamples)).isEqualTo(SampleEmbedRequest.Normal)
+  }
+
+  @Test
+  fun resolver_validSelection_selectsTheRequestedSampleEffectAndTheme() {
+    assertThat(
+      resolveSampleEmbed(
+        mapOf("embed" to "true", "sample" to "scaffold", "effect" to "glass", "theme" to "dark"),
+        CommonSamples,
+      ),
+    ).isEqualTo(
+      SampleEmbedRequest.Embedded(Sample.Scaffold, SampleEffect.Glass, SampleEmbedTheme.Dark),
+    )
+  }
+
+  @Test
+  fun resolver_acceptsEverySupportedCatalogPair() {
+    CommonSamples.forEach { sample ->
+      sample.effects.forEach { effect ->
+        assertThat(
+          resolveSampleEmbed(
+            mapOf("embed" to "true", "sample" to sample.route, "effect" to effect.name.lowercase()),
+            CommonSamples,
+          ),
+        ).isEqualTo(SampleEmbedRequest.Embedded(sample, effect, SampleEmbedTheme.System))
+      }
+    }
+  }
+
+  @Test
+  fun resolver_rejectsMissingUnknownAndUnsupportedSelections() {
+    val blurOnly = Sample(route = "blur", title = "Blur") { _, _ -> }
+    listOf(
+      mapOf("embed" to "true"),
+      mapOf("embed" to "true", "sample" to "missing", "effect" to "blur"),
+      mapOf("embed" to "true", "sample" to "blur", "effect" to "missing"),
+      mapOf("embed" to "true", "sample" to "blur", "effect" to "glass"),
+      mapOf("embed" to "false", "sample" to "blur", "effect" to "blur"),
+    ).forEach { query ->
+      assertThat(resolveSampleEmbed(query, listOf(blurOnly))).isInstanceOf<SampleEmbedRequest.Invalid>()
+    }
+  }
+
+  @Test
+  fun resolver_usesSystemThemeByDefaultAndAcceptsEveryTheme() {
+    val query = mapOf("embed" to "true", "sample" to "scaffold", "effect" to "blur")
+    assertThat(resolveSampleEmbed(query, CommonSamples))
+      .isEqualTo(SampleEmbedRequest.Embedded(Sample.Scaffold, SampleEffect.Blur, SampleEmbedTheme.System))
+
+    mapOf("system" to SampleEmbedTheme.System, "light" to SampleEmbedTheme.Light, "dark" to SampleEmbedTheme.Dark)
+      .forEach { (theme, expected) ->
+        assertThat(resolveSampleEmbed(query + ("theme" to theme), CommonSamples))
+          .isEqualTo(SampleEmbedRequest.Embedded(Sample.Scaffold, SampleEffect.Blur, expected))
+      }
+
+    assertThat(resolveSampleEmbed(query + ("theme" to "blue"), CommonSamples))
+      .isInstanceOf<SampleEmbedRequest.Invalid>()
+  }
+}

--- a/sample/web/README.md
+++ b/sample/web/README.md
@@ -69,5 +69,5 @@ playback, reset, and recording controls; navigation back to the sample browser i
 | Glass — Playground | `glass-playground` | `glass` |
 | Glass — Lab | `glass-lab` | `glass` |
 
-Find the first release that supports embedding in its release notes or documentation navigation, and
-pin that exact version in the article. A query string cannot add this feature to an older release.
+Check a release's `sample/web/README.md` for embedding support, then pin that exact documentation
+version in the article. A query string cannot add this feature to an older release.

--- a/sample/web/src/wasmJsMain/kotlin/dev/chrisbanes/haze/sample/Main.kt
+++ b/sample/web/src/wasmJsMain/kotlin/dev/chrisbanes/haze/sample/Main.kt
@@ -3,20 +3,55 @@
 
 package dev.chrisbanes.haze.sample
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.ComposeViewport
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+  val request = resolveSampleEmbed(sampleEmbedQuery(), Samples)
   ComposeViewport(viewportContainerId = "Sample") {
     PageLoadNotify()
-    Samples("Haze Samples")
+    when (request) {
+      SampleEmbedRequest.Normal -> Samples("Haze Samples")
+      is SampleEmbedRequest.Embedded -> EmbeddedSample(request)
+      is SampleEmbedRequest.Invalid -> InvalidSampleEmbed()
+    }
   }
 }
 
 external fun onLoadFinished()
+external fun queryParameter(name: String): String?
+
+private fun sampleEmbedQuery(): Map<String, String> = buildMap {
+  listOf("embed", "sample", "effect", "theme").forEach { name ->
+    queryParameter(name)?.let { put(name, it) }
+  }
+}
+
+@Composable
+private fun InvalidSampleEmbed() {
+  SamplesTheme {
+    Surface(modifier = Modifier.fillMaxSize()) {
+      Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier.fillMaxSize(),
+      ) {
+        Text("Invalid sample embed")
+        Text("Check the sample and effect query parameters.")
+      }
+    }
+  }
+}
 
 @Composable
 fun PageLoadNotify() {

--- a/sample/web/src/wasmJsMain/resources/app.js
+++ b/sample/web/src/wasmJsMain/resources/app.js
@@ -2,6 +2,10 @@ function onLoadFinished() {
     document.dispatchEvent(new Event("app-loaded"));
 }
 
+function queryParameter(name) {
+    return new URLSearchParams(window.location.search).get(name);
+}
+
 document.addEventListener("app-loaded", function() {
     document.getElementById("spinner").style.display = "none";
 });


### PR DESCRIPTION
Allow blog posts to embed a single interactive sample without the sample browser or controls that leave the demo. For example, `?embed=true&sample=scaffold&effect=glass&theme=light` opens the Glass Scaffold sample directly; URLs without embed mode keep the existing browser.

The web entry point validates the sample/effect selection and supports an optional light/dark theme override. The shared sample host hides exit controls while retaining demo interactions. `sample/web/README.md` documents version-pinned iframe markup with lazy loading, responsive width, and an author-set height.

## Validation

- Full `./gradlew check --no-scan` passed at `b4d9328`; the only subsequent change moves the guide into the sample README and removes its docs navigation entry.
- Shared sample tests, Wasm distribution, and unchanged sample screenshot verification passed.
- `properdocs build --strict` passed again after the guide move; `git diff --check` passed.
- Local browser checks covered narrow/wide iframes, independent sample state, internal scrolling, artwork navigation, URL decoding, invalid selections, and normal browsing.

Dialog and Popup embed tests hit a Compose JVM harness timeout, so their iframe behavior was checked in the browser. Fresh parallel agent review could not run because the requested reviewer type was unavailable. The feature-bearing deployed URL and hosting headers still need verification after publication; local iframe checks do not establish deployed-host behavior.
