### PR TITLE
Support direct sample links with navigation

### DIFF
--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/SampleEmbed.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/SampleEmbed.kt
@@ -26,52 +26,57 @@ public enum class SampleEmbedTheme {
   Dark,
 }
 
-public sealed interface SampleEmbedRequest {
-  public data object Normal : SampleEmbedRequest
+public sealed interface SampleLaunchRequest {
+  public data object Normal : SampleLaunchRequest
 
   @Poko
-  public class Embedded(
+  public class Selected(
     val sample: Sample,
     val effect: SampleEffect,
     val theme: SampleEmbedTheme,
-  ) : SampleEmbedRequest
+    val embedded: Boolean = true,
+  ) : SampleLaunchRequest
 
   @Poko
-  public class Invalid(val message: String) : SampleEmbedRequest
+  public class Invalid(val message: String) : SampleLaunchRequest
 }
 
-public fun resolveSampleEmbed(
+public fun resolveSampleLaunch(
   query: Map<String, String>,
   samples: List<Sample>,
-): SampleEmbedRequest {
-  if ("embed" !in query) return SampleEmbedRequest.Normal
-  if (query["embed"] != "true") return SampleEmbedRequest.Invalid("embed must be true")
+): SampleLaunchRequest {
+  val embedded = when (query["embed"]) {
+    "true" -> true
+    null, "false" -> false
+    else -> return SampleLaunchRequest.Invalid("embed must be true or false")
+  }
+  if (!embedded && "sample" !in query && "effect" !in query) return SampleLaunchRequest.Normal
 
-  val route = query["sample"] ?: return SampleEmbedRequest.Invalid("sample is required")
+  val route = query["sample"] ?: return SampleLaunchRequest.Invalid("sample is required")
   val effect = when (query["effect"]) {
     "blur" -> SampleEffect.Blur
     "glass" -> SampleEffect.Glass
-    null -> return SampleEmbedRequest.Invalid("effect is required")
-    else -> return SampleEmbedRequest.Invalid("effect is invalid")
+    null -> return SampleLaunchRequest.Invalid("effect is required")
+    else -> return SampleLaunchRequest.Invalid("effect is invalid")
   }
   val theme = when (query["theme"]) {
     null, "system" -> SampleEmbedTheme.System
     "light" -> SampleEmbedTheme.Light
     "dark" -> SampleEmbedTheme.Dark
-    else -> return SampleEmbedRequest.Invalid("theme is invalid")
+    else -> return SampleLaunchRequest.Invalid("theme is invalid")
   }
   val sample = samples.firstOrNull { it.route == route }
-    ?: return SampleEmbedRequest.Invalid("sample is invalid")
-  if (effect !in sample.effects) return SampleEmbedRequest.Invalid("effect is unsupported for sample")
+    ?: return SampleLaunchRequest.Invalid("sample is invalid")
+  if (effect !in sample.effects) return SampleLaunchRequest.Invalid("effect is unsupported for sample")
 
-  return SampleEmbedRequest.Embedded(sample, effect, theme)
+  return SampleLaunchRequest.Selected(sample, effect, theme, embedded)
 }
 
 internal val LocalSampleNavigationEnabled = staticCompositionLocalOf { true }
 
 @Composable
 public fun EmbeddedSample(
-  request: SampleEmbedRequest.Embedded,
+  request: SampleLaunchRequest.Selected,
   modifier: Modifier = Modifier,
 ) {
   val useDarkColors = when (request.theme) {

--- a/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
+++ b/sample/shared/src/commonMain/kotlin/dev/chrisbanes/haze/sample/Samples.kt
@@ -35,8 +35,12 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -352,6 +356,7 @@ fun Samples(
   samples: List<Sample> = Samples,
   forceBlur: Boolean = false,
   useDarkColors: Boolean = isSystemInDarkTheme(),
+  initialSelection: SampleLaunchRequest.Selected? = null,
 ) {
   val coilPlatformContext = LocalPlatformContext.current
   val inspectionMode = LocalInspectionMode.current
@@ -432,6 +437,16 @@ fun Samples(
               )
             }
           }
+        }
+      }
+      var initialSelectionApplied by rememberSaveable { mutableStateOf(false) }
+      LaunchedEffect(navController, initialSelection) {
+        if (!initialSelectionApplied) {
+          initialSelection?.let { selection ->
+            navController.navigate(selection.effect.route())
+            navController.navigate(selection.sample.route(selection.effect))
+          }
+          initialSelectionApplied = true
         }
       }
     }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/EmbeddedSampleTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/EmbeddedSampleTest.kt
@@ -42,7 +42,7 @@ class EmbeddedSampleTest : ContextTest() {
     }
 
     setContent {
-      EmbeddedSample(SampleEmbedRequest.Embedded(probe, SampleEffect.Glass, SampleEmbedTheme.Dark))
+      EmbeddedSample(SampleLaunchRequest.Selected(probe, SampleEffect.Glass, SampleEmbedTheme.Dark))
     }
 
     onNodeWithTag("embedded_sample").assertIsDisplayed()
@@ -61,7 +61,7 @@ class EmbeddedSampleTest : ContextTest() {
     setContent {
       androidx.compose.foundation.layout.Box(Modifier.size(width = width, height = 560.dp)) {
         EmbeddedSample(
-          SampleEmbedRequest.Embedded(Sample.Scaffold, SampleEffect.Glass, SampleEmbedTheme.Light),
+          SampleLaunchRequest.Selected(Sample.Scaffold, SampleEffect.Glass, SampleEmbedTheme.Light),
         )
       }
     }
@@ -78,7 +78,7 @@ class EmbeddedSampleTest : ContextTest() {
   fun embeddedMode_hidesCreditCardExitButton() = runComposeUiTest {
     setContent {
       EmbeddedSample(
-        SampleEmbedRequest.Embedded(Sample.CreditCard, SampleEffect.Glass, SampleEmbedTheme.System),
+        SampleLaunchRequest.Selected(Sample.CreditCard, SampleEffect.Glass, SampleEmbedTheme.System),
       )
     }
 
@@ -116,7 +116,7 @@ class EmbeddedSampleTest : ContextTest() {
     effect: SampleEffect = SampleEffect.Glass,
   ) = runComposeUiTest {
     setContent {
-      EmbeddedSample(SampleEmbedRequest.Embedded(sample, effect, SampleEmbedTheme.System))
+      EmbeddedSample(SampleLaunchRequest.Selected(sample, effect, SampleEmbedTheme.System))
     }
 
     onAllNodesWithContentDescription("Back").assertCountEquals(0)

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SampleEmbedTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SampleEmbedTest.kt
@@ -12,18 +12,45 @@ import kotlin.test.Test
 class SampleEmbedTest : ContextTest() {
   @Test
   fun resolver_withoutEmbedFlag_startsTheNormalApp() {
-    assertThat(resolveSampleEmbed(emptyMap(), CommonSamples)).isEqualTo(SampleEmbedRequest.Normal)
+    assertThat(resolveSampleLaunch(emptyMap(), CommonSamples)).isEqualTo(SampleLaunchRequest.Normal)
+    assertThat(resolveSampleLaunch(mapOf("embed" to "false"), CommonSamples))
+      .isEqualTo(SampleLaunchRequest.Normal)
+  }
+
+  @Test
+  fun resolver_selectionWithoutEmbedding_retainsNavigationAndTheme() {
+    val selection = mapOf("sample" to "glass-product", "effect" to "glass", "theme" to "dark")
+    listOf(selection, selection + ("embed" to "false")).forEach { query ->
+      assertThat(resolveSampleLaunch(query, CommonSamples)).isEqualTo(
+        SampleLaunchRequest.Selected(Sample.GlassProduct, SampleEffect.Glass, SampleEmbedTheme.Dark, embedded = false),
+      )
+    }
+  }
+
+  @Test
+  fun resolver_invalidNavigationSelection_showsAnError() {
+    listOf(
+      mapOf("sample" to "glass-product"),
+      mapOf("effect" to "glass"),
+      mapOf("sample" to "missing", "effect" to "glass"),
+      mapOf("sample" to "glass-product", "effect" to "blur"),
+      mapOf("sample" to "glass-product", "effect" to "glass", "theme" to "blue"),
+    ).forEach { query ->
+      listOf(query, query + ("embed" to "false")).forEach {
+        assertThat(resolveSampleLaunch(it, CommonSamples)).isInstanceOf<SampleLaunchRequest.Invalid>()
+      }
+    }
   }
 
   @Test
   fun resolver_validSelection_selectsTheRequestedSampleEffectAndTheme() {
     assertThat(
-      resolveSampleEmbed(
+      resolveSampleLaunch(
         mapOf("embed" to "true", "sample" to "scaffold", "effect" to "glass", "theme" to "dark"),
         CommonSamples,
       ),
     ).isEqualTo(
-      SampleEmbedRequest.Embedded(Sample.Scaffold, SampleEffect.Glass, SampleEmbedTheme.Dark),
+      SampleLaunchRequest.Selected(Sample.Scaffold, SampleEffect.Glass, SampleEmbedTheme.Dark),
     )
   }
 
@@ -32,11 +59,11 @@ class SampleEmbedTest : ContextTest() {
     CommonSamples.forEach { sample ->
       sample.effects.forEach { effect ->
         assertThat(
-          resolveSampleEmbed(
+          resolveSampleLaunch(
             mapOf("embed" to "true", "sample" to sample.route, "effect" to effect.name.lowercase()),
             CommonSamples,
           ),
-        ).isEqualTo(SampleEmbedRequest.Embedded(sample, effect, SampleEmbedTheme.System))
+        ).isEqualTo(SampleLaunchRequest.Selected(sample, effect, SampleEmbedTheme.System))
       }
     }
   }
@@ -50,25 +77,25 @@ class SampleEmbedTest : ContextTest() {
       mapOf("embed" to "true", "sample" to "missing", "effect" to "blur"),
       mapOf("embed" to "true", "sample" to "blur", "effect" to "missing"),
       mapOf("embed" to "true", "sample" to "blur", "effect" to "glass"),
-      mapOf("embed" to "false", "sample" to "blur", "effect" to "blur"),
+      mapOf("embed" to "invalid", "sample" to "blur", "effect" to "blur"),
     ).forEach { query ->
-      assertThat(resolveSampleEmbed(query, listOf(blurOnly))).isInstanceOf<SampleEmbedRequest.Invalid>()
+      assertThat(resolveSampleLaunch(query, listOf(blurOnly))).isInstanceOf<SampleLaunchRequest.Invalid>()
     }
   }
 
   @Test
   fun resolver_usesSystemThemeByDefaultAndAcceptsEveryTheme() {
     val query = mapOf("embed" to "true", "sample" to "scaffold", "effect" to "blur")
-    assertThat(resolveSampleEmbed(query, CommonSamples))
-      .isEqualTo(SampleEmbedRequest.Embedded(Sample.Scaffold, SampleEffect.Blur, SampleEmbedTheme.System))
+    assertThat(resolveSampleLaunch(query, CommonSamples))
+      .isEqualTo(SampleLaunchRequest.Selected(Sample.Scaffold, SampleEffect.Blur, SampleEmbedTheme.System))
 
     mapOf("system" to SampleEmbedTheme.System, "light" to SampleEmbedTheme.Light, "dark" to SampleEmbedTheme.Dark)
       .forEach { (theme, expected) ->
-        assertThat(resolveSampleEmbed(query + ("theme" to theme), CommonSamples))
-          .isEqualTo(SampleEmbedRequest.Embedded(Sample.Scaffold, SampleEffect.Blur, expected))
+        assertThat(resolveSampleLaunch(query + ("theme" to theme), CommonSamples))
+          .isEqualTo(SampleLaunchRequest.Selected(Sample.Scaffold, SampleEffect.Blur, expected))
       }
 
-    assertThat(resolveSampleEmbed(query + ("theme" to "blue"), CommonSamples))
-      .isInstanceOf<SampleEmbedRequest.Invalid>()
+    assertThat(resolveSampleLaunch(query + ("theme" to "blue"), CommonSamples))
+      .isInstanceOf<SampleLaunchRequest.Invalid>()
   }
 }

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
@@ -3,11 +3,7 @@
 
 package dev.chrisbanes.haze.sample
 
-import androidx.compose.material3.Button
 import androidx.compose.material3.Text
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -23,34 +19,9 @@ import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalTestApi::class)
 class SamplesTest : ContextTest() {
-  @Test
-  fun directLink_seedsNormalBackHistoryAndDoesNotReopenOnRecomposition() = runComposeUiTest {
-    var appTitle by mutableStateOf("Haze Samples")
-    val sample = Sample(route = "probe", title = "Probe", effects = listOf(SampleEffect.Glass)) { nav, effect ->
-      Button(onClick = { nav.popBackStack() }) { Text("Exit ${effect.label} probe") }
-    }
-    val selection = resolveSampleLaunch(mapOf("sample" to "probe", "effect" to "glass"), listOf(sample))
-      as SampleLaunchRequest.Selected
-    setContent {
-      Samples(appTitle = appTitle, samples = listOf(sample), initialSelection = selection)
-    }
-
-    onNodeWithText("Exit Glass probe").assertIsDisplayed()
-    withContext(Dispatchers.Main) { onNodeWithText("Exit Glass probe").performClick() }
-    onNodeWithTag("sample_list").assertIsDisplayed()
-    onNodeWithText("Exit Glass probe").assertDoesNotExist()
-    runOnIdle { appTitle = "Updated samples" }
-    onNodeWithText("Exit Glass probe").assertDoesNotExist()
-    withContext(Dispatchers.Main) { onNodeWithContentDescription("Back").performClick() }
-    onNodeWithTag("sample_effect_glass").assertIsDisplayed()
-    onNodeWithTag("sample_effect_blur").assertIsDisplayed()
-  }
-
   @Test
   fun commonSamples_routesAndTitlesAreUnique() {
     assertThat(CommonSamples.map(Sample::route).distinct().size)

--- a/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
+++ b/sample/shared/src/commonTest/kotlin/dev/chrisbanes/haze/sample/SamplesTest.kt
@@ -3,7 +3,11 @@
 
 package dev.chrisbanes.haze.sample
 
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
@@ -19,9 +23,34 @@ import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import dev.chrisbanes.haze.test.ContextTest
 import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalTestApi::class)
 class SamplesTest : ContextTest() {
+  @Test
+  fun directLink_seedsNormalBackHistoryAndDoesNotReopenOnRecomposition() = runComposeUiTest {
+    var appTitle by mutableStateOf("Haze Samples")
+    val sample = Sample(route = "probe", title = "Probe", effects = listOf(SampleEffect.Glass)) { nav, effect ->
+      Button(onClick = { nav.popBackStack() }) { Text("Exit ${effect.label} probe") }
+    }
+    val selection = resolveSampleLaunch(mapOf("sample" to "probe", "effect" to "glass"), listOf(sample))
+      as SampleLaunchRequest.Selected
+    setContent {
+      Samples(appTitle = appTitle, samples = listOf(sample), initialSelection = selection)
+    }
+
+    onNodeWithText("Exit Glass probe").assertIsDisplayed()
+    withContext(Dispatchers.Main) { onNodeWithText("Exit Glass probe").performClick() }
+    onNodeWithTag("sample_list").assertIsDisplayed()
+    onNodeWithText("Exit Glass probe").assertDoesNotExist()
+    runOnIdle { appTitle = "Updated samples" }
+    onNodeWithText("Exit Glass probe").assertDoesNotExist()
+    withContext(Dispatchers.Main) { onNodeWithContentDescription("Back").performClick() }
+    onNodeWithTag("sample_effect_glass").assertIsDisplayed()
+    onNodeWithTag("sample_effect_blur").assertIsDisplayed()
+  }
+
   @Test
   fun commonSamples_routesAndTitlesAreUnique() {
     assertThat(CommonSamples.map(Sample::route).distinct().size)

--- a/sample/shared/src/jvmTest/kotlin/dev/chrisbanes/haze/sample/SamplesJvmTest.kt
+++ b/sample/shared/src/jvmTest/kotlin/dev/chrisbanes/haze/sample/SamplesJvmTest.kt
@@ -3,12 +3,51 @@
 
 package dev.chrisbanes.haze.sample
 
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.v2.runComposeUiTest
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
+@OptIn(ExperimentalTestApi::class)
 class SamplesJvmTest {
+  // This test dispatches click actions to Main, which is provided by kotlinx-coroutines-swing here.
+  @Test
+  fun directLink_seedsNormalBackHistoryAndDoesNotReopenOnRecomposition() = runComposeUiTest {
+    var appTitle by mutableStateOf("Haze Samples")
+    val sample = Sample(route = "probe", title = "Probe", effects = listOf(SampleEffect.Glass)) { nav, effect ->
+      Button(onClick = { nav.popBackStack() }) { Text("Exit ${effect.label} probe") }
+    }
+    val selection = resolveSampleLaunch(mapOf("sample" to "probe", "effect" to "glass"), listOf(sample))
+      as SampleLaunchRequest.Selected
+    setContent {
+      Samples(appTitle = appTitle, samples = listOf(sample), initialSelection = selection)
+    }
+
+    onNodeWithText("Exit Glass probe").assertIsDisplayed()
+    withContext(Dispatchers.Main) { onNodeWithText("Exit Glass probe").performClick() }
+    onNodeWithTag("sample_list").assertIsDisplayed()
+    onNodeWithText("Exit Glass probe").assertDoesNotExist()
+    runOnIdle { appTitle = "Updated samples" }
+    onNodeWithText("Exit Glass probe").assertDoesNotExist()
+    withContext(Dispatchers.Main) { onNodeWithContentDescription("Back").performClick() }
+    onNodeWithTag("sample_effect_glass").assertIsDisplayed()
+    onNodeWithTag("sample_effect_blur").assertIsDisplayed()
+  }
+
   @Test
   fun kamera_isRegisteredAndExposesBothBuiltInEffects() {
     assertThat(Samples).contains(Kamera)

--- a/sample/web/README.md
+++ b/sample/web/README.md
@@ -25,10 +25,21 @@ https://chrisbanes.github.io/haze/<VERSION-WITH-EMBED-SUPPORT>/sample/wasm/index
 
 ## URL parameters
 
-`embed=true` enables the standalone sample view. It requires both `sample` and `effect`. The browser
+`sample` and `effect` together open a sample directly with normal navigation retained:
+
+```text
+https://chrisbanes.github.io/haze/<VERSION-WITH-EMBED-SUPPORT>/sample/wasm/index.html?sample=glass-product&effect=glass&theme=light
+```
+
+In-app Back returns to the effect's sample list, then the Blur/Glass chooser. These parameters select
+the initial screen only: navigating does not update the URL or add browser Back/Forward history.
+Omitting both parameters opens the ordinary chooser.
+
+`embed=true` enables the standalone sample view with navigation hidden. Omitting `embed` or setting
+`embed=false` retains navigation. Both selection modes require `sample` and `effect`. The browser
 decodes the query string and uses the first value if a key appears more than once. Unknown keys are
-ignored. Any missing or invalid explicit embed value, sample, effect, unsupported sample/effect pair,
-or theme shows a compact error instead of selecting another demo.
+ignored. Any invalid explicit embed value, incomplete selection, invalid sample or effect, unsupported
+sample/effect pair, or invalid theme shows a compact error instead of selecting another demo.
 
 | Parameter | Values | Default |
 | --- | --- | --- |
@@ -36,8 +47,9 @@ or theme shows a compact error instead of selecting another demo.
 | `effect` | `blur` or `glass`, when the chosen sample supports it | Required |
 | `theme` | `system`, `light`, or `dark` | `system` |
 
-The theme changes the sample app theme only. It does not synchronize with the parent page or recolor
-artwork that deliberately uses its own dark scene design. Each embed starts with the ordinary defaults
+The theme works for both direct sample links and embeds. It changes the sample app theme only.
+It does not synchronize with the parent page or recolor artwork that deliberately uses its own dark
+scene design. Each embed starts with the ordinary defaults
 for that sample. Its own controls remain available, including artwork paging, dialogs, drag gestures,
 playback, reset, and recording controls; navigation back to the sample browser is hidden.
 

--- a/sample/web/src/wasmJsMain/kotlin/dev/chrisbanes/haze/sample/Main.kt
+++ b/sample/web/src/wasmJsMain/kotlin/dev/chrisbanes/haze/sample/Main.kt
@@ -3,6 +3,7 @@
 
 package dev.chrisbanes.haze.sample
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,13 +18,25 @@ import androidx.compose.ui.window.ComposeViewport
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
-  val request = resolveSampleEmbed(sampleEmbedQuery(), Samples)
+  val request = resolveSampleLaunch(sampleEmbedQuery(), Samples)
   ComposeViewport(viewportContainerId = "Sample") {
     PageLoadNotify()
     when (request) {
-      SampleEmbedRequest.Normal -> Samples("Haze Samples")
-      is SampleEmbedRequest.Embedded -> EmbeddedSample(request)
-      is SampleEmbedRequest.Invalid -> InvalidSampleEmbed()
+      SampleLaunchRequest.Normal -> Samples("Haze Samples")
+      is SampleLaunchRequest.Selected -> if (request.embedded) {
+        EmbeddedSample(request)
+      } else {
+        Samples(
+          appTitle = "Haze Samples",
+          initialSelection = request,
+          useDarkColors = when (request.theme) {
+            SampleEmbedTheme.System -> isSystemInDarkTheme()
+            SampleEmbedTheme.Light -> false
+            SampleEmbedTheme.Dark -> true
+          },
+        )
+      }
+      is SampleLaunchRequest.Invalid -> InvalidSampleEmbed()
     }
   }
 }
@@ -46,7 +59,7 @@ private fun InvalidSampleEmbed() {
         verticalArrangement = Arrangement.Center,
         modifier = Modifier.fillMaxSize(),
       ) {
-        Text("Invalid sample embed")
+        Text("Invalid sample link")
         Text("Check the sample and effect query parameters.")
       }
     }


### PR DESCRIPTION
URLs such as `index.html?sample=glass-product&effect=glass` now open the selected sample with normal in-app navigation. Back returns through the effect’s sample list to the Blur/Glass chooser. Previously, selections were ignored without `embed=true`.

Omitting `embed` or setting `embed=false` retains navigation; `embed=true` keeps the standalone view. Both selection modes support `theme` and reject incomplete or invalid selections. Navigation does not change the URL or browser history. Includes updated URL documentation and regression coverage for back navigation and recomposition.

Validation: 38 targeted JVM tests passed, the Wasm entry point compiled, and Spotless completed.

The original full check hung in the shared navigation test, matching the Android host and macOS CI timeouts. The navigation regression test now lives in `jvmTest`, where its main-thread dispatcher is configured. After the fix, all 17 `SamplesTest` Android host tests and the JVM navigation regression test pass. Replacement CI passed: Linux build, Mac build, emulator tests, Android screenshot tests, and docs build.
